### PR TITLE
Include dynamic badges for colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,10 @@ face restore a particular generated image, pass it again with the same
 prompt and generated seed along with the `-U` and `-G` prompt
 arguments to perform those actions.
 
-## Google Colab
+## Google Colab <img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/artmen1516/472402c8ae9265c01859544f3d100111/raw/colab-message.json" alt="Status Message"/>
 
-Stable Diffusion AI Notebook: <a href="https://colab.research.google.com/github/lstein/stable-diffusion/blob/main/Stable_Diffusion_AI_Notebook.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <br>
+Stable Diffusion AI Notebook: <br>
+<a href="https://colab.research.google.com/github/lstein/stable-diffusion/blob/main/Stable_Diffusion_AI_Notebook.ipynb"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/artmen1516/472402c8ae9265c01859544f3d100111/raw/colab-main.json" alt="Open In Colab"/></a> <a href="https://colab.research.google.com/github/lstein/stable-diffusion/blob/development/Stable_Diffusion_AI_Notebook.ipynb"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/artmen1516/472402c8ae9265c01859544f3d100111/raw/colab-develop.json" alt="Open In Colab"/></a><br>
 Open and follow instructions to use an isolated environment running Dream.<br>
 
 Output example:


### PR DESCRIPTION
Hi, 
I noticed that some people were creating issues related to colab notebook not working, so I came up with the idea of creating badges with dynamic messages with notebook status to inform users about a problem without the need of creating a PR to update the badges or to include a message. Also I include the colab notebook badge from develop, this way users can access to early colab changes. The way I'm doing this is through github gists, currently I set it up with my account, but probably one of code mantainers should fork it, and modify the urls used in the readme to theirs, so they can have the control over the messages.

This is my private gist with the badges included in this PR https://gist.github.com/artmen1516/472402c8ae9265c01859544f3d100111
A more detailed information about how I made this at the end of gist Readme.

Here you can see the changes in my fork:
https://github.com/artmen1516/stable-diffusion/tree/patch-1#google-colab-

Please let me know what you think about this.