### PR TITLE
non-uniform cfg_scale, including 1.0 value

### DIFF
--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -20,7 +20,7 @@ def build_opt(post_data, seed, gfpgan_model_exists):
     setattr(opt, 'fit', 'fit' in post_data)
     setattr(opt, 'mask', 'mask' in post_data)
     setattr(opt, 'invert_mask', 'invert_mask' in post_data)
-    setattr(opt, 'cfg_scale', float(post_data['cfg_scale']))
+    setattr(opt, 'cfg_scale', [float(i) for i in post_data['cfg_scale'].split(',')])
     setattr(opt, 'sampler_name', post_data['sampler_name'])
     setattr(opt, 'gfpgan_strength', float(post_data['gfpgan_strength']) if gfpgan_model_exists else 0)
     setattr(opt, 'upscale', [int(post_data['upscale_level']), float(post_data['upscale_strength'])] if post_data['upscale_level'] != '' else None)

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -267,7 +267,6 @@ class Generate:
             if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
                 m.padding_mode = 'circular' if seamless else m._orig_padding_mode
         
-        assert cfg_scale > 1.0, 'CFG_Scale (-C) must be >1.0'
         assert (
             0.0 < strength < 1.0
         ), 'img2img and inpaint strength can only work with 0.0 < strength < 1.0'

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -103,7 +103,7 @@ class Generate:
             self,
             iterations            = 1,
             steps                 = 50,
-            cfg_scale             = 7.5,
+            cfg_scale             = [ 7.5 ],
             weights               = 'models/ldm/stable-diffusion-v1/model.ckpt',
             config                = 'configs/stable-diffusion/v1-inference.yaml',
             grid                  = False,

--- a/ldm/models/diffusion/ddim.py
+++ b/ldm/models/diffusion/ddim.py
@@ -127,7 +127,7 @@ class DDIMSampler(object):
         verbose=True,
         x_T=None,
         log_every_t=100,
-        unconditional_guidance_scale=1.0,
+        unconditional_guidance_scale=None,
         unconditional_conditioning=None,
         # this has to come in the same format as the conditioning, # e.g. as encoded tokens, ...
         **kwargs,
@@ -190,7 +190,7 @@ class DDIMSampler(object):
         noise_dropout=0.0,
         score_corrector=None,
         corrector_kwargs=None,
-        unconditional_guidance_scale=1.0,
+        unconditional_guidance_scale=None,
         unconditional_conditioning=None,
     ):
         device = self.model.betas.device
@@ -256,7 +256,7 @@ class DDIMSampler(object):
                 noise_dropout=noise_dropout,
                 score_corrector=score_corrector,
                 corrector_kwargs=corrector_kwargs,
-                unconditional_guidance_scale=unconditional_guidance_scale,
+                unconditional_guidance_scale=unconditional_guidance_scale[i%len(unconditional_guidance_scale)],
                 unconditional_conditioning=unconditional_conditioning,
             )
             img, pred_x0 = outs
@@ -286,7 +286,7 @@ class DDIMSampler(object):
         noise_dropout=0.0,
         score_corrector=None,
         corrector_kwargs=None,
-        unconditional_guidance_scale=1.0,
+        unconditional_guidance_scale=None,
         unconditional_conditioning=None,
     ):
         b, *_, device = *x.shape, x.device
@@ -379,7 +379,7 @@ class DDIMSampler(object):
             cond,
             t_start,
             img_callback=None,
-            unconditional_guidance_scale=1.0,
+            unconditional_guidance_scale=None,
             unconditional_conditioning=None,
             use_original_steps=False,
             init_latent       = None,
@@ -423,7 +423,7 @@ class DDIMSampler(object):
                 ts,
                 index=index,
                 use_original_steps=use_original_steps,
-                unconditional_guidance_scale=unconditional_guidance_scale,
+                unconditional_guidance_scale=unconditional_guidance_scale[i%len(unconditional_guidance_scale)],
                 unconditional_conditioning=unconditional_conditioning,
             )
 

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -10,14 +10,16 @@ class CFGDenoiser(nn.Module):
         self.inner_model = model
 
     def forward(self, x, sigma, uncond, cond, cond_scale):
-        if (cond_scale == 1.0):
+        cs = cond_scale.pop(0)
+        cond_scale.append(cs)
+        if (cs == 1.0):
             return self.inner_model(x, sigma, cond=cond)
         else:
             x_in = torch.cat([x] * 2)
             sigma_in = torch.cat([sigma] * 2)
             cond_in = torch.cat([uncond, cond])
             uncond, cond = self.inner_model(x_in, sigma_in, cond=cond_in).chunk(2)
-            return uncond + (cond - uncond) * cond_scale
+            return uncond + (cond - uncond) * cs
 
 
 
@@ -29,7 +31,9 @@ class KSampler(object):
         self.device   = device or choose_torch_device()
 
         def forward(self, x, sigma, uncond, cond, cond_scale):
-            if (cond_scale == 1.0):
+            cs = cond_scale.pop(0)
+            cond_scale.append(cs)
+            if (cs == 1.0):
                 return self.inner_model(x, sigma, cond=cond)
             else:
                 x_in = torch.cat([x] * 2)
@@ -38,7 +42,7 @@ class KSampler(object):
                 uncond, cond = self.inner_model(
                     x_in, sigma_in, cond=cond_in
                 ).chunk(2)
-                return uncond + (cond - uncond) * cond_scale
+                return uncond + (cond - uncond) * cs
 
     # most of these arguments are ignored and are only present for compatibility with
     # other samples

--- a/ldm/models/diffusion/plms.py
+++ b/ldm/models/diffusion/plms.py
@@ -128,7 +128,7 @@ class PLMSSampler(object):
         verbose=True,
         x_T=None,
         log_every_t=100,
-        unconditional_guidance_scale=1.0,
+        unconditional_guidance_scale=None,
         unconditional_conditioning=None,
         # this has to come in the same format as the conditioning, # e.g. as encoded tokens, ...
         **kwargs,
@@ -190,7 +190,7 @@ class PLMSSampler(object):
         noise_dropout=0.0,
         score_corrector=None,
         corrector_kwargs=None,
-        unconditional_guidance_scale=1.0,
+        unconditional_guidance_scale=None,
         unconditional_conditioning=None,
     ):
         device = self.model.betas.device
@@ -263,7 +263,7 @@ class PLMSSampler(object):
                 noise_dropout=noise_dropout,
                 score_corrector=score_corrector,
                 corrector_kwargs=corrector_kwargs,
-                unconditional_guidance_scale=unconditional_guidance_scale,
+                unconditional_guidance_scale=unconditional_guidance_scale[i%len(unconditional_guidance_scale)],
                 unconditional_conditioning=unconditional_conditioning,
                 old_eps=old_eps,
                 t_next=ts_next,
@@ -297,7 +297,7 @@ class PLMSSampler(object):
         noise_dropout=0.0,
         score_corrector=None,
         corrector_kwargs=None,
-        unconditional_guidance_scale=1.0,
+        unconditional_guidance_scale=None,
         unconditional_conditioning=None,
         old_eps=None,
         t_next=None,

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -206,6 +206,12 @@ def main_loop(t2i, outdir, prompt_as_dir, parser, infile):
 
         do_grid = opt.grid or t2i.grid
 
+        if opt.cfg_scale is not None:
+            opt.cfg_scale = [float(i) for i in opt.cfg_scale.split(',')]
+            steps = opt.steps or 50
+            while len(opt.cfg_scale) < steps: opt.cfg_scale.append(opt.cfg_scale[-1])
+            print(f'opt.cfg_scale {opt.cfg_scale}')
+
         if opt.with_variations is not None:
             # shotgun parsing, woo
             parts = []
@@ -567,8 +573,8 @@ def create_cmd_parser():
     parser.add_argument(
         '-C',
         '--cfg_scale',
-        default=7.5,
-        type=float,
+        default='7.5',
+        type=str,
         help='Classifier free guidance (CFG) scale - higher numbers cause generator to "try" harder.',
     )
     parser.add_argument(

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -30,7 +30,7 @@
           <label for="steps">Steps:</label>
           <input value="50" type="number" id="steps" name="steps">
           <label for="cfg_scale">Cfg Scale:</label>
-          <input value="7.5" type="number" id="cfg_scale" name="cfg_scale" step="any">
+          <input value="7.5" type="text" id="cfg_scale" name="cfg_scale">
           <label for="sampler_name">Sampler:</label>
           <select id="sampler_name" name="sampler_name" value="k_lms">
             <option value="ddim">DDIM</option>


### PR DESCRIPTION
Allow different cfg_scale value per each step, including 1.0 that is the fast unguided step. E.g.

`
dream> chair -G 0 -S 1 -s 10 -C 20 -A ddim
opt.cfg_scale [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0]
. . .
>>   1 image(s) generated in 6.26s
`
![000021 1](https://user-images.githubusercontent.com/113372415/189723613-a4fed933-c50a-401d-911b-b25876d2ed26.png)

`
dream> chair -G 0 -S 1 -s 10 -C 20,20,1,1,1,1,1,1,1,1 -A ddim
opt.cfg_scale [20.0, 20.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
. . .
>>   1 image(s) generated in 4.41s
`
![000020 1](https://user-images.githubusercontent.com/113372415/189723642-15bb1746-6b13-46fa-9ffe-7ef1e76e230e.png)
