### PR TITLE
feat(ci): add pyproject.toml with `blue` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.blue]
+line-length = 90
+target-version = ['py310']


### PR DESCRIPTION
As discussed in #631

For clarification, this **only a config file**. It has no effect on anything.

The config is for 'blue', the only really important option here is that we're setting line-length to 90.

'target-version' basically tells blue which version of Python we're using, as blue is aware of syntax differences between versions. 

Note that this does not mean that it's going to disallow earlier versions or anything like that; more like it allows *newer* constructs

Signed-off-by: Ben Alkov <ben.alkov@gmail.com>
