### PR TITLE
CLI: Show Progress / Save Progress / Generate Progress Video

### DIFF
--- a/docs/features/OTHER.md
+++ b/docs/features/OTHER.md
@@ -6,8 +6,7 @@ title: Others
 
 Stable Diffusion AI Notebook: <a
 href="https://colab.research.google.com/github/lstein/stable-diffusion/blob/main/notebooks/Stable_Diffusion_AI_Notebook.ipynb"
-target="_parent">
-<img
+target="_parent"> <img
 src="https://colab.research.google.com/assets/colab-badge.svg"
 alt="Open In Colab"/></a> <br> Open and follow instructions to use an isolated environment running
 Dream.<br>
@@ -25,6 +24,57 @@ for each `dream>` prompt as shown here:
 ```python
 dream> "pond garden with lotus by claude monet" --seamless -s100 -n4
 ```
+
+---
+
+## **Show Progress**
+
+Provides a visual preview of the image generation process.
+
+`-show_progress <step_count: int> <duration: float>`
+
+- `step_count`: The number of steps between each progress update. Default: `5`.
+
+- `duration`: The duration (in seconds) for how long you want the final image to be displayed before
+  the preview closes automatically. Default: `2`.
+
+- Set step_count to the same value as your steps to get a preview only when the image is fully
+  generated.
+
+- Enter duration: `0` to keep it open forever until user presses a key. Note that this will block
+  the code from running further until user input.
+
+If you have post processing options, the preview will close after image generation and reopen again
+with the updated changes.
+
+---
+
+## **Save Progress & Make Video**
+
+Allows you to save the intermediate steps during the image generation process and make a video out
+of it.
+
+`-save_progress <step_count: int default=5> <video_options: v | vo default: None>`
+
+- `step_count`: The number of steps between each intermediate image saved. When no value is given,
+  it defaults to `5`.
+- `video_options`: Allows you to generate a video from the intermediate images. Takes two options:
+  `v` (Video) or `vo` (Video Only)
+
+### **Usage**
+
+`-save_progress`: Saves intermediate frames every 5 steps. No video generation.
+
+`-save_progress 3`: Saves intermediate frames every 3 steps. No video generation.
+
+`-save_progress 3 v`: Saves intermediate frames every 3 steps. Also generates a video from the
+frames at the end.
+
+`-save_progress 3 vo`: Does not save intermediate frames but generates a video of the process every
+3 steps.
+
+`-show_progress 3 -save_progress 3 vo`: Shows a preview of the generation process updating every 3
+seconds while also saving a video of the same.
 
 ---
 

--- a/docs/other/CONTRIBUTORS.md
+++ b/docs/other/CONTRIBUTORS.md
@@ -54,6 +54,7 @@ We thank them for all of their time and hard work.
 - [Matthias Wild](https://github.com/mauwii)
 - [Kyle Schouviller](https://github.com/kyle0654)
 - [rabidcopy](https://github.com/rabidcopy)
+- [Kevin Schaul](https://github.com/kevinschaul)
 
 ## **Original CompVis Authors:**
 

--- a/ldm/dream/args.py
+++ b/ldm/dream/args.py
@@ -485,6 +485,19 @@ class Args(object):
             type=str,
             help='Directory to save generated images and a log of prompts and seeds',
         )
+        render_group.add_argument(
+            '-save_progress',
+            '--save_progress',
+            nargs='*',
+            help='Store in-progress images as the image is being rendered. Takes two values <step_count> : int <progress_video_type>: v (video) or vo (video only)'
+        )
+        render_group.add_argument(
+            '-show_progress',
+            '--show_progress',
+            nargs='*',
+            type=float,
+            help='Show image generation progress. Takes two values. <step_count: int> and <final_display_time: float>'
+        )
         img2img_group.add_argument(
             '-I',
             '--init_img',

--- a/ldm/util.py
+++ b/ldm/util.py
@@ -212,3 +212,22 @@ def parallel_data_prefetch(
         return out
     else:
         return gather_res
+
+def make_video(images, video_location):
+    import cv2
+    width, height = images[0].size
+
+    video = cv2.VideoWriter(video_location, cv2.VideoWriter_fourcc(*'mp4v'), 20.0, (width, height))
+
+    #draw stuff that goes on every frame here
+    for image in images:
+        image = cv2.cvtColor(np.array(image), cv2.COLOR_BGR2RGB)
+        video.write(image)
+    
+    video.release()
+
+def show_progress(image):
+    import cv2
+    image = cv2.cvtColor(np.array(image), cv2.COLOR_BGR2RGB)
+    cv2.imshow('Preview', image)
+    cv2.waitKey(1)


### PR DESCRIPTION
This is a PR that brings progress features to the CLI. This PR incorporates #623 by @kevinschaul -- Added him to Contributors list.

---

# Features

- Show Progress
- Save Progress
- Generate Progress Video

Example Usage:

`<prompt> -s 40 -G 1 -show_progress 1 3 -save_progress 1 vo`

This command will run the prompt and display a visual preview of the process. The final output will be displayed for 3 seconds before it closes automatically. The prompt has post processing of face restoration. The restoration will take place after the preview closes. Once the restoration is completed, the preview once again loads up to show you the final new updated image for another 3 seconds.

When the process is done, you will find a video of the generation process along with your generated image. More documentation below and in the docs.

---

## **Show Progress**

Provides a visual preview of the image generation process.

`-show_progress <step_count: int> <duration: float>`

- `step_count`: The number of steps between each progress update. Default: `5`

- `duration`: The duration (in seconds) for how long you want the final image to be displayed before
  the preview closes automatically. Default: `2`

- Enter duration as `0` to keep it open forever until user presses a key. Note that this will block the code
  from running further until user input.

If you have post processing options, the preview will close after image generation and reopen again
with the updated changes.

---

## **Save Progress & Make Video**

Allows you to save the intermediate steps during the image generation process and make a video out
of it.

`-save_progress <step_count: int default=5> <video_options: v | vo default: None>`

- `step_count`: The number of steps between each intermediate image saved. When no value is given,
  it defaults to `5`.
- `video_options`: Allows you to generate a video from the intermediate images. Takes two options:
  `v` (Video) or `vo` (Video Only)

### **Usage**

`-save_progress`: Saves intermediate frames every 5 steps. No video generation.

`-save_progress 3`: Saves intermediate frames every 3 steps. No video generation.

`-save_progress 3 v`: Saves intermediate frames every 3 steps. Also generates a video from the
frames at the end.

`-save_progress 3 vo`: Does not save intermediate frames but generates a video of the process every
3 steps.

`-show progress 3 -save_progress 3 vo`: Shows a preview of the generation process updating every 3
seconds while also saving a video of the same.

---

## Performance

I've done testing on various combinations. No issues so far. Fixed all I could find. Feel free to test and report back to me. Thank you.

- There is no obvious memory consumptions changes from any of these features. I don't expect them to be. 
- The inference speed however is another story. Because images are being generated, anytime they are loaded to render as preview or save for progress, it slows down the overall inference time a tad bit. On most 8GB systems, this isn't a huge loss given  you can now preview and gen videos while the whole process happens. If you're on a lower end system, you can pass a higher step value to keep the inference speed high. Unfortunately there's no way to dodge it == More data == slower. Simple as that.