### PR TITLE
Use model_url instead of model_path for gfpgan and CodeFormer

### DIFF
--- a/scripts/preload_models.py
+++ b/scripts/preload_models.py
@@ -92,7 +92,7 @@ if gfpgan:
 
         if not os.path.exists(model_dest):
             print('downloading gfpgan model file...')
-            urllib.request.urlretrieve(model_path,model_dest)
+            urllib.request.urlretrieve(model_url,model_dest)
     except Exception:
         import traceback
         print('Error loading GFPGAN:')
@@ -107,7 +107,7 @@ try:
         if not os.path.exists(model_dest):
             print('downloading codeformer model file...')
             os.makedirs(os.path.dirname(model_dest), exist_ok=True)
-            urllib.request.urlretrieve(model_path,model_dest)
+            urllib.request.urlretrieve(model_url,model_dest)
 except Exception:
     import traceback
     print('Error loading CodeFormer:')


### PR DESCRIPTION
Fixes lstein/stable-diffusion#678
