### PR TITLE
Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # ignore default image save location and model symbolic link
 outputs/
 models/ldm/stable-diffusion-v1/model.ckpt
-ldm/restoration/codeformer/weights
+ldm/dream/restoration/codeformer/weights
 
 # ignore the Anaconda/Miniconda installer used while building Docker image
 anaconda.sh

--- a/ldm/dream/args.py
+++ b/ldm/dream/args.py
@@ -573,14 +573,14 @@ class Args(object):
             '-G',
             '--gfpgan_strength',
             type=float,
-            help='The strength at which to apply the GFPGAN model to the result, in order to improve faces.',
+            help='The strength at which to apply the face restoration to the result.',
             default=0.0,
         )
         postprocessing_group.add_argument(
             '-cf',
             '--codeformer_fidelity',
             type=float,
-            help='Takes values between 0 and 1. 0 produces high quality but low accuracy. 1 produces high accuracy but low quality.',
+            help='Used along with CodeFormer. Takes values between 0 and 1. 0 produces high quality but low accuracy. 1 produces high accuracy but low quality.',
             default=0.75
         )
         postprocessing_group.add_argument(

--- a/ldm/dream/restoration/__init__.py
+++ b/ldm/dream/restoration/__init__.py
@@ -1,0 +1,1 @@
+from .base import Restoration

--- a/ldm/dream/restoration/base.py
+++ b/ldm/dream/restoration/base.py
@@ -27,7 +27,7 @@ class Restoration():
         return CodeFormerRestoration()
 
     # Upscale Models
-    def load_ersgan(self):
+    def load_esrgan(self):
         from ldm.dream.restoration.realesrgan import ESRGAN
         esrgan = ESRGAN(self.esrgan_bg_tile)
         print('>> ESRGAN Initialized')

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -54,7 +54,7 @@ def main():
         else:
             print('>> Face restoration disabled')
         if opt.esrgan:
-            esrgan = restoration.load_ersgan()
+            esrgan = restoration.load_esrgan()
         else:
             print('>> Upscaling disabled')
     except (ModuleNotFoundError, ImportError):


### PR DESCRIPTION
Pushing some bug fixes as I test them.

**Fixed**

- Restoration being imported incorrectly in dream.py
- Updating the gitignore location for the codeformer weights.
- Fixed load_esrgan not being spelled correctly.
- Updated `-G` arg description to say it controls face restoration strength instead of just GFPGAN. Because it also controls codeformer strength now.
- Updated `-cf` arg description to mention that it works with CodeFormer.