### PR TITLE
Fix `ResolvePackageNotFound` error on Intel Macs

### DIFF
--- a/docs/installation/INSTALL_MAC.md
+++ b/docs/installation/INSTALL_MAC.md
@@ -124,7 +124,7 @@ ln -s "$PATH_TO_CKPT/sd-v1-4.ckpt" \
     === "Intel x86_64"
 
         ```bash
-        PIP_EXISTS_ACTION=w CONDA_SUBDIR=osx-x86_64 \
+        PIP_EXISTS_ACTION=w CONDA_SUBDIR=osx-64 \
           conda env create \
           -f environment-mac.yaml \
           && conda activate ldm


### PR DESCRIPTION
I had to use `osx-64` not `osx-x86-64` for conda to install the required packages from conda-forge