### PR TITLE
Remove unneeded `pip install -e` from environment.yaml which prevents deployment with Meadowrun

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -36,4 +36,3 @@ dependencies:
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
     - -e git+https://github.com/lstein/GFPGAN@fix-dark-cast-images#egg=gfpgan
-    - -e .


### PR DESCRIPTION
As it is, the repo (and the original compviz) is not deployable with Meadowrun on Amazon AWS.
All it takes to get it working is to remove the line `-e .` at the bottom of `environment.yaml` because
Meadowrun doesn’t (yet) support installing the current code as an editable pip package.
This change does not affect regular usage of the repo AFAIK

Taken from https://github.com/hrichardlee/stable-diffusion/commit/b0cc2e6fa0cd17275bbdee41b974aac0f94b39d3
and the explanation at https://medium.com/@meadowrun/how-to-run-stable-diffusion-on-ec2-e447333d820

I tested deployment on AWS from my fork
Thank you !