### PR TITLE
Allow socket middleware to work on custom ports

### DIFF
--- a/frontend/src/app/socketio/middleware.ts
+++ b/frontend/src/app/socketio/middleware.ts
@@ -24,7 +24,7 @@ import * as InvokeAI from '../invokeai';
 export const socketioMiddleware = () => {
   const { hostname, port } = new URL(window.location.href);
 
-  const socketio = io(`http://${hostname}:9090`);
+  const socketio = io(`http://${hostname}:${port}`);
 
   let areListenersSet = false;
 


### PR DESCRIPTION
I have other apps that listen on :9090, so I tried setting a custom port and found that this port was hardcoded here. Confirmed that this fix worked for me.

Note that setting port 80 (with sudo) will receive a CORS error unless this other line is also updated. The CORS setting will have to require the `http://localhost` origin, `http://localhost:80` is not sufficient for CORS, even though this line will successfully connect socketio to `http://localhost:80`. https://github.com/invoke-ai/InvokeAI/blob/f1d4862b132a3c604db9632862192f24fe01b3bd/backend/server.py#L98