### PR TITLE
Restoration Modules are now optional

### DIFF
--- a/ldm/dream/restoration/base.py
+++ b/ldm/dream/restoration/base.py
@@ -1,34 +1,38 @@
 class Restoration():
-    def __init__(self, gfpgan_dir='./src/gfpgan', gfpgan_model_path='experiments/pretrained_models/GFPGANv1.3.pth', esrgan_bg_tile=400) -> None:
-        self.gfpgan_dir = gfpgan_dir
-        self.gfpgan_model_path = gfpgan_model_path
-        self.esrgan_bg_tile = esrgan_bg_tile
+    def __init__(self) -> None:
+        pass
 
-    def load_face_restore_models(self):
+    def load_face_restore_models(self, gfpgan_dir='./src/gfpgan', gfpgan_model_path='experiments/pretrained_models/GFPGANv1.3.pth'):
         # Load GFPGAN
-        gfpgan = self.load_gfpgan()
+        gfpgan = self.load_gfpgan(gfpgan_dir, gfpgan_model_path)
         if gfpgan.gfpgan_model_exists:
             print('>> GFPGAN Initialized')
+        else:
+            print('>> GFPGAN Disabled')
+            gfpgan = None
         
         # Load CodeFormer
         codeformer = self.load_codeformer()
         if codeformer.codeformer_model_exists:
             print('>> CodeFormer Initialized')
+        else:
+            print('>> CodeFormer Disabled')
+            codeformer = None
         
         return gfpgan, codeformer
 
     # Face Restore Models
-    def load_gfpgan(self):
+    def load_gfpgan(self, gfpgan_dir, gfpgan_model_path):
         from ldm.dream.restoration.gfpgan import GFPGAN
-        return GFPGAN(self.gfpgan_dir, self.gfpgan_model_path)
+        return GFPGAN(gfpgan_dir, gfpgan_model_path)
 
     def load_codeformer(self):
         from ldm.dream.restoration.codeformer import CodeFormerRestoration
         return CodeFormerRestoration()
 
     # Upscale Models
-    def load_esrgan(self):
+    def load_esrgan(self, esrgan_bg_tile=400):
         from ldm.dream.restoration.realesrgan import ESRGAN
-        esrgan = ESRGAN(self.esrgan_bg_tile)
+        esrgan = ESRGAN(esrgan_bg_tile)
         print('>> ESRGAN Initialized')
         return esrgan;

--- a/ldm/dream/restoration/gfpgan.py
+++ b/ldm/dream/restoration/gfpgan.py
@@ -17,8 +17,8 @@ class GFPGAN():
         self.gfpgan_model_exists = os.path.isfile(self.model_path)
 
         if not self.gfpgan_model_exists:
-            raise Exception(
-                'GFPGAN model not found at path ' + self.model_path)
+            print('## NOT FOUND: GFPGAN model not found at ' + self.model_path)
+            return None
         sys.path.append(os.path.abspath(gfpgan_dir))
 
     def model_exists(self):

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -726,11 +726,17 @@ class Generate:
                     else:
                         print(">> ESRGAN is disabled. Image not upscaled.")
                 if strength > 0:
-                    if self.gfpgan is not None and self.codeformer is not None:
-                        if facetool == 'codeformer':
-                            image = self.codeformer.process(image=image, strength=strength, device=self.device, seed=seed, fidelity=codeformer_fidelity)
+                    if self.gfpgan is not None or self.codeformer is not None:
+                        if self.gfpgan is None:
+                            if facetool == 'codeformer':
+                                if self.codeformer is not None:
+                                    image = self.codeformer.process(image=image, strength=strength, device=self.device, seed=seed, fidelity=codeformer_fidelity)
+                                else:
+                                    print('>> CodeFormer not found. Face restoration is disabled.')
+                            else:    
+                                print('>> GFPGAN not found. Face restoration is disabled.')
                         else:
-                            image = self.gfpgan.process(image, strength, seed)
+                            image = self.gfpgan.process(image, strength, seed)                            
                     else:
                         print(">> Face Restoration is disabled.")
             except Exception as e:

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -47,16 +47,17 @@ def main():
     # Loading Face Restoration and ESRGAN Modules
     try:
         gfpgan, codeformer, esrgan = None, None, None
-        from ldm.dream.restoration import Restoration
-        restoration = Restoration(opt.gfpgan_dir, opt.gfpgan_model_path, opt.esrgan_bg_tile)
-        if opt.restore:
-            gfpgan, codeformer = restoration.load_face_restore_models()
-        else:
-            print('>> Face restoration disabled')
-        if opt.esrgan:
-            esrgan = restoration.load_esrgan()
-        else:
-            print('>> Upscaling disabled')
+        if opt.restore or opt.esrgan:
+            from ldm.dream.restoration import Restoration
+            restoration = Restoration()
+            if opt.restore:
+                gfpgan, codeformer = restoration.load_face_restore_models(opt.gfpgan_dir, opt.gfpgan_model_path)
+            else:
+                print('>> Face restoration disabled')
+            if opt.esrgan:
+                esrgan = restoration.load_esrgan(opt.esrgan_bg_tile)
+            else:
+                print('>> Upscaling disabled')
     except (ModuleNotFoundError, ImportError):
         import traceback
         print(traceback.format_exc(), file=sys.stderr)


### PR DESCRIPTION
### Restoration Modules are now optional

Fixes. #749

This PR reworks how the restoration modules are loaded.

1. GFPGAN, CodeFormer and ESRGAN models are on by default.
2. If GFPGAN or CodeFormer models are not found, then instead of crashing the app, the user is notified and the app loads with Face Restoration disabled.
3. If only one of GFPGAN or CodeFormer models are not found, then the app loads with one of those enabled.
4. When you try to restore faces, the model defaults to GFPGAN but gives a notification error that face restoration is disabled if GFPGAN is not found. You can still use CodeFormer to restore by passing `ft` if you have only CodeFormer enabled.
5. You can completely turn off face restoration and upscaling using the `--no_restore` or `--no_upscale` switches.