### PR TITLE
Fix exception when inpainting with DDIM sampler

### DIFF
--- a/ldm/dream/generator/inpaint.py
+++ b/ldm/dream/generator/inpaint.py
@@ -34,9 +34,9 @@ class Inpaint(Img2Img):
             )
             sampler = DDIMSampler(self.model, device=self.model.device)
 
-            sampler.make_schedule(
-                ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False
-            )
+        sampler.make_schedule(
+            ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False
+        )
 
         scope = choose_autocast(self.precision)
         with scope(self.model.device.type):


### PR DESCRIPTION
When `Generate.prompt2image` is called in inpainting mode (including an init image plus a mask) and the sampler name is set to `ddim`, then the following exception occurs today:

```
AttributeError: 'DDIMSampler' object has no attribute 'ddim_alphas'
```

This happens because the line that creates the schedule only gets called in the case where a fallback sampler is used (i.e. any sampler other than DDIM). Creating the schedule unconditionally by moving the `make_scedule` call outside of the `if` block fixes this issue.