### PR TITLE
facexlib and codeformer are broken on mps currently, force CPU device, works around  issue #713

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -742,7 +742,8 @@ class Generate:
                             if self.codeformer is None:
                                 print('>> CodeFormer not found. Face restoration is disabled.')
                             else:
-                                image = self.codeformer.process(image=image, strength=strength, device=self.device, seed=seed, fidelity=codeformer_fidelity)                                
+                                cf_device = 'cpu' if str(self.device) == 'mps' else self.device
+                                image = self.codeformer.process(image=image, strength=strength, device=cf_device, seed=seed, fidelity=codeformer_fidelity)
                     else:
                         print(">> Face Restoration is disabled.")
             except Exception as e:


### PR DESCRIPTION
This will make codeformer face restoration work on macOS by forcing facexlib and codeformer to use CPU.

facexlib triggers a fatal error in the Metal Graphs, codeformer is just broke.

See https://github.com/invoke-ai/InvokeAI/issues/713 for more details.
