### PR TITLE
fix(install): pin 'transformers'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ taming-transformers-rom1504
 test-tube
 torch-fidelity
 torchmetrics
-transformers
+transformers==4.21.*
 flask==2.1.3
 flask_socketio==5.3.0
 flask_cors==3.0.10


### PR DESCRIPTION
For installs using 'requirements*.txt':

Either Huggingface's 'transformers' lib introduced a regression in v4.22, or we changed how we're using 'transformers' in such a way that we break when using v4.22.

Pin 'transformers==4.21.*'

Signed-off-by: Ben Alkov <ben.alkov@gmail.com>
