### PR TITLE
fix case where there are too many pictures to fit to socket for WebUI 

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -192,7 +192,7 @@ def handle_request_all_images():
     paths = list(filter(os.path.isfile, glob.glob(result_path + "*.png")))
     paths.sort(key=lambda x: os.path.getmtime(x))
     image_array = []
-    for path in paths:
+    for path in paths[-500:]:
         metadata = retrieve_metadata(path)
         image_array.append({"url": path, "metadata": metadata["sd-metadata"]})
     socketio.emit("galleryImages", {"images": image_array})


### PR DESCRIPTION
When there are many files in output directory (thousands), WebUI is slow until it reads all files. Also when there are too many files, they do not fit socket max size and gallery remains empty.

So this reads only last 500 files.