### PR TITLE
Pin openh264 to 2.3.0, Fixes #787

### DIFF
--- a/environment-mac.yaml
+++ b/environment-mac.yaml
@@ -30,6 +30,7 @@ dependencies:
   - nomkl
   - numpy==1.23.2
   - omegaconf==2.1.1
+  - openh264==2.3.0
   - onnx==1.12.0
   - onnxruntime==1.12.1
   - protobuf==3.20.1


### PR DESCRIPTION
Pin `openh264` to 2.3.0 until OpenCV supports 2.3.1 or newer. Added just to `environment-mac.yml` since I know this happens on M1 / Apple Silicon Macs (running macOS 13) and that's all I can test on.