### PR TITLE
ESRGAN Improvements

### DIFF
--- a/ldm/dream/args.py
+++ b/ldm/dream/args.py
@@ -594,7 +594,7 @@ class Args(object):
             '--upscale',
             nargs='+',
             type=float,
-            help='Scale factor (2, 4) for upscaling final output followed by upscaling strength (0-1.0). If strength not specified, defaults to 0.75',
+            help='Scale factor (1, 2, 3, 4, etc..) for upscaling final output followed by upscaling strength (0-1.0). If strength not specified, defaults to 0.75',
             default=None,
         )
         postprocessing_group.add_argument(

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -724,14 +724,6 @@ class Generate:
         for r in image_list:
             image, seed = r
             try:
-                if upscale is not None:
-                    if self.esrgan is not None:
-                        if len(upscale) < 2:
-                            upscale.append(0.75)
-                        image = self.esrgan.process(
-                            image, upscale[1], seed, int(upscale[0]))
-                    else:
-                        print(">> ESRGAN is disabled. Image not upscaled.")
                 if strength > 0:
                     if self.gfpgan is not None or self.codeformer is not None:
                         if facetool == 'gfpgan':
@@ -747,6 +739,14 @@ class Generate:
                                 image = self.codeformer.process(image=image, strength=strength, device=cf_device, seed=seed, fidelity=codeformer_fidelity)
                     else:
                         print(">> Face Restoration is disabled.")
+                if upscale is not None:
+                    if self.esrgan is not None:
+                        if len(upscale) < 2:
+                            upscale.append(0.75)
+                        image = self.esrgan.process(
+                            image, upscale[1], seed, int(upscale[0]))
+                    else:
+                        print(">> ESRGAN is disabled. Image not upscaled.")
             except Exception as e:
                 print(
                     f'>> Error running RealESRGAN or GFPGAN. Your image was not upscaled.\n{e}'

--- a/scripts/preload_models.py
+++ b/scripts/preload_models.py
@@ -49,33 +49,13 @@ except ModuleNotFoundError:
 if gfpgan:
     print('Loading models from RealESRGAN and facexlib')
     try:
-        from basicsr.archs.rrdbnet_arch import RRDBNet
+        from realesrgan.archs.srvgg_arch import SRVGGNetCompact
         from facexlib.utils.face_restoration_helper import FaceRestoreHelper
 
         RealESRGANer(
-            scale=2,
-            model_path='https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth',
-            model=RRDBNet(
-                num_in_ch=3,
-                num_out_ch=3,
-                num_feat=64,
-                num_block=23,
-                num_grow_ch=32,
-                scale=2,
-            ),
-        )
-
-        RealESRGANer(
             scale=4,
-            model_path='https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth',
-            model=RRDBNet(
-                num_in_ch=3,
-                num_out_ch=3,
-                num_feat=64,
-                num_block=23,
-                num_grow_ch=32,
-                scale=4,
-            ),
+            model_path='https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.5.0/realesr-general-x4v3.pth',
+            model = SRVGGNetCompact(num_in_ch=3, num_out_ch=3, num_feat=64, num_conv=32, upscale=4, act_type='prelu')
         )
 
         FaceRestoreHelper(1, det_model='retinaface_resnet50')


### PR DESCRIPTION
Addressing #802

---

### ESRGAN Improvements

**Important Changes**

- ESRGAN now uses the new light weight model `realesr-general-x4v3` model instead of the older 4x model. The older model was 64MB in size compared to the 4.64MB of the new model. The inference times are significantly faster. Did not notice any great loss in quality. *Note: The Real-ESRGAN repo states that there are chances this light weight model might fail in some extreme cases. I haven't found any but it's a point to note.*
- `-U` or `--upscale` are now capable of taking any value for the scale factor and not just 2 or 4. Using `1` will sharpen the output but retain the size. As the model is meant for 4x scaling, any value up to `4` will yield good results. Anything above is simple upscaling and will eventually deteriorate in quality.
- Face Restoration now happens BEFORE upscaling. Initially I did it the other way around because I wanted to offer a larger resolution image for the face restoration tool to work with. But I now notice that this is only effective until a certain point. Once the scaling factor exceeds sizes that the face restoration model is trained for, the face restoration quality deteriorates drastically. So instead it is better to perform this at the base resolution and then upscale that result with ESRGAN. **Note: I am still a bit uncertain on this. I will do more test results to figure out which is the best order**

**User End Changes**

- The new model requires version `0.3.0` or higher of `realesrgan`. So please remove realesrgan and reinstall with `pip install realesrgan`.

---

I'll leave this as a draft for now. Once these changes have been tested, I'll go ahead and finalize this.