### PR TITLE
Fix error when displaying in-progress images

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -672,9 +672,10 @@ def generate_images(generation_parameters, esrgan_parameters, gfpgan_parameters)
             and step < generation_parameters["steps"] - 1
         ):
             image = generate.sample_to_image(sample)
-            path = save_image(
-                image, generation_parameters, intermediate_path, step_index
-            )
+
+            metadata = parameters_to_generated_image_metadata(generation_parameters)
+            command = parameters_to_command(generation_parameters)
+            path = save_image(image, command, metadata, intermediate_path, step_index=step_index, postprocessing=False)
 
             step_index += 1
             socketio.emit(

--- a/backend/server.py
+++ b/backend/server.py
@@ -379,7 +379,7 @@ def handle_run_gfpgan_event(original_image, gfpgan_parameters):
         "gfpganResult",
         {
             "url": os.path.relpath(path),
-            "mtime": os.path.mtime(path),
+            "mtime": os.path.getmtime(path),
             "metadata": metadata,
         },
     )

--- a/ldm/dream/generator/base.py
+++ b/ldm/dream/generator/base.py
@@ -22,6 +22,7 @@ class Generator():
         self.downsampling_factor = downsampling   # BUG: should come from model or config
         self.variation_amount    = 0
         self.with_variations     = []
+        self.free_gpu_mem        = False
 
     # this is going to be overridden in img2img.py, txt2img.py and inpaint.py
     def get_make_image(self,prompt,**kwargs):

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -173,7 +173,8 @@ class Generate:
             config                = None,
             gfpgan=None,
             codeformer=None,
-            esrgan=None
+            esrgan=None,
+            free_gpu_mem=False,
     ):
         models              = OmegaConf.load(conf)
         mconfig             = models[model]
@@ -200,6 +201,7 @@ class Generate:
         self.gfpgan = gfpgan
         self.codeformer = codeformer
         self.esrgan = esrgan
+        self.free_gpu_mem = free_gpu_mem
 
         # Note that in previous versions, there was an option to pass the
         # device to Generate(). However the device was then ignored, so


### PR DESCRIPTION
Fixes #822

During my last refactor of metadata handling in the new UI, the `save_image` function had changed but I didn't update its call in the progress callback. This corrects the call.