### PR TITLE
Fixes error on new UI when progress images is enabled

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -683,7 +683,7 @@ def generate_images(generation_parameters, esrgan_parameters, gfpgan_parameters)
                 {
                     "url": os.path.relpath(path),
                     "mtime": os.path.getmtime(path),
-                    "metadata": generation_parameters,
+                    "metadata": metadata,
                 },
             )
         socketio.emit("progressUpdate", progress)

--- a/backend/server.py
+++ b/backend/server.py
@@ -672,9 +672,10 @@ def generate_images(generation_parameters, esrgan_parameters, gfpgan_parameters)
             and step < generation_parameters["steps"] - 1
         ):
             image = generate.sample_to_image(sample)
-            path = save_image(
-                image, generation_parameters, intermediate_path, step_index
-            )
+
+            metadata = parameters_to_generated_image_metadata(generation_parameters)
+            command = parameters_to_command(generation_parameters)
+            path = save_image(image, command, metadata, intermediate_path, step_index=step_index, postprocessing=False)
 
             step_index += 1
             socketio.emit(


### PR DESCRIPTION
Fixes #822

During my last refactor of metadata handling in the new UI, the save_image function had changed but I didn't update its call in the progress callback. This corrects the call.