### PR TITLE
improve behavior and fix bugs in CLI history handling and completion

### DIFF
--- a/ldm/dream/readline.py
+++ b/ldm/dream/readline.py
@@ -11,8 +11,7 @@ seeds:
 import os
 import re
 import atexit
-
-completer = None
+from ldm.dream.args import Args
 
 # ---------------readline utilities---------------------
 try:
@@ -20,10 +19,6 @@ try:
     readline_available = True
 except:
     readline_available = False
-
-#to simulate what happens on windows systems, uncomment
-# this line
-#readline_available = False
 
 IMG_EXTENSIONS     = ('.png','.jpg','.jpeg')
 COMMANDS = (
@@ -49,7 +44,7 @@ COMMANDS = (
     '-save_orig','--save_original',
     '--skip_normalize','-x',
     '--log_tokenization','-t',
-    '!fix','!fetch',
+    '!fix','!fetch','!history',
     )
 IMG_PATH_COMMANDS = (
     '--outdir[=\s]',
@@ -71,6 +66,7 @@ class Completer:
         self.matches     = list()
         self.default_dir = None
         self.linebuffer  = None
+        self.auto_history_active = True
         return
 
     def complete(self, text, state):
@@ -109,7 +105,8 @@ class Completer:
         '''
         Pass thru to readline
         '''
-        readline.add_history(line)
+        if not self.auto_history_active:
+            readline.add_history(line)
 
     def remove_history_item(self,pos):
         readline.remove_history_item(pos)
@@ -247,29 +244,35 @@ class DummyCompleter(Completer):
     def set_line(self,line):
         print(f'# {line}')
 
-if readline_available:
-    completer = Completer(COMMANDS)
-    
-    readline.set_completer(
-        completer.complete
-    )
-    readline.set_auto_history(False)
-    readline.set_pre_input_hook(completer._pre_input_hook)
-    readline.set_completer_delims(' ')
-    readline.parse_and_bind('tab: complete')
-    readline.parse_and_bind('set print-completions-horizontally off')
-    readline.parse_and_bind('set page-completions on')
-    readline.parse_and_bind('set skip-completed-text on')
-    readline.parse_and_bind('set bell-style visible')
-    readline.parse_and_bind('set show-all-if-ambiguous on')
-    
-    histfile = os.path.join(os.path.expanduser('~'), '.dream_history')
-    try:
-        readline.read_history_file(histfile)
-        readline.set_history_length(1000)
-    except FileNotFoundError:
-        pass
-    atexit.register(readline.write_history_file, histfile)
+def get_completer(opt:Args)->Completer:
+    if readline_available:
+        completer = Completer(COMMANDS)
 
-else:
-    completer = DummyCompleter(COMMANDS)
+        readline.set_completer(
+            completer.complete
+        )
+        # pyreadline3 does not have a set_auto_history() method
+        try:
+            readline.set_auto_history(False)
+            completer.auto_history_active = False
+        except:
+            completer.auto_history_active = True
+        readline.set_pre_input_hook(completer._pre_input_hook)
+        readline.set_completer_delims(' ')
+        readline.parse_and_bind('tab: complete')
+        readline.parse_and_bind('set print-completions-horizontally off')
+        readline.parse_and_bind('set page-completions on')
+        readline.parse_and_bind('set skip-completed-text on')
+        readline.parse_and_bind('set show-all-if-ambiguous on')
+
+        histfile = os.path.join(os.path.expanduser(opt.outdir), '.dream_history')
+        try:
+            readline.read_history_file(histfile)
+            readline.set_history_length(1000)
+        except FileNotFoundError:
+            pass
+        atexit.register(readline.write_history_file, histfile)
+
+    else:
+        completer = DummyCompleter(COMMANDS)
+    return completer

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -583,6 +583,9 @@ class Generate:
                 strength    = opt.strength,
                 image_callback = callback,
                 )
+        elif tool is None:
+            print(f'* please provide at least one postprocessing option, such as -G or -U')
+            return None
         else:
             print(f'* postprocessing tool {tool} is not yet supported')
             return None


### PR DESCRIPTION
-if readline.set_auto_history() is not implemented, as in pyreadline3, will fall back gracefully to automatic history saving. The only issue with this is that !history commands will be recorded in the history. 
-!fetch on missing file no longer crashes script
-!history is now one of the autocomplete commands
-.dream_history now stored in output directory rather than ~user directory.

An important limitation of the last feature is that the history is loaded and saved to the .dream_history file in the --outdir directory specified at script launch time. It is not swapped around when the --outdir is changed during the session.