### PR TITLE
missing flag in wget download example

### DIFF
--- a/docs/features/UPSCALE.md
+++ b/docs/features/UPSCALE.md
@@ -31,7 +31,7 @@ into **src/gfpgan/experiments/pretrained_models**. On Mac and Linux systems,
 here's how you'd do it using **wget**:
 
 ```bash
-wget https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth src/gfpgan/experiments/pretrained_models/
+wget https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth -P src/gfpgan/experiments/pretrained_models/
 ```
 
 Make sure that you're in the InvokeAI directory when you do this.


### PR DESCRIPTION
The documentation shows a wget command to download the gfpgan files and was missing the `-P` flag