### PR TITLE
new --inpaint_replace option for inpainting

### DIFF
--- a/docs/features/INPAINTING.md
+++ b/docs/features/INPAINTING.md
@@ -6,27 +6,55 @@ title: Inpainting
 
 ## **Creating Transparent Regions for Inpainting**
 
-Inpainting is really cool. To do it, you start with an initial image and use a photoeditor to make
-one or more regions transparent (i.e. they have a "hole" in them). You then provide the path to this
-image at the dream> command line using the `-I` switch. Stable Diffusion will only paint within the
-transparent region.
+Inpainting is really cool. To do it, you start with an initial image
+and use a photoeditor to make one or more regions transparent
+(i.e. they have a "hole" in them). You then provide the path to this
+image at the dream> command line using the `-I` switch. Stable
+Diffusion will only paint within the transparent region.
 
-There's a catch. In the current implementation, you have to prepare the initial image correctly so
-that the underlying colors are preserved under the transparent area. Many imaging editing
-applications will by default erase the color information under the transparent pixels and replace
-them with white or black, which will lead to suboptimal inpainting. You also must take care to
-export the PNG file in such a way that the color information is preserved.
+There's a catch. In the current implementation, you have to prepare
+the initial image correctly so that the underlying colors are
+preserved under the transparent area. Many imaging editing
+applications will by default erase the color information under the
+transparent pixels and replace them with white or black, which will
+lead to suboptimal inpainting. It often helps to apply incomplete
+transparency, such as any value between 1 and 99%
 
-If your photoeditor is erasing the underlying color information, `dream.py` will give you a big fat
-warning. If you can't find a way to coax your photoeditor to retain color values under transparent
-areas, then you can combine the `-I` and `-M` switches to provide both the original unedited image
-and the masked (partially transparent) image:
+You also must take care to export the PNG file in such a way that the
+color information is preserved. There is often an option in the export
+dialog that lets you specify this.
+
+If your photoeditor is erasing the underlying color information,
+`dream.py` will give you a big fat warning. If you can't find a way to
+coax your photoeditor to retain color values under transparent areas,
+then you can combine the `-I` and `-M` switches to provide both the
+original unedited image and the masked (partially transparent) image:
 
 ```bash
 dream> "man with cat on shoulder" -I./images/man.png -M./images/man-transparent.png
 ```
 
 We are hoping to get rid of the need for this workaround in an upcoming release.
+
+### Inpainting is not changing the masked region enough!
+
+One of the things to understand about how inpainting works is that it
+is equivalent to running img2img on just the masked (transparent)
+area. img2img builds on top of the existing image data, and therefore
+will attempt to preserve colors, shapes and textures to the best of
+its ability. Unfortunately this means that if you want to make a
+dramatic change in the inpainted region, for example replacing a red
+wall with a blue one, the algorithm will fight you.
+
+You have a couple of options. The first is to increase the values of
+the requested steps (`-sXXX`), strength (`-f0.XX`), and/or
+condition-free guidance (`-CXX.X`). If this is not working for you, a
+more extreme step is to provide the `--inpaint_replace` option. This
+causes the algorithm to entirely ignore the data underneath the masked
+region and to treat this area like a blank canvas. This will enable
+you to replace colored regions entirely, but beware that the masked
+region will not blend in with the surrounding unmasked regions as
+well.
 
 ---
 

--- a/ldm/dream/generator/base.py
+++ b/ldm/dream/generator/base.py
@@ -5,6 +5,7 @@ including img2img, txt2img, and inpaint
 import torch
 import numpy as  np
 import random
+import os
 from tqdm import tqdm, trange
 from PIL               import Image
 from einops import rearrange, repeat
@@ -158,3 +159,14 @@ class Generator():
 
         return v2
 
+    # this is a handy routine for debugging use. Given a generated sample,
+    # convert it into a PNG image and store it at the indicated path
+    def save_sample(self, sample, filepath):
+        image = self.sample_to_image(sample)
+        dirname = os.path.dirname(filepath) or '.'
+        if not os.path.exists(dirname):
+            print(f'** creating directory {dirname}')
+            os.makedirs(dirname, exist_ok=True)
+        image.save(filepath,'PNG')
+
+        

--- a/ldm/dream/generator/inpaint.py
+++ b/ldm/dream/generator/inpaint.py
@@ -18,7 +18,7 @@ class Inpaint(Img2Img):
     @torch.no_grad()
     def get_make_image(self,prompt,sampler,steps,cfg_scale,ddim_eta,
                        conditioning,init_image,mask_image,strength,
-                       step_callback=None,**kwargs):
+                       step_callback=None,inpaint_replace=False,**kwargs):
         """
         Returns a function returning an image derived from the prompt and
         the initial image + mask.  Return value depends on the seed at
@@ -57,6 +57,12 @@ class Inpaint(Img2Img):
                 torch.tensor([t_enc]).to(self.model.device),
                 noise=x_T
             )
+
+            # to replace masked area with latent noise
+            if inpaint_replace:
+                print('>> inpaint will ignore what was under the mask')
+                l_noise = self.get_noise(kwargs['width'],kwargs['height'])
+                z_enc   = z_enc * mask_image + (1.0-mask_image) * l_noise
 
             # decode it
             samples = sampler.decode(

--- a/ldm/dream/generator/txt2img.py
+++ b/ldm/dream/generator/txt2img.py
@@ -31,7 +31,7 @@ class Txt2Img(Generator):
             if self.free_gpu_mem and self.model.model.device != self.model.device:
                 self.model.model.to(self.model.device)
                                 
-            sampler.make_schedule(ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=True)
+            sampler.make_schedule(ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False)
 
             samples, _ = sampler.sample(
                 batch_size                   = 1,

--- a/ldm/dream/readline.py
+++ b/ldm/dream/readline.py
@@ -45,6 +45,7 @@ COMMANDS = (
     '--skip_normalize','-x',
     '--log_tokenization','-t',
     '--hires_fix',
+    '--inpaint_replace','-r',
     '!fix','!fetch','!history',
     )
 IMG_PATH_COMMANDS = (

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -285,6 +285,8 @@ class Generate:
             codeformer_fidelity = None,
             save_original    = False,
             upscale          = None,
+            # this is specific to inpainting and causes more extreme inpainting
+            inpaint_replace  = False,
             # Set this True to handle KeyboardInterrupt internally
             catch_interrupts = False,
             hires_fix        = False,
@@ -430,6 +432,7 @@ class Generate:
                 strength=strength,
                 embiggen=embiggen,
                 embiggen_tiles=embiggen_tiles,
+                inpaint_replace=inpaint_replace,
             )
 
             if init_color:
@@ -950,10 +953,6 @@ class Generate:
         from ldm.dream.generator.base import downsampling
         image = image.resize((image.width//downsampling, image.height //
                               downsampling), resample=Image.Resampling.NEAREST)
-        # print(
-        #     f'>> DEBUG: writing the mask to mask.png'
-        #     )
-        # image.save('mask.png')
         image = np.array(image)
         image = image.astype(np.float32) / 255.0
         image = image[None].transpose(0, 3, 1, 2)

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -119,7 +119,7 @@ class KSampler(Sampler):
             'uncond': unconditional_conditioning,
             'cond_scale': unconditional_guidance_scale,
         }
-        print(f'>> Sampling with k__{self.schedule}')
+        print(f'>> Sampling with k_{self.schedule}')
         return (
             K.sampling.__dict__[f'sample_{self.schedule}'](
                 model_wrap_cfg, x, sigmas, extra_args=extra_args,

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -305,7 +305,7 @@ def main_loop(gen, opt, infile):
                         dream_prompt    = formatted_dream_prompt,
                         metadata        = metadata_dumps(
                             opt,
-                            seeds      = [seed],
+                            seeds      = [first_seed or seed],
                             model_hash = gen.model_hash,
                         ),
                         name      = filename,
@@ -324,7 +324,6 @@ def main_loop(gen, opt, infile):
                 opt.last_operation='generate'
                 gen.prompt2image(
                     image_callback=image_writer,
-#                    step_callback=gen.write_intermediate_images(5,'./outputs/img-samples/intermediates'), #DEBUGGING ONLY - DELETE
                     catch_interrupts=catch_ctrl_c,
                     **vars(opt)
                 )
@@ -433,6 +432,7 @@ def prepare_image_metadata(
         formatted_dream_prompt = '!fix '+opt.dream_prompt_str(seed=seed)
     else:
         formatted_dream_prompt = opt.dream_prompt_str(seed=seed)
+
     return filename,formatted_dream_prompt
 
 def choose_postprocess_name(opt,prefix,seed) -> str:


### PR DESCRIPTION
- add a `--inpaint_replace` option that fills masked regions with latent noise. This allows radical changes to inpainted regions at the cost of losing context.
- fix up readline, arg processing and metadata writing to accommodate this change
- fixed bug in storage and retrieval of variations, discovered incidentally during testing
- update documentation