### PR TITLE
fix --grid and seed metadata

### DIFF
--- a/ldm/dream/args.py
+++ b/ldm/dream/args.py
@@ -274,7 +274,10 @@ class Args(object):
         # the arg value. For example, the --grid and --individual options are a little
         # funny because of their push/pull relationship. This is how to handle it.
         if name=='grid':
-            return not cmd_switches.individual and value_arg  # arg supersedes cmd
+            if cmd_switches.individual:
+                return False
+            else:
+                return value_cmd or value_arg
         return value_cmd if value_cmd is not None else value_arg
 
     def __setattr__(self,name,value):

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -232,7 +232,7 @@ def main_loop(gen, opt, infile):
                 path     = os.path.join(opt.outdir,basename)
                 setattr(opt,attr,path)
 
-        # retrieve previous valueof seed if requested
+        # retrieve previous value of seed if requested
         if opt.seed is not None and opt.seed < 0:   
             try:
                 opt.seed = last_results[opt.seed][1]
@@ -299,13 +299,12 @@ def main_loop(gen, opt, infile):
                         postprocessed,
                         first_seed
                     )
-
                     path = file_writer.save_image_and_prompt_to_png(
                         image           = image,
                         dream_prompt    = formatted_dream_prompt,
                         metadata        = metadata_dumps(
                             opt,
-                            seeds      = [seed],
+                            seeds      = [seed if opt.variation_amount==0 and len(prior_variations)==0 else first_seed],
                             model_hash = gen.model_hash,
                         ),
                         name      = filename,
@@ -324,7 +323,6 @@ def main_loop(gen, opt, infile):
                 opt.last_operation='generate'
                 gen.prompt2image(
                     image_callback=image_writer,
-#                    step_callback=gen.write_intermediate_images(5,'./outputs/img-samples/intermediates'), #DEBUGGING ONLY - DELETE
                     catch_interrupts=catch_ctrl_c,
                     **vars(opt)
                 )
@@ -420,8 +418,8 @@ def prepare_image_metadata(
     if postprocessed and opt.save_original:
         filename = choose_postprocess_name(opt,prefix,seed)
     else:
-        filename = f'{prefix}.{seed}.png'        
-        
+        filename = f'{prefix}.{seed}.png'
+
     if opt.variation_amount > 0:
         first_seed             = first_seed or seed
         this_variation         = [[seed, opt.variation_amount]]


### PR DESCRIPTION
- When generating multiple images, the first seed was being used for second
      and subsequent files. This should only happen when variations are being
      generated. Now fixed.
- Restore correct behavior of --grid argument
