### PR TITLE
add enhancements to CLI command-line completion and history

### DIFF
--- a/docs/features/CLI.md
+++ b/docs/features/CLI.md
@@ -246,10 +246,9 @@ Outputs:
 ## !fetch
 
 This command retrieves the generation parameters from a previously
-generated image and either loads them into the command line
-(Linux|Mac), or prints them out in a comment for copy-and-paste
-(Windows). You may provide either the name of a file in the current
-output directory, or a full file path.
+generated image and either loads them into the command line.  You may
+provide either the name of a file in the current output directory, or
+a full file path.
 
 ~~~
 dream> !fetch 0000015.8929913.png
@@ -285,10 +284,25 @@ dream> !20
 dream> watercolor of beautiful woman sitting under tree wearing broad hat and flowing garment -v0.2 -n6 -S2878767194
 ~~~
 
+## !search <search string>
+
+This is similar to !history but it only returns lines that contain
+`search string`. For example:
+
+~~~
+dream> !search surreal
+[21] surrealist painting of beautiful woman sitting under tree wearing broad hat and flowing garment -v0.2 -n6 -S2878767194
+~~~
+
+## !clear
+
+This clears the search history from memory and disk. Be advised that
+this operation is irreversible and does not issue any warnings!
+
 # Command-line editing and completion
 
-If you are on a Macintosh or Linux machine, the command-line offers
-convenient history tracking, editing, and command completion.
+The command-line offers convenient history tracking, editing, and
+command completion.
 
 - To scroll through previous commands and potentially edit/reuse them, use the up and down cursor keys.
 - To edit the current command, use the left and right cursor keys to position the cursor, and then backspace, delete or insert characters.
@@ -298,7 +312,8 @@ convenient history tracking, editing, and command completion.
 - To paste a cut section back in, position the cursor where you want to paste, and type CTRL-Y
 
 Windows users can get similar, but more limited, functionality if they
-launch dream.py with the "winpty" program:
+launch dream.py with the "winpty" program and have the `pyreadline3`
+library installed:
 
 ~~~
 > winpty python scripts\dream.py

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
     - send2trash==1.8.0
     - pillow==9.2.0
     - einops==0.3.0
+    - pyreadline3
     - torch-fidelity==0.3.0
     - transformers==4.19.2
     - torchmetrics==0.6.0

--- a/ldm/dream/readline.py
+++ b/ldm/dream/readline.py
@@ -18,10 +18,7 @@ try:
     import readline
     readline_available = True
 except (ImportError,ModuleNotFoundError):
-    try:
-        import pyreadline3
-    except (ImportError,ModuleNotFoundError):
-        readline_available = False
+    readline_available = False
 
 IMG_EXTENSIONS     = ('.png','.jpg','.jpeg')
 COMMANDS = (

--- a/ldm/dream/readline.py
+++ b/ldm/dream/readline.py
@@ -17,8 +17,11 @@ from ldm.dream.args import Args
 try:
     import readline
     readline_available = True
-except:
-    readline_available = False
+except (ImportError,ModuleNotFoundError):
+    try:
+        import pyreadline3
+    except (ImportError,ModuleNotFoundError):
+        readline_available = False
 
 IMG_EXTENSIONS     = ('.png','.jpg','.jpeg')
 COMMANDS = (
@@ -45,7 +48,7 @@ COMMANDS = (
     '--skip_normalize','-x',
     '--log_tokenization','-t',
     '--hires_fix',
-    '!fix','!fetch','!history',
+    '!fix','!fetch','!history','!search','!clear',
     )
 IMG_PATH_COMMANDS = (
     '--outdir[=\s]',
@@ -60,7 +63,7 @@ IMG_FILE_COMMANDS=(
     )
 path_regexp = '('+'|'.join(IMG_PATH_COMMANDS+IMG_FILE_COMMANDS) + ')\s*\S*$'
 
-class Completer:
+class Completer(object):
     def __init__(self, options):
         self.options     = sorted(options)
         self.seeds       = set()
@@ -109,6 +112,19 @@ class Completer:
         if not self.auto_history_active:
             readline.add_history(line)
 
+    def clear_history(self):
+        '''
+        Pass clear_history() thru to readline
+        '''
+        readline.clear_history()
+
+    def search_history(self,match:str):
+        '''
+        Like show_history() but only shows items that
+        contain the match string.
+        '''
+        self.show_history(match)
+
     def remove_history_item(self,pos):
         readline.remove_history_item(pos)
 
@@ -135,7 +151,7 @@ class Completer:
     def get_history_item(self,index):
         return readline.get_history_item(index)
 
-    def show_history(self):
+    def show_history(self,match=None):
         '''
         Print the session history using the pydoc pager
         '''
@@ -147,7 +163,10 @@ class Completer:
             return
         
         for i in range(0,h_len):
-            lines.append(f'[{i+1}] {self.get_history_item(i+1)}')
+            line = self.get_history_item(i+1)
+            if match and match not in line:
+                continue
+            lines.append(f'[{i+1}] {line}')
         pydoc.pager('\n'.join(lines))
 
     def set_line(self,line)->None:
@@ -232,6 +251,9 @@ class DummyCompleter(Completer):
         
     def add_history(self,line):
         self.history.append(line)
+
+    def clear_history(self):
+        self.history = list()
 
     def get_current_history_length(self):
         return len(self.history)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pudb
 pytorch-lightning
 scikit-image>=0.19
 streamlit
+pyreadline3
 # "CompVis/taming-transformers" IS NOT INSTALLABLE
 # This is a drop-in replacement
 taming-transformers-rom1504

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -183,6 +183,15 @@ def main_loop(gen, opt, infile):
                 completer.show_history()
                 continue
 
+            elif subcommand.startswith('search'):
+                search_str = command.replace('!search ','',1)
+                completer.show_history(search_str)
+                continue
+
+            elif subcommand.startswith('clear'):
+                completer.clear_history()
+                continue
+
             elif re.match('^(\d+)',subcommand):
                 command_no = re.match('^(\d+)',subcommand).groups()[0]
                 command    = completer.get_line(int(command_no))


### PR DESCRIPTION
- Added support for pyreadline3 so that Window users can benefit.
- Added the `!search` command to search the history for a matching string: 
~~~
!search puppies
[20] puppies at the food bowl -Ak_lms
[54] house overrun by hungry puppies -C20 -s100
~~~
- Added the `!clear` command to clear the in-memory and on-disk command history.