### PR TITLE
Revert to old kdiffusion schedule

### DIFF
--- a/ldm/dream/generator/txt2img.py
+++ b/ldm/dream/generator/txt2img.py
@@ -31,7 +31,7 @@ class Txt2Img(Generator):
             if self.free_gpu_mem and self.model.model.device != self.model.device:
                 self.model.model.to(self.model.device)
                                 
-            sampler.make_schedule(ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=True)
+            sampler.make_schedule(ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False)
 
             samples, _ = sampler.sample(
                 batch_size                   = 1,


### PR DESCRIPTION
This puts the ksamplers back the way they were before I tried the Karras noise scheduler. Will continue to experiment offline.