### PR TITLE
Remove extra randn call in ksampler leading to break in reproducibility

### DIFF
--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -174,7 +174,7 @@ class KSampler(Sampler):
         sigmas = self.karras_sigmas[-S-1:]
         
         if x_T is not None:
-            x = x_T + torch.randn([batch_size, *shape], device=self.device) * sigmas[0]
+            x = x_T * sigmas[0]
         else:
             x = torch.randn([batch_size, *shape], device=self.device) * sigmas[0]
 


### PR DESCRIPTION
Hi @lstein 
I found one issue (?) in ksampler, an extra random generation. It will change all subsequent noise / random generations if we not set/reset the seed. Just removing it give me images much closer to saved results.
Probably fixes #966. Image comparison required.
 