### PR TITLE
restore ability of ksamplers to process -v variation options

### DIFF
--- a/ldm/dream/generator/img2img.py
+++ b/ldm/dream/generator/img2img.py
@@ -49,6 +49,7 @@ class Img2Img(Generator):
                 img_callback = step_callback,
                 unconditional_guidance_scale=cfg_scale,
                 unconditional_conditioning=uc,
+                init_latent = self.init_latent,  # changes how noising is performed in ksampler
             )
 
             return self.sample_to_image(samples)

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -174,9 +174,14 @@ class KSampler(Sampler):
         # sigmas are set up in make_schedule - we take the last steps items
         total_steps = len(self.sigmas)
         sigmas = self.sigmas[-S-1:]
-        
+
+        # x_T is variation noise. When an init image is provided (in x0) we need to add
+        # more randomness to the starting image.
         if x_T is not None:
-            x = x_T + torch.randn([batch_size, *shape], device=self.device) * sigmas[0]
+            if x0 is not None:
+                x = x_T + torch.randn([batch_size, *shape], device=self.device) * sigmas[0]
+            else:
+                x = x_T * sigmas[0]
         else:
             x = torch.randn([batch_size, *shape], device=self.device) * sigmas[0]
 

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -179,7 +179,7 @@ class KSampler(Sampler):
         # more randomness to the starting image.
         if x_T is not None:
             if x0 is not None:
-                x = x_T + torch.randn([batch_size, *shape], device=self.device) * sigmas[0]
+                x = x_T + torch.randn_like(x0, device=self.device) * sigmas[0]
             else:
                 x = x_T * sigmas[0]
         else:


### PR DESCRIPTION
- supersedes #977
- A limitation of this fix is that it works with txt2img only, and not with img2img. Please use plms or ddim samplers for applying minor variations to img2img until a better solution is found.