### PR TITLE
hotfix(venv): rename 'ldm' -> 'invokeai'

### DIFF
--- a/docs/installation/INSTALL_LINUX.md
+++ b/docs/installation/INSTALL_LINUX.md
@@ -40,23 +40,23 @@ This will create InvokeAI folder where you will follow the rest of the steps.
 ```
 
 5. Use anaconda to copy necessary python packages, create a new python
-   environment named `ldm` and activate the environment.
+   environment named `invokeai` and activate the environment.
 
 
 ```
 (base) ~/InvokeAI$ conda env create
-(base) ~/InvokeAI$ conda activate ldm
-(ldm) ~/InvokeAI$
+(base) ~/InvokeAI$ conda activate invokeai
+(invokeai) ~/InvokeAI$
 ```
 
-    After these steps, your command prompt will be prefixed by `(ldm)` as shown
+    After these steps, your command prompt will be prefixed by `(invokeai)` as shown
     above.
 
 6. Load a couple of small machine-learning models required by stable diffusion:
 
 
 ```
-(ldm) ~/InvokeAI$ python3 scripts/preload_models.py
+(invokeai) ~/InvokeAI$ python3 scripts/preload_models.py
 ```
 
     !!! note
@@ -81,24 +81,24 @@ This will create InvokeAI folder where you will follow the rest of the steps.
 
 
 ```
-(ldm) ~/InvokeAI$ mkdir -p models/ldm/stable-diffusion-v1
-(ldm) ~/InvokeAI$ ln -sf /path/to/sd-v1-4.ckpt models/ldm/stable-diffusion-v1/model.ckpt
+(invokeai) ~/InvokeAI$ mkdir -p models/ldm/stable-diffusion-v1
+(invokeai) ~/InvokeAI$ ln -sf /path/to/sd-v1-4.ckpt models/ldm/stable-diffusion-v1/model.ckpt
 ```
 
 8. Start generating images!
 
 ```
 # for the pre-release weights use the -l or --liaon400m switch
-(ldm) ~/InvokeAI$ python3 scripts/invoke.py -l
+(invokeai) ~/InvokeAI$ python3 scripts/invoke.py -l
 
 # for the post-release weights do not use the switch
-(ldm) ~/InvokeAI$ python3 scripts/invoke.py
+(invokeai) ~/InvokeAI$ python3 scripts/invoke.py
 
 # for additional configuration switches and arguments, use -h or --help
-(ldm) ~/InvokeAI$ python3 scripts/invoke.py -h
+(invokeai) ~/InvokeAI$ python3 scripts/invoke.py -h
 ```
 
-9. Subsequently, to relaunch the script, be sure to run "conda activate ldm" (step 5, second command), enter the `InvokeAI` directory, and then launch the invoke script (step 8). If you forget to activate the ldm environment, the script will fail with multiple `ModuleNotFound` errors.
+9. Subsequently, to relaunch the script, be sure to run "conda activate invokeai" (step 5, second command), enter the `InvokeAI` directory, and then launch the invoke script (step 8). If you forget to activate the 'invokeai' environment, the script will fail with multiple `ModuleNotFound` errors.
 
 ## Updating to newer versions of the script
 
@@ -106,7 +106,7 @@ This will create InvokeAI folder where you will follow the rest of the steps.
 This distribution is changing rapidly. If you used the `git clone` method (step 5) to download the InvokeAI directory, then to update to the latest and greatest version, launch the Anaconda window, enter `InvokeAI` and type:
 
 ```
-(ldm) ~/InvokeAI$ git pull
+(invokeai) ~/InvokeAI$ git pull
 ```
 
 This will bring your local copy into sync with the remote one.

--- a/docs/installation/INSTALL_WINDOWS.md
+++ b/docs/installation/INSTALL_WINDOWS.md
@@ -56,9 +56,9 @@ cd InvokeAI
 
 ```
 conda env create       (step 6a)
-conda activate ldm     (step 6b)
+conda activate invokeai     (step 6b)
 ```
-    This will install all python requirements and activate the "ldm" environment
+    This will install all python requirements and activate the "invokeai" environment
     which sets PATH and other environment variables properly.
 
     Note that the long form of the first command is `conda env create -f environment.yml`. If the
@@ -107,7 +107,7 @@ you may instead create a shortcut to it from within `models\ldm\stable-diffusion
     python scripts\invoke.py
     ```
 
-10. Subsequently, to relaunch the script, first activate the Anaconda command window (step 3),enter the InvokeAI directory (step 5, `cd \path\to\InvokeAI`), run `conda activate ldm` (step 6b), and then launch the invoke script (step 9).
+10. Subsequently, to relaunch the script, first activate the Anaconda command window (step 3),enter the InvokeAI directory (step 5, `cd \path\to\InvokeAI`), run `conda activate invokeai` (step 6b), and then launch the invoke script (step 9).
 
     **Note:** Tildebyte has written an alternative
     ["Easy peasy Windows install"](https://github.com/invoke-ai/InvokeAI/wiki/Easy-peasy-Windows-install)

--- a/environment-mac.yml
+++ b/environment-mac.yml
@@ -1,4 +1,4 @@
-name: ldm
+name: invokeai
 channels:
   - pytorch
   - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: ldm
+name: invokeai
 channels:
   - pytorch
   - defaults

--- a/notebooks/Stable-Diffusion-local-Windows.ipynb
+++ b/notebooks/Stable-Diffusion-local-Windows.ipynb
@@ -52,14 +52,14 @@
    "outputs": [],
    "source": [
     "%%cmd\n",
-    "pew new --python 3.10 -r requirements-lin-win-colab-CUDA.txt --dont-activate invoke-ai"
+    "pew new --python 3.10 -r requirements-lin-win-colab-CUDA.txt --dont-activate invokeai"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Switch the notebook kernel to the new 'invoke-ai' environment!\n",
+    "# Switch the notebook kernel to the new 'invokeai' environment!\n",
     "\n",
     "## VSCode: restart VSCode and come back to this cell\n",
     "\n",
@@ -67,7 +67,7 @@
     "1. Type \"Select Interpreter\" and select \"Jupyter: Select Interpreter to Start Jupyter Server\"\n",
     "1. VSCode will say that it needs to install packages. Click the \"Install\" button.\n",
     "1. Once the install is finished, do 1 & 2 again\n",
-    "1. Pick 'invoke-ai'\n",
+    "1. Pick 'invokeai'\n",
     "1. Run the following cell"
    ]
   },
@@ -88,7 +88,7 @@
     "## Jupyter/JupyterLab\n",
     "\n",
     "1. Run the cell below\n",
-    "1. Click on the toolbar where it says \"(ipyknel)\" ↗️. You should get a pop-up asking you to \"Select Kernel\". Pick 'invoke-ai' from the drop-down.\n"
+    "1. Click on the toolbar where it says \"(ipyknel)\" ↗️. You should get a pop-up asking you to \"Select Kernel\". Pick 'invokeai' from the drop-down.\n"
    ]
   },
   {
@@ -106,9 +106,9 @@
    "source": [
     "# DO NOT RUN THIS CELL IF YOU ARE USING VSCODE!!\n",
     "%%cmd\n",
-    "pew workon invoke-ai\n",
+    "pew workon invokeai\n",
     "pip3 install ipykernel\n",
-    "python -m ipykernel install --name=invoke-ai"
+    "python -m ipykernel install --name=invokeai"
    ]
   },
   {
@@ -183,7 +183,7 @@
     "Now:\n",
     "\n",
     "1. `cd` to wherever the 'InvokeAI' directory is\n",
-    "1. Run `pew workon invoke-ai`\n",
+    "1. Run `pew workon invokeai`\n",
     "1. Run `winpty python scripts\\dream.py`"
    ]
   },


### PR DESCRIPTION
This is targeting 'main' as this is a hotfix for 2.0.

'ldm' as venv name will definitely collide with other repo's venv names