### PR TITLE
update mac instructions to use invokeai for env name

### DIFF
--- a/docs/installation/INSTALL_MAC.md
+++ b/docs/installation/INSTALL_MAC.md
@@ -99,7 +99,7 @@ PIP_EXISTS_ACTION=w CONDA_SUBDIR=osx-64 conda env create -f environment-mac.yml
 # END ARCHITECTURE-DEPENDENT STEP #
 
 # Activate the environment (you need to do this every time you want to run SD)
-conda activate ldm
+conda activate invokeai
 
 # This will download some bits and pieces and make take a while
 python scripts/preload_models.py
@@ -155,7 +155,7 @@ conda install \
   pytorch \
   torchvision \
   -c pytorch-nightly \
-  -n ldm
+  -n invokeai
 ```
 
 
@@ -180,12 +180,12 @@ Or you could try to completley reset Anaconda:
 
 ---
 
-### "No module named cv2", torch, 'ldm', 'transformers', 'taming', etc
+### "No module named cv2", torch, 'invokeai', 'transformers', 'taming', etc
 
 There are several causes of these errors:
 
-1. Did you remember to `conda activate ldm`? If your terminal prompt begins with
-   "(ldm)" then you activated it. If it begins with "(base)" or something else
+1. Did you remember to `conda activate invokeai`? If your terminal prompt begins with
+   "(invokeai)" then you activated it. If it begins with "(base)" or something else
    you haven't.
 
 2. You might've run `./scripts/preload_models.py` or `./scripts/invoke.py`
@@ -199,17 +199,17 @@ There are several causes of these errors:
 
     ```bash
     conda deactivate
-    conda env remove -n ldm
+    conda env remove -n invokeai
     conda env create -f environment-mac.yml
     ```
     
-4. If you have activated the ldm virtual environment and tried rebuilding it,
+4. If you have activated the linvokeaidm virtual environment and tried rebuilding it,
    maybe the problem could be that I have something installed that you don't and
    you'll just need to manually install it. Make sure you activate the virtual
    environment so it installs there instead of globally.
 
     ```bash
-    conda activate ldm
+    conda activate invokeai
     pip install <package name>
     ```
 
@@ -267,12 +267,12 @@ should actually be the _same python_, which you can verify by comparing the
 output of `python3 -V` and `python -V`.
 
 ```bash
-(ldm) % which python
-/Users/name/miniforge3/envs/ldm/bin/python
+(invokeai) % which python
+/Users/name/miniforge3/envs/invokeai/bin/python
 ```
 
 The above is what you'll see if you have miniforge and correctly activated the
-ldm environment, while usingd the standalone setup instructions above.
+invokeai environment, while usingd the standalone setup instructions above.
 
 If you otherwise installed via pyenv, you will get this result:
 
@@ -452,7 +452,7 @@ this issue too. I should probably test it.
 ### "view size is not compatible with input tensor's size and stride"
 
 ```bash
-File "/opt/anaconda3/envs/ldm/lib/python3.10/site-packages/torch/nn/functional.py", line 2511, in layer_norm
+File "/opt/anaconda3/envs/invokeai/lib/python3.10/site-packages/torch/nn/functional.py", line 2511, in layer_norm
 return torch.layer_norm(input, normalized_shape, weight, bias, eps, torch.backends.cudnn.enabled)
 RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
 ```
@@ -488,7 +488,7 @@ Generating:   0%|                                                              |
                                                                                                     loc("mps_add"("(mpsFileLoc): /AppleInternal/Library/BuildRoots/20d6c351-ee94-11ec-bcaf-7247572f23b4/Library/Caches/com.apple.xbs/Sources/MetalPerformanceShadersGraph/mpsgraph/MetalPerformanceShadersGraph/Core/Files/MPSGraphUtilities.mm":219:0)): error: input types 'tensor<2x1280xf32>' and 'tensor<*xf16>' are not broadcast compatible
 LLVM ERROR: Failed to infer result type(s).
 Abort trap: 6
-/Users/[...]/opt/anaconda3/envs/ldm/lib/python3.9/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
+/Users/[...]/opt/anaconda3/envs/invokeai/lib/python3.9/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
   warnings.warn('resource_tracker: There appear to be %d '
 ```
 


### PR DESCRIPTION
Fixes #1025.

I only updated the Mac instructions since those were the only ones I could actually verify. 3 references to ldm are still present but those refer to still existing file paths ("ldm/modules", "models/ldm/stable-diffusion-v1").

The main fix is for line 102 which I'm guessing is blocking a lot of people who don't have the knowledge/experience to realize what's going wrong.