### PR TITLE
Don't hardcode protocol in socketio URL

### DIFF
--- a/frontend/src/app/socketio/middleware.ts
+++ b/frontend/src/app/socketio/middleware.ts
@@ -24,7 +24,7 @@ import * as InvokeAI from '../invokeai';
 export const socketioMiddleware = () => {
   const { hostname, port } = new URL(window.location.href);
 
-  const socketio = io(`http://${hostname}:${port}`, {
+  const socketio = io(`//${hostname}:${port}`, {
     timeout: 60000,
   });
 


### PR DESCRIPTION
If InvokeAI is behind a reverse-proxy like nginx using HTTPS, then the frontend can't talk to the websocket unless it is also using HTTPS. Just specifying '//' in the URL will tell the browser to use whatever protocol it already used to load the frontend.

---

To get my own deployment working behind nginx with SSL, I also had to manually update the generated `frontend/dist/assets/index.js`, but I don't know how to generate that so I didn't include it in this patch. 