### PR TITLE
Print out the device type which is used

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -172,6 +172,7 @@ class Generate:
         # device to Generate(). However the device was then ignored, so
         # it wasn't actually doing anything. This logic could be reinstated.
         device_type = choose_torch_device()
+        print(f'>> Using device_type {device_type}')
         self.device = torch.device(device_type)
         if full_precision:
             if self.precision != 'auto':


### PR DESCRIPTION
Print out the device type which is used for generating images. Saw a few times that people asked why it took so long and run into the same issue, because I had the wrong torch version installed.
Not sure if the right place, but definitely an important information cuda, cpu or mps?