### PR TITLE
Forward dream.py to invoke.py using the same interpreter, add deprecation warning

### DIFF
--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -5,6 +5,7 @@ import warnings
 import invoke
 
 if __name__ == '__main__':
-    warnings.warn("dream.py is deprecated, please run invoke.py instead",
+    warnings.warn("dream.py is being deprecated, please run invoke.py for the "
+                  "new UI/API or legacy_api.py for the old API",
                   DeprecationWarning)
     invoke.main()

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) 2022 Lincoln D. Stein (https://github.com/lstein)
 
-import sys
-import os.path
+import warnings
+import invoke
 
-script_path = sys.argv[0]
-script_args = sys.argv[1:]
-script_dir,script_name = os.path.split(script_path)
-script_dest = os.path.join(script_dir,'invoke.py')
-os.execlp('python3','python3',script_dest,*script_args)
-
+if __name__ == '__main__':
+    warnings.warn("dream.py is deprecated, please run invoke.py instead",
+                  DeprecationWarning)
+    invoke.main()


### PR DESCRIPTION
Just a bit cleaner to forward using `import` instead of reexecuting python, also running "python3" risks bringing up the wrong interpreter. Added a deprecation warning as well.