### PR TITLE
fix noisy images at high step counts

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -636,6 +636,13 @@ class Args(object):
             dest='hires_fix',
             help='Create hires image using img2img to prevent duplicated objects'
         )
+        render_group.add_argument(
+            '--save_intermediates',
+            type=int,
+            default=0,
+            dest='save_intermediates',
+            help='Save every nth intermediate image into an "intermediates" directory within the output directory'
+        )
         img2img_group.add_argument(
             '-I',
             '--init_img',

--- a/ldm/invoke/readline.py
+++ b/ldm/invoke/readline.py
@@ -31,6 +31,7 @@ COMMANDS = (
     '--perlin',
     '--grid','-g',
     '--individual','-i',
+    '--save_intermediates',
     '--init_img','-I',
     '--init_mask','-M',
     '--init_color',

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -98,7 +98,8 @@ class KSampler(Sampler):
             rho=7.,
             device=self.device,
         )
-        self.sigmas = self.karras_sigmas
+        self.sigmas = self.model_sigmas
+        #self.sigmas = self.karras_sigmas
         
     # ALERT: We are completely overriding the sample() method in the base class, which
     # means that inpainting will not work. To get this to work we need to be able to

--- a/ldm/models/diffusion/sampler.py
+++ b/ldm/models/diffusion/sampler.py
@@ -140,7 +140,7 @@ class Sampler(object):
         conditioning=None,
         callback=None,
         normals_sequence=None,
-        img_callback=None,
+        img_callback=None,   # TODO: this is very confusing because it is called "step_callback" elsewhere. Change.
         quantize_x0=False,
         eta=0.0,
         mask=None,


### PR DESCRIPTION
At step counts greater than ~75, the ksamplers start producing noisy images when using the Karras noise schedule. This PR reverts to using the model's own noise schedule, which eliminates the problem at the cost of slowing convergence at lower step counts.

This PR also introduces a new CLI `--save_intermediates <n>` argument, which will save every nth intermediate image into a subdirectory named `intermediates/<image_prefix>`.

Addresses issue #1083.