### PR TITLE
Only output facetool parameters if enhancing faces

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -242,13 +242,12 @@ class Args(object):
         else:
             switches.append(f'-A {a["sampler_name"]}')
 
-        # facetool-specific parameters
-        if a['facetool']:
-            switches.append(f'-ft {a["facetool"]}')
+        # facetool-specific parameters, only print if running facetool
         if a['facetool_strength']:
             switches.append(f'-G {a["facetool_strength"]}')
-        if a['codeformer_fidelity']:
-            switches.append(f'-cf {a["codeformer_fidelity"]}')
+            switches.append(f'-ft {a["facetool"]}')
+            if a["facetool"] == "codeformer":
+                switches.append(f'-cf {a["codeformer_fidelity"]}')
 
         if a['outcrop']:
             switches.append(f'-c {" ".join([str(u) for u in a["outcrop"]])}')


### PR DESCRIPTION
A partial solution to #1101, don't print the default facetool parameters if face enhancement is not even enabled. This doesn't solve the saving or loading issue, but it will make the output less confusing.

For example of the prompt text rendering being confusing see: https://github.com/invoke-ai/InvokeAI/pull/1108#issuecomment-1279846403

Example with no facetool, no parameters:
```
invoke> test -s1
[121] outputs/img-samples/000060.1125788153.png: "test" -s 1 -S 1125788153 -W 512 -H 512 -C 7.5 -A k_lms
```

Example with gfpgan:
```
invoke> test -s1 -G1
[122] outputs/img-samples/000061.3072109442.png: "test" -s 1 -S 3072109442 -W 512 -H 512 -C 7.5 -A k_lms -G 1.0 -ft gfpgan
```

Example with codeformer:
```
invoke> test -s1 -G2 -ft codeformer -cf 0.75
[123] outputs/img-samples/000062.2347390908.png: "test" -s 1 -S 2347390908 -W 512 -H 512 -C 7.5 -A k_lms -G 2.0 -ft codeformer -cf 0.75
```
