### PR TITLE
Handle KeyboardInterrupt in invoke.py loop

### DIFF
--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -120,12 +120,20 @@ def main_loop(gen, opt, infile):
         path_max = 260
         name_max = 255
 
+    catch_ctrl_c = infile is None # if running interactively, we catch keyboard interrupts
+
     while not done:
 
         operation = 'generate'
 
         try:
             command = get_next_command(infile)
+        except KeyboardInterrupt:
+            if catch_ctrl_c:
+                print()
+                continue
+            else:
+                raise
         except EOFError:
             done = True
             continue
@@ -294,7 +302,6 @@ def main_loop(gen, opt, infile):
                 last_results.append([path, seed])
 
             if operation == 'generate':
-                catch_ctrl_c = infile is None # if running interactively, we catch keyboard interrupts
                 opt.last_operation='generate'
                 gen.prompt2image(
                     image_callback=image_writer,


### PR DESCRIPTION
I am constantly killing invoke.py by mistake by hitting CTRL+C when I just want to clear the line. Not sure if others have this problem, but maybe better to follow other readline apps like python and bash that exit only when you hit CTRL+D or quit explicitly?