### PR TITLE
remove irrelevant switches from normalized dream command

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -245,19 +245,20 @@ class Args(object):
             switches.append(f'-A {a["sampler_name"]}')
 
         # facetool-specific parameters
-        if a['facetool']:
-            switches.append(f'-ft {a["facetool"]}')
         if a['facetool_strength']:
             switches.append(f'-G {a["facetool_strength"]}')
-        if a['codeformer_fidelity']:
-            switches.append(f'-cf {a["codeformer_fidelity"]}')
+            if a['facetool']:
+                switches.append(f'-ft {a["facetool"]}')
+            if a['codeformer_fidelity']:
+                switches.append(f'-cf {a["codeformer_fidelity"]}')
 
-        if a['outcrop']:
-            switches.append(f'-c {" ".join([str(u) for u in a["outcrop"]])}')
-
-        # esrgan-specific parameters
+        # esrgan/upscaling
         if a['upscale']:
             switches.append(f'-U {" ".join([str(u) for u in a["upscale"]])}')
+
+        # outcropping
+        if a['outcrop']:
+            switches.append(f'-c {" ".join([str(u) for u in a["outcrop"]])}')
 
         # embiggen parameters
         if a['embiggen']:


### PR DESCRIPTION
The normalized dream command that gets written into the log was including irrelevant switches from face reconstruction. These have now been suppressed unless face reconstruction was activated.