### PR TITLE
Fix discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ generation process. It runs on Windows, Mac and Linux machines, with
 GPU cards with as little as 4 GB of RAM. It provides both a polished
 Web interface (see below), and an easy-to-use command-line interface.
 
-**Quick links**: [<a href="https://discord.gg/NwVCmKwY">Discord Server</a>] [<a href="https://invoke-ai.github.io/InvokeAI/">Documentation and Tutorials</a>] [<a href="https://github.com/invoke-ai/InvokeAI/">Code and Downloads</a>] [<a href="https://github.com/invoke-ai/InvokeAI/issues">Bug Reports</a>] [<a href="https://github.com/invoke-ai/InvokeAI/discussions">Discussion, Ideas & Q&A</a>]
+**Quick links**: [<a href="https://discord.gg/ZmtBAhwWhy">Discord Server</a>] [<a href="https://invoke-ai.github.io/InvokeAI/">Documentation and Tutorials</a>] [<a href="https://github.com/invoke-ai/InvokeAI/">Code and Downloads</a>] [<a href="https://github.com/invoke-ai/InvokeAI/issues">Bug Reports</a>] [<a href="https://github.com/invoke-ai/InvokeAI/discussions">Discussion, Ideas & Q&A</a>]
 
 <div align="center"><img src="docs/assets/invoke-web-server-1.png" width=640></div>
 


### PR DESCRIPTION
The discord badge has the correct link but the quick links did not