### PR TITLE
Fix typo in docs: s/Formally/Formerly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # InvokeAI: A Stable Diffusion Toolkit
 
-_Formally known as lstein/stable-diffusion_
+_Formerly known as lstein/stable-diffusion_
 
 ![project logo](docs/assets/logo.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ title: Home
 -->
 <div align="center" markdown>
 
-# ^^**InvokeAI: A Stable Diffusion Toolkit**^^ :tools: <br> <small>Formally known as lstein/stable-diffusion</small>
+# ^^**InvokeAI: A Stable Diffusion Toolkit**^^ :tools: <br> <small>Formerly known as lstein/stable-diffusion</small>
 
 ![project logo](assets/logo.png)
 


### PR DESCRIPTION
Feels silly to make a PR for such a trivial thing, but that typo at the top of the docs has been bugging me for a while. Hopefully I'll have something more substantial to contribute in future PRs once I take some time to get more acquainted with the code. :)