### PR TITLE
Correct color channels in upscale using array slicing

### DIFF
--- a/ldm/invoke/restoration/realesrgan.py
+++ b/ldm/invoke/restoration/realesrgan.py
@@ -60,14 +60,18 @@ class ESRGAN():
             print(
                 f'>> Real-ESRGAN Upscaling seed:{seed} : scale:{upsampler_scale}x'
             )
+            
+        # REALSRGAN expects a BGR np array; make array and flip channels
+        bgr_image_array = np.array(image, dtype=np.uint8)[...,::-1]
         
         output, _ = upsampler.enhance(
-            np.array(image, dtype=np.uint8),
+            bgr_image_array,
             outscale=upsampler_scale,
             alpha_upsampler='realesrgan',
         )
 
-        res = Image.fromarray(output)
+        # Flip the channels back to RGB
+        res = Image.fromarray(output[...,::-1])
 
         if strength < 1.0:
             # Resize the image to the new image if the sizes have changed


### PR DESCRIPTION
Similar to issue #1175, REALSRGAN expects BGR as input instead of RGB. This implementation reused the same numpy array slicing code as #1178.