### PR TITLE
Metadata storage and retrieval fixes

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -113,8 +113,8 @@ PRECISION_CHOICES = [
 ]
 
 # is there a way to pick this up during git commits?
-APP_ID      = 'lstein/stable-diffusion'
-APP_VERSION = 'v1.15'
+APP_ID      = 'invoke-ai/InvokeAI'
+APP_VERSION = 'v2.02'
 
 class ArgFormatter(argparse.RawTextHelpFormatter):
         # use defined argument order to display usage
@@ -841,7 +841,7 @@ def metadata_dumps(opt,
     # remove any image keys not mentioned in RFC #266
     rfc266_img_fields = ['type','postprocessing','sampler','prompt','seed','variations','steps',
                          'cfg_scale','threshold','perlin','step_number','width','height','extra','strength',
-                         'init_img','init_mask']
+                         'init_img','init_mask','facetool','facetool_strength','upscale']
 
     rfc_dict ={}
 

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -172,6 +172,7 @@ class Args(object):
         command = cmd_string.replace("'", "\\'")
         try:
             elements = shlex.split(command)
+            elements = [x.replace("\\'","'") for x in elements]
         except ValueError:
             import sys, traceback
             print(traceback.format_exc(), file=sys.stderr)
@@ -924,7 +925,7 @@ def metadata_loads(metadata) -> list:
         for image in images:
             # repack the prompt and variations
             if 'prompt' in image:
-                image['prompt']     = ','.join([':'.join([x['prompt'],   str(x['weight'])]) for x in image['prompt']])
+                image['prompt']     = repack_prompt(image['prompt'])
             if 'variations' in image:
                 image['variations'] = ','.join([':'.join([str(x['seed']),str(x['weight'])]) for x in image['variations']])
             # fix a bit of semantic drift here
@@ -932,11 +933,18 @@ def metadata_loads(metadata) -> list:
             opt = Args()
             opt._cmd_switches = Namespace(**image)
             results.append(opt)
-    except KeyError as e:
+    except Exception as e:
         import sys, traceback
-        print('>> badly-formatted metadata',file=sys.stderr)
+        print('>> could not read metadata',file=sys.stderr)
         print(traceback.format_exc(), file=sys.stderr)
     return results
+
+def repack_prompt(prompt_list:list)->str:
+    # in the common case of no weighting syntax, just return the prompt as is
+    if len(prompt_list) > 1:
+        return ','.join([':'.join([x['prompt'], str(x['weight'])]) for x in prompt_list])
+    else:
+        return prompt_list[0]['prompt']
 
 # image can either be a file path on disk or a base64-encoded
 # representation of the file's contents

--- a/ldm/invoke/pngwriter.py
+++ b/ldm/invoke/pngwriter.py
@@ -38,7 +38,7 @@ class PngWriter:
         info = PngImagePlugin.PngInfo()
         info.add_text('Dream', dream_prompt)
         if metadata:
-          info.add_text('sd-metadata', json.dumps(metadata))
+            info.add_text('sd-metadata', json.dumps(metadata))
         image.save(path, 'PNG', pnginfo=info, compress_level=compress_level)
         return path
 

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -748,19 +748,33 @@ def retrieve_dream_command(opt,command,completer):
     will retrieve and format the dream command used to generate the image,
     and pop it into the readline buffer (linux, Mac), or print out a comment
     for cut-and-paste (windows)
+
     Given a wildcard path to a folder with image png files, 
     will retrieve and format the dream command used to generate the images,
     and save them to a file commands.txt for further processing
     '''
     if len(command) == 0:
         return
+
     tokens = command.split()
     if len(tokens) > 1:
-        outfilepath = tokens[1]
-    else:
-        outfilepath = "commands.txt"
-        
+        return write_commands(opt,tokens)
+
+    try:
+        cmd = dream_cmd_from_png(tokens[0])
+    except OSError:
+        print(f'## {path}: file could not be read')
+    except (KeyError, AttributeError, IndexError):
+        print(f'## {path}: file has no metadata')
+    except:
+        print(f'## {path}: file could not be processed')
+    if len(cmd)>0:
+        completer.set_line(cmd)
+
+def write_commands(opt, tokens:list):
     file_path = tokens[0]    
+    outfilepath = tokens[1]
+        
     dir,basename = os.path.split(file_path)
     if len(dir) == 0:
         dir = opt.outdir
@@ -775,28 +789,23 @@ def retrieve_dream_command(opt,command,completer):
         return
  
     commands = []
+    cmd = None
     for path in paths:
         try:
             cmd = dream_cmd_from_png(path)
         except OSError:
             print(f'## {path}: file could not be read')
-            continue
         except (KeyError, AttributeError, IndexError):
             print(f'## {path}: file has no metadata')
-            continue
         except:
             print(f'## {path}: file could not be processed')
-            continue
-            
-        commands.append(f'# {path}')
-        commands.append(cmd)
- 
-    with open(outfilepath, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(commands))
-    print(f'>> File {outfilepath} with commands created')
-
-    if len(commands) == 2:
-       completer.set_line(commands[1])
+        if cmd:
+            commands.append(f'# {path}')
+            commands.append(cmd)
+    if len(commands)>0:
+        with open(outfilepath, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(commands))
+        print(f'>> File {outfilepath} with commands created')
 
 ######################################
 

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -757,31 +757,29 @@ def retrieve_dream_command(opt,command,completer):
         return
 
     tokens = command.split()
-    if len(tokens) > 1:
-        return write_commands(opt,tokens)
+    dir,basename = os.path.split(tokens[0])
+    if len(dir) == 0:
+        path = os.path.join(opt.outdir,basename)
+    else:
+        path = tokens[0]
 
+    if len(tokens) > 1:
+        return write_commands(opt, path, tokens[1])
+
+    cmd = ''
     try:
-        cmd = dream_cmd_from_png(tokens[0])
+        cmd = dream_cmd_from_png(path)
     except OSError:
-        print(f'## {path}: file could not be read')
+        print(f'## {tokens[0]}: file could not be read')
     except (KeyError, AttributeError, IndexError):
-        print(f'## {path}: file has no metadata')
+        print(f'## {tokens[0]}: file has no metadata')
     except:
-        print(f'## {path}: file could not be processed')
+        print(f'## {tokens[0]}: file could not be processed')
     if len(cmd)>0:
         completer.set_line(cmd)
 
-def write_commands(opt, tokens:list):
-    file_path = tokens[0]    
-    outfilepath = tokens[1]
-        
+def write_commands(opt, file_path:str, outfilepath:str):
     dir,basename = os.path.split(file_path)
-    if len(dir) == 0:
-        dir = opt.outdir
-        
-    outdir,outname = os.path.split(outfilepath)    
-    if len(outdir) == 0:
-        outfilepath = os.path.join(dir,outname)
     try:
         paths = list(Path(dir).glob(basename))
     except ValueError:
@@ -793,8 +791,6 @@ def write_commands(opt, tokens:list):
     for path in paths:
         try:
             cmd = dream_cmd_from_png(path)
-        except OSError:
-            print(f'## {path}: file could not be read')
         except (KeyError, AttributeError, IndexError):
             print(f'## {path}: file has no metadata')
         except:
@@ -803,6 +799,9 @@ def write_commands(opt, tokens:list):
             commands.append(f'# {path}')
             commands.append(cmd)
     if len(commands)>0:
+        dir,basename = os.path.split(outfilepath)
+        if len(dir)==0:
+            outfilepath = os.path.join(opt.outdir,basename)
         with open(outfilepath, 'w', encoding='utf-8') as f:
             f.write('\n'.join(commands))
         print(f'>> File {outfilepath} with commands created')


### PR DESCRIPTION
This PR fixes several bugs in how the CLI stores, processes and retrieves metadata:

- fix incorrect handling of single quotes in prompts
- facetool and upscale arguments passed during image generation now written into metadata
- cleaned up handling of !fetch command