### PR TITLE
Let the text-to-mask `.mask.png` file be used as a mask

### DIFF
--- a/docs/features/INPAINTING.md
+++ b/docs/features/INPAINTING.md
@@ -81,15 +81,18 @@ text2mask feature. The syntax is `!mask /path/to/image.png -tm <text>
 It will generate three files:
 
 - The image with the selected area highlighted.
+  - it will be named XXXXX.<imagename>.<prompt>.selected.png
 - The image with the un-selected area highlighted.
+  - it will be named XXXXX.<imagename>.<prompt>.deselected.png
 - The image with the selected area converted into a black and white
-  image according to the threshold level.
+  image according to the threshold level
+  - it will be named XXXXX.<imagename>.<prompt>.masked.png
 
-Note that none of these images are intended to be used as the mask
-passed to invoke via `-M` and may give unexpected results if you try
-to use them this way. Instead, use `!mask` for testing that you are
-selecting the right mask area, and then do inpainting using the
-best selection term and threshold.
+The `.masked.png` file can then be directly passed to the `invoke>`
+prompt in the CLI via the `-M` argument. Do not attempt this with
+the `selected.png` or `deselected.png` files, as they contain some
+transparency throughout the image and will not produce the desired
+results.
 
 Here is an example of how `!mask` works:
 
@@ -120,7 +123,7 @@ It looks like we selected the hair pretty well at the 0.5 threshold
 let's have some fun:
 
 ```
-invoke> medusa with cobras -I ./test-pictures/curly.png -tm hair 0.5 -C20
+invoke> medusa with cobras -I ./test-pictures/curly.png -M 000019.curly.hair.masked.png -C20
 >> loaded input image of size 512x512 from ./test-pictures/curly.png
 ...
 Outputs:
@@ -128,6 +131,13 @@ Outputs:
 ```
 
 <img src="../assets/inpainting/000024.801380492.png">
+
+You can also skip the `!mask` creation step and just select the masked
+
+region directly:
+```
+invoke> medusa with cobras -I ./test-pictures/curly.png -tm hair -C20
+```
 
 ### Inpainting is not changing the masked region enough!
 

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -911,9 +911,12 @@ class Generate:
     # with alpha transparency. It converts it into a black/white
     # image with the transparent part black.
     def _image_to_mask(self, mask_image, invert=False) -> Image:
-        # Obtain the mask from the transparency channel
-        mask = Image.new(mode="L", size=mask_image.size, color=255)
-        mask.putdata(mask_image.getdata(band=3))
+        if mask_image.mode in ('L','RGB'):
+            mask = mask_image
+        else:
+            # Obtain the mask from the transparency channel
+            mask = Image.new(mode="L", size=mask_image.size, color=255)
+            mask.putdata(mask_image.getdata(band=3))
         if invert:
             mask = ImageOps.invert(mask)
         return mask


### PR DESCRIPTION
Ironically, the black and white mask file generated by the `invoke> !mask` command could not be passed as the mask to `img2img`. This is now fixed and the documentation updated.