### PR TITLE
refactor inpainting code

### DIFF
--- a/ldm/invoke/generator/img2img.py
+++ b/ldm/invoke/generator/img2img.py
@@ -4,9 +4,12 @@ ldm.invoke.generator.img2img descends from ldm.invoke.generator
 
 import torch
 import numpy as  np
-from ldm.invoke.devices             import choose_autocast
-from ldm.invoke.generator.base      import Generator
-from ldm.models.diffusion.ddim     import DDIMSampler
+import PIL
+from PIL import Image
+from torch import Tensor
+from ldm.invoke.devices import choose_autocast
+from ldm.invoke.generator.base import Generator
+from ldm.models.diffusion.ddim import DDIMSampler
 
 class Img2Img(Generator):
     def __init__(self, model, precision):
@@ -25,6 +28,9 @@ class Img2Img(Generator):
             ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False
         )
 
+        if isinstance(init_image, PIL.Image.Image):
+            init_image = self._image_to_tensor(init_image)
+            
         scope = choose_autocast(self.precision)
         with scope(self.model.device.type):
             self.init_latent = self.model.get_first_stage_encoding(
@@ -68,3 +74,12 @@ class Img2Img(Generator):
             shape = init_latent.shape
             x = (1-self.perlin)*x + self.perlin*self.get_perlin_noise(shape[3], shape[2])
         return x
+    
+    def _image_to_tensor(self, image:Image, normalize:bool=True)->Tensor:
+        image = np.array(image).astype(np.float32) / 255.0
+        image = image[None].transpose(0, 3, 1, 2)
+        image = torch.from_numpy(image)
+        if normalize:
+            image = 2.0 * image - 1.0
+        return image.to(self.model.device)
+

--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -4,15 +4,20 @@ ldm.invoke.generator.inpaint descends from ldm.invoke.generator
 
 import torch
 import numpy as  np
+import PIL
+from PIL import Image, ImageFilter
 from einops import rearrange, repeat
-from ldm.invoke.devices             import choose_autocast
-from ldm.invoke.generator.img2img   import Img2Img
-from ldm.models.diffusion.ddim     import DDIMSampler
+from ldm.invoke.devices import choose_autocast
+from ldm.invoke.generator.base import downsampling
+from ldm.invoke.generator.img2img import Img2Img
+from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.ksampler import KSampler
 
 class Inpaint(Img2Img):
     def __init__(self, model, precision):
         self.init_latent = None
+        self.original_image = None
+        self.original_mask = None
         super().__init__(model, precision)
 
     @torch.no_grad()
@@ -34,6 +39,21 @@ class Inpaint(Img2Img):
         sampler.make_schedule(
             ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False
         )
+
+        if isinstance(init_image, PIL.Image.Image):
+            self.original_image = init_image
+            init_image = self._image_to_tensor(init_image)
+
+        if isinstance(mask_image, PIL.Image.Image):
+            self.original_mask = mask_image
+            mask_image = mask_image.resize(
+                (
+                    mask_image.width // downsampling,
+                    mask_image.height // downsampling
+                ),
+                resample=Image.Resampling.NEAREST
+            )
+            mask_image = self._image_to_tensor(mask_image,normalize=False)
 
         mask_image = mask_image[0][0].unsqueeze(0).repeat(4,1,1).unsqueeze(0)
         mask_image = repeat(mask_image, '1 ... -> b ...', b=1)
@@ -83,4 +103,14 @@ class Inpaint(Img2Img):
         return make_image
 
 
+    def sample_to_image(self, samples) -> Image:
+        painted_image = super().sample_to_image(samples)
+        if self.original_image is not None and self.original_mask is not None:
+
+            print('>> Restoring unmasked regions of initial image')
+            mask = self.original_mask.convert('L')
+            blur = mask.filter(filter=ImageFilter.GaussianBlur(radius=2))
+            painted_image.paste(self.original_image, (0,0), blur)
+
+        return painted_image
 


### PR DESCRIPTION
DO NOT MERGE - this is for comparison only with #1218

- Refactor how init image and mask are passed around. In this version, they remain Images until they get to img2img and inpainting layers, rather than being converted into Tensors in generate.

- After generating inpainted image, paints over the unmasked areas with the original image using a slightly blurred mask. This is redundant with PR #1218