### PR TITLE
Raise exception instead of undefined internal state

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -72,8 +72,11 @@ class ModelCache(object):
                 self.models[model_name]['hash'] = hash
             except Exception as e:
                 print(f'** model {model_name} could not be loaded: {str(e)}')
-                print(f'** restoring {self.current_model}')
-                return self.get_model(self.current_model)
+                if self.current_model:
+                    print(f'** restoring {self.current_model}')
+                    return self.get_model(self.current_model)
+                else:
+                    raise
         
         self.current_model = model_name
         self._push_newest_model(model_name)


### PR DESCRIPTION
Hi, please consider raising a proper exception here instead of an undefined internal state. This happens for example if the filepath to the model.ckpt is invalid on first load.