### PR TITLE
Update IMG2IMG.md

### DIFF
--- a/docs/features/IMG2IMG.md
+++ b/docs/features/IMG2IMG.md
@@ -121,8 +121,6 @@ Both of the outputs look kind of like what I was thinking of. With the strength 
 
 If you want to try this out yourself, all of these are using a seed of `1592514025` with a width/height of `384`, step count `10`, the default sampler (`k_lms`), and the single-word prompt `"fire"`:
 
-If you want to try this out yourself, all of these are using a seed of `1592514025` with a width/height of `384`, step count `10`, the default sampler (`k_lms`), and the single-word prompt `fire`:
-
 ```commandline
 invoke> "fire" -s10 -W384 -H384 -S1592514025 -I /tmp/fire-drawing.png --strength 0.7
 ```


### PR DESCRIPTION
removes duplicate paragraph

I know the contrib sections states to base against development, but with this being just a doc update I assumed there would be no breaking changes.