### PR TITLE
Use proper authentication to download model

### DIFF
--- a/.github/workflows/create-caches.yml
+++ b/.github/workflows/create-caches.yml
@@ -57,7 +57,7 @@ jobs:
             || curl \
               -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" \
               -o models/ldm/stable-diffusion-v1/model.ckpt \
-              -O -L https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt
+              -L https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt
 
       - name: Activate Conda Env
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/create-caches.yml
+++ b/.github/workflows/create-caches.yml
@@ -54,7 +54,8 @@ jobs:
           [[ -d models/ldm/stable-diffusion-v1 ]] \
             || mkdir -p models/ldm/stable-diffusion-v1
           [[ -r models/ldm/stable-diffusion-v1/model.ckpt ]] \
-            || curl --user "${{ secrets.HUGGINGFACE_TOKEN }}" \
+            || curl \
+              -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" \
               -o models/ldm/stable-diffusion-v1/model.ckpt \
               -O -L https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt
 

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -14,16 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        stable-diffusion-model: ['https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt']
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
             environment-file: environment.yml
             default-shell: bash -l {0}
-            stable-diffusion-model: https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt
           - os: macos-latest
             environment-file: environment-mac.yml
             default-shell: bash -l {0}
-            stable-diffusion-model: https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt
     name: Test invoke.py on ${{ matrix.os }} with conda
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -74,7 +74,7 @@ jobs:
             || curl \
               -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" \
               -o models/ldm/stable-diffusion-v1/model.ckpt \
-              -O -L ${{ matrix.stable-diffusion-model }}
+              -L ${{ matrix.stable-diffusion-model }}
 
       - name: Activate Conda Env
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -71,7 +71,8 @@ jobs:
           [[ -d models/ldm/stable-diffusion-v1 ]] \
             || mkdir -p models/ldm/stable-diffusion-v1
           [[ -r models/ldm/stable-diffusion-v1/model.ckpt ]] \
-            || curl --user "${{ secrets.HUGGINGFACE_TOKEN }}" \
+            || curl \
+              -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" \
               -o models/ldm/stable-diffusion-v1/model.ckpt \
               -O -L ${{ matrix.stable-diffusion-model }}
 


### PR DESCRIPTION
use propper bearer authentication to download the stable-diffusion model from huggingface.co, instead of `--user "username:token"`

@lstein: This should be even easier to reproduce, since the there should be only the huggingface token in `secrets.HUGGINGFACE_TOKEN` (but no linebreak in the end, so only `hf_blablalba`)

Also removeing -O since we don't want a file with original name as output, but already defined a outputfile