### PR TITLE
Hires problems at low strength.

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -234,6 +234,8 @@ class Args(object):
             switches.append('--seamless')
         if a['hires_fix']:
             switches.append('--hires_fix')
+            if a['strength'] and a['strength']>0:
+                switches.append(f'-f {a["strength"]}')
 
         # img2img generations have parameters relevant only to them and have special handling
         if a['init_img'] and len(a['init_img'])>0:

--- a/ldm/invoke/generator/txt2img2img.py
+++ b/ldm/invoke/generator/txt2img2img.py
@@ -10,6 +10,8 @@ from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.invoke.generator.omnibus import Omnibus
 from ldm.models.diffusion.shared_invokeai_diffusion import InvokeAIDiffuserComponent
 from PIL import Image
+from ldm.invoke.devices import choose_autocast
+from ldm.invoke.image_util import InitImageResizer
 
 class Txt2Img2Img(Generator):
     def __init__(self, model, precision):
@@ -44,16 +46,13 @@ class Txt2Img2Img(Generator):
                     ddim_num_steps=steps, ddim_eta=ddim_eta, verbose=False
             )
 
-            #x = self.get_noise(init_width, init_height)
-            x = x_T
-
             if self.free_gpu_mem and self.model.model.device != self.model.device:
                 self.model.model.to(self.model.device)
 
             samples, _ = sampler.sample(
                 batch_size                   = 1,
                 S                            = steps,
-                x_T                          = x,
+                x_T                          = x_T,
                 conditioning                 = c,
                 shape                        = shape,
                 verbose                      = False,
@@ -69,11 +68,21 @@ class Txt2Img2Img(Generator):
                  )
 
             # resizing
-            samples = torch.nn.functional.interpolate(
-                samples,
-                size=(height // self.downsampling_factor, width // self.downsampling_factor),
-                mode="bilinear"
-            )
+
+            image = self.sample_to_image(samples)
+            image = InitImageResizer(image).resize(width, height)
+
+            image = np.array(image).astype(np.float32) / 255.0
+            image = image[None].transpose(0, 3, 1, 2)
+            image = torch.from_numpy(image)
+            image = 2.0 * image - 1.0
+            image = image.to(self.model.device)
+
+            scope = choose_autocast(self.precision)
+            with scope(self.model.device.type):
+                samples = self.model.get_first_stage_encoding(
+                    self.model.encode_first_stage(image)
+                ) # move back to latent space
 
             t_enc = int(strength * steps)
             ddim_sampler = DDIMSampler(self.model, device=self.model.device)


### PR DESCRIPTION
I've been playing around with the hires option.

My impression was that it should produce the same thing as doing the small image generation and then img2img with `--fit` and the larger H/W. 

```
bacon sushi -s 100 -S1
bacon sushi -s 100 -S1 -I outputs/img-samples/000001.1.png -H 1024 -W 1024 --fit
```
![000002 1](https://user-images.githubusercontent.com/244130/198860968-8d9fdce2-6e5e-45b4-9c5d-80ba559b5da0.png)

should do the same thing as

```
bacon sushi -s 100 -S1 -H 1024 -W 1024 --hires_fix
```
![000003 1](https://user-images.githubusercontent.com/244130/198860964-33c88679-600c-49ee-bc67-3a9ffe1cc0cf.png)

It's close but not the same.

However when I tried adding a low strength value, things got weird.
```
bacon sushi -s 100 -S1 -H 1024 -W 1024 --hires_fix --strength 0.01
```
gave me a blurry mess:
![000007 1](https://user-images.githubusercontent.com/244130/198860614-ac134f5a-e55c-4e5a-9ded-a90497d350c0.png)

Compared to
```
bacon sushi -s 100 -S1 -I outputs/img-samples/000001.1.png -H 1024 -W 1024 --fit --strength 0.01
```
![000006 1](https://user-images.githubusercontent.com/244130/198860638-498e142b-50c4-41c4-905d-3cd684b20507.png)

My suspicion is that it looks like it was way downscaled before being upscaled, so I tried converting it out to an image for the resizing and then back to samples, and it looks pretty close to the two step version.

```
# with the PR
bacon sushi -s 100 -S1 -H 1024 -W 1024 --hires_fix --strength 0.01
```
![000007 1](https://user-images.githubusercontent.com/244130/198860757-6beefebd-9dc1-4e6b-9d8c-0f6fc52d967f.png)

and the high strength version matches the two step version as well:
```
# with the PR
bacon sushi -s 100 -S1 -H 1024 -W 1024 --hires_fix
```
![000003 1](https://user-images.githubusercontent.com/244130/198861222-7384fb0c-b9b6-4564-9f4b-6625c273f424.png)


Small version for ref:
![000001 1](https://user-images.githubusercontent.com/244130/198860820-aa09e236-e2ff-4190-b18a-bae2b281eec1.png)

----
I also added `strength` to the metadata when `hires_fix` is present.

I'm a noob at python and ML, so it wouldn't surprise me if there was a better way to fix this. I mainly was copying bits from other places in the app.

