### PR TITLE
Fix minor training bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -918,7 +918,7 @@ if __name__ == '__main__':
             config.model.base_learning_rate,
         )
         if not cpu:
-            ngpu = len(lightning_config.trainer.gpus.strip(',').split(','))
+            ngpu = len(str(lightning_config.trainer.gpus).strip(',').split(','))
         else:
             ngpu = 1
         if 'accumulate_grad_batches' in lightning_config.trainer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ opencv-python
 pillow
 pip>=22
 pudb
-pytorch-lightning
+pytorch-lightning==1.6.5
 scikit-image>=0.19
 streamlit
 pyreadline3


### PR DESCRIPTION
* **peg pytorch-lightning version to 1.6.5 to prevent bug TestTubeLogger errors during training**
It might not be the best solution to set the pytorch-lightning to a static version, but it works as a bugfix until an enhancement is merged.
* **coerce lightning_config.trainer.gpus to string so it does not cause error when it is an int**

Fixes #1168 and #773 