### PR TITLE
Option to directly invert the grayscale heatmap - fix

### DIFF
--- a/ldm/invoke/txt2mask.py
+++ b/ldm/invoke/txt2mask.py
@@ -44,7 +44,7 @@ class SegmentedGrayscale(object):
         self.image = image
         
     def to_grayscale(self,invert:bool=False)->Image:
-        return self._rescale(Image.fromarray(np.uint8((255 if invert else 0) - self.heatmap * 255)))
+        return self._rescale(Image.fromarray(np.uint8(255 - self.heatmap * 255 if invert else self.heatmap * 255)))
 
     def to_mask(self,threshold:float=0.5)->Image:
         discrete_heatmap = self.heatmap.lt(threshold).int()


### PR DESCRIPTION
Tested with `!mask outputs/img-samples/000025.2634654006.png -tm hair`

selected
![000026 000025 2634654006 hair selected](https://user-images.githubusercontent.com/75758219/199360443-4e89fdb8-97c5-43e8-b0b1-a82b5d241800.png)

deselected
![000026 000025 2634654006 hair deselected](https://user-images.githubusercontent.com/75758219/199360439-c1c4f2cf-0550-4d8d-936e-4129c7406aa7.png)

masked
![000026 000025 2634654006 hair masked](https://user-images.githubusercontent.com/75758219/199360441-b1bca204-bb80-43cc-88e8-051e24d8f65e.png)

