### PR TITLE
Prevent outcrop error when no callback is supplied

### DIFF
--- a/ldm/invoke/restoration/outcrop.py
+++ b/ldm/invoke/restoration/outcrop.py
@@ -32,7 +32,7 @@ class Outcrop(object):
 
         result= self.generate.prompt2image(
             orig_opt.prompt,
-            seed        = orig_opt.seed,    # uncomment to make it deterministic
+            seed        = orig_opt.seed,    # uncomment to make it non-deterministic
             sampler     = self.generate.sampler,
             steps       = opt.steps,
             cfg_scale   = opt.cfg_scale,
@@ -41,7 +41,7 @@ class Outcrop(object):
             height      = extended_image.height,
             init_img    = extended_image,
             strength    = 0.90,
-            image_callback = wrapped_callback,
+            image_callback = wrapped_callback if image_callback else None,
             seam_size = opt.seam_size or 96,
             seam_blur = opt.seam_blur or 16,
             seam_strength = opt.seam_strength or 0.7,

--- a/ldm/invoke/restoration/outcrop.py
+++ b/ldm/invoke/restoration/outcrop.py
@@ -32,7 +32,7 @@ class Outcrop(object):
 
         result= self.generate.prompt2image(
             orig_opt.prompt,
-            seed        = orig_opt.seed,    # uncomment to make it non-deterministic
+            seed        = orig_opt.seed,    # uncomment to make it deterministic
             sampler     = self.generate.sampler,
             steps       = opt.steps,
             cfg_scale   = opt.cfg_scale,


### PR DESCRIPTION
```
│    28 │   │   self.generate._set_sampler()                                   │
│    29 │   │                                                                  │
│    30 │   │   def wrapped_callback(img,seed,**kwargs):                       │
│ ❱  31 │   │   │   image_callback(img,orig_opt.seed,use_prefix=prefix,**kwarg │
│    32 │   │                                                                  │
│    33 │   │   result= self.generate.prompt2image(                            │
│    34 │   │   │   orig_opt.prompt,                                           │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: 'NoneType' object is not callable
```