### PR TITLE
Web UI:  Add configurable save_intermediates settings dialog #1213

### DIFF
--- a/frontend/src/common/util/parameterTranslation.ts
+++ b/frontend/src/common/util/parameterTranslation.ts
@@ -62,7 +62,7 @@ export const frontendToBackendParameters = (
     shouldRandomizeSeed,
   } = optionsState;
 
-  const { shouldDisplayInProgressType } = systemState;
+  const { shouldDisplayInProgressType, saveIntermediates } = systemState;
 
   const generationParameters: { [k: string]: any } = {
     prompt,
@@ -76,7 +76,8 @@ export const frontendToBackendParameters = (
     sampler_name: sampler,
     seed,
     progress_images: shouldDisplayInProgressType === 'full-res',
-    progress_latents: shouldDisplayInProgressType === 'latents'
+    progress_latents: shouldDisplayInProgressType === 'latents',
+    save_intermediates: saveIntermediates,
   };
 
   generationParameters.seed = shouldRandomizeSeed

--- a/frontend/src/features/system/SettingsModal/SettingsModal.tsx
+++ b/frontend/src/features/system/SettingsModal/SettingsModal.tsx
@@ -15,9 +15,10 @@ import {
 import { createSelector } from '@reduxjs/toolkit';
 import _, { isEqual } from 'lodash';
 import { cloneElement, ReactElement } from 'react';
-import { RootState, useAppSelector } from '../../../app/store';
+import { RootState, useAppDispatch, useAppSelector } from '../../../app/store';
 import { persistor } from '../../../main';
 import {
+  setSaveIntermediates,
   setShouldConfirmOnDelete,
   setShouldDisplayGuides,
   setShouldDisplayInProgressType,
@@ -26,6 +27,7 @@ import {
 import ModelList from './ModelList';
 import { SettingsModalItem, SettingsModalSelectItem } from './SettingsModalItem';
 import { IN_PROGRESS_IMAGE_TYPES } from '../../../app/constants';
+import IAINumberInput from '../../../common/components/IAINumberInput';
 
 const systemSelector = createSelector(
   (state: RootState) => state.system,
@@ -60,6 +62,9 @@ type SettingsModalProps = {
  * Secondary post-reset modal is included here.
  */
 const SettingsModal = ({ children }: SettingsModalProps) => {
+  const dispatch = useAppDispatch();
+  const saveIntermediates = useAppSelector((state: RootState) => state.system.saveIntermediates)
+  const steps = useAppSelector((state: RootState) => state.options.steps);
   const {
     isOpen: isSettingsModalOpen,
     onOpen: onSettingsModalOpen,
@@ -77,6 +82,8 @@ const SettingsModal = ({ children }: SettingsModalProps) => {
     shouldConfirmOnDelete,
     shouldDisplayGuides,
   } = useAppSelector(systemSelector);
+
+  const handleChangeSteps = (value: number) => dispatch(setSaveIntermediates(value));
 
   /**
    * Resets localstorage, then opens a secondary modal informing user to
@@ -121,6 +128,18 @@ const SettingsModal = ({ children }: SettingsModalProps) => {
                 settingTitle="Display Help Icons"
                 isChecked={shouldDisplayGuides}
                 dispatcher={setShouldDisplayGuides}
+              />
+
+              <IAINumberInput
+                styleClass="save-intermediates"
+                label="Save images every n steps"
+                min={1}
+                max={steps - 1}
+                step={1}
+                onChange={handleChangeSteps}
+                value={saveIntermediates}
+                width="auto"
+                textAlign="center"
               />
             </div>
 

--- a/frontend/src/features/system/systemSlice.ts
+++ b/frontend/src/features/system/systemSlice.ts
@@ -34,6 +34,7 @@ export interface SystemState
   currentStatus: string;
   currentStatusHasSteps: boolean;
   shouldDisplayGuides: boolean;
+  saveIntermediates: number;
   wasErrorSeen: boolean;
   isCancelable: boolean;
 }
@@ -45,6 +46,7 @@ const initialSystemState = {
   shouldShowLogViewer: false,
   shouldDisplayInProgressType: "none",
   shouldDisplayGuides: true,
+  saveIntermediates: 5,
   isGFPGANAvailable: true,
   isESRGANAvailable: true,
   socketId: '',
@@ -81,6 +83,9 @@ export const systemSlice = createSlice({
     },
     setCurrentStatus: (state, action: PayloadAction<string>) => {
       state.currentStatus = action.payload;
+    },
+    setSaveIntermediates: (state, action: PayloadAction<number>) => {
+      state.saveIntermediates = action.payload;
     },
     setSystemStatus: (state, action: PayloadAction<InvokeAI.SystemStatus>) => {
       return { ...state, ...action.payload };
@@ -183,6 +188,7 @@ export const systemSlice = createSlice({
 
 export const {
   setShouldDisplayInProgressType,
+  setSaveIntermediates,
   setIsProcessing,
   addLogEntry,
   setShouldShowLogViewer,


### PR DESCRIPTION
Add `save_intermediate` option in settings dialog.

![image](https://user-images.githubusercontent.com/5537428/199479166-65c90df5-b495-4620-8d76-d979328f6112.png)
