### PR TITLE
Restore reproducibility when steps is not multiple of 3

### DIFF
--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -89,7 +89,6 @@ def make_ddim_timesteps(
     # assert ddim_timesteps.shape[0] == num_ddim_timesteps
     # add one to get the final alpha values right (the ones from first scale to data during sampling)
     steps_out = ddim_timesteps + 1
-    # steps_out = ddim_timesteps
 
     if verbose:
         print(f'Selected timesteps for ddim sampler: {steps_out}')

--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -66,7 +66,12 @@ def make_ddim_timesteps(
         c = num_ddpm_timesteps // num_ddim_timesteps
         if c < 1:
           c = 1
-        ddim_timesteps = (np.arange(0, num_ddim_timesteps) * c).astype(int)
+        
+        # remove 1 final step when num_ddim_timesteps is multiple of 3 to prevent index out of bound error
+        if num_ddim_timesteps % 3 == 0:
+            ddim_timesteps = np.asarray(list(range(0, num_ddpm_timesteps, c)))[:-1]
+        else:
+            ddim_timesteps = np.asarray(list(range(0, num_ddpm_timesteps, c)))
     elif ddim_discr_method == 'quad':
         ddim_timesteps = (
             (


### PR DESCRIPTION
An update to issue #1254 that occurred after fixing the out of bound error #1137, this PR will restore the reproducibility for steps that is not multiple of 3.

Also, the new implementation is based on array slicing instead of `np.arrange` for better readability and performance (I have bench-marked both methods with `timeit` module and the array slicing method is slightly faster)