### PR TITLE
Fix for parser error doing `.swap` on any empty target `()`

### DIFF
--- a/ldm/invoke/prompt_parser.py
+++ b/ldm/invoke/prompt_parser.py
@@ -143,7 +143,7 @@ class CrossAttentionControlSubstitute(CrossAttentionControlledFragment):
         ])
     """
     def __init__(self, original: list, edited: list, options: dict=None):
-        self.original = original
+        self.original = original if len(original)>0 else [Fragment('')]
         self.edited = edited if len(edited)>0 else [Fragment('')]
 
         default_options = {

--- a/tests/test_prompt_parser.py
+++ b/tests/test_prompt_parser.py
@@ -274,6 +274,9 @@ class PromptParserTestCase(unittest.TestCase):
                          parse_prompt('a forest landscape "".swap("in winter")'))
         self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a forest landscape', 1),
                                                                    CrossAttentionControlSubstitute([Fragment('',1)], [Fragment('in winter',1)])])]),
+                         parse_prompt('a forest landscape ().swap(in winter)'))
+        self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a forest landscape', 1),
+                                                                   CrossAttentionControlSubstitute([Fragment('',1)], [Fragment('in winter',1)])])]),
                          parse_prompt('a forest landscape " ".swap("in winter")'))
 
         self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a forest landscape', 1),


### PR DESCRIPTION
With the current parser logic, `a fantasy forest landscape "".swap("in winter")` works but `a fantasy forest landscape ().swap("in winter")` (note empty parentheses) does not. 

These should both work. This pull request fixes that.