### PR TITLE
HOTFIX: fix Windows library dependency issues

### DIFF
--- a/requirements-lin-win-colab-CUDA.txt
+++ b/requirements-lin-win-colab-CUDA.txt
@@ -2,6 +2,6 @@
 
 # Get hardware-appropriate torch/torchvision 
 --extra-index-url https://download.pytorch.org/whl/cu116 --trusted-host https://download.pytorch.org
-torch
-torchvision
+torch==1.12.1
+torchvision==0.13.1
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,6 @@ realesrgan
 diffusers
 git+https://github.com/openai/CLIP.git@main#egg=clip
 git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion
-git+https://github.com/TencentARC/GFPGAN.git#egg=gfpgan
+git+https://github.com/invoke-ai/Real-ESRGAN.git#egg=realesrgan
+git+https://github.com/invoke-ai/GFPGAN.git#egg=gfpgan
 -e git+https://github.com/invoke-ai/clipseg.git@models-rename#egg=clipseg


### PR DESCRIPTION
This commit addresses two bugs:

1) invokeai.py crashes immediately with a message about an undefined
   attritube sigKILL (closes #1288). The fix is to pin torch at 1.12.1.

2) Version 1.4.2 of basicsr fails to load properly on Windows, and is
   a requirement of realesrgan, however 1.4.1 works. Pinning basicsr
   in our requirements file resulted in a dependency conflict, so I
   ended up cloning realesrgan into the invoke-ai Git space and changing
   the requirements file there.

If there is a more elegant solution, please advise. 

This PR needs testing on a Windows platform. Both a desktop install and the docker build need to be tested. I will wait until I get positive confirmation before merging.