### PR TITLE
remove --no_interactive from preload_scripts.py example

### DIFF
--- a/docs/installation/INSTALL_MAC.md
+++ b/docs/installation/INSTALL_MAC.md
@@ -119,7 +119,7 @@ will do our best to help.
     ```bash
     # This will take some time, depending on the speed of your internet connection
     # and will consume about 10GB of space
-    python scripts/preload_models.py --no-interactive
+    python scripts/preload_models.py
     ```
 
 !!! todo "Run InvokeAI!"


### PR DESCRIPTION
Instructions tell user to use the --no_interactive flag, but this will bypass the model downloading step. This flag was intended for use in automated scripts such as CI workflows.