### PR TITLE
Fix WebUI Image Generation Being Broken

### DIFF
--- a/backend/invoke_ai_web_server.py
+++ b/backend/invoke_ai_web_server.py
@@ -617,7 +617,7 @@ class InvokeAIWebServer:
                 if (
                     generation_parameters["progress_images"]
                     and step % generation_parameters['save_intermediates'] == 0
-                    and step < generation_parameters["steps"] - 1
+                    and step < generation_parameters["steps"]
                 ):
                     image = self.generate.sample_to_image(sample)
                     metadata = self.parameters_to_generated_image_metadata(


### PR DESCRIPTION
#1357 accounts for the indexing in the python script itself. But this inadvertently broke the web server that does the same leading to an out of bounds error. Fixing it.
