### PR TITLE
Support inpainting at a different size than the input image

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -299,6 +299,9 @@ class Generate:
             upscale          = None,
             # this is specific to inpainting and causes more extreme inpainting
             inpaint_replace  = 0.0,
+            # This controls the size at which inpaint occurs (scaled up for inpaint, then back down for the result)
+            inpaint_width    = None,
+            inpaint_height   = None,
             # This will help match inpainted areas to the original image more smoothly
             mask_blur_radius: int = 8,
             # Set this True to handle KeyboardInterrupt internally
@@ -490,7 +493,9 @@ class Generate:
                 seam_strength = seam_strength,
                 seam_steps = seam_steps,
                 tile_size = tile_size,
-                force_outpaint = force_outpaint
+                force_outpaint = force_outpaint,
+                inpaint_width  = inpaint_width,
+                inpaint_height = inpaint_height
             )
 
             if init_color:

--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -160,6 +160,9 @@ class Inpaint(Img2Img):
         the time you call it.  kwargs are 'init_latent' and 'strength'
         """
 
+        self.inpaint_width = inpaint_width
+        self.inpaint_height = inpaint_height
+
         if isinstance(init_image, PIL.Image.Image):
             self.pil_image = init_image
 
@@ -253,10 +256,6 @@ class Inpaint(Img2Img):
 
             result = self.sample_to_image(samples)
 
-            # Resize if necessary
-            if inpaint_width and inpaint_height:
-                result = result.resize(self.pil_image.size)
-
             # Seam paint if this is our first pass (seam_size set to 0 during seam painting)
             if seam_size > 0:
                 result = self.seam_paint(
@@ -322,6 +321,10 @@ class Inpaint(Img2Img):
 
     def sample_to_image(self, samples)->Image.Image:
         gen_result = super().sample_to_image(samples).convert('RGB')
+
+        # Resize if necessary
+        if self.inpaint_width and self.inpaint_height:
+            gen_result = gen_result.resize(self.pil_image.size)
 
         if self.pil_image is None or self.pil_mask is None:
             return gen_result


### PR DESCRIPTION
Supports optionally resizing the image to a larger resolution for inpainting, then scaling back down before color correction and recombination. Produces better results when inpainting small areas.