### PR TITLE
[Web UI] Load models on connect

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -81,10 +81,6 @@ const App = () => {
   const { shouldShowGalleryButton, shouldShowOptionsPanelButton } =
     useAppSelector(appSelector);
 
-  useEffect(() => {
-    dispatch(requestSystemConfig());
-  }, [dispatch]);
-
   return (
     <div className="App">
       <ImageUploader>

--- a/frontend/src/app/socketio/listeners.ts
+++ b/frontend/src/app/socketio/listeners.ts
@@ -32,7 +32,7 @@ import {
   setInitialImage,
   setMaskPath,
 } from '../../features/options/optionsSlice';
-import { requestImages, requestNewImages } from './actions';
+import { requestImages, requestNewImages, requestSystemConfig } from './actions';
 import {
   clearImageToInpaint,
   setImageToInpaint,
@@ -56,6 +56,7 @@ const makeSocketIOListeners = (
       try {
         dispatch(setIsConnected(true));
         dispatch(setCurrentStatus('Connected'));
+        dispatch(requestSystemConfig());
         const gallery: GalleryState = getState().gallery;
 
         if (gallery.categories.user.latest_mtime) {


### PR DESCRIPTION
Web UI now loads models when it reconnects, allowing users to not need to refresh the page if they add a new model or change a default and restart the server.