### PR TITLE
fix invoke.py crash if no models.yaml file present

### DIFF
--- a/ldm/invoke/readline.py
+++ b/ldm/invoke/readline.py
@@ -284,6 +284,7 @@ class Completer(object):
             switch,partial_path  = match.groups()
         partial_path = partial_path.lstrip()
 
+
         matches = list()
         path = os.path.expanduser(partial_path)
 
@@ -321,6 +322,7 @@ class Completer(object):
                 matches.append(
                     switch+os.path.join(os.path.dirname(full_path), node)
                 )
+
         return matches
 
 class DummyCompleter(Completer):


### PR DESCRIPTION
- Script will now offer the user the ability to create a minimal models.yaml and then gracefully exit.
- Closes #1420

This is not the most graceful implementation, but it works in a pinch.