### PR TITLE
Remove gfpgan_dir

### DIFF
--- a/docs/features/CLI.md
+++ b/docs/features/CLI.md
@@ -99,8 +99,7 @@ overridden on a per-prompt basis (see
 | `--sampler <sampler>`                     | `-A<sampler>`                             | `k_lms`                                        | Sampler to use. Use `-h` to get list of available samplers.                                          |
 | `--seamless`                              |                                           | `False`                                        | Create interesting effects by tiling elements of the image.                                          |
 | `--embedding_path <path>`                 |                                           | `None`                                         | Path to pre-trained embedding manager checkpoints, for custom models                                 |
-| `--gfpgan_dir`                            |                                           | `src/gfpgan`                                   | Path to where GFPGAN is installed.                                                                   |
-| `--gfpgan_model_path`                     |                                           | `experiments/pretrained_models/GFPGANv1.4.pth` | Path to GFPGAN model file, relative to `--gfpgan_dir`.                                               |
+| `--gfpgan_model_path`                     |                                           | `experiments/pretrained_models/GFPGANv1.4.pth` | Path to GFPGAN model file.                                              |
 | `--free_gpu_mem`                          |                                           | `False`                                        | Free GPU memory after sampling, to allow image decoding and saving in low VRAM conditions            |
 | `--precision`                             |                                           | `auto`                                         | Set model precision, default is selected by device. Options: auto, float32, float16, autocast        |
 

--- a/docs/features/POSTPROCESS.md
+++ b/docs/features/POSTPROCESS.md
@@ -6,48 +6,38 @@ title: Postprocessing
 
 ## Intro
 
-This extension provides the ability to restore faces and upscale
-images.
+This extension provides the ability to restore faces and upscale images.
 
-Face restoration and upscaling can be applied at the time you generate
-the images, or at any later time against a previously-generated PNG
-file, using the [!fix](#fixing-previously-generated-images)
-command. [Outpainting and outcropping](OUTPAINTING.md) can only be
-applied after the fact.
+Face restoration and upscaling can be applied at the time you generate the
+images, or at any later time against a previously-generated PNG file, using the
+[!fix](#fixing-previously-generated-images) command.
+[Outpainting and outcropping](OUTPAINTING.md) can only be applied after the
+fact.
 
 ## Face Fixing
 
 The default face restoration module is GFPGAN. The default upscale is
-Real-ESRGAN. For an alternative face restoration module, see [CodeFormer
-Support](#codeformer-support) below.
+Real-ESRGAN. For an alternative face restoration module, see
+[CodeFormer Support](#codeformer-support) below.
 
-As of version 1.14, environment.yaml will install the Real-ESRGAN
-package into the standard install location for python packages, and
-will put GFPGAN into a subdirectory of "src" in the InvokeAI
-directory. Upscaling with Real-ESRGAN should "just work" without
-further intervention. Simply pass the `--upscale` (`-U`) option on the
-`invoke>` command line, or indicate the desired scale on the popup in
-the Web GUI.
+As of version 1.14, environment.yaml will install the Real-ESRGAN package into
+the standard install location for python packages, and will put GFPGAN into a
+subdirectory of "src" in the InvokeAI directory. Upscaling with Real-ESRGAN
+should "just work" without further intervention. Simply pass the `--upscale`
+(`-U`) option on the `invoke>` command line, or indicate the desired scale on
+the popup in the Web GUI.
 
-**GFPGAN** requires a series of downloadable model files to
-work. These are loaded when you run `scripts/preload_models.py`. If
-GFPAN is failing with an error, please run the following from the
-InvokeAI directory:
+**GFPGAN** requires a series of downloadable model files to work. These are
+loaded when you run `scripts/preload_models.py`. If GFPAN is failing with an
+error, please run the following from the InvokeAI directory:
 
 ```bash
 python scripts/preload_models.py
 ```
 
-If you do not run this script in advance, the GFPGAN module will attempt
-to download the models files the first time you try to perform facial
+If you do not run this script in advance, the GFPGAN module will attempt to
+download the models files the first time you try to perform facial
 reconstruction.
-
-Alternatively, if you have GFPGAN installed elsewhere, or if you are
-using an earlier version of this package which asked you to install
-GFPGAN in a sibling directory, you may use the `--gfpgan_dir` argument
-with `invoke.py` to set a custom path to your GFPGAN directory. _There
-are other GFPGAN related boot arguments if you wish to customize
-further._
 
 ## Usage
 
@@ -119,15 +109,15 @@ actions.
 This repo also allows you to perform face restoration using
 [CodeFormer](https://github.com/sczhou/CodeFormer).
 
-In order to setup CodeFormer to work, you need to download the models
-like with GFPGAN. You can do this either by running
-`preload_models.py` or by manually downloading the [model
-file](https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth)
+In order to setup CodeFormer to work, you need to download the models like with
+GFPGAN. You can do this either by running `preload_models.py` or by manually
+downloading the
+[model file](https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth)
 and saving it to `ldm/invoke/restoration/codeformer/weights` folder.
 
-You can use `-ft` prompt argument to swap between CodeFormer and the
-default GFPGAN. The above mentioned `-G` prompt argument will allow
-you to control the strength of the restoration effect.
+You can use `-ft` prompt argument to swap between CodeFormer and the default
+GFPGAN. The above mentioned `-G` prompt argument will allow you to control the
+strength of the restoration effect.
 
 ### Usage
 
@@ -157,9 +147,9 @@ situations when there is very little facial data to work with.
 ## Fixing Previously-Generated Images
 
 It is easy to apply face restoration and/or upscaling to any
-previously-generated file. Just use the syntax `!fix path/to/file.png
-<options>`. For example, to apply GFPGAN at strength 0.8 and upscale
-2X for a file named `./outputs/img-samples/000044.2945021133.png`,
+previously-generated file. Just use the syntax
+`!fix path/to/file.png <options>`. For example, to apply GFPGAN at strength 0.8
+and upscale 2X for a file named `./outputs/img-samples/000044.2945021133.png`,
 just run:
 
 ```bash

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -552,14 +552,8 @@ class Args(object):
         postprocessing_group.add_argument(
             '--gfpgan_model_path',
             type=str,
-            default='experiments/pretrained_models/GFPGANv1.4.pth',
-            help='Indicates the path to the GFPGAN model, relative to --gfpgan_dir.',
-        )
-        postprocessing_group.add_argument(
-            '--gfpgan_dir',
-            type=str,
-            default='./src/gfpgan',
-            help='Indicates the directory containing the GFPGAN code.',
+            default='./models/gfpgan/GFPGANv1.4.pth',
+            help='Indicates the path to the GFPGAN model',
         )
         web_server_group.add_argument(
             '--web',

--- a/ldm/invoke/restoration/base.py
+++ b/ldm/invoke/restoration/base.py
@@ -2,9 +2,9 @@ class Restoration():
     def __init__(self) -> None:
         pass
 
-    def load_face_restore_models(self, gfpgan_dir='./src/gfpgan', gfpgan_model_path='experiments/pretrained_models/GFPGANv1.4.pth'):
+    def load_face_restore_models(self, gfpgan_model_path='./models/gfpgan/GFPGANv1.4.pth'):
         # Load GFPGAN
-        gfpgan = self.load_gfpgan(gfpgan_dir, gfpgan_model_path)
+        gfpgan = self.load_gfpgan(gfpgan_model_path)
         if gfpgan.gfpgan_model_exists:
             print('>> GFPGAN Initialized')
         else:
@@ -22,9 +22,9 @@ class Restoration():
         return gfpgan, codeformer
 
     # Face Restore Models
-    def load_gfpgan(self, gfpgan_dir, gfpgan_model_path):
+    def load_gfpgan(self, gfpgan_model_path):
         from ldm.invoke.restoration.gfpgan import GFPGAN
-        return GFPGAN(gfpgan_dir, gfpgan_model_path)
+        return GFPGAN(gfpgan_model_path)
 
     def load_codeformer(self):
         from ldm.invoke.restoration.codeformer import CodeFormerRestoration

--- a/ldm/invoke/restoration/gfpgan.py
+++ b/ldm/invoke/restoration/gfpgan.py
@@ -10,16 +10,14 @@ from PIL import Image
 class GFPGAN():
     def __init__(
             self,
-            gfpgan_dir='src/gfpgan',
-            gfpgan_model_path='experiments/pretrained_models/GFPGANv1.4.pth') -> None:
+            gfpgan_model_path='./models/gfpgan/GFPGANv1.4.pth') -> None:
 
-        self.model_path = os.path.join(gfpgan_dir, gfpgan_model_path)
+        self.model_path = os.path.join(gfpgan_model_path)
         self.gfpgan_model_exists = os.path.isfile(self.model_path)
 
         if not self.gfpgan_model_exists:
             print('## NOT FOUND: GFPGAN model not found at ' + self.model_path)
             return None
-        sys.path.append(os.path.abspath(gfpgan_dir))
 
     def model_exists(self):
         return os.path.isfile(self.model_path)
@@ -50,7 +48,7 @@ class GFPGAN():
                 f'>> WARNING: GFPGAN not initialized.'
             )
             print(
-                f'>> Download https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth to {self.model_path}, \nor change GFPGAN directory with --gfpgan_dir.'
+                f'>> Download https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth to {self.model_path}'
             )
 
         image = image.convert('RGB')

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -804,7 +804,7 @@ def load_face_restoration(opt):
             from ldm.invoke.restoration import Restoration
             restoration = Restoration()
             if opt.restore:
-                gfpgan, codeformer = restoration.load_face_restore_models(opt.gfpgan_dir, opt.gfpgan_model_path)
+                gfpgan, codeformer = restoration.load_face_restore_models(opt.gfpgan_model_path)
             else:
                 print('>> Face restoration disabled')
             if opt.esrgan:

--- a/scripts/legacy_api.py
+++ b/scripts/legacy_api.py
@@ -487,14 +487,8 @@ def create_argv_parser():
     parser.add_argument(
         '--gfpgan_model_path',
         type=str,
-        default='experiments/pretrained_models/GFPGANv1.3.pth',
-        help='Indicates the path to the GFPGAN model, relative to --gfpgan_dir.',
-    )
-    parser.add_argument(
-        '--gfpgan_dir',
-        type=str,
-        default='./src/gfpgan',
-        help='Indicates the directory containing the GFPGAN code.',
+        default='./models/gfpgan/GFPGANv1.4.pth',
+        help='Indicates the path to the GFPGAN model.',
     )
     parser.add_argument(
         '--web',

--- a/scripts/preload_models.py
+++ b/scripts/preload_models.py
@@ -446,15 +446,15 @@ def download_gfpgan():
     for model in (
             [
                 'https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth',
-                'src/gfpgan/experiments/pretrained_models/GFPGANv1.4.pth'
+                './models/gfpgan/GFPGANv1.4.pth'
             ],
             [
                 'https://github.com/xinntao/facexlib/releases/download/v0.1.0/detection_Resnet50_Final.pth',
-                './gfpgan/weights/detection_Resnet50_Final.pth'
+                './models/gfpgan/weights/detection_Resnet50_Final.pth'
             ],
             [
                 'https://github.com/xinntao/facexlib/releases/download/v0.2.2/parsing_parsenet.pth',
-                './gfpgan/weights/parsing_parsenet.pth'
+                './models/gfpgan/weights/parsing_parsenet.pth'
             ],
     ):
         model_url,model_dest  = model


### PR DESCRIPTION
gfpgan_dir is no longer needed because we are now installing gfpgan directly to the env. The user can just pass the path to the model file directly now using `--gfpgan_model_path` if they want to use a custom path for the checkpoint.