### PR TITLE
prevent two models from being marked default in models.yaml

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -109,10 +109,13 @@ class ModelCache(object):
         Set the default model. The change will not take
         effect until you call model_cache.commit()
         '''
+        print(f'DEBUG: before set_default_model()\n{OmegaConf.to_yaml(self.config)}')
         assert model_name in self.models,f"unknown model '{model_name}'"
-        for model in self.models:
-            self.models[model].pop('default',None)
-        self.models[model_name]['default'] = True
+        config = self.config
+        for model in config:
+            config[model].pop('default',None)
+        config[model_name]['default'] = True
+        print(f'DEBUG: after set_default_model():\n{OmegaConf.to_yaml(self.config)}')
 
     def list_models(self) -> dict:
         '''

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -584,7 +584,7 @@ def write_config_file(conf_path, gen, model_name, new_config, clobber=False, mak
 
     try:
         print('>> Verifying that new model loads...')
-        yaml_str = gen.model_cache.add_model(model_name, new_config, clobber)
+        gen.model_cache.add_model(model_name, new_config, clobber)
         assert gen.set_model(model_name) is not None, 'model failed to load'
     except AssertionError as e:
         print(f'** aborting **')


### PR DESCRIPTION
Due to a logic bug, models imported via `!import_model` and marked `default=true` did not remove the default tag from the previous default model. This PR corrects this bug.