### PR TITLE
Fix perf issue from cache clear

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -282,7 +282,6 @@ class CrossAttention(nn.Module):
 
     def get_attention_mem_efficient(self, q, k, v):
         if q.device.type == 'cuda':
-            torch.cuda.empty_cache()
             #print("in get_attention_mem_efficient with q shape", q.shape, ", k shape", k.shape, ", free memory is", get_mem_free_total(q.device))
             return self.einsum_op_cuda(q, k, v)
 


### PR DESCRIPTION
Fixes #1426 by removing torch cuda clear, which didn't appear to be reducing VRAM usage, but was significantly impacting performance (e.g. this reduces generation time from 15s to 6s in my testing).