### PR TITLE
Optimized Docker image for cloud and local use, with external model cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,25 @@
 *
-!environment*.yml
+
+!backend
+!frontend
+!scripts
+!server
+!static
+!LICENSE*
+!main.py
+!setup.py
 !docker-build
+!ldm
+
+# Guard against pulling in any models that might exist in the directory tree
+**/*.pt*
+
+# unignore configs, but only ignore the custom models.yaml, in case it exists
+!configs
+configs/models.yaml
+
+# unignore environment dirs/files, but ignore the environment.yml file or symlink in case it exists
+!environment*
+environment.yml
+
+**/__pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !main.py
 !setup.py
 !docker-build
+docker-build/Dockerfile
 !ldm
 !installer
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !setup.py
 !docker-build
 !ldm
+!installer
 
 # Guard against pulling in any models that might exist in the directory tree
 **/*.pt*

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -1,9 +1,22 @@
-name: Build cloud image
+name: Build and push cloud image
 on:
+  workflow_dispatch:
   push:
-    # TEMP until PR is ready
     branches:
+    - main
+    - development
+    ## temp
     - docker-min
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
@@ -18,13 +31,30 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Build container
+
+    - if: github.event_name != 'pull_request'
+      name: Docker login
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push cloud image
       uses: docker/build-push-action@v3
       with:
         context: .
         file: docker-build/Dockerfile.cloud
         platforms: Linux/${{ matrix.arch }}
-        push: false
-        tags: local/invokeai:${{ matrix.arch }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -37,6 +37,11 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+          type=sha
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -1,0 +1,30 @@
+name: Build cloud image
+on:
+  push:
+    # TEMP until PR is ready
+    branches:
+    - docker-min
+
+jobs:
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        # only x86_64 for now. aarch64+cuda isn't really a thing yet
+        arch:
+        - x86_64
+    runs-on: ubuntu-latest
+    name: ${{ matrix.arch }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build container
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: docker-build/Dockerfile.cloud
+        platforms: Linux/${{ matrix.arch }}
+        push: false
+        tags: local/invokeai:${{ matrix.arch }}

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -1,13 +1,42 @@
 # Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
 
-FROM nvidia/cuda:11.7.1-runtime-ubuntu22.04 AS base
+#### Builder stage ####
+
+FROM library/ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
-# # no __pycache__ - unclear if there is a benefit
-# ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONDONTWRITEBYTECODE=1
 # unbuffered output, ensures stdout and stderr are printed in the correct order
 ENV PYTHONUNBUFFERED=1
 
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt update && apt install -y \
+    libglib2.0-0 \
+    libgl1-mesa-glx \
+    python3-venv \
+    python3-pip
+
+
+ARG APP_ROOT=/invokeai
+WORKDIR ${APP_ROOT}
+
+ENV VIRTUAL_ENV=${APP_ROOT}/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    cp installer/py3.10-linux-x86_64-cuda-reqs.txt requirements.txt && \
+    python3 -m venv ${VIRTUAL_ENV} &&\
+    pip install --extra-index-url https://download.pytorch.org/whl/cu116 \
+        torch==1.12.0+cu116 \
+        torchvision==0.13.0+cu116 &&\
+    pip install -r requirements.txt &&\
+    pip install -e .
+
+
+#### Runtime stage ####
+
+FROM ubuntu:22.04 as runtime
 RUN apt update && apt install -y \
     git \
     curl \
@@ -16,36 +45,18 @@ RUN apt update && apt install -y \
     bzip2 \
     libglib2.0-0 \
     libgl1-mesa-glx \
+    python3-venv \
+    python3-pip \
     && apt-get clean
 
-# Micromamba is a minimal conda implementation
-ENV MAMBA_ROOT_PREFIX=/opt/conda
-RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+ARG APP_ROOT=/invokeai
+WORKDIR ${APP_ROOT}
 
-WORKDIR /invokeai
+ENV VIRTUAL_ENV=${APP_ROOT}/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-### Cache the dependencies first
-# Avoid re-downloading the dependencies when unrelated files change in context
-#
-# We could use relative paths in the environment file, but it's not currently set up that way.
-# So we copy it to the working directory to maintain compatibility with other installation methods
-COPY environments-and-requirements/environment-lin-cuda.yml environment.yml
+COPY --from=builder ${APP_ROOT} ${APP_ROOT}
 
-# Patch the env file to remove installation of local package
-RUN sed -i '/-e \./d' environment.yml
-RUN micromamba create -y -f environment.yml &&\
-    micromamba clean --all -f -y &&\
-    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+ENTRYPOINT ["bash", "-c", "python3 scripts/invoke.py" ]
 
-### Copy the rest of the context and install local package
-COPY . .
-RUN micromamba -n invokeai run pip install -e .
-
-### Default model config
-RUN cp configs/models.yaml.example configs/models.yaml
-
-ENTRYPOINT ["bash"]
-
-EXPOSE 9090
-
-CMD [ "-c", "micromamba -r ${MAMBA_ROOT_PREFIX} -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"]
+CMD ["--web", "--host 0.0.0.0"]

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
+
+FROM nvidia/cuda:11.7.1-runtime-ubuntu22.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+# # no __pycache__ - unclear if there is a benefit
+# ENV PYTHONDONTWRITEBYTECODE=1
+# unbuffered output, ensures stdout and stderr are printed in the correct order
+ENV PYTHONUNBUFFERED=1
+
+RUN apt update && apt install -y \
+    git \
+    curl \
+    ncdu \
+    iotop \
+    bzip2 \
+    libglib2.0-0 \
+    libgl1-mesa-glx \
+    && apt-get clean
+
+# Micromamba is a minimal conda implementation
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+
+WORKDIR /invokeai
+
+### Cache the dependencies first
+# Avoid re-downloading the dependencies when unrelated files change in context
+#
+# We could use relative paths in the environment file, but it's not currently set up that way.
+# So we copy it to the working directory to maintain compatibility with other installation methods
+COPY environments-and-requirements/environment-lin-cuda.yml environment.yml
+
+# Patch the env file to remove installation of local package
+RUN sed -i '/-e \./d' environment.yml
+RUN micromamba create -y -f environment.yml &&\
+    micromamba clean --all -f -y &&\
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+
+### Copy the rest of the context and install local package
+COPY . .
+RUN micromamba -n invokeai run pip install -e .
+
+### Default model config
+RUN cp configs/models.yaml.example configs/models.yaml
+
+ENTRYPOINT ["bash"]
+
+EXPOSE 9090
+
+CMD [ "-c", "micromamba -r ${MAMBA_ROOT_PREFIX} -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"]

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -1,0 +1,56 @@
+# Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
+
+# InvokeAI root directory in the container
+INVOKEAI_ROOT=/invokeai
+# Destination directory for cache on the host
+INVOKEAI_CACHEDIR=${HOME}/invokeai
+
+DOCKER_BUILDKIT=1
+IMAGE=local/invokeai:latest
+
+# Downloads will end up in ${INVOKEAI_CACHEDIR}.
+# Contents can be moved to a persistent storage and used to rehydrate the cache,
+# to be mounted into the container.
+
+# TBD: cache dir may be modified at runtime due to checksum calculations
+# for custom models. Ideally the checksums would be precomputed and stored in the cache.
+# Also CLI requires RW on first run when populating torch cache.
+
+build:
+	docker buildx build -t local/invokeai:latest -f Dockerfile.cloud ..
+
+# Populate the cache. Config is copied first, so it's there for the model preload step.
+load-models: _copy-config
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
+		${IMAGE} \
+		-c "micromamba -r /opt/conda -n invokeai run python scripts/load_models.py"
+
+run:
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
+		--entrypoint bash -p9090:9090 \
+		${IMAGE} \
+		-c "micromamba -r /opt/conda -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"
+
+shell:
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
+		--entrypoint bash \
+		${IMAGE} --
+
+# This is an intermediate task that copies the contents of the config dir into the cache.
+# This prepares the cached config dir, so that when we run the model preload with the config mounted,
+# it is already populated.
+_copy-config:
+	docker run --rm -it \
+		-v ${INVOKEAI_CACHEDIR}/config:${INVOKEAI_ROOT}/tmp/config \
+		--workdir ${INVOKEAI_ROOT} \
+		--entrypoint bash ${IMAGE} \
+		-c "cp -r ./tmp/config/* ./config/"
+
+
+.PHONY: build preload run shell _copy-config

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -1,56 +1,52 @@
 # Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
 
-# InvokeAI root directory in the container
-INVOKEAI_ROOT=/invokeai
-# Destination directory for cache on the host
+# Directory in the container where the INVOKEAI_ROOT will be mounted
+INVOKEAI_ROOT=/mnt/invokeai
+# Host directory to contain the model cache. Will be mounted at INVOKEAI_ROOT path in the container
 INVOKEAI_CACHEDIR=${HOME}/invokeai
 
 DOCKER_BUILDKIT=1
 IMAGE=local/invokeai:latest
 
-# Downloads will end up in ${INVOKEAI_CACHEDIR}.
-# Contents can be moved to a persistent storage and used to rehydrate the cache,
-# to be mounted into the container.
+USER=$(shell id -u)
+GROUP=$(shell id -g)
 
-# TBD: cache dir may be modified at runtime due to checksum calculations
-# for custom models. Ideally the checksums would be precomputed and stored in the cache.
-# Also CLI requires RW on first run when populating torch cache.
+# All downloaded models and config will end up in ${INVOKEAI_CACHEDIR}.
+# Contents can be moved to a persistent storage and used to rehydrate the cache on another host
 
 build:
 	docker buildx build -t local/invokeai:latest -f Dockerfile.cloud ..
 
-# Populate the cache. Config is copied first, so it's there for the model preload step.
-load-models: _copy-config
+# Populate the cache.
+# First, pre-seed the config dir on the host with the content from the image,
+# such that the model preload step can run with the config mounted and pre-populated.
+# Then, run `load-models` to cache models, VAE, other static data.
+load-models:
+	docker run --rm -it \
+		-v ${INVOKEAI_CACHEDIR}/configs:/mnt/configs \
+		--entrypoint bash ${IMAGE} \
+		-c "cp -r ./configs/* /mnt/configs/"
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
-		${IMAGE} \
-		-c "micromamba -r /opt/conda -n invokeai run python scripts/load_models.py"
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		--entrypoint bash ${IMAGE} \
+		-c "micromamba -n invokeai run python scripts/load_models.py --root ${INVOKEAI_ROOT}"
+	sudo chown -R ${USER}:${GROUP} ${INVOKEAI_CACHEDIR}
 
+# Run the container with the cache mounted and the web server exposed on port 9090
 run:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
-		--entrypoint bash -p9090:9090 \
-		${IMAGE} \
-		-c "micromamba -r /opt/conda -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		--entrypoint bash -p9090:9090 ${IMAGE} \
+		-c "micromamba -n invokeai run python scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
 
+# Run the container with the cache mounted and open a bash shell instead of the Invoke CLI or webserver
 shell:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
-		--entrypoint bash \
-		${IMAGE} --
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
+		--entrypoint bash ${IMAGE} --
 
-# This is an intermediate task that copies the contents of the config dir into the cache.
-# This prepares the cached config dir, so that when we run the model preload with the config mounted,
-# it is already populated.
-_copy-config:
-	docker run --rm -it \
-		-v ${INVOKEAI_CACHEDIR}/config:${INVOKEAI_ROOT}/tmp/config \
-		--workdir ${INVOKEAI_ROOT} \
-		--entrypoint bash ${IMAGE} \
-		-c "cp -r ./tmp/config/* ./config/"
-
-
-.PHONY: build preload run shell _copy-config
+.PHONY: build preload run shell

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -15,13 +15,12 @@ GROUP=$(shell id -g)
 # Contents can be moved to a persistent storage and used to rehydrate the cache on another host
 
 build:
-	docker buildx build -t local/invokeai:latest -f Dockerfile.cloud ..
+	docker build -t local/invokeai:latest -f Dockerfile.cloud ..
 
-# Populate the cache.
-# First, pre-seed the config dir on the host with the content from the image,
-# such that the model preload step can run with the config mounted and pre-populated.
-# Then, run `load-models` to cache models, VAE, other static data.
-load-models:
+# Copy only the content of config dir first, such that the configuration
+# script can run with the expected config dir already populated.
+# Then, run the configuration script.
+configure:
 	docker run --rm -it \
 		-v ${INVOKEAI_CACHEDIR}/configs:/mnt/configs \
 		--entrypoint bash ${IMAGE} \
@@ -29,17 +28,24 @@ load-models:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
 		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
-		--entrypoint bash ${IMAGE} \
-		-c "micromamba -n invokeai run python scripts/load_models.py --root ${INVOKEAI_ROOT}"
+		${IMAGE} \
+		-c "scripts/configure_invokeai.py --root ${INVOKEAI_ROOT}"
 	sudo chown -R ${USER}:${GROUP} ${INVOKEAI_CACHEDIR}
 
 # Run the container with the cache mounted and the web server exposed on port 9090
-run:
+web:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
 		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
 		--entrypoint bash -p9090:9090 ${IMAGE} \
-		-c "micromamba -n invokeai run python scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
+		-c "scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
+
+cli:
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		--entrypoint bash ${IMAGE} \
+		-c "scripts/invoke.py --root ${INVOKEAI_ROOT}"
 
 # Run the container with the cache mounted and open a bash shell instead of the Invoke CLI or webserver
 shell:
@@ -49,4 +55,4 @@ shell:
 		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
 		--entrypoint bash ${IMAGE} --
 
-.PHONY: build preload run shell
+.PHONY: build configure web cli shell


### PR DESCRIPTION
### What this does

- Initially intended/tested for cloud deployments, further adapted for local use
- Can be used locally on CUDA-capable systems. The **only** dependencies are `docker` with the nvidia runtime, and `make` for convenience. (e.g. not even a local `python` is required). Fully tested on Linux only (Ubuntu 22.04/CUDA 11.7). Will most likely work on Windows/WSL2.
- Significant optimizations to Docker build:
  - No `git clone` happens inside docker build - only context is used
  - Attempts to utilize docker layer cache as efficiently as possible by splitting out local package installation
  - reduces image size by at least 2GB compared to the current Docker x86_64 image, might be possible to optimize further.
- Supports the latest unified caching mechanism specified by  `$INVOKE_ROOT` or `--root` options
- Includes a `Makefile` for easy building/running (was quick to throw together, but it can be easily rewritten as bash or docker-compose, as this is currently not used in the project)
- adds Github actions for automated image building and pushing, ready for use with e.g. an existing `INVOKE_ROOT` cache on a cloud runner. No special privileges or secrets are required for image build/push.

### Testing/usage:

- `cd docker-build`
- `make load-models` (Huggingface token will be prompted for if not already set via env var)
- `make run`
- access the web UI on `http://localhost:9090`
- examine the `~/invokeai` directory which will be populated with the expected `INVOKE_ROOT` contents

This PR does not touch any existing local docker setup to avoid surprises to existing users, except un-ignoring some paths from `.dockerignore` at build time. Should have no practical effect on existing users. But it can easily and optimally replace the existing docker setup. Future work can replace `Makefile` with  `docker-compose`, if desirable.
