### PR TITLE
Fix basicsr conflicts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@ ldm/invoke/server_legacy.py @CapableWeb
 scripts/legacy_api.py @CapableWeb
 tests/legacy_tests.sh @CapableWeb
 installer/ @tildebyte
+.github/workflows/ @mauwii

--- a/environments-and-requirements/environment-lin-aarch64.yml
+++ b/environments-and-requirements/environment-lin-aarch64.yml
@@ -40,5 +40,5 @@ dependencies:
       - git+https://github.com/openai/CLIP.git@main#egg=clip
       - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
       - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
-      - git+https://github.com/invoke-ai/GFPGAN#egg=gfpgan
+      - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
       - -e .

--- a/environments-and-requirements/environment-lin-amd.yml
+++ b/environments-and-requirements/environment-lin-amd.yml
@@ -41,5 +41,5 @@ dependencies:
     - git+https://github.com/openai/CLIP.git@main#egg=clip
     - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
     - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
-    - git+https://github.com/invoke-ai/GFPGAN#egg=gfpgan
+    - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
     - -e .

--- a/environments-and-requirements/environment-lin-cuda.yml
+++ b/environments-and-requirements/environment-lin-cuda.yml
@@ -41,5 +41,5 @@ dependencies:
     - git+https://github.com/openai/CLIP.git@main#egg=clip
     - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
     - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
-    - git+https://github.com/invoke-ai/GFPGAN#egg=gfpgan
+    - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
     - -e .

--- a/environments-and-requirements/environment-mac.yml
+++ b/environments-and-requirements/environment-mac.yml
@@ -57,7 +57,7 @@ dependencies:
       - git+https://github.com/openai/CLIP.git@main#egg=clip
       - git+https://github.com/invoke-ai/k-diffusion.git@mps#egg=k_diffusion
       - git+https://github.com/invoke-ai/Real-ESRGAN.git#egg=realesrgan
-      - git+https://github.com/invoke-ai/GFPGAN.git#egg=gfpgan
+      - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
       - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
       - -e .
 variables:

--- a/environments-and-requirements/environment-win-cuda.yml
+++ b/environments-and-requirements/environment-win-cuda.yml
@@ -42,5 +42,5 @@ dependencies:
     - git+https://github.com/openai/CLIP.git@main#egg=clip
     - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
     - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
-    - git+https://github.com/invoke-ai/GFPGAN#egg=gfpgan
+    - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.1#egg=gfpgan
     - -e .

--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -26,11 +26,10 @@ scikit-image>=0.19
 send2trash
 streamlit
 taming-transformers-rom1504
-test-tube
+test-tube>=0.7.5
 torch-fidelity
 torchmetrics
 transformers==4.21.*
 git+https://github.com/openai/CLIP.git@main#egg=clip
 git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion
 git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
-git+https://github.com/invoke-ai/GFPGAN#egg=gfpgan

--- a/environments-and-requirements/requirements-lin-amd.txt
+++ b/environments-and-requirements/requirements-lin-amd.txt
@@ -4,4 +4,5 @@
 --extra-index-url https://download.pytorch.org/whl/rocm5.1.1 --trusted-host https://download.pytorch.org
 torch
 torchvision
+git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
 -e .

--- a/environments-and-requirements/requirements-lin-arm64.txt
+++ b/environments-and-requirements/requirements-lin-arm64.txt
@@ -1,3 +1,4 @@
 --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 -r environments-and-requirements/requirements-base.txt
+git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
 -e .

--- a/environments-and-requirements/requirements-lin-cuda.txt
+++ b/environments-and-requirements/requirements-lin-cuda.txt
@@ -1,2 +1,3 @@
 -r environments-and-requirements/requirements-base.txt
+git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
 -e .

--- a/environments-and-requirements/requirements-mac-mps-cpu.txt
+++ b/environments-and-requirements/requirements-mac-mps-cpu.txt
@@ -3,4 +3,5 @@
 protobuf==3.19.6
 torch<1.13.0
 torchvision<0.14.0
+- git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
 -e .

--- a/environments-and-requirements/requirements-win-colab-cuda.txt
+++ b/environments-and-requirements/requirements-win-colab-cuda.txt
@@ -2,7 +2,7 @@
 
 # Get hardware-appropriate torch/torchvision 
 --extra-index-url https://download.pytorch.org/whl/cu116 --trusted-host https://download.pytorch.org
-basicsr==1.4.1
 torch==1.12.1
 torchvision==0.13.1
+git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.1#egg=gfpgan
 -e .


### PR DESCRIPTION
# Fix `basicsr` incompatibilities

The issue is the basicsr 1.4.2 doesn't work on Windows, and 1.4.1 doesn't work on Mac. However, GFPGAN requires 1.4.2 or higher.
    
To work around this, we pull in either of two different branches of the invoke-ai fork of GFPGAN, depending on the OS. This seems to be working well with the conda install, but I'm still getting issues with the pip-only install when trying to load the _Windows_ requirements file on Linux ("torch not found" error). I'm not sure if this is a problem that will appear on a real Windows system, but needs testing. The workaround is to run `pip install torch==1.12.*`
