### PR TITLE
Fix macOS install.sh by patching sysconfig

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -29,7 +29,7 @@ OS_NAME=$(uname -s)
 case "${OS_NAME}" in
     Linux*)     OS_NAME="linux";;
     Darwin*)    OS_NAME="darwin";;
-    *)          echo -e "\n----- Unknown OS: $OS_NAME! This script runs only on Linux or MacOS -----\n" && exit
+    *)          echo -e "\n----- Unknown OS: $OS_NAME! This script runs only on Linux or macOS -----\n" && exit
 esac
 
 OS_ARCH=$(uname -m)
@@ -154,6 +154,19 @@ echo -e "\n***** Unpacked python-build-standalone *****\n"
 
 # create venv
 _err_msg="\n----- problem creating venv -----\n"
+
+if [ "$OS_NAME" == "darwin" ]; then
+    # patch sysconfig so that extensions can build properly
+    # adapted from https://github.com/cashapp/hermit-packages/commit/fcba384663892f4d9cfb35e8639ff7a28166ee43
+    PYTHON_INSTALL_DIR="$(pwd)/python"
+    SYSCONFIG="$(echo python/lib/python*/_sysconfigdata_*.py)"
+    TMPFILE="$(mktemp)"
+    chmod +w "${SYSCONFIG}"
+    cp "${SYSCONFIG}" "${TMPFILE}"
+    sed "s,'/install,'${PYTHON_INSTALL_DIR},g" "${TMPFILE}" > "${SYSCONFIG}"
+    rm -f ${TMPFILE}
+fi
+
 ./python/bin/python3 -E -s -m venv .venv
 _err_exit $? _err_msg
 # In reality, the following is ALL that 'activate.bat' does,

--- a/source_installer/install.sh
+++ b/source_installer/install.sh
@@ -95,7 +95,7 @@ source "$CONDA_BASEPATH/etc/profile.d/conda.sh" # otherwise conda complains abou
 
 conda activate
 if [ "$OS_NAME" == "mac" ]; then
-    echo "Macintosh system detected. Installing MPS and CPU support."
+    echo "macOS detected. Installing MPS and CPU support."
     ln -sf environments-and-requirements/environment-mac.yml environment.yml
 else
     if (lsmod | grep amdgpu) &>/dev/null ; then


### PR DESCRIPTION
On macOS, patch python sysconfig just before creating the venv so that extensions (greenlet & grpcio) can build. 

Ref https://github.com/indygreg/python-build-standalone/issues/103, in particular the solution from @alecthomas posted here: https://github.com/indygreg/python-build-standalone/issues/103#issuecomment-1234942425

To use: checkout, cd into `installer`, run `create_installers.sh`, copy `InvokeAI-mac.zip` into an empty folder outside of your existing invokeAI install, unzip it and run `install.sh`. 