### PR TITLE
Feature: embiggen_strength

### DIFF
--- a/docs/features/EMBIGGEN.md
+++ b/docs/features/EMBIGGEN.md
@@ -85,7 +85,7 @@ increasing size, every tile after the first in a row or column
 effectively only covers an extra `1 - overlap_ratio` on each axis. If
 the input/`--init_img` is same size as a tile, the ideal (for time)
 scaling factors with the default overlap (0.25) are 1.75, 2.5, 3.25,
-4.0 etc..
+4.0, etc.
 
 `-embiggen_tiles <spaced list of tiles>`
 
@@ -99,6 +99,15 @@ coherency reasons.
 Tiles are numbered starting with one, and left-to-right,
 top-to-bottom.  So, if you are generating a 3x3 tiled image, the
 middle row would be `4 5 6`.
+
+`-embiggen_strength <strength>`
+
+Another advanced option if you want to experiment with the strength parameter
+that embiggen uses when it calls Img2Img. Values range from 0.0 to 1.0
+and lower values preserve more of the character of the initial image.
+Values that are too high will result in a completely different end image,
+while values that are too low will result in an image not dissimilar to one
+you would get with ESRGAN upscaling alone. The default value is 0.4.
 
 ### Examples
 

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -288,8 +288,9 @@ class Generate:
             strength         = None,
             init_color       = None,
             # these are specific to embiggen (which also relies on img2img args)
-            embiggen       =    None,
-            embiggen_tiles =    None,
+            embiggen          = None,
+            embiggen_tiles    = None,
+            embiggen_strength = None,
             # these are specific to GFPGAN/ESRGAN
             gfpgan_strength=    0,
             facetool         = None,
@@ -344,6 +345,7 @@ class Generate:
            perlin                          // optional 0-1 value to add a percentage of perlin noise to the initial noise
            embiggen                        // scale factor relative to the size of the --init_img (-I), followed by ESRGAN upscaling strength (0-1.0), followed by minimum amount of overlap between tiles as a decimal ratio (0 - 1.0) or number of pixels
            embiggen_tiles                  // list of tiles by number in order to process and replace onto the image e.g. `0 2 4`
+           embiggen_strength               // strength for embiggen. 0.0 preserves image exactly, 1.0 replaces it completely
 
         To use the step callback, define a function that receives two arguments:
         - Image GPU data
@@ -485,6 +487,7 @@ class Generate:
                 perlin=perlin,
                 embiggen=embiggen,
                 embiggen_tiles=embiggen_tiles,
+                embiggen_strength=embiggen_strength,
                 inpaint_replace=inpaint_replace,
                 mask_blur_radius=mask_blur_radius,
                 safety_checker=checker,
@@ -634,6 +637,8 @@ class Generate:
             # fetch the metadata from the image
             generator = self.select_generator(embiggen=True)
             opt.strength  = 0.40
+            if opt.embiggen_strength is not None:
+                opt.strength = embiggen_strength
             print(f'>> Setting img2img strength to {opt.strength} for happy embiggening')
             generator.generate(
                 prompt,
@@ -649,6 +654,7 @@ class Generate:
                 height      = opt.height,
                 embiggen    = opt.embiggen,
                 embiggen_tiles = opt.embiggen_tiles,
+                embiggen_strength = opt.embiggen_strength,
                 image_callback = callback,
             )
         elif tool == 'outpaint':

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -636,9 +636,7 @@ class Generate:
         elif tool == 'embiggen':
             # fetch the metadata from the image
             generator = self.select_generator(embiggen=True)
-            opt.strength  = 0.40
-            if opt.embiggen_strength is not None:
-                opt.strength = embiggen_strength
+            opt.strength = opt.embiggen_strength or 0.40
             print(f'>> Setting img2img strength to {opt.strength} for happy embiggening')
             generator.generate(
                 prompt,

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -286,6 +286,8 @@ class Args(object):
             switches.append(f'--embiggen {" ".join([str(u) for u in a["embiggen"]])}')
         if a['embiggen_tiles']:
             switches.append(f'--embiggen_tiles {" ".join([str(u) for u in a["embiggen_tiles"]])}')
+        if a['embiggen_strength']:
+            switches.append(f'--embiggen_strength {a["embiggen_strength"]}')
 
         # outpainting parameters
         if a['out_direction']:
@@ -914,6 +916,13 @@ class Args(object):
             type=int,
             help='For embiggen, provide list of tiles to process and replace onto the image e.g. `1 3 5`.',
             default=None,
+        )
+        postprocessing_group.add_argument(
+            '--embiggen_strength',
+            '-embiggen_strength',
+            type=float,
+            help='The strength of the embiggen img2img step, defaults to 0.4',
+            default=0.4,
         )
         special_effects_group.add_argument(
             '--seamless',

--- a/ldm/invoke/server.py
+++ b/ldm/invoke/server.py
@@ -30,6 +30,7 @@ def build_opt(post_data, seed, gfpgan_model_exists):
     # however, this code is here against that eventuality
     setattr(opt, 'embiggen', None)
     setattr(opt, 'embiggen_tiles', None)
+    setattr(opt, 'embiggen_strength', None)
 
     setattr(opt, 'facetool_strength', float(post_data['facetool_strength']) if gfpgan_model_exists else 0)
     setattr(opt, 'upscale', [int(post_data['upscale_level']), float(post_data['upscale_strength'])] if post_data['upscale_level'] != '' else None)


### PR DESCRIPTION
Added the ability to adjust the number of steps (strength) that `--embiggen` uses, defaulting to the 0.4 that it was originally set to.