### PR TITLE
Installer fixes

### DIFF
--- a/docs/installation/INSTALL_MANUAL.md
+++ b/docs/installation/INSTALL_MANUAL.md
@@ -256,7 +256,16 @@ steps:
     source invokeai/bin/activate
     ```
 
-4.  Pick the correct `requirements*.txt` file for your hardware and operating
+4. On **Macintosh Systems** run the following command:
+
+   ```
+   pip install pytorch<1.12 torchvision<0.14.0
+   ```
+
+   (This avoids a downstream error later when the `basicsr` package can't find torch,
+   and also avoids a performance regression when using torch 1.13 on Macintoshes)
+
+5.  Pick the correct `requirements*.txt` file for your hardware and operating
     system.
 
     We have created a series of environment files suited for different operating
@@ -303,13 +312,80 @@ steps:
     created in the InvokeAI root directory and that it points to the correct
     file in `environments-and-requirements`.
 
-5.  Run PIP
+6.  Run PIP
 
     Be sure that the `invokeai` environment is active before doing this:
 
     ```bash
     pip install --prefer-binary -r requirements.txt
     ```
+
+7.  Download the model weights files:
+
+    !!! tip
+
+        If you have already downloaded the weights file(s) for another Stable
+        Diffusion distribution, you may skip this step (by selecting "skip" when
+        prompted) and configure InvokeAI to use the previously-downloaded files. The
+        process for this is described in [here](INSTALLING_MODELS.md).
+
+    ```bash
+    python scripts/preload_models.py
+    ```
+
+    The script `preload_models.py` will interactively guide you through the
+    process of downloading and installing the weights files needed for InvokeAI.
+    Note that the main Stable Diffusion weights file is protected by a license
+    agreement that you have to agree to. The script will list the steps you need
+    to take to create an account on the site that hosts the weights files,
+    accept the agreement, and provide an access token that allows InvokeAI to
+    legally download and install the weights files.
+
+    If you get an error message about a module not being installed, check that
+    the `invokeai` environment is active and if not, repeat step 5.
+
+8.  Run the command-line- or the web- interface:
+
+    !!! example ""
+
+        !!! warning "Make sure that the conda environment is activated, which should create `(invokeai)` in front of your prompt!"
+
+        === "CLI"
+
+            ```bash
+            python scripts/invoke.py
+            ```
+
+        === "local Webserver"
+
+            ```bash
+            python scripts/invoke.py --web
+            ```
+
+        === "Public Webserver"
+
+            ```bash
+            python scripts/invoke.py --web --host 0.0.0.0
+            ```
+
+        If you choose the run the web interface, point your browser at
+        http://localhost:9090 in order to load the GUI.
+
+9. Render away!
+
+    Browse the [features](../features/CLI.md) section to learn about all the things you
+    can do with InvokeAI.
+
+    Note that some GPUs are slow to warm up. In particular, when using an AMD
+    card with the ROCm driver, you may have to wait for over a minute the first
+    time you try to generate an image. Fortunately, after the warm up period
+    rendering will be fast.
+
+10. Subsequently, to relaunch the script, be sure to run `source
+      invokeai/bin/activate` enter the `InvokeAI` directory, and then
+      launch the invoke script. If you forget to activate the
+      'invokeai' environment, the script will fail with multiple
+      `ModuleNotFound` errors.
 
 ---
 

--- a/docs/installation/INSTALL_MANUAL.md
+++ b/docs/installation/INSTALL_MANUAL.md
@@ -41,6 +41,8 @@ command-line completion.
     Macintosh users with MPS acceleration, or anybody with a CPU-only system,
     can skip this step.
 
+    !!! warning "Windows users, if Conda gives you the error 'CONDASSLError: OpenSSL appears to be unavailable', please see Troubleshooting for a solution."    
+
 2.  You will need to install Anaconda3 and Git if they are not already
     available. Use your operating system's preferred package manager, or
     download the installers manually. You can find them here:
@@ -295,13 +297,7 @@ steps:
             copy environments-and-requirements\requirements-lin-win-colab-cuda.txt requirements.txt
             ```
 
-        !!! warning
-
-            Please do not link or copy `environments-and-requirements/requirements-base.txt`.
-            This is a base requirements file that does not have the platform-specific
-            libraries. Also, be sure to link or copy the platform-specific file to
-	    a top-level file named `requirements.txt` as shown here. Running pip on
-	    a requirements file in a subdirectory will not work as expected.
+        !!! warning "Please do not link or copy `environments-and-requirements/requirements-base.txt`. This is a base requirements file that does not have the platform-specific libraries. Also, be sure to link or copy the platform-specific file to a top-level file named `requirements.txt` as shown here. Running pip on a requirements file in a subdirectory will not work as expected."
 
     When this is done, confirm that a file named `requirements.txt` has been
     created in the InvokeAI root directory and that it points to the correct
@@ -345,6 +341,13 @@ You can keep doing this until all requirements are satisfied and the `invoke.py`
 script runs without errors. Please report to
 [Issues](https://github.com/invoke-ai/InvokeAI/issues) what you were able to do
 to work around the problem so that others can benefit from your investigation.
+
+#### Conda fails with the error "CONDASSLError: OpenSSL appears to be unavailable"
+
+The verified solution from https://github.com/conda/conda/issues/11795 is:
+
+Copy `libcrypto-1_1-x64.dll` and `libssl-1_1-x64.dll` from `C:\Users\username\miniconda3\Library\bin`
+to `C:\Users\username\miniconda3\DLLs`
 
 ### Create Conda Environment fails on MacOS
 

--- a/source_installer/install.sh
+++ b/source_installer/install.sh
@@ -52,8 +52,6 @@ MICROMAMBA_DOWNLOAD_URL="https://micro.mamba.pm/api/micromamba/${MAMBA_OS_NAME}-
 REPO_URL="https://github.com/invoke-ai/InvokeAI.git"
 umamba_exists="F"
 
-echo "Downloading micromamba from $MICROMAMBA_DOWNLOAD_URL to $MAMBA_ROOT_PREFIX/micromamba"
-
 # figure out whether git and conda needs to be installed
 if [ -e "$INSTALL_ENV_DIR" ]; then export PATH="$INSTALL_ENV_DIR/bin:$PATH"; fi
 
@@ -63,6 +61,13 @@ if ! which git &>/dev/null; then PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL git";
 
 if "$MAMBA_ROOT_PREFIX/micromamba" --version &>/dev/null; then umamba_exists="T"; fi
 
+echo "-----------------------------------------------------------------------------"
+echo "DEBUG:"
+echo "OS_NAME=$OS_NAME, OS_ARCH=$OS_ARCH, MAMBA_ARCH=$MAMBA_ARCH, PY_ARCH=$PY_ARCH"
+echo "Micromamba download URL = $MICROMAMBA_DOWNLOAD_URL"
+echo "Packages to install = $PACKAGES_TO_INSTALL"
+echo "-----------------------------------------------------------------------------"
+
 # (if necessary) install git and conda into a contained environment
 if [ "$PACKAGES_TO_INSTALL" != "" ]; then
     # download micromamba
@@ -70,6 +75,10 @@ if [ "$PACKAGES_TO_INSTALL" != "" ]; then
         echo "Downloading micromamba from $MICROMAMBA_DOWNLOAD_URL to $MAMBA_ROOT_PREFIX/micromamba"
 
         mkdir -p "$MAMBA_ROOT_PREFIX"
+	echo "------------DEBUG-----------------------------------------"
+	echo "curl -L \"$MICROMAMBA_DOWNLOAD_URL\" | tar -xvj bin/micromamba -O > \"$MAMBA_ROOT_PREFIX/micromamba\""
+	echo "-----------------------------------------------------------"
+	
         curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvj bin/micromamba -O > "$MAMBA_ROOT_PREFIX/micromamba"
 
         chmod u+x "$MAMBA_ROOT_PREFIX/micromamba"
@@ -99,7 +108,6 @@ if [ -e "$INSTALL_ENV_DIR" ]; then export PATH="$INSTALL_ENV_DIR/bin:$PATH"; fi
 # get the repo (and load into the current directory)
 if [ ! -e ".git" ]; then
     git init
-    git config --local init.defaultBranch main
     git remote add origin "$REPO_URL"
     git fetch
     git checkout origin/main -ft

--- a/source_installer/install.sh
+++ b/source_installer/install.sh
@@ -17,7 +17,7 @@ echo ""
 OS_NAME=$(uname -s)
 case "${OS_NAME}" in
     Linux*)     OS_NAME="linux";;
-    Darwin*)    OS_NAME="mac";;
+    Darwin*)    OS_NAME="osx";;
     *)          echo "Unknown OS: $OS_NAME! This script runs only on Linux or Mac" && exit
 esac
 
@@ -29,14 +29,30 @@ case "${OS_ARCH}" in
 esac
 
 # https://mamba.readthedocs.io/en/latest/installation.html
-if [ "$OS_NAME" == "linux" ] && [ "$OS_ARCH" == "arm64" ]; then OS_ARCH="aarch64"; fi
+MAMBA_OS_NAME=$OS_NAME
+MAMBA_ARCH=$OS_ARCH
+
+if [ "$OS_ARCH" == "linux" ]; then
+    MAMBA_ARCH="aarch64"
+fi
+
+if [ "$OS_ARCH" == "x86_64" ]; then
+    MAMBA_ARCH="64"
+fi
+
+PY_ARCH=$OS_ARCH
+if [ "$OS_ARCH" == "arm64" ]; then
+    PY_ARCH="aarch64"
+fi
 
 # config
 export MAMBA_ROOT_PREFIX="$(pwd)/installer_files/mamba"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
-MICROMAMBA_DOWNLOAD_URL="https://micro.mamba.pm/api/micromamba/${OS_NAME}-${OS_ARCH}/latest"
+MICROMAMBA_DOWNLOAD_URL="https://micro.mamba.pm/api/micromamba/${MAMBA_OS_NAME}-${MAMBA_ARCH}/latest"
 REPO_URL="https://github.com/invoke-ai/InvokeAI.git"
 umamba_exists="F"
+
+echo "Downloading micromamba from $MICROMAMBA_DOWNLOAD_URL to $MAMBA_ROOT_PREFIX/micromamba"
 
 # figure out whether git and conda needs to be installed
 if [ -e "$INSTALL_ENV_DIR" ]; then export PATH="$INSTALL_ENV_DIR/bin:$PATH"; fi
@@ -94,7 +110,7 @@ CONDA_BASEPATH=$(conda info --base)
 source "$CONDA_BASEPATH/etc/profile.d/conda.sh" # otherwise conda complains about 'shell not initialized' (needed when running in a script)
 
 conda activate
-if [ "$OS_NAME" == "mac" ]; then
+if [ "$OS_NAME" == "osx" ]; then
     echo "Macintosh system detected. Installing MPS and CPU support."
     ln -sf environments-and-requirements/environment-mac.yml environment.yml
 else


### PR DESCRIPTION
Two fixes:

- Micromamba download URL for Macintoshes was incorrect in the source installer version. This has been fixed.
- Added documentation for fixing the #1463 issue in which a fresh install of Conda didn't work because of a misnamed ssl library