### PR TITLE
Fix install.sh tar command 

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -91,7 +91,7 @@ if [ "$PACKAGES_TO_INSTALL" != "" ]; then
     # download micromamba
     echo -e "\n***** Downloading micromamba from $MICROMAMBA_DOWNLOAD_URL to micromamba *****\n"
 
-    curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvj bin/micromamba -O > micromamba
+    curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvjO bin/micromamba > micromamba
 
     chmod u+x "micromamba"
 


### PR DESCRIPTION
Moved the -O from after the file to after the tar command for compatibility with macOS. 

See https://github.com/invoke-ai/InvokeAI/issues/1500

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>