### PR TITLE
Fix micromamba tar command for macOS

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -91,7 +91,7 @@ if [ "$PACKAGES_TO_INSTALL" != "" ]; then
     # download micromamba
     echo -e "\n***** Downloading micromamba from $MICROMAMBA_DOWNLOAD_URL to micromamba *****\n"
 
-    curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvj bin/micromamba -O > micromamba
+    curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvjO bin/micromamba > micromamba
 
     chmod u+x "micromamba"
 


### PR DESCRIPTION
This has been merged into development and is now proposed as a hotfix to `main`

Moved the -O from after the file to after the tar command for compatibility with macOS

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>