### PR TITLE
remove several debugging messages

### DIFF
--- a/backend/invoke_ai_web_server.py
+++ b/backend/invoke_ai_web_server.py
@@ -65,7 +65,6 @@ class InvokeAIWebServer:
         if opt.cors:
             socketio_args["cors_allowed_origins"] = opt.cors
 
-        print(f'DEBUG: static_folder should be at {os.path.join(args.root_dir,"frontend/dist")}')
         self.app = Flask(
             __name__, static_url_path="", static_folder=os.path.join(args.root_dir,"frontend/dist")
         )

--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -111,13 +111,11 @@ class ModelCache(object):
         Set the default model. The change will not take
         effect until you call model_cache.commit()
         '''
-        print(f'DEBUG: before set_default_model()\n{OmegaConf.to_yaml(self.config)}')
         assert model_name in self.models,f"unknown model '{model_name}'"
         config = self.config
         for model in config:
             config[model].pop('default',None)
         config[model_name]['default'] = True
-        print(f'DEBUG: after set_default_model():\n{OmegaConf.to_yaml(self.config)}')
 
     def list_models(self) -> dict:
         '''

--- a/ldm/invoke/restoration/outcrop.py
+++ b/ldm/invoke/restoration/outcrop.py
@@ -31,8 +31,6 @@ class Outcrop(object):
             preferred_seed = orig_opt.seed if orig_opt.seed >= 0 else seed
             image_callback(img,preferred_seed,use_prefix=prefix,**kwargs)
 
-        print(f'DEBUG: seed={opt.seed or orig_opt.seed}')
-        print(f'DEBUG: prompt={opt.prompt}')
         result= self.generate.prompt2image(
             opt.prompt,
             seed        = opt.seed or orig_opt.seed,


### PR DESCRIPTION
- dangling debug messages in several files, introduced during testing of the external root directory
- these need to be removed before they are interpreted as errors by users