### PR TITLE
Fix issues with Globals.root not being consistent when run using web gui.

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -44,7 +44,7 @@ def main():
             args.max_loaded_models = 1
 
     # alert - setting a global here
-    Globals.root = os.path.expanduser(args.root_dir or os.environ.get('INVOKEAI_ROOT') or '.')
+    Globals.root = os.path.expanduser(args.root_dir or os.environ.get('INVOKEAI_ROOT') or os.path.abspath('.'))
     print(f'>> InvokeAI runtime directory is "{Globals.root}"')
 
     # loading here to avoid long delays on startup


### PR DESCRIPTION
When started from web GUI, '.' is expanded as .../InvokeAI and sometimes .../Invoke/Idm. 
causing https://github.com/invoke-ai/InvokeAI/issues/1522

This doesn't happen from the CLI.

This PR expands '.' when first set.
