### PR TITLE
fixes configure_invokeai.py crash on Windows systems

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -331,7 +331,7 @@ class ModelCache(object):
         with open(tmpfile, 'w') as outfile:
             outfile.write(self.preamble())
             outfile.write(yaml_str)
-        os.rename(tmpfile,config_file_path)
+        os.replace(tmpfile,config_file_path)
 
     def preamble(self):
         '''

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -232,7 +232,7 @@ def migrate_models_ckpt():
     rename = yes_or_no(f'Ok to rename it to "{new_name}" for future reference?')
     if rename:
         print(f'model.ckpt => {new_name}')
-        os.rename(os.path.join(model_path,'model.ckpt'),os.path.join(model_path,new_name))
+        os.replace(os.path.join(model_path,'model.ckpt'),os.path.join(model_path,new_name))
             
 #---------------------------------------------
 def download_weight_datasets(models:dict, access_token:str):
@@ -340,12 +340,12 @@ def update_config_file(successfully_downloaded:dict,opt:dict):
     try:
         if os.path.exists(config_file):
             print(f'** {config_file} exists. Renaming to {config_file}.orig')
-            os.rename(config_file,f'{config_file}.orig')
+            os.replace(config_file,f'{config_file}.orig')
         tmpfile = os.path.join(os.path.dirname(config_file),'new_config.tmp')
         with open(tmpfile, 'w') as outfile:
             outfile.write(Config_preamble)
             outfile.write(yaml)
-        os.rename(tmpfile,config_file)
+        os.replace(tmpfile,config_file)
 
     except Exception as e:
         print(f'**Error creating config file {config_file}: {str(e)} **')


### PR DESCRIPTION
The step in which the new models.yaml file replaces the old one was crashing on Windows due to the fact that on Windows, the os.rename() function will refuse to replace an existing file, unlike the behavior on Linux and Mac. The os.replace() function, which was introduced in python3, supposedly fixes this.

**Please test on Windows 10 to see if this really does fix the problem.**