### PR TITLE
High priority PR: Fix broken setup and install

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -17,6 +17,7 @@ import transformers
 import traceback
 import textwrap
 import contextlib
+from typing import Union
 from omegaconf import OmegaConf
 from omegaconf.errors import ConfigAttributeError
 from ldm.util import instantiate_from_config, ask_user
@@ -388,7 +389,7 @@ class ModelCache(object):
     def _has_cuda(self) -> bool:
         return self.device.type == 'cuda'
 
-    def _cached_sha256(self,path,data) -> str | bytes:
+    def _cached_sha256(self,path,data) -> Union[str, bytes]:
         dirname    = os.path.dirname(path)
         basename   = os.path.basename(path)
         base, _    = os.path.splitext(basename)

--- a/scripts/load_models.py
+++ b/scripts/load_models.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# Copyright (c) 2022 Lincoln D. Stein (https://github.com/lstein)
+# Before running stable-diffusion on an internet-isolated machine,
+# run this script from one with internet connectivity. The
+# two machines must share a common .cache directory.
+
+import warnings
+import configure_invokeai
+
+if __name__ == '__main__':
+    configure_invokeai.main()
+

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Image Processing',
     ],
-    scripts = ['scripts/invoke.py','scripts/load_models.py','scripts/sd-metadata.py'],
+    scripts = ['scripts/invoke.py','scripts/configure_invokeai.py','scripts/sd-metadata.py'],
     data_files=[('frontend',frontend_files)],
 )
 


### PR DESCRIPTION
# High Priority fix

Currently `development` will neither install cleanly nor run on Python 3.9. There are two fixes here:

1. setup.py has been updated to refer to `configure_invokeai.py`, which is the new name for `load_models.py`
2. `load_models.py` has been installed as an alias of `configure_invokeai.py` to avoid other related breakage
3. The use of the union typing hint "|" in `model_cache.py` only works on Python 3.10 or higher. I have replaced with `Union[]` to work on earlier versions.