### PR TITLE
feat(install): unify setup.py, requirements.in, pip

### DIFF
--- a/installer/install.bat
+++ b/installer/install.bat
@@ -122,7 +122,7 @@ set err_msg=----- pip update failed -----
 .venv\Scripts\python -m pip install %no_cache_dir% --no-warn-script-location --upgrade pip wheel
 if %errorlevel% neq 0 goto err_exit
 
-echo ***** Updated pip *****
+echo ***** Updated pip and wheel *****
 
 set err_msg=----- requirements file copy failed -----
 copy installer\py3.10-windows-x86_64-cuda-reqs.txt requirements.txt
@@ -132,14 +132,16 @@ set err_msg=----- main pip install failed -----
 .venv\Scripts\python -m pip install %no_cache_dir% --no-warn-script-location -r requirements.txt
 if %errorlevel% neq 0 goto err_exit
 
+echo ***** Installed Python dependencies *****
+
 set err_msg=----- InvokeAI setup failed -----
 .venv\Scripts\python -m pip install %no_cache_dir% --no-warn-script-location -e .
 if %errorlevel% neq 0 goto err_exit
 
-echo ***** Installed Python dependencies *****
+echo ***** Installed InvokeAI *****
 
-echo ***** Installing invoke.bat ******
 copy installer\invoke.bat .\invoke.bat
+echo ***** Installed invoke launcher script ******
 
 @rem more cleanup
 rd /s /q installer installer_files

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -192,7 +192,7 @@ _err_msg="\n----- pip update failed -----\n"
 .venv/bin/python3 -m pip install "$no_cache_dir" --no-warn-script-location --upgrade pip wheel
 _err_exit $? _err_msg
 
-echo -e "\n***** Updated pip *****\n"
+echo -e "\n***** Updated pip and wheel *****\n"
 
 _err_msg="\n----- requirements file copy failed -----\n"
 cp installer/py3.10-${OS_NAME}-"${OS_ARCH}"-${CD}-reqs.txt requirements.txt
@@ -202,14 +202,16 @@ _err_msg="\n----- main pip install failed -----\n"
 .venv/bin/python3 -m pip install "$no_cache_dir" --no-warn-script-location -r requirements.txt
 _err_exit $? _err_msg
 
+echo -e "\n***** Installed Python dependencies *****\n"
+
 _err_msg="\n----- InvokeAI setup failed -----\n"
 .venv/bin/python3 -m pip install "$no_cache_dir" --no-warn-script-location -e .
 _err_exit $? _err_msg
 
-echo -e "\n***** Installed Python dependencies *****\n"
+echo -e "\n***** Installed InvokeAI *****\n"
 
-echo -e "\n***** Installing invoke.sh ******\n"
 cp installer/invoke.sh .
+echo -e "\n***** Installed invoke launcher script ******\n"
 
 # more cleanup
 rm -rf installer/ installer_files/

--- a/installer/requirements.in
+++ b/installer/requirements.in
@@ -1,5 +1,5 @@
 --prefer-binary
---extra-index-url https://download.pytorch.org/whl/cu116
+--extra-index-url https://download.pytorch.org/whl/torch_stable.html
 --trusted-host https://download.pytorch.org
 accelerate~=0.14
 albumentations
@@ -23,7 +23,7 @@ torchvision==0.13.0 ; platform_system == 'Darwin'
 torchvision==0.13.0+cu116 ; platform_system == 'Linux' or platform_system == 'Windows'
 transformers
 picklescan
-https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip
-https://github.com/invoke-ai/clipseg/archive/1f754751c85d7d4255fa681f4491ff5711c1c288.zip
-https://github.com/TencentARC/GFPGAN/archive/2eac2033893ca7f427f4035d80fe95b92649ac56.zip
-https://github.com/invoke-ai/k-diffusion/archive/7f16b2c33411f26b3eae78d10648d625cb0c1095.zip
+clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip
+clipseg @ https://github.com/invoke-ai/clipseg/archive/1f754751c85d7d4255fa681f4491ff5711c1c288.zip
+gfpgan @ https://github.com/TencentARC/GFPGAN/archive/2eac2033893ca7f427f4035d80fe95b92649ac56.zip
+k-diffusion @ https://github.com/invoke-ai/k-diffusion/archive/7f16b2c33411f26b3eae78d10648d625cb0c1095.zip

--- a/setup.py
+++ b/setup.py
@@ -3,24 +3,25 @@ import re
 
 from setuptools import setup, find_packages
 
+
 def frontend_files(directory):
-     paths = []
-     for (path, directories, filenames) in os.walk(directory):
-         for filename in filenames:
-             paths.append(os.path.join(path, filename))
-     return paths
+    paths = []
+    for (path, _, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join(path, filename))
+    return paths
 
 
 def _get_requirements(path):
     try:
         with open(path) as f:
             packages = f.read().splitlines()
-    except (IOError, OSError) as ex:
-        raise RuntimeError("Can't open file with requirements: %s", repr(ex))
- 
+    except OSError as ex:
+        raise RuntimeError('Cannot open file with requirements: %s', repr(ex))
+
     # Drop option lines
-    packages = [package for package in packages if not re.match(r"^--", package)]
-    packages = [package for package in packages if not re.match(r"^http", package)]
+    packages = [package for package in packages if not re.match(r'^--', package)]
+    print(f'Packages found for "install_requires":\n{packages}')
     return packages
 
 
@@ -31,9 +32,9 @@ VERSION = '2.1.4'
 DESCRIPTION = ('An implementation of Stable Diffusion which provides various new features'
                ' and options to aid the image generation process')
 LONG_DESCRIPTION = ('This version of Stable Diffusion features a slick WebGUI, an'
-                     ' interactive command-line script that combines text2img and img2img'
-                     ' functionality in a "dream bot" style interface, and multiple features'
-                     ' and other enhancements.')
+                    ' interactive command-line script that combines text2img and img2img'
+                    ' functionality in a "dream bot" style interface, and multiple features'
+                    ' and other enhancements.')
 HOMEPAGE = 'https://github.com/invoke-ai/InvokeAI'
 
 setup(
@@ -47,6 +48,9 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests.*']),
     install_requires=_get_requirements('installer/requirements.in'),
+    dependency_links=['https://download.pytorch.org/whl/torch_stable.html'],
+    scripts=['scripts/invoke.py', 'scripts/configure_invokeai.py', 'scripts/sd-metadata.py'],
+    data_files=[('frontend', frontend_files)],
     python_requires='>=3.8, <4',
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -70,7 +74,4 @@ setup(
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Image Processing',
     ],
-    scripts = ['scripts/invoke.py','scripts/configure_invokeai.py','scripts/sd-metadata.py'],
-    data_files=[('frontend',frontend_files)],
 )
-


### PR DESCRIPTION
This allows populating setup.py's 'install_requires' directly from 'requirements.in'

- setup.py:
  - read 'requirements.in' instead of 'requirements.txt'
  - add correct upstream pytorch repo to "dependency_links"
- requirements.in:
  - append "name @" to git packages
  - fix torch repo URL -> 'download.pytorch.org/whl/torch_stable.html'

ALso tweaked some logging and formatting here and there

Signed-off-by: Ben Alkov <ben.alkov@gmail.com>