### PR TITLE
make the docstring more readable and improve the list_models logic

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -125,15 +125,18 @@ class ModelCache(object):
     def list_models(self) -> dict:
         '''
         Return a dict of models in the format:
-        { model_name1: {'status': ('active'|'cached'|'not loaded'),
-                        'description': description,
-                       },
-          model_name2: { etc }
+        {
+            model_name1: {
+                'status': ('active'|'cached'|'not loaded'),
+                'description': description,
+               },
+            model_name2: { etc },
+        }
         '''
-        result = dict()
-        for name in self.config:
+        models = {}
+        for name, config in self.config.items():
             try:
-                description = self.config[name].description
+                description = config.description
             except ConfigAttributeError:
                 description = '<no description>'
 
@@ -144,11 +147,13 @@ class ModelCache(object):
             else:
                 status = 'not loaded'
 
-            result[name]={
-                'status' : status,
-                'description' : description
-            }
-        return result
+            models = models.update(
+                name = {
+                    'status': status,
+                    'description': description,
+                })
+
+        return models
 
     def print_models(self) -> None:
         '''


### PR DESCRIPTION
dict.update is more performant, on the side note, we can use something like

```
from typing import TypedDict


class ModelInfo(TypedDict):
  status: str
  description: str


def list_models(...) -> dict[str, ModelInfo]:
  ...
```

edit: or maybe we can use Dict from the typing module for compatibility reasons*

