### PR TITLE
Optimized Docker build with support for external working directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 *
 !backend
 !frontend
-!installer
+!binary_installer
 !ldm
 !main.py
 !scripts

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
 *
 !backend
-!configs
-!environments-and-requirements
 !frontend
 !installer
 !ldm
@@ -10,3 +8,17 @@
 !server
 !static
 !setup.py
+!LICENSE*
+
+# Guard against pulling in any models that might exist in the directory tree
+**/*.pt*
+
+# unignore configs, but only ignore the custom models.yaml, in case it exists
+!configs
+configs/models.yaml
+
+# unignore environment dirs/files, but ignore the environment.yml file or symlink in case it exists
+!environment*
+environment.yml
+
+**/__pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !static
 !setup.py
 !docker-build
+!docs
 docker-build/Dockerfile
 
 # Guard against pulling in any models that might exist in the directory tree

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,8 @@
 !server
 !static
 !setup.py
-!LICENSE*
+!docker-build
+docker-build/Dockerfile
 
 # Guard against pulling in any models that might exist in the directory tree
 **/*.pt*

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -1,9 +1,22 @@
-name: Build cloud image
+name: Build and push cloud image
 on:
+  workflow_dispatch:
   push:
-    # TEMP until PR is ready
     branches:
+    - main
+    - development
+    ## temp
     - docker-min
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
@@ -18,13 +31,30 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Build container
+
+    - if: github.event_name != 'pull_request'
+      name: Docker login
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push cloud image
       uses: docker/build-push-action@v3
       with:
         context: .
         file: docker-build/Dockerfile.cloud
         platforms: Linux/${{ matrix.arch }}
-        push: false
-        tags: local/invokeai:${{ matrix.arch }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -37,6 +37,11 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+          type=sha
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -5,8 +5,6 @@ on:
     branches:
     - main
     - development
-    ## temp
-    - docker-min
     tags:
       - v*
 

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -1,0 +1,30 @@
+name: Build cloud image
+on:
+  push:
+    # TEMP until PR is ready
+    branches:
+    - docker-min
+
+jobs:
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        # only x86_64 for now. aarch64+cuda isn't really a thing yet
+        arch:
+        - x86_64
+    runs-on: ubuntu-latest
+    name: ${{ matrix.arch }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build container
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: docker-build/Dockerfile.cloud
+        platforms: Linux/${{ matrix.arch }}
+        push: false
+        tags: local/invokeai:${{ matrix.arch }}

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -57,6 +57,6 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 COPY --from=builder ${APP_ROOT} ${APP_ROOT}
 
-ENTRYPOINT ["bash", "-c", "python3 scripts/invoke.py" ]
+ENTRYPOINT ["bash"]
 
-CMD ["--web", "--host 0.0.0.0"]
+CMD ["-c", "python3 scripts/invoke.py --web --host 0.0.0.0"]

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -1,13 +1,42 @@
 # Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
 
-FROM nvidia/cuda:11.7.1-runtime-ubuntu22.04 AS base
+#### Builder stage ####
+
+FROM library/ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
-# # no __pycache__ - unclear if there is a benefit
-# ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONDONTWRITEBYTECODE=1
 # unbuffered output, ensures stdout and stderr are printed in the correct order
 ENV PYTHONUNBUFFERED=1
 
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt update && apt install -y \
+    libglib2.0-0 \
+    libgl1-mesa-glx \
+    python3-venv \
+    python3-pip
+
+
+ARG APP_ROOT=/invokeai
+WORKDIR ${APP_ROOT}
+
+ENV VIRTUAL_ENV=${APP_ROOT}/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    cp installer/py3.10-linux-x86_64-cuda-reqs.txt requirements.txt && \
+    python3 -m venv ${VIRTUAL_ENV} &&\
+    pip install --extra-index-url https://download.pytorch.org/whl/cu116 \
+        torch==1.12.0+cu116 \
+        torchvision==0.13.0+cu116 &&\
+    pip install -r requirements.txt &&\
+    pip install -e .
+
+
+#### Runtime stage ####
+
+FROM ubuntu:22.04 as runtime
 RUN apt update && apt install -y \
     git \
     curl \
@@ -16,36 +45,18 @@ RUN apt update && apt install -y \
     bzip2 \
     libglib2.0-0 \
     libgl1-mesa-glx \
+    python3-venv \
+    python3-pip \
     && apt-get clean
 
-# Micromamba is a minimal conda implementation
-ENV MAMBA_ROOT_PREFIX=/opt/conda
-RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+ARG APP_ROOT=/invokeai
+WORKDIR ${APP_ROOT}
 
-WORKDIR /invokeai
+ENV VIRTUAL_ENV=${APP_ROOT}/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-### Cache the dependencies first
-# Avoid re-downloading the dependencies when unrelated files change in context
-#
-# We could use relative paths in the environment file, but it's not currently set up that way.
-# So we copy it to the working directory to maintain compatibility with other installation methods
-COPY environments-and-requirements/environment-lin-cuda.yml environment.yml
+COPY --from=builder ${APP_ROOT} ${APP_ROOT}
 
-# Patch the env file to remove installation of local package
-RUN sed -i '/-e \./d' environment.yml
-RUN micromamba create -y -f environment.yml &&\
-    micromamba clean --all -f -y &&\
-    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+ENTRYPOINT ["bash", "-c", "python3 scripts/invoke.py" ]
 
-### Copy the rest of the context and install local package
-COPY . .
-RUN micromamba -n invokeai run pip install -e .
-
-### Default model config
-RUN cp configs/models.yaml.example configs/models.yaml
-
-ENTRYPOINT ["bash"]
-
-EXPOSE 9090
-
-CMD [ "-c", "micromamba -r ${MAMBA_ROOT_PREFIX} -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"]
+CMD ["--web", "--host 0.0.0.0"]

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
+
+FROM nvidia/cuda:11.7.1-runtime-ubuntu22.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+# # no __pycache__ - unclear if there is a benefit
+# ENV PYTHONDONTWRITEBYTECODE=1
+# unbuffered output, ensures stdout and stderr are printed in the correct order
+ENV PYTHONUNBUFFERED=1
+
+RUN apt update && apt install -y \
+    git \
+    curl \
+    ncdu \
+    iotop \
+    bzip2 \
+    libglib2.0-0 \
+    libgl1-mesa-glx \
+    && apt-get clean
+
+# Micromamba is a minimal conda implementation
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+
+WORKDIR /invokeai
+
+### Cache the dependencies first
+# Avoid re-downloading the dependencies when unrelated files change in context
+#
+# We could use relative paths in the environment file, but it's not currently set up that way.
+# So we copy it to the working directory to maintain compatibility with other installation methods
+COPY environments-and-requirements/environment-lin-cuda.yml environment.yml
+
+# Patch the env file to remove installation of local package
+RUN sed -i '/-e \./d' environment.yml
+RUN micromamba create -y -f environment.yml &&\
+    micromamba clean --all -f -y &&\
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+
+### Copy the rest of the context and install local package
+COPY . .
+RUN micromamba -n invokeai run pip install -e .
+
+### Default model config
+RUN cp configs/models.yaml.example configs/models.yaml
+
+ENTRYPOINT ["bash"]
+
+EXPOSE 9090
+
+CMD [ "-c", "micromamba -r ${MAMBA_ROOT_PREFIX} -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"]

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -1,59 +1,85 @@
+#######################
 #### Builder stage ####
 
 FROM library/ubuntu:22.04 AS builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV PYTHONDONTWRITEBYTECODE=1
-# unbuffered output, ensures stdout and stderr are printed in the correct order
-ENV PYTHONUNBUFFERED=1
+ARG DEBIAN_FRONTEND=noninteractive
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt-get install -y \
+        git \
+        libglib2.0-0 \
+        libgl1-mesa-glx \
+        python3-venv \
+        python3-pip \
+        build-essential \
+        python3-opencv \
+        libopencv-dev
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt update && apt install -y \
-    libglib2.0-0 \
-    libgl1-mesa-glx \
-    python3-venv \
-    python3-pip
+# This is needed for patchmatch support
+RUN cd /usr/lib/x86_64-linux-gnu/pkgconfig/ &&\
+   ln -sf opencv4.pc opencv.pc
 
+ARG WORKDIR=/invokeai
+WORKDIR ${WORKDIR}
 
-ARG APP_ROOT=/invokeai
-WORKDIR ${APP_ROOT}
-
-ENV VIRTUAL_ENV=${APP_ROOT}/.venv
+ENV VIRTUAL_ENV=${WORKDIR}/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \
-    cp installer/py3.10-linux-x86_64-cuda-reqs.txt requirements.txt && \
     python3 -m venv ${VIRTUAL_ENV} &&\
     pip install --extra-index-url https://download.pytorch.org/whl/cu116 \
         torch==1.12.0+cu116 \
         torchvision==0.13.0+cu116 &&\
+    pip install -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.3#egg=pypatchmatch
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    cp installer/py3.10-linux-x86_64-cuda-reqs.txt requirements.txt && \
     pip install -r requirements.txt &&\
     pip install -e .
 
 
+#######################
 #### Runtime stage ####
 
-FROM ubuntu:22.04 as runtime
-RUN apt update && apt install -y \
-    git \
-    curl \
-    ncdu \
-    iotop \
-    bzip2 \
-    libglib2.0-0 \
-    libgl1-mesa-glx \
-    python3-venv \
-    python3-pip \
-    && apt-get clean
+FROM library/ubuntu:22.04 as runtime
 
-ARG APP_ROOT=/invokeai
-WORKDIR ${APP_ROOT}
+ARG DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt install -y --no-install-recommends \
+        git \
+        curl \
+        ncdu \
+        iotop \
+        bzip2 \
+        libglib2.0-0 \
+        libgl1-mesa-glx \
+        python3-venv \
+        python3-pip \
+        build-essential \
+        python3-opencv \
+        libopencv-dev &&\
+    apt-get clean && apt-get autoclean
 
-ENV VIRTUAL_ENV=${APP_ROOT}/.venv
+ARG WORKDIR=/invokeai
+WORKDIR ${WORKDIR}
+
+ENV INVOKEAI_ROOT=/mnt/invokeai
+ENV VIRTUAL_ENV=${WORKDIR}/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder ${APP_ROOT} ${APP_ROOT}
+COPY --from=builder ${WORKDIR} ${WORKDIR}
+COPY --from=builder /usr/lib/x86_64-linux-gnu/pkgconfig /usr/lib/x86_64-linux-gnu/pkgconfig
+
+# build patchmatch
+RUN python -c "from patchmatch import patch_match"
+
+## workaround for non-existent initfile when runtime directory is mounted; see #1613
+RUN touch /root/.invokeai
 
 ENTRYPOINT ["bash"]
 

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \
-    cp installer/py3.10-linux-x86_64-cuda-reqs.txt requirements.txt && \
+    cp binary_installer/py3.10-linux-x86_64-cuda-reqs.txt requirements.txt && \
     pip install -r requirements.txt &&\
     pip install -e .
 

--- a/docker-build/Dockerfile.cloud
+++ b/docker-build/Dockerfile.cloud
@@ -1,5 +1,3 @@
-# Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
-
 #### Builder stage ####
 
 FROM library/ubuntu:22.04 AS builder

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -1,0 +1,56 @@
+# Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
+
+# InvokeAI root directory in the container
+INVOKEAI_ROOT=/invokeai
+# Destination directory for cache on the host
+INVOKEAI_CACHEDIR=${HOME}/invokeai
+
+DOCKER_BUILDKIT=1
+IMAGE=local/invokeai:latest
+
+# Downloads will end up in ${INVOKEAI_CACHEDIR}.
+# Contents can be moved to a persistent storage and used to rehydrate the cache,
+# to be mounted into the container.
+
+# TBD: cache dir may be modified at runtime due to checksum calculations
+# for custom models. Ideally the checksums would be precomputed and stored in the cache.
+# Also CLI requires RW on first run when populating torch cache.
+
+build:
+	docker buildx build -t local/invokeai:latest -f Dockerfile.cloud ..
+
+# Populate the cache. Config is copied first, so it's there for the model preload step.
+load-models: _copy-config
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
+		${IMAGE} \
+		-c "micromamba -r /opt/conda -n invokeai run python scripts/load_models.py"
+
+run:
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
+		--entrypoint bash -p9090:9090 \
+		${IMAGE} \
+		-c "micromamba -r /opt/conda -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"
+
+shell:
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
+		--entrypoint bash \
+		${IMAGE} --
+
+# This is an intermediate task that copies the contents of the config dir into the cache.
+# This prepares the cached config dir, so that when we run the model preload with the config mounted,
+# it is already populated.
+_copy-config:
+	docker run --rm -it \
+		-v ${INVOKEAI_CACHEDIR}/config:${INVOKEAI_ROOT}/tmp/config \
+		--workdir ${INVOKEAI_ROOT} \
+		--entrypoint bash ${IMAGE} \
+		-c "cp -r ./tmp/config/* ./config/"
+
+
+.PHONY: build preload run shell _copy-config

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -1,9 +1,9 @@
 # Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
 
-# Directory in the container where the INVOKEAI_ROOT will be mounted
+# Directory in the container where the INVOKEAI_ROOT (runtime dir) will be mounted
 INVOKEAI_ROOT=/mnt/invokeai
-# Host directory to contain the model cache. Will be mounted at INVOKEAI_ROOT path in the container
-INVOKEAI_CACHEDIR=${HOME}/invokeai
+# Host directory to contain the runtime dir. Will be mounted at INVOKEAI_ROOT path in the container
+HOST_MOUNT_PATH=${HOME}/invokeai
 
 DOCKER_BUILDKIT=1
 IMAGE=local/invokeai:latest
@@ -11,47 +11,45 @@ IMAGE=local/invokeai:latest
 USER=$(shell id -u)
 GROUP=$(shell id -g)
 
-# All downloaded models and config will end up in ${INVOKEAI_CACHEDIR}.
-# Contents can be moved to a persistent storage and used to rehydrate the cache on another host
+# All downloaded models, config, etc will end up in ${HOST_MOUNT_PATH} on the host.
+# This is consistent with the expected non-Docker behaviour.
+# Contents can be moved to a persistent storage and used to prime the cache on another host.
 
 build:
 	docker build -t local/invokeai:latest -f Dockerfile.cloud ..
 
-# Copy only the content of config dir first, such that the configuration
-# script can run with the expected config dir already populated.
-# Then, run the configuration script.
 configure:
-	docker run --rm -it \
-		-v ${INVOKEAI_CACHEDIR}/configs:/mnt/configs \
-		--entrypoint bash ${IMAGE} \
-		-c "cp -r ./configs/* /mnt/configs/"
 	docker run --rm -it --runtime=nvidia --gpus=all \
-		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
-		${IMAGE} \
-		-c "scripts/configure_invokeai.py --root ${INVOKEAI_ROOT}"
-	sudo chown -R ${USER}:${GROUP} ${INVOKEAI_CACHEDIR}
+		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
+		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
+		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
+		--entrypoint bash \
+		${IMAGE} -c "scripts/configure_invokeai.py"
+	sudo chown -R ${USER}:${GROUP} ${HOST_MOUNT_PATH}
 
-# Run the container with the cache mounted and the web server exposed on port 9090
+# Run the container with the runtime dir mounted and the web server exposed on port 9090
 web:
 	docker run --rm -it --runtime=nvidia --gpus=all \
-		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
+		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
+		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
 		--entrypoint bash -p9090:9090 ${IMAGE} \
 		-c "scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
 
+# Run the cli with the runtime dir mounted
 cli:
 	docker run --rm -it --runtime=nvidia --gpus=all \
-		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
+		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
+		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
 		--entrypoint bash ${IMAGE} \
 		-c "scripts/invoke.py --root ${INVOKEAI_ROOT}"
 
 # Run the container with the cache mounted and open a bash shell instead of the Invoke CLI or webserver
 shell:
 	docker run --rm -it --runtime=nvidia --gpus=all \
-		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
+		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
 		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
 		--entrypoint bash ${IMAGE} --
 

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -1,56 +1,52 @@
 # Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
 
-# InvokeAI root directory in the container
-INVOKEAI_ROOT=/invokeai
-# Destination directory for cache on the host
+# Directory in the container where the INVOKEAI_ROOT will be mounted
+INVOKEAI_ROOT=/mnt/invokeai
+# Host directory to contain the model cache. Will be mounted at INVOKEAI_ROOT path in the container
 INVOKEAI_CACHEDIR=${HOME}/invokeai
 
 DOCKER_BUILDKIT=1
 IMAGE=local/invokeai:latest
 
-# Downloads will end up in ${INVOKEAI_CACHEDIR}.
-# Contents can be moved to a persistent storage and used to rehydrate the cache,
-# to be mounted into the container.
+USER=$(shell id -u)
+GROUP=$(shell id -g)
 
-# TBD: cache dir may be modified at runtime due to checksum calculations
-# for custom models. Ideally the checksums would be precomputed and stored in the cache.
-# Also CLI requires RW on first run when populating torch cache.
+# All downloaded models and config will end up in ${INVOKEAI_CACHEDIR}.
+# Contents can be moved to a persistent storage and used to rehydrate the cache on another host
 
 build:
 	docker buildx build -t local/invokeai:latest -f Dockerfile.cloud ..
 
-# Populate the cache. Config is copied first, so it's there for the model preload step.
-load-models: _copy-config
+# Populate the cache.
+# First, pre-seed the config dir on the host with the content from the image,
+# such that the model preload step can run with the config mounted and pre-populated.
+# Then, run `load-models` to cache models, VAE, other static data.
+load-models:
+	docker run --rm -it \
+		-v ${INVOKEAI_CACHEDIR}/configs:/mnt/configs \
+		--entrypoint bash ${IMAGE} \
+		-c "cp -r ./configs/* /mnt/configs/"
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
-		${IMAGE} \
-		-c "micromamba -r /opt/conda -n invokeai run python scripts/load_models.py"
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		--entrypoint bash ${IMAGE} \
+		-c "micromamba -n invokeai run python scripts/load_models.py --root ${INVOKEAI_ROOT}"
+	sudo chown -R ${USER}:${GROUP} ${INVOKEAI_CACHEDIR}
 
+# Run the container with the cache mounted and the web server exposed on port 9090
 run:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
-		--entrypoint bash -p9090:9090 \
-		${IMAGE} \
-		-c "micromamba -r /opt/conda -n invokeai run python scripts/invoke.py --web --host 0.0.0.0"
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		--entrypoint bash -p9090:9090 ${IMAGE} \
+		-c "micromamba -n invokeai run python scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
 
+# Run the container with the cache mounted and open a bash shell instead of the Invoke CLI or webserver
 shell:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
-		-v ${INVOKEAI_CACHEDIR}/root-cache:/root/.cache \
-		--entrypoint bash \
-		${IMAGE} --
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
+		--entrypoint bash ${IMAGE} --
 
-# This is an intermediate task that copies the contents of the config dir into the cache.
-# This prepares the cached config dir, so that when we run the model preload with the config mounted,
-# it is already populated.
-_copy-config:
-	docker run --rm -it \
-		-v ${INVOKEAI_CACHEDIR}/config:${INVOKEAI_ROOT}/tmp/config \
-		--workdir ${INVOKEAI_ROOT} \
-		--entrypoint bash ${IMAGE} \
-		-c "cp -r ./tmp/config/* ./config/"
-
-
-.PHONY: build preload run shell _copy-config
+.PHONY: build preload run shell

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -15,13 +15,12 @@ GROUP=$(shell id -g)
 # Contents can be moved to a persistent storage and used to rehydrate the cache on another host
 
 build:
-	docker buildx build -t local/invokeai:latest -f Dockerfile.cloud ..
+	docker build -t local/invokeai:latest -f Dockerfile.cloud ..
 
-# Populate the cache.
-# First, pre-seed the config dir on the host with the content from the image,
-# such that the model preload step can run with the config mounted and pre-populated.
-# Then, run `load-models` to cache models, VAE, other static data.
-load-models:
+# Copy only the content of config dir first, such that the configuration
+# script can run with the expected config dir already populated.
+# Then, run the configuration script.
+configure:
 	docker run --rm -it \
 		-v ${INVOKEAI_CACHEDIR}/configs:/mnt/configs \
 		--entrypoint bash ${IMAGE} \
@@ -29,17 +28,24 @@ load-models:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
 		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
-		--entrypoint bash ${IMAGE} \
-		-c "micromamba -n invokeai run python scripts/load_models.py --root ${INVOKEAI_ROOT}"
+		${IMAGE} \
+		-c "scripts/configure_invokeai.py --root ${INVOKEAI_ROOT}"
 	sudo chown -R ${USER}:${GROUP} ${INVOKEAI_CACHEDIR}
 
 # Run the container with the cache mounted and the web server exposed on port 9090
-run:
+web:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
 		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
 		--entrypoint bash -p9090:9090 ${IMAGE} \
-		-c "micromamba -n invokeai run python scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
+		-c "scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
+
+cli:
+	docker run --rm -it --runtime=nvidia --gpus=all \
+		-v ${INVOKEAI_CACHEDIR}:${INVOKEAI_ROOT} \
+		-v ${INVOKEAI_CACHEDIR}/.cache:/root/.cache \
+		--entrypoint bash ${IMAGE} \
+		-c "scripts/invoke.py --root ${INVOKEAI_ROOT}"
 
 # Run the container with the cache mounted and open a bash shell instead of the Invoke CLI or webserver
 shell:
@@ -49,4 +55,4 @@ shell:
 		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
 		--entrypoint bash ${IMAGE} --
 
-.PHONY: build preload run shell
+.PHONY: build configure web cli shell

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -3,7 +3,6 @@ INVOKEAI_ROOT=/mnt/invokeai
 # Host directory to contain the runtime dir. Will be mounted at INVOKEAI_ROOT path in the container
 HOST_MOUNT_PATH=${HOME}/invokeai
 
-DOCKER_BUILDKIT=1
 IMAGE=local/invokeai:latest
 
 USER=$(shell id -u)
@@ -14,41 +13,32 @@ GROUP=$(shell id -g)
 # Contents can be moved to a persistent storage and used to prime the cache on another host.
 
 build:
-	docker build -t local/invokeai:latest -f Dockerfile.cloud ..
+	DOCKER_BUILDKIT=1 docker build -t local/invokeai:latest -f Dockerfile.cloud ..
 
 configure:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
-		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
 		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
-		--entrypoint bash \
-		${IMAGE} -c "scripts/configure_invokeai.py"
-	sudo chown -R ${USER}:${GROUP} ${HOST_MOUNT_PATH}
+		${IMAGE} -c "python scripts/configure_invokeai.py"
 
 # Run the container with the runtime dir mounted and the web server exposed on port 9090
 web:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
-		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
 		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
-		--entrypoint bash -p9090:9090 ${IMAGE} \
-		-c "scripts/invoke.py --web --host 0.0.0.0 --root ${INVOKEAI_ROOT}"
+		-p 9090:9090 \
+		${IMAGE} -c "python scripts/invoke.py --web --host 0.0.0.0"
 
 # Run the cli with the runtime dir mounted
 cli:
 	docker run --rm -it --runtime=nvidia --gpus=all \
 		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
-		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
 		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
-		--entrypoint bash ${IMAGE} \
-		-c "scripts/invoke.py --root ${INVOKEAI_ROOT}"
+		${IMAGE} -c "python scripts/invoke.py"
 
-# Run the container with the cache mounted and open a bash shell instead of the Invoke CLI or webserver
+# Run the container with the runtime dir mounted and open a bash shell
 shell:
 	docker run --rm -it --runtime=nvidia --gpus=all \
-		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} \
-		-v ${HOST_MOUNT_PATH}/.cache:/root/.cache \
-		-e INVOKEAI_ROOT=${INVOKEAI_ROOT} \
-		--entrypoint bash ${IMAGE} --
+		-v ${HOST_MOUNT_PATH}:${INVOKEAI_ROOT} ${IMAGE} --
 
 .PHONY: build configure web cli shell

--- a/docker-build/Makefile
+++ b/docker-build/Makefile
@@ -1,5 +1,3 @@
-# Copyright (c) 2022 Eugene Brodsky (https://github.com/ebr)
-
 # Directory in the container where the INVOKEAI_ROOT (runtime dir) will be mounted
 INVOKEAI_ROOT=/mnt/invokeai
 # Host directory to contain the runtime dir. Will be mounted at INVOKEAI_ROOT path in the container


### PR DESCRIPTION
### What this does

- Adds a new `Dockerfile.cloud` intended for use with remote deployments. Extensively tested on Linux (x86_64 / CUDA), but not macOS or Windows. (Hence a new Dockerfile.cloud, to avoid surprises to users of current docker setup).
- Docker image does not bake in the models, and is 4 layers deep (2.5GB compressed, mainly `pytorch`). Utilizes docker build-time cache and multi-stage builds. Requires Docker Buildkit for caching (`DOCKER_BUILDKIT=1`).
- The runtime directory (`INVOKEAI_ROOT` which contains models, config, etc) is expected to be mounted into the container, allowing for seamless upgrades with no data loss
- Adds Github actions for automated image building and pushing. No special privileges or secrets are required for this. If this is merged, it will continuously build & push a `ghcr.io/invokeai` image. Github actions and package storage are free for open-source projects. Because no models are bundled, this is compliant with existing licensing and may be freely publicised and distributed.

### Use this on Runpod

Try this template: https://runpod.io/gsc?template=vm19ukkycf&ref=mk65wpsa (should be self-explanatory - see README :laughing:)

At a high-level:
- run the pod with an interactive shell to see the runtime directory;
- stop the pod and run again, this time with the web UI.


### Testing/usage locally (Linux only right now!):

PR includes a `Makefile` for easy building/running/demo purpose. If desirable, this can be easily rewritten as a shell script or `docker-compose`.

- `cd docker-build`
- `make build`
- `make configure` (the usual configuration flow will be executed, including the prompt for HF token)
- `make cli` or `make web`
- access the web UI on `http://localhost:9090`
- examine the `~/invokeai` directory which will be populated with the expected `INVOKEAI_ROOT` contents
- the location of the INVOKEAI_ROOT may be changed by setting the env var as usual

### Caveats

Some files in the runtime dir (e.g. outputs) may be owned by the root user. A fix for this is upcoming; in the meantime `sudo chown -R $(id -u):$(id -g) ~/invokeai` can be used to fix ownership