### PR TITLE
prevent crash that occurs when changing models.yaml on windows systems

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -298,7 +298,7 @@ class ModelCache(object):
         with open(tmpfile, 'w') as outfile:
             outfile.write(self.preamble())
             outfile.write(yaml_str)
-        os.rename(tmpfile,config_file_path)
+        os.replace(tmpfile,config_file_path)
 
     def preamble(self):
         '''

--- a/ldm/modules/image_degradation/utils_image.py
+++ b/ldm/modules/image_degradation/utils_image.py
@@ -193,7 +193,7 @@ def mkdir_and_rename(path):
     if os.path.exists(path):
         new_name = path + '_archived_' + get_timestamp()
         print('Path already exists. Rename it to [{:s}]'.format(new_name))
-        os.rename(path, new_name)
+        os.replace(path, new_name)
     os.makedirs(path)
 
 

--- a/scripts/preload_models.py
+++ b/scripts/preload_models.py
@@ -260,7 +260,7 @@ def migrate_models_ckpt():
     rename = yes_or_no(f'Ok to rename it to "{new_name}" for future reference?')
     if rename:
         print(f'model.ckpt => {new_name}')
-        os.rename(os.path.join(Model_dir,'model.ckpt'),os.path.join(Model_dir,new_name))
+        os.replace(os.path.join(Model_dir,'model.ckpt'),os.path.join(Model_dir,new_name))
             
 #---------------------------------------------
 def download_weight_datasets(models:dict, access_token:str):
@@ -347,12 +347,12 @@ def update_config_file(successfully_downloaded:dict,opt:dict):
     try:
         if os.path.exists(Config_file):
             print(f'** {Config_file} exists. Renaming to {Config_file}.orig')
-            os.rename(Config_file,f'{Config_file}.orig')
+            os.replace(Config_file,f'{Config_file}.orig')
         tmpfile = os.path.join(os.path.dirname(Config_file),'new_config.tmp')
         with open(tmpfile, 'w') as outfile:
             outfile.write(Config_preamble)
             outfile.write(yaml)
-        os.rename(tmpfile,Config_file)
+        os.replace(tmpfile,Config_file)
 
     except Exception as e:
         print(f'**Error creating config file {Config_file}: {str(e)} **')


### PR DESCRIPTION
Windows does not support an atomic `os.rename()` operation, which causes a crash during model importation when the code tries to rename the temporary `models.yaml.temp ` file to `models.yaml`. 

This PR changes the call to `os.replace()`, which does the same thing.

Note that I'm making this a hotfix against `main` as multiple users have run into this bug. The fix is already accepted in `development`.