### PR TITLE
Fix for extra pip install -e . for mac pip install

### DIFF
--- a/environments-and-requirements/requirements-mac-mps-cpu.txt
+++ b/environments-and-requirements/requirements-mac-mps-cpu.txt
@@ -1,7 +1,9 @@
+--prefer-binary
+
 -r environments-and-requirements/requirements-base.txt
 
 grpcio<1.51.0
 protobuf==3.19.6
 torch<1.13.0
 torchvision<0.14.0
-# -e .
+-e .


### PR DESCRIPTION
https://github.com/invoke-ai/InvokeAI/pull/1521 added an extra step to the pip only install on do a `-e .`  removing the same action from the requirements-*.txt files  

This tries to get rid of it for the mac as I didn't need to do it. The only differences are I use `python 3.10` and run with `--prefer-binary`.
I've put the prefer binary option back in into environments-and-requirements/requirements-mac-mps-cpu.txt
and reinstated the  `-e .`

If this works its worth testing on the on other requirements files.