### PR TITLE
add a --no-patchmatch option to disable patchmatch loading

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -44,8 +44,10 @@ def main():
             print('--max_loaded_models must be >= 1; using 1')
             args.max_loaded_models = 1
 
-    # alert - setting a global here
+    # alert - setting globals here
     Globals.root = os.path.expanduser(args.root_dir or os.environ.get('INVOKEAI_ROOT') or os.path.abspath('.'))
+    Globals.try_patchmatch = args.patchmatch
+    
     print(f'>> InvokeAI runtime directory is "{Globals.root}"')
 
     # loading here to avoid long delays on startup

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -465,6 +465,12 @@ class Args(object):
             action='store_true',
             help='Check for and blur potentially NSFW images',
         )
+        model_group.add_argument(
+            '--patchmatch',
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help='Load the patchmatch extension for outpainting. Use --no-patchmatch to disable.',
+        )
         file_group.add_argument(
             '--from_file',
             dest='infile',

--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -17,13 +17,19 @@ from ldm.models.diffusion.ddim     import DDIMSampler
 from ldm.models.diffusion.ksampler import KSampler
 from ldm.invoke.generator.base import downsampling
 from ldm.util import debug_image
-from patchmatch import patch_match
-
+from ldm.invoke.globals import Globals
 
 infill_methods: list[str] = list()
 
-if patch_match.patchmatch_available:
-    infill_methods.append('patchmatch')
+if Globals.try_patchmatch:
+    from patchmatch import patch_match
+    if patch_match.patchmatch_available:
+        print('>> Patchmatch initialized')
+        infill_methods.append('patchmatch')
+    else:
+        print('>> Patchmatch not loaded, please see https://github.com/invoke-ai/InvokeAI/blob/patchmatch-install-docs/docs/installation/INSTALL_PATCHMATCH.md')
+else:
+    print('>> Patchmatch loading disabled')
 
 infill_methods.append('tile')
 

--- a/ldm/invoke/globals.py
+++ b/ldm/invoke/globals.py
@@ -18,3 +18,7 @@ Globals.root = '.'
 
 # Where to look for the initialization file
 Globals.initfile = os.path.expanduser('~/.invokeai')
+
+# Awkward workaround to disable attempted loading of pypatchmatch
+# which is causing CI tests to error out.
+Globals.try_patchmatch = True


### PR DESCRIPTION
This feature was added to prevent the CI Macintosh tests from erroring out when patchmatch is unable to retrieve its shared library from github assets.