### PR TITLE
Fixes for #1604

### DIFF
--- a/ldm/invoke/generator/base.py
+++ b/ldm/invoke/generator/base.py
@@ -141,15 +141,18 @@ class Generator():
         np_init_rgb_pixels_masked = init_rgb_pixels[mask_pixels, :]
         np_image_masked = np_image[mask_pixels, :]
 
-        init_means = np_init_rgb_pixels_masked.mean(axis=0)
-        init_std = np_init_rgb_pixels_masked.std(axis=0)
-        gen_means = np_image_masked.mean(axis=0)
-        gen_std = np_image_masked.std(axis=0)
+        if np_init_rgb_pixels_masked.size > 0:
+            init_means = np_init_rgb_pixels_masked.mean(axis=0)
+            init_std = np_init_rgb_pixels_masked.std(axis=0)
+            gen_means = np_image_masked.mean(axis=0)
+            gen_std = np_image_masked.std(axis=0)
 
-        # Color correct
-        np_matched_result = np_image.copy()
-        np_matched_result[:,:,:] = (((np_matched_result[:,:,:].astype(np.float32) - gen_means[None,None,:]) / gen_std[None,None,:]) * init_std[None,None,:] + init_means[None,None,:]).clip(0, 255).astype(np.uint8)
-        matched_result = Image.fromarray(np_matched_result, mode='RGB')
+            # Color correct
+            np_matched_result = np_image.copy()
+            np_matched_result[:,:,:] = (((np_matched_result[:,:,:].astype(np.float32) - gen_means[None,None,:]) / gen_std[None,None,:]) * init_std[None,None,:] + init_means[None,None,:]).clip(0, 255).astype(np.uint8)
+            matched_result = Image.fromarray(np_matched_result, mode='RGB')
+        else:
+            matched_result = Image.fromarray(np_image, mode='RGB')
 
         # Blur the mask out (into init image) by specified amount
         if mask_blur_radius > 0:

--- a/ldm/invoke/restoration/realesrgan.py
+++ b/ldm/invoke/restoration/realesrgan.py
@@ -5,7 +5,7 @@ import os
 
 from ldm.invoke.globals import Globals
 from PIL import Image
-
+from PIL.Image import Image as ImageType
 
 class ESRGAN():
     def __init__(self, bg_tile_size=400) -> None:
@@ -41,7 +41,7 @@ class ESRGAN():
 
         return bg_upsampler
 
-    def process(self, image, strength: float, seed: str = None, upsampler_scale: int = 2):
+    def process(self, image: ImageType, strength: float, seed: str = None, upsampler_scale: int = 2):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=DeprecationWarning)
             warnings.filterwarnings('ignore', category=UserWarning)
@@ -62,7 +62,9 @@ class ESRGAN():
             print(
                 f'>> Real-ESRGAN Upscaling seed:{seed} : scale:{upsampler_scale}x'
             )
-            
+        # ESRGAN outputs images with partial transparency if given RGBA images; convert to RGB
+        image = image.convert("RGB")
+
         # REALSRGAN expects a BGR np array; make array and flip channels
         bgr_image_array = np.array(image, dtype=np.uint8)[...,::-1]
         


### PR DESCRIPTION
ESRGAN is known to have poor handling of RGBA images: https://github.com/xinntao/ESRGAN/issues/18

If we give it an RGBA image, it will output an image where the alpha channel has partial transparency across many pixels. 

The simplest solution is to convert the image to RGB before handing to ESRGAN (that is what this PR does).

Preserving alpha (of an input image with some transparency) is tricky. An *approximation* of the output alpha channel can be created by simply resizing the input image's alpha channel, but this isn't quite correct, because the RGB data is modified during upscaling. Other approaches are discussed in the above ESRGAN issue. 

Because there is no good method I could find with my brief search, and because I don't think it is really useful for our case, one effect of this PR is that images with partial transparency, when processed by ESRGAN, will have the alpha channel totally dropped.

Actual changes in this PR:
- Converts image to RGB before running ESRGAN
- Also adds typing for image input.