### PR TITLE
revert to older version of list_models()

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -126,18 +126,15 @@ class ModelCache(object):
     def list_models(self) -> dict:
         '''
         Return a dict of models in the format:
-        {
-            model_name1: {
-                'status': ('active'|'cached'|'not loaded'),
-                'description': description,
-               },
-            model_name2: { etc },
-        }
+        { model_name1: {'status': ('active'|'cached'|'not loaded'),
+                        'description': description,
+                       },
+          model_name2: { etc }
         '''
         models = {}
-        for name, config in self.config.items():
+        for name in self.config:
             try:
-                description = config.description
+                description = self.config[name].description
             except ConfigAttributeError:
                 description = '<no description>'
 
@@ -148,12 +145,10 @@ class ModelCache(object):
             else:
                 status = 'not loaded'
 
-            models.update(
-                name = {
-                    'status': status,
-                    'description': description,
-                })
-
+            models[name]={
+                'status' : status,
+                'description' : description
+            }
         return models
 
     def print_models(self) -> None:


### PR DESCRIPTION
# Fix display of a single model named "name"

This restores the correct behavior of list_models() and quenches the bug of list_models() returning a single model entry named "name".

I have not investigated what was wrong with the new version, but I think it may have to do with changes to the behavior in dict.update()