### PR TITLE
fix error when inpainting using runwayml inpainting model

### DIFF
--- a/ldm/invoke/generator/omnibus.py
+++ b/ldm/invoke/generator/omnibus.py
@@ -12,6 +12,8 @@ from ldm.invoke.generator.txt2img import Txt2Img
 class Omnibus(Img2Img,Txt2Img):
     def __init__(self, model, precision):
         super().__init__(model, precision)
+        self.pil_mask = None
+        self.pil_image = None
 
     def get_make_image(
             self,


### PR DESCRIPTION
- error was "Omnibus object has no attribute pil_image"
- closes #1596