### PR TITLE
Non-code change to trigger CI test

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,3 +26,4 @@ To build for production: `npm build` / `yarn build`
 ## TODO
 
 - Search repo for "TODO"
+ 

--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -207,7 +207,7 @@ class ModelCache(object):
         if not os.path.isabs(weights):
             weights = os.path.normpath(os.path.join(Globals.root,weights))
         # scan model
-        self.scan_model(model_name, weights)
+        # self.scan_model(model_name, weights)
 
         print(f'>> Loading {model_name} from {weights}')
 

--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -207,7 +207,7 @@ class ModelCache(object):
         if not os.path.isabs(weights):
             weights = os.path.normpath(os.path.join(Globals.root,weights))
         # scan model
-        # self.scan_model(model_name, weights)
+        self.scan_model(model_name, weights)
 
         print(f'>> Loading {model_name} from {weights}')
 


### PR DESCRIPTION
Pickle scanning is causing CI tests to fail. This PR includes a single space in a README. Let's see if it passes the pickle.