### PR TITLE
disable NSFW checker loading during the CI tests

### DIFF
--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           time python scripts/invoke.py \
             --no-patchmatch \
-	    --no-nsfw_checker \
+            --no-nsfw_checker \
             --model ${{ matrix.stable-diffusion-model }} \
             --from_file ${{ env.TEST_PROMPTS }} \
             --root="${{ env.INVOKEAI_ROOT }}" \

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           time python scripts/invoke.py \
             --no-patchmatch \
+	    --no-nsfw_checker \
             --model ${{ matrix.stable-diffusion-model }} \
             --from_file ${{ env.TEST_PROMPTS }} \
             --root="${{ env.INVOKEAI_ROOT }}" \

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           time ${{ env.pythonLocation }}/bin/python scripts/invoke.py \
             --no-patchmatch \
-	    --no-nsfw_checker \
+            --no-nsfw_checker \
             --model ${{ matrix.stable-diffusion-model }} \
             --from_file ${{ env.TEST_PROMPTS }} \
             --root="${{ env.INVOKEAI_ROOT }}" \

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -114,6 +114,7 @@ jobs:
         run: |
           time ${{ env.pythonLocation }}/bin/python scripts/invoke.py \
             --no-patchmatch \
+	    --no-nsfw_checker \
             --model ${{ matrix.stable-diffusion-model }} \
             --from_file ${{ env.TEST_PROMPTS }} \
             --root="${{ env.INVOKEAI_ROOT }}" \

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -468,7 +468,7 @@ class Args(object):
             action=argparse.BooleanOptionalAction,
             dest='safety_checker',
             default=False,
-            help='Check for and blur potentially NSFW images. Use --no-nsfw_checker to disable.',
+            help='Check for and blur potentially NSFW images.',
         )
         model_group.add_argument(
             '--patchmatch',

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -463,9 +463,12 @@ class Args(object):
             default='auto',
         )
         model_group.add_argument(
+            '--nsfw_checker'
             '--safety_checker',
-            action='store_true',
-            help='Check for and blur potentially NSFW images',
+            action=argparse.BooleanOptionalAction,
+            dest='safety_checker',
+            default=False,
+            help='Check for and blur potentially NSFW images. Use --no-nsfw_checker to disable.',
         )
         model_group.add_argument(
             '--patchmatch',


### PR DESCRIPTION
## Disable NSFW checker loading during CI action tests

The NSFW filter apparently causes invoke.py to crash during CI testing, possibly due to out of memory errors. This workaround disables NSFW model loading.