### PR TITLE
change download links to release candidate

### DIFF
--- a/docs/installation/INSTALL_INVOKE.md
+++ b/docs/installation/INSTALL_INVOKE.md
@@ -35,8 +35,8 @@ recommended model weights files.
 ## Steps to Install
 
 1. Download the
-   [latest release](https://github.com/invoke-ai/InvokeAI/releases/latest) of
-   InvokeAI's installer for your platform. Look for a file named InvokeAI-binary-<your platform>.zip
+   [latest release](https://github.com/invoke-ai/InvokeAI/releases/tag/2.2.0-rc4) of
+   InvokeAI's installer for your platform. Look for a file named `InvokeAI-binary-<your platform>.zip`
 
 2. Place the downloaded package someplace where you have plenty of HDD space,
    and have full permissions (i.e. `~/` on Lin/Mac; your home folder on Windows)

--- a/docs/installation/INSTALL_SOURCE.md
+++ b/docs/installation/INSTALL_SOURCE.md
@@ -27,7 +27,7 @@ Though there are multiple steps, there really is only one click involved to kick
 off the process.
 
 1.  The source installer is distributed in ZIP files. Go to the
-    [latest release](https://github.com/invoke-ai/InvokeAI/releases/latest), and
+    [latest release](https://github.com/invoke-ai/InvokeAI/releases/tag/2.2.0-rc4), and
     look for a series of files named:
 
     - invokeAI-src-installer-mac.zip


### PR DESCRIPTION
Hotfix to change the documentation download links to point to the release candidate. I will bypass branch protections to push this out.