### PR TITLE
Updates docs release link to `latest`

### DIFF
--- a/docs/installation/INSTALL_INVOKE.md
+++ b/docs/installation/INSTALL_INVOKE.md
@@ -35,7 +35,7 @@ recommended model weights files.
 ## Steps to Install
 
 1. Download the
-   [latest release](https://github.com/invoke-ai/InvokeAI/releases/tag/2.2.0-rc4) of
+   [latest release](https://github.com/invoke-ai/InvokeAI/releases/latest) of
    InvokeAI's installer for your platform. Look for a file named `InvokeAI-binary-<your platform>.zip`
 
 2. Place the downloaded package someplace where you have plenty of HDD space,


### PR DESCRIPTION
Updates docs release link to `latest`

Was rc4. Now `latest`.