### PR TITLE
more installer fixes

### DIFF
--- a/binary_installer/install.bat.in
+++ b/binary_installer/install.bat.in
@@ -10,7 +10,8 @@
 
 @rem This enables a user to install this project without manually installing git or Python
 
-PUSHD %~dp0
+@rem change to the script's directory
+PUSHD "%~dp0"
 
 set "no_cache_dir=--no-cache-dir"
 if "%1" == "use-cache" (

--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -198,7 +198,7 @@ _err_exit $? _err_msg
 echo -e "\n***** Updated pip *****\n"
 
 _err_msg="\n----- requirements file copy failed -----\n"
-cp binary_installer/py3.10-${OS_NAME}-"${OS_ARCH}"-${CD}-reqs.txt requirements.txt
+cp installer/py3.10-${OS_NAME}-"${OS_ARCH}"-${CD}-reqs.txt requirements.txt
 _err_exit $? _err_msg
 
 _err_msg="\n----- main pip install failed -----\n"
@@ -213,12 +213,11 @@ _err_exit $? _err_msg
 
 echo -e "\n***** Installed InvokeAI *****\n"
 
-cp binary_installer/invoke.sh.in ./invoke.sh
-chmod a+x ./invoke.sh
+cp installer/invoke.sh .
 echo -e "\n***** Installed invoke launcher script ******\n"
 
 # more cleanup
-rm -rf binary_installer/ installer_files/
+rm -rf installer/ installer_files/
 
 # preload the models
 .venv/bin/python3 scripts/configure_invokeai.py
@@ -229,7 +228,7 @@ deactivate
 echo -e "\n***** Finished downloading models *****\n"
 
 echo "All done! Run the command"
-echo "  \"$scriptdir/invoke.sh\""
+echo "  $scriptdir/invoke.sh"
 echo "to start InvokeAI."
 read -p "Press any key to exit..."
 exit

--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -198,7 +198,7 @@ _err_exit $? _err_msg
 echo -e "\n***** Updated pip *****\n"
 
 _err_msg="\n----- requirements file copy failed -----\n"
-cp installer/py3.10-${OS_NAME}-"${OS_ARCH}"-${CD}-reqs.txt requirements.txt
+cp binary_installer/py3.10-${OS_NAME}-"${OS_ARCH}"-${CD}-reqs.txt requirements.txt
 _err_exit $? _err_msg
 
 _err_msg="\n----- main pip install failed -----\n"
@@ -213,11 +213,11 @@ _err_exit $? _err_msg
 
 echo -e "\n***** Installed InvokeAI *****\n"
 
-cp installer/invoke.sh .
+cp binary_installer/invoke.sh .
 echo -e "\n***** Installed invoke launcher script ******\n"
 
 # more cleanup
-rm -rf installer/ installer_files/
+rm -rf binary_installer/ installer_files/
 
 # preload the models
 .venv/bin/python3 scripts/configure_invokeai.py

--- a/binary_installer/invoke.sh.in
+++ b/binary_installer/invoke.sh.in
@@ -4,6 +4,11 @@ set -eu
 
 . .venv/bin/activate
 
+# set required env var for torch on mac MPS
+ if [ "$(uname -s)" == "Darwin" ]; then
+     export PYTORCH_ENABLE_MPS_FALLBACK=1
+ fi
+
 echo "Do you want to generate images using the"
 echo "1. command-line"
 echo "2. browser-based UI"

--- a/source_installer/install.bat.in
+++ b/source_installer/install.bat.in
@@ -9,6 +9,9 @@
 
 @rem This enables a user to install this project without manually installing conda and git.
 
+@rem change to the script's directory
+PUSHD "%~dp0"
+
 echo "InvokeAI source installer..."
 echo ""
 echo "Some of the installation steps take a long time to run. Please be patient."

--- a/source_installer/invoke.sh.in
+++ b/source_installer/invoke.sh.in
@@ -10,6 +10,11 @@ source "$CONDA_BASEPATH/etc/profile.d/conda.sh" # otherwise conda complains abou
 
 conda activate invokeai
 
+# set required env var for torch on mac MPS
+￼if [ "$(uname -s)" == "Darwin" ]; then
+￼    export PYTORCH_ENABLE_MPS_FALLBACK=1
+￼fi
+￼
 if [ "$0" != "bash" ]; then
     echo "Do you want to generate images using the"
     echo "1. command-line"


### PR DESCRIPTION
- The previous fix for the "install in Windows system directory" error would fail if the path includes directories with spaces in them. This fixes that.

- In addition, addressing the same issue in source installer, although not yet reported in wild.
- Add back MPS fallback for M1 machines.