### PR TITLE
Yet more installer fixes

### DIFF
--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -213,7 +213,7 @@ _err_exit $? _err_msg
 
 echo -e "\n***** Installed InvokeAI *****\n"
 
-cp binary_installer/invoke.sh .
+cp binary_installer/invoke.sh.in ./invoke.sh
 echo -e "\n***** Installed invoke launcher script ******\n"
 
 # more cleanup


### PR DESCRIPTION
This one addresses an error in which the installer is unable to copy `invoke.sh.in` to `invoke.sh`
