### PR TITLE
(installer) fix syntax error in invoke.sh.in

### DIFF
--- a/source_installer/invoke.sh.in
+++ b/source_installer/invoke.sh.in
@@ -14,7 +14,7 @@ conda activate invokeai
 if [ "$(uname -s)" == "Darwin" ]; then
     export PYTORCH_ENABLE_MPS_FALLBACK=1
 fi
-￼
+
 if [ "$0" != "bash" ]; then
     echo "Do you want to generate images using the"
     echo "1. command-line"

--- a/source_installer/invoke.sh.in
+++ b/source_installer/invoke.sh.in
@@ -11,9 +11,9 @@ source "$CONDA_BASEPATH/etc/profile.d/conda.sh" # otherwise conda complains abou
 conda activate invokeai
 
 # set required env var for torch on mac MPS
-￼if [ "$(uname -s)" == "Darwin" ]; then
-￼    export PYTORCH_ENABLE_MPS_FALLBACK=1
-￼fi
+if [ "$(uname -s)" == "Darwin" ]; then
+    export PYTORCH_ENABLE_MPS_FALLBACK=1
+fi
 ￼
 if [ "$0" != "bash" ]; then
     echo "Do you want to generate images using the"


### PR DESCRIPTION
extra spaces cause syntax errors; found by https://discord.com/channels/1020123559063990373/1048313657177677824/1048319303390343178

Fixes #1717 