### PR TITLE
Make PaperCut and VoxelArt models load again

### DIFF
--- a/configs/stable-diffusion/v1-inference.yaml
+++ b/configs/stable-diffusion/v1-inference.yaml
@@ -32,7 +32,7 @@ model:
         placeholder_strings: ["*"]
         initializer_words: ['sculpture']
         per_image_tokens: false
-        num_vectors_per_token: 8
+        num_vectors_per_token: 1
         progressive_words: False
 
     unet_config:


### PR DESCRIPTION
This corrects a regression in loading of these models due to a change of the embedding_manager parameter `num_vectors_per_token`

Reverting to the original version (1) does not seem to affect concept embeddings.

Fixes #1718