### PR TITLE
documentation fixes for 2.2.3

### DIFF
--- a/docs/installation/INSTALL_SOURCE.md
+++ b/docs/installation/INSTALL_SOURCE.md
@@ -29,9 +29,9 @@ off the process.
     [latest release](https://github.com/invoke-ai/InvokeAI/releases/latest), and
     look for a series of files named:
 
-    - invokeAI-src-installer-mac.zip
-    - invokeAI-src-installer-windows.zip
-    - invokeAI-src-installer-linux.zip
+    - invokeAI-src-installer-<VERSION>-mac.zip
+    - invokeAI-src-installer-<VERSION>-windows.zip
+    - invokeAI-src-installer-<VERSION>-linux.zip
 
     Download the one that is appropriate for your operating system.
 
@@ -50,18 +50,26 @@ off the process.
     inflating: invokeAI\readme.txt
     ```
 
-3.  If you are using a desktop GUI, double-click the installer file. It will be
+3. If you are a Macintosh user, you may need to authorize the InvokeAI
+   installer by opening a terminal window and typing `xcode-select
+   --install`. Alternatively, you may install Xcode thorugh a graphical
+   user interface. Information is available at https://www.freecodecamp.org/news/how-to-download-and-install-xcode/
+
+   If installation fails with an `EnvironmentNameNotFound` error, then
+   you will need to install Xcode!!
+
+4.  If you are using a desktop GUI, double-click the installer file. It will be
     named `install.bat` on Windows systems and `install.sh` on Linux and
     Macintosh systems.
 
-4.  Alternatively, from the command line, run the shell script or .bat file:
+5.  Alternatively, from the command line, run the shell script or .bat file:
 
     ```cmd
     C:\Documents\Linco> cd invokeAI
     C:\Documents\Linco\invokeAI> install.bat
     ```
 
-5.  Sit back and let the install script work. It will install various binary
+6.  Sit back and let the install script work. It will install various binary
     requirements including Conda, Git and Python, then download the current
     InvokeAI code and install it along with its dependencies.
 
@@ -74,7 +82,7 @@ off the process.
     and nothing is happening, you can interrupt the script with ^C. You may restart
     it and it will pick up where it left off.
 
-6.  After installation completes, the installer will launch a script called
+7.  After installation completes, the installer will launch a script called
     `configure_invokeai.py`, which will guide you through the first-time process of
     selecting one or more Stable Diffusion model weights files, downloading and
     configuring them.
@@ -90,7 +98,7 @@ off the process.
     prompted) and configure InvokeAI to use the previously-downloaded files. The
     process for this is described in [Installing Models](INSTALLING_MODELS.md).
 
-7.  The script will now exit and you'll be ready to generate some images. The
+8.  The script will now exit and you'll be ready to generate some images. The
     invokeAI directory will contain numerous files. Look for a shell script
     named `invoke.sh` (Linux/Mac) or `invoke.bat` (Windows). Launch the script
     by double-clicking it or typing its name at the command-line:

--- a/docs/installation/INSTALL_SOURCE.md
+++ b/docs/installation/INSTALL_SOURCE.md
@@ -50,13 +50,17 @@ off the process.
     inflating: invokeAI\readme.txt
     ```
 
-3. If you are a Macintosh user, you may need to authorize the InvokeAI
-   installer by opening a terminal window and typing `xcode-select
-   --install`. Alternatively, you may install Xcode thorugh a graphical
-   user interface. Information is available at https://www.freecodecamp.org/news/how-to-download-and-install-xcode/
-
-   If installation fails with an `EnvironmentNameNotFound` error, then
-   you will need to install Xcode!!
+3. If you are a macOS user, you may need to install the Xcode command line tools. 
+   These are a set of tools that are needed to run certain applications in a Terminal, 
+   including InvokeAI. This package is provided directly by Apple.
+   
+   To install, open a terminal window and run `xcode-select --install`. You will get
+   a macOS system popup guiding you through the install. If you already have them
+   installed, you will instead see some output in the Terminal advising you that the 
+   tools are already installed.
+   
+   More information can be found here:
+   https://www.freecodecamp.org/news/install-xcode-command-line-tools/
 
 4.  If you are using a desktop GUI, double-click the installer file. It will be
     named `install.bat` on Windows systems and `install.sh` on Linux and

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -5,7 +5,7 @@ title: Overview
 We offer several ways to install InvokeAI, each one suited to your
 experience and preferences.
 
-1. InvokeAI source code installer
+1.  [InvokeAI source code installer](INSTALL_SOURCE.md)
     This is a script that will install Python, the Anaconda ("conda")
     package manager, all of InvokeAI's its essential third party
     libraries and InvokeAI itself. It includes access to a "developer
@@ -18,7 +18,8 @@ experience and preferences.
     stay on the cutting edge of InvokeAI development and are not
     afraid of occasional breakage.
     
-    To get started go to the bottom of the [Latest Release Page](https://github.com/invoke-ai/InvokeAI/releases/latest)
+    To get started go to the bottom of the
+    [Latest Release Page](https://github.com/invoke-ai/InvokeAI/releases/latest)
     and download the .zip file for your platform. Unzip the file.
     If you are on a Windows system, double-click on the `install.bat`
     script. On a Mac or Linux system, navigate to the file `install.sh`

--- a/source_installer/install.sh.in
+++ b/source_installer/install.sh.in
@@ -117,10 +117,10 @@ status=$?
 if test $status -ne 0
 then
     if [ "$OS_NAME" == "osx" ]; then
-	echo "Python failed to install the environment. You may need to authorize"
-	echo "it to do so by installing the Xcode tools. See step number 3 of"
+	echo "Python failed to install the environment. You may need to install"
+	echo "the Xcode command line tools to proceed. See step number 3 of"
 	echo "https://invoke-ai.github.io/InvokeAI/INSTALL_SOURCE#walk_through for"
-	echo "Xcode installation instructions and then run this script again."
+	echo "installation instructions and then run this script again."
     else
 	echo "Something went wrong while installing Python libraries and cannot continue."
 	echo "See https://invoke-ai.github.io/InvokeAI/INSTALL_SOURCE#troubleshooting for troubleshooting"

--- a/source_installer/install.sh.in
+++ b/source_installer/install.sh.in
@@ -116,10 +116,17 @@ status=$?
 
 if test $status -ne 0
 then
-    echo "Something went wrong while installing Python libraries and cannot continue."
-    echo "See https://invoke-ai.github.io/InvokeAI/INSTALL_SOURCE#troubleshooting for troubleshooting"
-    echo "tips, or visit https://invoke-ai.github.io/InvokeAI/#installation for alternative"
-    echo "installation methods"
+    if [ "$OS_NAME" == "osx" ]; then
+	echo "Python failed to install the environment. You may need to authorize"
+	echo "it to do so by installing the Xcode tools. See step number 3 of"
+	echo "https://invoke-ai.github.io/InvokeAI/INSTALL_SOURCE#walk_through for"
+	echo "Xcode installation instructions and then run this script again."
+    else
+	echo "Something went wrong while installing Python libraries and cannot continue."
+	echo "See https://invoke-ai.github.io/InvokeAI/INSTALL_SOURCE#troubleshooting for troubleshooting"
+	echo "tips, or visit https://invoke-ai.github.io/InvokeAI/#installation for alternative"
+	echo "installation methods"
+    fi
 else
     ln -sf ./source_installer/invoke.sh.in ./invoke.sh
     ln -sf ./source_installer/update.sh.in ./update.sh


### PR DESCRIPTION
- Add Xcode installation instructions to source installer walkthrough
- Fix link to source installer page from installer overview
- If OSX install crashes, script will tell Mac users to go to the docs to learn how to install Xcode