### PR TITLE
Modify installer links to point closer to the source installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This fork is supported across Linux, Windows and Macintosh. Linux
 users can use either an Nvidia-based card (with CUDA support) or an
 AMD card (using the ROCm driver). For full installation and upgrade
 instructions, please see:
-[InvokeAI Installation Overview](https://invoke-ai.github.io/InvokeAI/installation/)
+[InvokeAI Installation Overview](https://invoke-ai.github.io/InvokeAI/installation/INSTALL_SOURCE/)
 
 ### Hardware Requirements
 

--- a/docs/installation/INSTALL_SOURCE.md
+++ b/docs/installation/INSTALL_SOURCE.md
@@ -29,9 +29,9 @@ off the process.
     [latest release](https://github.com/invoke-ai/InvokeAI/releases/latest), and
     look for a series of files named:
 
-    - invokeAI-src-installer-mac.zip
-    - invokeAI-src-installer-windows.zip
-    - invokeAI-src-installer-linux.zip
+    - [invokeAI-src-installer-2.2.3-mac.zip](https://github.com/invoke-ai/InvokeAI/releases/latest/download/invokeAI-src-installer-2.2.3-mac.zip)
+    - [invokeAI-src-installer-2.2.3-windows.zip](https://github.com/invoke-ai/InvokeAI/releases/latest/download/invokeAI-src-installer-2.2.3-windows.zip)
+    - [invokeAI-src-installer-2.2.3-linux.zip](https://github.com/invoke-ai/InvokeAI/releases/latest/download/invokeAI-src-installer-2.2.3-windows.zip)
 
     Download the one that is appropriate for your operating system.
 


### PR DESCRIPTION
Currently a few clicks are needed to get to the source installer, and a couple more clicks to get to the installer bundle. *Proposing* to update links to point more closely to the source installer, and to link installer bundles directly from Github releases, at least for 2.2.3, in an attempt to smooth over first-time installation experience.

NB - if we remove the version from the filenames, we can have an always-up-to-date link to the latest release assets without having to build the docs.