### PR TITLE
add powershell wrapper for the Windows installer

### DIFF
--- a/source_installer/Install.ps1
+++ b/source_installer/Install.ps1
@@ -1,0 +1,31 @@
+#!/usr/bin/env pwsh
+$invokeAiVersion = "2.2.3" # this can be dynamic if removed from filename
+$installBundleFilename = "invokeAI-src-installer-${invokeAiVersion}-windows.zip"
+
+# TODO: we should prompt the user for the path here
+$installFolder = "${home}/invokeai/installer"
+
+$installBundleUrl = "https://github.com/invoke-ai/InvokeAI/releases/latest/download/${installBundleFilename}"
+
+New-Item -itemtype Directory -Path $installFolder -Force
+cd $installFolder
+
+# download the install bundle
+# below is needed because by default the client uses TLS<1.2, which fails with SChannel on modern websites.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $installBundleUrl -UseBasicParsing -Outfile $installBundleFilename;
+
+## Alt way of downloading, untested
+# $client = New-Object System.Net.WebClient
+# $client.DownloadFile($installBundleUrl, $installBundleFilename)
+
+# extract zip
+Expand-Archive -LiteralPath $installBundleFilename -DestinationPath $installFolder -Force
+
+# do the installation
+# hardcoded folder name in the zip
+cd invokeAI
+$process = Start-Process -FilePath "install.bat" -Wait -PassThru
+if ($process.ExitCode -ne 0) {
+    throw "Installation failed."
+}


### PR DESCRIPTION
*proposal / for discussion*

hoping :crossed_fingers: for a "pipe to bash" equivalent on Windows, to put this activity "on rails" such that there's less room for user error.

Requires testing by someone on a Windows system with antivirus enabled, in Powershell, by copying and pasting this command:

```
Invoke-WebRequest -Uri https://raw.githubusercontent.com/invoke-ai/InvokeAI/1acba80e6691b5b0a81377366228c9d9e8232f71/source_installer/Install.ps1 -UseBasicParsing -OutFile Install.ps1; .\Install.ps1
```

If that pans out, such command can be added to documentation, for a `curl | bash -c `-like  experience (yuck, but it does help)