### PR TITLE
add documentation warning about 1650/60 cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ You wil need one of the following:
 - An NVIDIA-based graphics card with 4 GB or more VRAM memory.
 - An Apple computer with an M1 chip.
 
+We do not recommend the GTX 1650 or 1660 series video cards. They are
+unable to run in half-precision mode and do not have sufficient VRAM
+to render 512x512 images.
+
 #### Memory
 
 - At least 12 GB Main Memory RAM.

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,10 @@ You wil need one of the following:
 - :simple-amd: An AMD-based graphics card with 4 GB or more VRAM memory (Linux only)
 - :fontawesome-brands-apple: An Apple computer with an M1 chip.
 
+We do not recommend the GTX 1650 or 1660 series video cards. They are
+unable to run in half-precision mode and do not come with sufficient VRAM
+to render 512x512 images.
+
 ### :fontawesome-solid-memory: Memory
 
 - At least 12 GB Main Memory RAM.


### PR DESCRIPTION
Several users have been trying to run InvokeAI on GTX 1650 and 1660 cards. They really can't because these cards don't work with half-precision and only have 4-6GB of memory. Added a warning to the docs (in two places) about this problem.