### PR TITLE
Allow k_dpmpp_2s_ancestral and k_dpmpp_2m

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -986,6 +986,8 @@ class Generate:
             self.sampler = KSampler(self.model, 'heun', device=self.device)
         elif self.sampler_name == 'k_lms':
             self.sampler = KSampler(self.model, 'lms', device=self.device)
+        elif self.sampler_name[:2] == 'k_': # and f'sample_{self.sampler_name[2:]}' in K.sampling.__dict__:
+            self.sampler = KSampler(self.model, self.sampler_name[2:], device=self.device)
         else:
             msg = f'>> Unsupported Sampler: {self.sampler_name}, Defaulting to plms'
             self.sampler = PLMSSampler(self.model, device=self.device)


### PR DESCRIPTION
Tested and works so far for 'k_dpmpp_2s_ancestral' and 'k_dpmpp_2m'. NOT working for 'k_dpm_fast', 'k_dpm_adaptive' out of the box