### PR TITLE
Fix a bug when enhancing JPG images

### DIFF
--- a/ldm/invoke/pngwriter.py
+++ b/ldm/invoke/pngwriter.py
@@ -57,8 +57,13 @@ def retrieve_metadata(img_path):
     metadata stored there, as a dict
     '''
     im = Image.open(img_path)
-    md = im.text.get('sd-metadata', '{}')
-    dream_prompt = im.text.get('Dream', '')
+    if hasattr(im, 'text'):
+        md = im.text.get('sd-metadata', '{}')
+        dream_prompt = im.text.get('Dream', '')
+    else:
+        # When trying to retrieve metadata from images without a 'text' payload, such as JPG images.
+        md = '{}'
+        dream_prompt = ''
     return {'sd-metadata': json.loads(md), 'Dream': dream_prompt}
 
 def write_metadata(img_path:str, meta:dict):


### PR DESCRIPTION
Currently there's an error when trying to upscale a JPG image that is imported to the UI. This happens only after the upscaling is complete, when InvokeAI tries to copy over the metadata from the original.