### PR TITLE
Create Launcher Files in ~/invokeai

### DIFF
--- a/binary_installer/install.bat.in
+++ b/binary_installer/install.bat.in
@@ -24,7 +24,9 @@ set INSTALL_ENV_DIR=%cd%\installer_files\env
 @rem https://mamba.readthedocs.io/en/latest/installation.html
 set MICROMAMBA_DOWNLOAD_URL=https://github.com/cmdr2/stable-diffusion-ui/releases/download/v1.1/micromamba.exe
 set RELEASE_URL=https://github.com/invoke-ai/InvokeAI
-set RELEASE_SOURCEBALL=/archive/refs/heads/main.tar.gz
+@rem set RELEASE_SOURCEBALL=/archive/refs/heads/main.tar.gz
+echo *** CHANGE SOURCEBALL BACK TO MAIN ***
+set RELEASE_SOURCEBALL=/archive/refs/heads/lstein-config-launch.tar.gz
 set PYTHON_BUILD_STANDALONE_URL=https://github.com/indygreg/python-build-standalone/releases/download
 set PYTHON_BUILD_STANDALONE=20221002/cpython-3.10.7+20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz
 

--- a/binary_installer/install.bat.in
+++ b/binary_installer/install.bat.in
@@ -147,7 +147,7 @@ echo ***** Installed invoke launcher script ******
 rd /s /q binary_installer installer_files
 
 @rem preload the models
-call .venv\Scripts\python scripts\configure_invokeai.py
+call .venv\Scripts\python scripts\configure_invokeai.py --create_launchers
 set err_msg=----- model download clone failed -----
 if %errorlevel% neq 0 goto err_exit
 deactivate

--- a/binary_installer/install.bat.in
+++ b/binary_installer/install.bat.in
@@ -146,7 +146,7 @@ copy binary_installer\invoke.bat.in .\invoke.bat
 echo ***** Installed invoke launcher script ******
 
 @rem preload the models
-call .venv\Scripts\python scripts\configure_invokeai.py --create_launchers
+call .venv\Scripts\python scripts\configure_invokeai.py --create_launchers binary
 set err_msg=----- model download clone failed -----
 if %errorlevel% neq 0 goto err_exit
 deactivate

--- a/binary_installer/install.bat.in
+++ b/binary_installer/install.bat.in
@@ -145,14 +145,14 @@ if %errorlevel% neq 0 goto err_exit
 copy binary_installer\invoke.bat.in .\invoke.bat
 echo ***** Installed invoke launcher script ******
 
-@rem more cleanup
-rd /s /q binary_installer installer_files
-
 @rem preload the models
 call .venv\Scripts\python scripts\configure_invokeai.py --create_launchers
 set err_msg=----- model download clone failed -----
 if %errorlevel% neq 0 goto err_exit
 deactivate
+
+@rem more cleanup
+rd /s /q binary_installer installer_files
 
 echo ***** Finished downloading models *****
 

--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -221,7 +221,7 @@ echo -e "\n***** Installed invoke launcher script ******\n"
 rm -rf binary_installer/ installer_files/
 
 # preload the models
-.venv/bin/python3 scripts/configure_invokeai.py
+.venv/bin/python3 scripts/configure_invokeai.py  --create_launchers
 _err_msg="\n----- model download clone failed -----\n"
 _err_exit $? _err_msg
 deactivate

--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -85,7 +85,9 @@ fi
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
 MICROMAMBA_DOWNLOAD_URL="https://micro.mamba.pm/api/micromamba/${MAMBA_OS_NAME}-${MAMBA_ARCH}/latest"
 RELEASE_URL=https://github.com/invoke-ai/InvokeAI
-RELEASE_SOURCEBALL=/archive/refs/heads/main.tar.gz
+#RELEASE_SOURCEBALL=/archive/refs/heads/main.tar.gz
+echo "**** CHANGE RELEASE SOURCEBALL TO MAIN ****"
+RELEASE_SOURCEBALL=/archive/refs/heads/lstein-config-launch.tar.gz
 PYTHON_BUILD_STANDALONE_URL=https://github.com/indygreg/python-build-standalone/releases/download
 if [ "$OS_NAME" == "darwin" ]; then
     PYTHON_BUILD_STANDALONE=20221002/cpython-3.10.7+20221002-${PY_ARCH}-apple-darwin-install_only.tar.gz

--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -220,7 +220,7 @@ chmod a+rx ./invoke.sh
 echo -e "\n***** Installed invoke launcher script ******\n"
 
 # preload the models
-.venv/bin/python3 scripts/configure_invokeai.py  --create_launchers
+.venv/bin/python3 scripts/configure_invokeai.py  --create_launchers binary
 _err_msg="\n----- model download clone failed -----\n"
 _err_exit $? _err_msg
 deactivate

--- a/binary_installer/install.sh.in
+++ b/binary_installer/install.sh.in
@@ -219,14 +219,14 @@ cp binary_installer/invoke.sh.in ./invoke.sh
 chmod a+rx ./invoke.sh
 echo -e "\n***** Installed invoke launcher script ******\n"
 
-# more cleanup
-rm -rf binary_installer/ installer_files/
-
 # preload the models
 .venv/bin/python3 scripts/configure_invokeai.py  --create_launchers
 _err_msg="\n----- model download clone failed -----\n"
 _err_exit $? _err_msg
 deactivate
+
+# more cleanup
+rm -rf binary_installer/ installer_files/
 
 echo -e "\n***** Finished downloading models *****\n"
 

--- a/binary_installer/invoke.sh.in
+++ b/binary_installer/invoke.sh.in
@@ -2,6 +2,10 @@
 
 set -eu
 
+# ensure we're in the correct folder in case user's CWD is somewhere else
+scriptdir=$(dirname "$0")
+cd "$scriptdir"
+
 . .venv/bin/activate
 
 # set required env var for torch on mac MPS

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -718,9 +718,8 @@ def create_launchers(root:str):
         outfile = os.path.join(root,os.path.basename(outbase))
         with open(infile,'r') as input, open(outfile,'w') as output:
             for line in input:
-                if line.startswith('#!'):
-                    output.write(line)
-                    output.write(f'cd "{repodir}"')
+                if line.startswith('scriptdir'):
+                    output.write(f'scriptdir="{repodir}"\n')
                 elif line.startswith('PUSHD'):
                     output.write(f'PUSHD "{repodir}"\n')
                 else:

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -709,10 +709,10 @@ def initialize_rootdir(root:str,yes_to_all:bool=False):
 ''')
 
 #-------------------------------------
-def create_launchers(root:str):
+def create_launchers(root:str,launcher_type:str):
     repodir = os.path.normpath(os.path.join(os.path.dirname(__file__),'..'))
     for template in ('invoke.sh.in','invoke.bat.in'):
-        infile = os.path.join(repodir,'binary_installer',template)
+        infile = os.path.join(repodir,f'{launcher_type}_installer',template)
         assert os.path.exists(infile),f'the file {infile} does not exist'
         outbase,_ = os.path.splitext(infile)
         outfile = os.path.join(root,os.path.basename(outbase))
@@ -756,7 +756,8 @@ def main():
                         help='answer "yes" to all prompts')
     parser.add_argument('--create_launchers',
                         dest='create_launchers',
-                        action='store_true',
+                        type=str,
+                        choices=['binary','source'],
                         help='create invoke.bat and invoke.sh launchers in rootdir')
     parser.add_argument('--config_file',
                         '-c',
@@ -804,7 +805,7 @@ def main():
         print(f'\nA problem occurred during initialization.\nThe error was: "{str(e)}"')
         print(traceback.format_exc())
     if opt.create_launchers:
-        create_launchers(Globals.root)
+        create_launchers(Globals.root,opt.create_launchers)
 
 #-------------------------------------
 if __name__ == '__main__':

--- a/source_installer/install.bat.in
+++ b/source_installer/install.bat.in
@@ -107,7 +107,7 @@ copy source_installer\update.bat.in .\update.bat
 
 call conda activate invokeai
 @rem call configure script
-call python scripts\configure_invokeai.py  --create_launchers
+call python scripts\configure_invokeai.py  --create_launchers source
 if "%ERRORLEVEL%" NEQ "0" (
    echo ""
    echo "The configure script crashed or was cancelled."

--- a/source_installer/install.bat.in
+++ b/source_installer/install.bat.in
@@ -105,7 +105,7 @@ copy source_installer\update.bat.in .\update.bat
 
 call conda activate invokeai
 @rem call configure script
-call python scripts\configure_invokeai.py
+call python scripts\configure_invokeai.py  --create_launchers
 if "%ERRORLEVEL%" NEQ "0" (
    echo ""
    echo "The configure script crashed or was cancelled."

--- a/source_installer/install.bat.in
+++ b/source_installer/install.bat.in
@@ -80,7 +80,9 @@ if not exist ".git" (
     call git config --local init.defaultBranch main
     call git remote add origin %REPO_URL%
     call git fetch
-    call git checkout origin/main -ft
+@rem    call git checkout origin/main -ft
+    echo CHANGE REP BACK TO MAIN
+    call git checkout origin/lstein-config-launch
 )
 
 @rem activate the base env

--- a/source_installer/install.sh.in
+++ b/source_installer/install.sh.in
@@ -136,7 +136,7 @@ else
     conda activate invokeai
     # configure
     echo "Calling the configure_invokeai script"
-    python scripts/configure_invokeai.py
+    python scripts/configure_invokeai.py --create_launchers
     status=$?
     if test $status -ne 0
        then

--- a/source_installer/install.sh.in
+++ b/source_installer/install.sh.in
@@ -90,7 +90,9 @@ if [ ! -e ".git" ]; then
     git config --local init.defaultBranch main
     git remote add origin "$REPO_URL"
     git fetch
-    git checkout origin/main -ft
+    echo "CHANGE BRANCH BACK TO MAIN"
+    #    git checkout origin/main -ft
+    get checkout origin/lstein-config-launch
 fi
 
 # create the environment

--- a/source_installer/install.sh.in
+++ b/source_installer/install.sh.in
@@ -138,7 +138,7 @@ else
     conda activate invokeai
     # configure
     echo "Calling the configure_invokeai script"
-    python scripts/configure_invokeai.py --create_launchers
+    python scripts/configure_invokeai.py --create_launchers source
     status=$?
     if test $status -ne 0
        then

--- a/source_installer/install.sh.in
+++ b/source_installer/install.sh.in
@@ -92,7 +92,7 @@ if [ ! -e ".git" ]; then
     git fetch
     echo "CHANGE BRANCH BACK TO MAIN"
     #    git checkout origin/main -ft
-    get checkout origin/lstein-config-launch
+    git checkout origin/lstein-config-launch
 fi
 
 # create the environment

--- a/source_installer/invoke.bat.in
+++ b/source_installer/invoke.bat.in
@@ -1,6 +1,7 @@
 @echo off
 
 PUSHD "%~dp0"
+
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
 

--- a/source_installer/invoke.sh.in
+++ b/source_installer/invoke.sh.in
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+# ensure we're in the correct folder in case user's CWD is somewhere else
+scriptdir=$(dirname "$0")
+cd "$scriptdir"
 
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
 if [ -e "$INSTALL_ENV_DIR" ]; then export PATH="$INSTALL_ENV_DIR/bin:$PATH"; fi

--- a/source_installer/update.bat.in
+++ b/source_installer/update.bat.in
@@ -1,5 +1,6 @@
 @echo off
 
+PUSHD "%~dp0"
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
 
@@ -11,7 +12,7 @@ if exist ".git" (
 
 conda env update
 conda activate invokeai
-python scripts/preload_models.py
+python scripts/configure_invokeai.py --create_launchers
 
 echo "Press any key to continue"
 pause

--- a/source_installer/update.sh.in
+++ b/source_installer/update.sh.in
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ensure we're in the correct folder in case user's CWD is somewhere else
+scriptdir=$(dirname "$0")
+cd "$scriptdir"
 
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
 if [ -e "$INSTALL_ENV_DIR" ]; then export PATH="$INSTALL_ENV_DIR/bin:$PATH"; fi
@@ -21,6 +24,6 @@ case "${OS_NAME}" in
     *)          echo "Unknown OS: $OS_NAME! This script runs only on Linux or Mac" && exit
 esac
 
-python scripts/preload_models.py
+python scripts/configure_invokeai.py --create_launchers
 
 


### PR DESCRIPTION
# Create Launcher Files in the ~/invokeai directory

To solve the "there's no invoke.bat!" issue, this PR adds a function to `configure_invokeai.py` to create the appropriate launcher script in the `~/invokeai` runtime directory. It is hacky to do it this way, but the configure script has immediate access to the user's selection of the root directory and this seemed more reliable to me than passing the root directory back from the configure script to the install script. Also we can tell the user to run the configure script in order to create the "missing" launcher.

I have tested this on Linux with both the binary and source installers. The Windows version needs extensive testing. In order to make testing work, I have changed the REPO to the branch `lstein-config-launch` in all the install scripts. They will need to be changed back to `main` prior to release.