### PR TITLE
[WIP] Global runtime directory path resolution

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -94,10 +94,10 @@ import base64
 import functools
 import warnings
 import ldm.invoke.pngwriter
-from pathlib import Path
-from ldm.invoke.globals import Globals
 from ldm.invoke.prompt_parser import split_weighted_subprompts
+from ldm.invoke.config import RuntimeDir, Config
 
+## TODO import these from Config?
 SAMPLER_CHOICES = [
     'ddim',
     'k_dpm_2_a',
@@ -369,6 +369,10 @@ class Args(object):
         This defines all the arguments used on the command line when you launch
         the CLI or web backend.
         '''
+
+        runtime_dir = RuntimeDir()
+        runtime_dir.set_root()
+
         parser = PagingArgumentParser(
             description=
             """
@@ -392,20 +396,21 @@ class Args(object):
         deprecated_group.add_argument('--weights') # deprecated
         model_group.add_argument(
             '--root_dir',
-            default=None,
-            help=f'Path to directory containing "models", "outputs" and "configs". If not present will look in environment variable INVOKEAI_ROOT and default to {Globals.root}',
+            '--root',
+            default = runtime_dir.root,
+            help=f'Path to directory containing "models", "outputs" and "configs". If not present will look in environment variable INVOKEAI_ROOT and default to "{runtime_dir.root}"',
         )
         model_group.add_argument(
             '--config',
             '-c',
             '-config',
             dest='conf',
-            default='./configs/models.yaml',
-            help='Path to configuration file for alternate models.',
+            default = runtime_dir.paths.configs.location / 'models.yaml',
+            help=f'Path to configuration file for alternate models. [{runtime_dir.paths.configs.location / "models.yaml"}]',
         )
         model_group.add_argument(
             '--model',
-            help='Indicates which diffusion model to load (defaults to "default" stanza in configs/models.yaml)',
+            help=f'Indicates which diffusion model to load (defaults to "default" stanza in {runtime_dir.paths.configs.location / "models.yaml"})',
         )
         model_group.add_argument(
             '--png_compression','-z',
@@ -468,8 +473,8 @@ class Args(object):
             '--outdir',
             '-o',
             type=str,
-            help='Directory to save generated images and a log of prompts and seeds. Default: outputs/img-samples',
-            default='outputs/img-samples',
+            default=runtime_dir.paths.outputs.location / "img-samples",
+            help=f'Directory to save generated images and a log of prompts and seeds. [{runtime_dir.paths.outputs.location / "img-samples"}]',
         )
         file_group.add_argument(
             '--prompt_as_dir',

--- a/ldm/invoke/config.py
+++ b/ldm/invoke/config.py
@@ -1,0 +1,187 @@
+# from omegaconf import OmegaConf
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+from .globals import Globals
+from .paths import Paths
+
+try:
+    from rich.console import Console
+    from rich.prompt import Prompt, Confirm
+    console = Console()
+    print = console.print
+    line = console.line
+except Exception:
+    line = print("\n")
+
+@dataclass
+class Config:
+
+    try_patchmatch = Globals.try_patchmatch
+
+    enable_safety_checker = True
+    default_sampler = 'k_heun'
+    default_steps = '20'  # deliberately a string - see test below
+
+    sampler_choices = ['ddim','k_dpm_2_a','k_dpm_2','k_euler_a','k_euler','k_heun','k_lms','plms']
+
+    # future
+    user_weights_dirs = []
+
+class RuntimeDir:
+    """
+    Manages the runtime directory
+    """
+
+    def __init__(self, root_path: str = None) -> None:
+
+        self.config = Config()
+        self.paths = Paths()
+
+        # these properties are exposed from the paths class for convenience
+        self.root = self.paths.root.location
+        self.outputs = self.paths.outputs.location
+
+    def set_root(self, root_path: str = None) -> Path:
+        """
+        Determine the path to the runtime directory in an order of precedence
+        """
+
+        if os.getenv("INVOKEAI_OUTPUTS") is not None:
+            print(f"INVOKEAI_ROOT={root_path} environment variable is set")
+
+        self.paths.set_root(root_path)
+        self.root = self.paths.root.location
+        print(f"Using {Path(root_path).expanduser().resolve()} as the InvokeAI runtime directory")
+        return root_path
+
+    def set_outputs(self, output_path: str = None) -> Path:
+        # Check CLI flag
+        if output_path is None:
+            # Check env var
+            ### NOT YET DOCUMENTED
+            if (output_path := os.getenv("INVOKEAI_OUTPUTS")) is not None:
+                print(f"Found INVOKEAI_OUTPUTS={output_path} environment variable")
+            else:
+                output_path = self.paths.outputs["location"]
+        else:
+            output_path = Path(output_path).expanduser().resolve()
+
+        print(f"Generated images will be found under {output_path}")
+
+        self.paths.set_root(output_path)
+        self.output_path = Path(output_path)
+        return output_path
+
+    def validate(self) -> bool:
+        """
+        Validate that the runtime dir is correctly configured
+        """
+
+        print(f"Validating the runtime directory at {self.root.expanduser().resolve()}")
+
+        missing = False
+        for this in self.paths.get():
+            abspath = this.location.expanduser().resolve()
+            if abspath.exists():
+                msg_prefix = ":white_check_mark:"
+            else:
+                msg_prefix = ":x:"
+                missing = True
+            print(f"{msg_prefix} {this.description} {this.kind} at {abspath}")
+
+        return not missing
+
+    def initialize(self, yes_to_all=False):
+        """
+        Initialize the runtime directory tree
+        """
+
+        print(f"[bold]Initializing invokeai runtime directory at {self.root}...")
+
+
+
+        # console.print()
+
+        # print(f'\nYou may change the chosen directories at any time by editing the --root and --outdir options in "{Globals.initfile}",')
+        # print(f'You may also change the runtime directory by setting the environment variable INVOKEAI_ROOT.\n')
+
+
+        # if not yes_to_all:
+        #     print('The NSFW (not safe for work) checker blurs out images that potentially contain sexual imagery.')
+        #     print('It can be selectively enabled at run time with --nsfw_checker, and disabled with --no-nsfw_checker.')
+        #     print('The following option will set whether the checker is enabled by default. Like other options, you can')
+        #     print(f'change this setting later by editing the file {Globals.initfile}.')
+        #     enable_safety_checker = yes_or_no('Enable the NSFW checker by default?',enable_safety_checker)
+
+        #     print('\nThe next choice selects the sampler to use by default. Samplers have different speed/performance')
+        #     print('tradeoffs. If you are not sure what to select, accept the default.')
+        #     sampler = None
+        #     while sampler not in sampler_choices:
+        #         sampler = input(f'Default sampler to use? ({", ".join(sampler_choices)}) [{default_sampler}]:') or default_sampler
+
+        #     print('\nThe number of denoising steps affects both the speed and quality of the images generated.')
+        #     print('Higher steps often (but not always) increases the quality of the image, but increases image')
+        #     print('generation time. This can be changed at run time. Accept the default if you are unsure.')
+        #     steps = ''
+        #     while not steps.isnumeric():
+        #         steps = input(f'Default number of steps to use during generation? [{default_steps}]:') or default_steps
+        # else:
+        #     sampler = default_sampler
+        #     steps = default_steps
+
+        # safety_checker = '--nsfw_checker' if enable_safety_checker else '--no-nsfw_checker'
+
+        # for name in ('models','configs','embeddings'):
+        #     os.makedirs(os.path.join(root,name), exist_ok=True)
+        # for src in (['configs']):
+        #     dest = os.path.join(root,src)
+        #     if not os.path.samefile(src,dest):
+        #         shutil.copytree(src,dest,dirs_exist_ok=True)
+        #     os.makedirs(outputs, exist_ok=True)
+
+        # init_file = os.path.expanduser(Globals.initfile)
+
+
+    #-------------------------------------
+
+
+class PlainTextInitFile():
+    """
+    Manages the plaintext init file used to configure the launch scripts
+    """
+
+    def __init__(self, filepath, outputs, safety_checker, sampler, steps) -> None:
+        self.filepath = filepath
+        self.outputs = outputs
+        self.safety_checker = safety_checker
+        self.sampler = sampler
+        self.steps = steps
+
+    def create(self, filepath: Path):
+        console.print(f"Creating the initialization file at {filepath}")
+        with open(filepath,"w") as f:
+            f.write(
+# tempted to template this, but it will be deprecated soon
+f'''
+# InvokeAI initialization file
+# This is the InvokeAI initialization file, which contains command-line default values.
+# Feel free to edit. If anything goes wrong, you can re-initialize this file by deleting
+# or renaming it and then running configure_invokeai.py again.
+
+# the --outdir option controls the default location of image files.
+--outdir="{self.outputs}"
+
+# generation arguments
+{self.safety_checker}
+--sampler={self.sampler}
+--steps={self.steps}
+
+# You may place other  frequently-used startup commands here, one or more per line.
+# Examples:
+# --web --host=0.0.0.0
+# --steps=20
+# -Ak_euler_a -C10.0
+#
+''')

--- a/ldm/invoke/config.py
+++ b/ldm/invoke/config.py
@@ -53,6 +53,8 @@ class RuntimeDir:
         self.root = self.paths.root.location
 
         print(f"Using {Path(self.root).expanduser().resolve()} as the InvokeAI runtime directory")
+        console.line()
+
         return self.root
 
     def set_outputs(self, output_path: str = None) -> Path:
@@ -77,7 +79,7 @@ class RuntimeDir:
         Validate that the runtime dir is correctly configured
         """
 
-        console.rule(f"Validating the runtime directory at {self.root.expanduser().resolve()}")
+        console.rule(f"Validating directory structure at {self.root.expanduser().resolve()}")
         console.line()
 
         missing = False
@@ -90,6 +92,7 @@ class RuntimeDir:
                 missing = True
             print(f"{msg_prefix} {this.description} {this.kind}: {abspath}")
 
+        console.line()
         return not missing
 
     def initialize(self, yes_to_all=False):

--- a/ldm/invoke/globals.py
+++ b/ldm/invoke/globals.py
@@ -10,17 +10,18 @@ the attributes:
   - try_patchmatch - option to globally disable loading of 'patchmatch' module
 '''
 
-import os
 from argparse import Namespace
+from pathlib import Path
 
 Globals = Namespace()
 
 # This is usually overwritten by the command line and/or environment variables
-Globals.root = '.'
+Globals.root = '~/invokeai'
 
-# Where to look for the initialization file
-Globals.initfile = os.path.expanduser('~/.invokeai')
+Globals.initfile = "invokeai.init"
 
 # Awkward workaround to disable attempted loading of pypatchmatch
 # which is causing CI tests to error out.
 Globals.try_patchmatch = True
+
+Globals.debug = False

--- a/ldm/invoke/paths.py
+++ b/ldm/invoke/paths.py
@@ -1,0 +1,111 @@
+"""
+Filesystem paths
+"""
+
+from pathlib import Path
+from typing import Union
+from dataclasses import dataclass
+import inspect
+import os
+
+@dataclass
+class PathSpec:
+    kind: str
+    description: str
+    location: Path
+
+class Paths:
+    def __init__(self, root_dir: Union[str, Path] = None) -> None:
+
+        self.set_root(root_dir)
+
+    def set_root(self, path: Union[str, Path] = None) -> Path:
+
+        if path is None:
+            if (path := os.getenv("INVOKEAI_ROOT")) is None:
+                # Default location
+                path = "~/invokeai"
+
+        self.root_dir = Path(path)
+        return path
+
+    @property
+    def root(self) -> PathSpec:
+        return PathSpec(
+            kind = "directory",
+            description = "InvokeAI runtime (root)",
+            location = self.root_dir
+        )
+
+    @property
+    def models(self) -> PathSpec:
+        return PathSpec(
+            kind = "directory",
+            description = "Model cache",
+            location = self.root.location / "models"
+        )
+
+    @property
+    def configs(self) -> PathSpec:
+        return PathSpec(
+            kind = "directory",
+            description = "Common configuration files",
+            location = self.root.location / "configs"
+        )
+
+    @property
+    def outputs(self) -> PathSpec:
+        return PathSpec(
+            kind = "directory",
+            description = "Image outputs",
+            location = self.root.location / "outputs"
+        )
+
+    @property
+    def default_weights(self) -> PathSpec:
+        return PathSpec(
+            kind = "directory",
+            description = "Default SD weights",
+            location = self.models.location / "ldm/stable-diffusion-v1"
+        )
+
+    @property
+    def sd_configs(self) -> PathSpec:
+        return PathSpec(
+            kind = "directory",
+            description = "SD model parameters",
+            location = self.configs.location / "stable-diffusion"
+        )
+
+    @property
+    def models_config(self) -> PathSpec:
+        return PathSpec(
+            kind = "file",
+            description = "Known models configuration",
+            location = self.configs.location / "models.yaml"
+        )
+
+    @property
+    def initfile(self) -> PathSpec:
+        return PathSpec(
+            kind = "file",
+            description = "Application init",
+            location = self.root.location / "invokeai.init"
+        )
+
+    ## not yet in use
+    # @property
+    # def main_config(self) -> PathSpec:
+    #     return PathSpec(
+    #         kind = "file",
+    #         description = "Application configuration",
+    #         location = self.root.location / "invokeai.yaml"
+    #     )
+
+    def get(self) -> list[PathSpec]:
+        """
+        Returns a list of all defined PathSpecs
+        """
+
+        attrs = inspect.getmembers(self, predicate = lambda m: not (inspect.isroutine(m)))
+        return [a[1] for a in attrs if isinstance(a[1], PathSpec)]

--- a/ldm/invoke/paths.py
+++ b/ldm/invoke/paths.py
@@ -33,7 +33,7 @@ class Paths:
     def root(self) -> PathSpec:
         return PathSpec(
             kind = "directory",
-            description = "InvokeAI runtime (root)",
+            description = "InvokeAI application",
             location = self.root_dir
         )
 
@@ -91,6 +91,14 @@ class Paths:
             kind = "file",
             description = "Application init",
             location = self.root.location / "invokeai.init"
+        )
+
+    @property
+    def core_models(self) -> PathSpec:
+        return PathSpec(
+            kind = "file",
+            description = "Core supported models config",
+            location = self.configs.location / "INITIAL_MODELS.yaml"
         )
 
     ## not yet in use

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -574,30 +574,6 @@ def download_weights(opt:dict) -> Union[str, None]:
         return "some of the model weights downloads were not successful"
 
 #-------------------------------------
-def get_root(root:str=None)->str:
-    if root:
-        return root
-    elif os.environ.get('INVOKEAI_ROOT'):
-        return os.environ.get('INVOKEAI_ROOT')
-    else:
-        init_file = os.path.expanduser(Globals.initfile)
-        if not os.path.exists(init_file):
-            return None
-
-    # if we get here, then we read from initfile
-    root = None
-    with open(init_file, 'r') as infile:
-        lines = infile.readlines()
-        for l in lines:
-            if re.search('\s*#',l): # ignore comments
-                continue
-            match = re.search('--root\s*=?\s*"?([^"]+)"?',l)
-            if match:
-                root = match.groups()[0]
-                root = root.strip()
-    return root
-
-#-------------------------------------
 def select_root(root:str, yes_to_all:bool=False):
     default = root or os.path.expanduser('~/invokeai')
     if (yes_to_all):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 def list_files(directory):
     return [os.path.join(directory,x) for x in os.listdir(directory) if os.path.isfile(os.path.join(directory,x))]
 
-VERSION = '2.2.0'
+VERSION = '2.2.3'
 DESCRIPTION = ('An implementation of Stable Diffusion which provides various new features'
                ' and options to aid the image generation process')
 LONG_DESCRIPTION = ('This version of Stable Diffusion features a slick WebGUI, an'


### PR DESCRIPTION
Introduces a `paths` module which has no dependencies outside of stdlib, and so can be used outside of venv. Paths are defined as data structures and are dynamically updated. Intended usage: this module should be a single entrypoint to path resolution across the app and any scripts.

Also introduces a global `runtime_dir` or `RD` object, which uses the `paths` module and manages/validates the directory structure, including helpful messaging.

Fixes #1613, supercedes #1615. Related to #1786 - path resolution will need to be updated there to use the new paths module