### PR TITLE
invoke script cds to its location before running

### DIFF
--- a/binary_installer/invoke.sh.in
+++ b/binary_installer/invoke.sh.in
@@ -2,6 +2,10 @@
 
 set -eu
 
+# ensure we're in the correct folder in case user's CWD is somewhere else
+scriptdir=$(dirname "$0")
+cd "$scriptdir"
+￼
 . .venv/bin/activate
 
 # set required env var for torch on mac MPS


### PR DESCRIPTION
This PR ensures that when the binary installer's `invoke.sh` script runs, it changes the current working directory to match its install location.

The same change is also found in PR #1786