### PR TITLE
Add windows to test workflows

### DIFF
--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   matrix:
     strategy:
-      fail-fast: false
       matrix:
         stable-diffusion-model:
           - 'stable-diffusion-1.5'

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   matrix:
     strategy:
+      fail-fast: false
       matrix:
         stable-diffusion-model:
           - 'stable-diffusion-1.5'

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -27,18 +27,22 @@ jobs:
             os: ubuntu-latest
             curl-command: curl
             github-env: $GITHUB_ENV
+            default-shell: bash -l {0}
           - environment-yaml: environment-lin-cuda.yml
             os: ubuntu-latest
             curl-command: curl
             github-env: $GITHUB_ENV
+            default-shell: bash -l {0}
           - environment-yaml: environment-mac.yml
             os: macos-12
             curl-command: curl
             github-env: $GITHUB_ENV
+            default-shell: bash -l {0}
           - environment-yaml: environment-win-cuda.yml
             os: windows-2022
             curl-command: curl.exe
             github-env: $env:GITHUB_ENV
+            default-shell: pwsh
           - stable-diffusion-model: stable-diffusion-1.5
             stable-diffusion-model-url: https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt
             stable-diffusion-model-dl-path: models/ldm/stable-diffusion-v1
@@ -48,6 +52,9 @@ jobs:
     env:
       CONDA_ENV_NAME: invokeai
       INVOKEAI_ROOT: '${{ github.workspace }}/invokeai'
+    defaults:
+      run:
+        shell: ${{ matrix.default-shell }}
     steps:
       - name: Checkout sources
         id: checkout-sources
@@ -115,7 +122,7 @@ jobs:
 
       - name: Run the tests
         id: run-tests
-        if: ${{ matrix.os }} != windows-2022
+        if: ${{ matrix.os != windows-2022 }}
         run: |
           time python scripts/invoke.py \
             --no-patchmatch \
@@ -127,7 +134,7 @@ jobs:
 
       - name: export conda env
         id: export-conda-env
-        if: ${{ matrix.os }} != windows-2022
+        if: ${{ matrix.os != windows-2022 }}
         run: |
           mkdir -p outputs/img-samples
           conda env export --name ${{ env.CONDA_ENV_NAME }} > ${{ env.INVOKEAI_ROOT }}/outputs/environment-${{ runner.os }}-${{ runner.arch }}.yml

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
       - 'development'
-      - 'fix-gh-actions-fork'
+      - 'add-windows-to-workflows'
   pull_request:
     branches:
       - 'main'
@@ -20,16 +20,24 @@ jobs:
           - environment-lin-amd.yml
           - environment-lin-cuda.yml
           - environment-mac.yml
+          - environment-win-cuda.yml
         include:
           - environment-yaml: environment-lin-amd.yml
             os: ubuntu-latest
-            default-shell: bash -l {0}
+            curl-command: curl
+            github-env: $GITHUB_ENV
           - environment-yaml: environment-lin-cuda.yml
             os: ubuntu-latest
-            default-shell: bash -l {0}
+            curl-command: curl
+            github-env: $GITHUB_ENV
           - environment-yaml: environment-mac.yml
             os: macos-12
-            default-shell: bash -l {0}
+            curl-command: curl
+            github-env: $GITHUB_ENV
+          - environment-yaml: environment-win-cuda.yml
+            os: windows-2022
+            curl-command: curl.exe
+            github-env: $env:GITHUB_ENV
           - stable-diffusion-model: stable-diffusion-1.5
             stable-diffusion-model-url: https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt
             stable-diffusion-model-dl-path: models/ldm/stable-diffusion-v1
@@ -39,9 +47,6 @@ jobs:
     env:
       CONDA_ENV_NAME: invokeai
       INVOKEAI_ROOT: '${{ github.workspace }}/invokeai'
-    defaults:
-      run:
-        shell: ${{ matrix.default-shell }}
     steps:
       - name: Checkout sources
         id: checkout-sources
@@ -72,15 +77,15 @@ jobs:
 
       - name: set test prompt to main branch validation
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: echo "TEST_PROMPTS=tests/preflight_prompts.txt" >> $GITHUB_ENV
+        run: echo "TEST_PROMPTS=tests/preflight_prompts.txt" >> ${{ matrix.github-env }}
 
       - name: set test prompt to development branch validation
         if: ${{ github.ref == 'refs/heads/development' }}
-        run: echo "TEST_PROMPTS=tests/dev_prompts.txt" >> $GITHUB_ENV
+        run: echo "TEST_PROMPTS=tests/dev_prompts.txt" >> ${{ matrix.github-env }}
 
       - name: set test prompt to Pull Request validation
         if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/development' }}
-        run: echo "TEST_PROMPTS=tests/validate_pr_prompt.txt" >> $GITHUB_ENV
+        run: echo "TEST_PROMPTS=tests/validate_pr_prompt.txt" >> ${{ matrix.github-env }}
 
       - name: Use Cached Stable Diffusion Model
         id: cache-sd-model
@@ -96,10 +101,7 @@ jobs:
         if: ${{ steps.cache-sd-model.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p "${{ env.INVOKEAI_ROOT }}/${{ matrix.stable-diffusion-model-dl-path }}"
-          curl \
-            -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" \
-            -o "${{ env.INVOKEAI_ROOT }}/${{ matrix.stable-diffusion-model-dl-path }}/${{ matrix.stable-diffusion-model-dl-name }}" \
-            -L ${{ matrix.stable-diffusion-model-url }}
+          ${{ matrix.curl-command }} -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" -o "${{ env.INVOKEAI_ROOT }}/${{ matrix.stable-diffusion-model-dl-path }}/${{ matrix.stable-diffusion-model-dl-name }}" -L ${{ matrix.stable-diffusion-model-url }}
 
       - name: run configure_invokeai.py
         id: run-preload-models
@@ -112,6 +114,7 @@ jobs:
 
       - name: Run the tests
         id: run-tests
+        if: ${{ matrix.os }} != windows-2022
         run: |
           time python scripts/invoke.py \
             --no-patchmatch \
@@ -123,11 +126,13 @@ jobs:
 
       - name: export conda env
         id: export-conda-env
+        if: ${{ matrix.os }} != windows-2022
         run: |
           mkdir -p outputs/img-samples
-          conda env export --name ${{ env.CONDA_ENV_NAME }} > outputs/img-samples/environment-${{ runner.os }}-${{ runner.arch }}.yml
+          conda env export --name ${{ env.CONDA_ENV_NAME }} > ${{ env.INVOKEAI_ROOT }}/outputs/environment-${{ runner.os }}-${{ runner.arch }}.yml
 
       - name: Archive results
+        if: ${{ matrix.os }} != windows-2022
         id: archive-results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -23,12 +23,12 @@ jobs:
           - environment-win-cuda.yml
         include:
           - environment-yaml: environment-lin-amd.yml
-            os: ubuntu-latest
+            os: ubuntu-22.04
             curl-command: curl
             github-env: $GITHUB_ENV
             default-shell: bash -l {0}
           - environment-yaml: environment-lin-cuda.yml
-            os: ubuntu-latest
+            os: ubuntu-22.04
             curl-command: curl
             github-env: $GITHUB_ENV
             default-shell: bash -l {0}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run the tests
         id: run-tests
-        if: ${{ matrix.os != windows-2022 }}
+        if: matrix.os != 'windows-2022'
         run: |
           time python scripts/invoke.py \
             --no-patchmatch \
@@ -133,13 +133,13 @@ jobs:
 
       - name: export conda env
         id: export-conda-env
-        if: ${{ matrix.os != windows-2022 }}
+        if: matrix.os != 'windows-2022'
         run: |
           mkdir -p outputs/img-samples
           conda env export --name ${{ env.CONDA_ENV_NAME }} > ${{ env.INVOKEAI_ROOT }}/outputs/environment-${{ runner.os }}-${{ runner.arch }}.yml
 
       - name: Archive results
-        if: ${{ matrix.os }} != windows-2022
+        if: matrix.os != 'windows-2022'
         id: archive-results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - 'main'
       - 'development'
-      - 'add-windows-to-workflows'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   matrix:
     strategy:
-      fail-fast: false
       matrix:
         stable-diffusion-model:
           - stable-diffusion-1.5

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -60,15 +60,15 @@ jobs:
 
       - name: set test prompt to main branch validation
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: echo "TEST_PROMPTS=tests/preflight_prompts.txt" >> $GITHUB_ENV
+        run: echo "TEST_PROMPTS=tests/preflight_prompts.txt" >> ${{ matrix.github-env }}
 
       - name: set test prompt to development branch validation
         if: ${{ github.ref == 'refs/heads/development' }}
-        run: echo "TEST_PROMPTS=tests/dev_prompts.txt" >> $GITHUB_ENV
+        run: echo "TEST_PROMPTS=tests/dev_prompts.txt" >> ${{ matrix.github-env }}
 
       - name: set test prompt to Pull Request validation
         if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/development' }}
-        run: echo "TEST_PROMPTS=tests/validate_pr_prompt.txt" >> $GITHUB_ENV
+        run: echo "TEST_PROMPTS=tests/validate_pr_prompt.txt" >> ${{ matrix.github-env }}
 
       - name: create requirements.txt
         run: cp 'environments-and-requirements/${{ matrix.requirements-file }}' '${{ matrix.requirements-file }}'

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -46,12 +46,22 @@ jobs:
             stable-diffusion-model-dl-name: v1-5-pruned-emaonly.ckpt
     name: ${{ matrix.requirements-file }} on ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    env:
-      INVOKEAI_ROOT: '${{ github.workspace }}/invokeai'
     steps:
       - name: Checkout sources
         id: checkout-sources
         uses: actions/checkout@v3
+
+      - name: set INVOKEAI_ROOT Windows
+        if: matrix.os == 'windows-2022'
+        run: |
+          echo "INVOKEAI_ROOT=${{ github.workspace }}\invokeai" >> ${{ matrix.github-env }}
+          echo "INVOKEAI_OUTDIR=${{ github.workspace }}\invokeai\outputs" >> ${{ matrix.github-env }}
+
+      - name: set INVOKEAI_ROOT others
+        if: matrix.os != 'windows-2022'
+        run: |
+          echo "INVOKEAI_ROOT=${{ github.workspace }}/invokeai" >> ${{ matrix.github-env }}
+          echo "INVOKEAI_OUTDIR=${{ github.workspace }}/invokeai/outputs" >> ${{ matrix.github-env }}
 
       - name: create models.yaml from example
         run: |
@@ -109,7 +119,7 @@ jobs:
       - name: Run the tests
         id: run-tests
         # if: matrix.os != 'windows-2022'
-        run: python3 scripts/invoke.py --no-patchmatch --no-nsfw_checker --model ${{ matrix.stable-diffusion-model }} --from_file ${{ env.TEST_PROMPTS }} --root="${{ env.INVOKEAI_ROOT }}" --outdir="${{ env.INVOKEAI_ROOT }}/outputs"
+        run: python3 scripts/invoke.py --no-patchmatch --no-nsfw_checker --model ${{ matrix.stable-diffusion-model }} --from_file ${{ env.TEST_PROMPTS }} --root="${{ env.INVOKEAI_ROOT }}" --outdir="${{ env.INVOKEAI_OUTDIR }}"
 
       - name: Archive results
         id: archive-results

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -118,12 +118,12 @@ jobs:
 
       - name: Run the tests
         id: run-tests
-        # if: matrix.os != 'windows-2022'
+        if: matrix.os != 'windows-2022'
         run: python3 scripts/invoke.py --no-patchmatch --no-nsfw_checker --model ${{ matrix.stable-diffusion-model }} --from_file ${{ env.TEST_PROMPTS }} --root="${{ env.INVOKEAI_ROOT }}" --outdir="${{ env.INVOKEAI_OUTDIR }}"
 
       - name: Archive results
         id: archive-results
-        # if: matrix.os != 'windows-2022'
+        if: matrix.os != 'windows-2022'
         uses: actions/upload-artifact@v3
         with:
           name: results_${{ matrix.requirements-file }}_${{ matrix.python-version }}

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -108,19 +108,12 @@ jobs:
 
       - name: Run the tests
         id: run-tests
-        if: matrix.os != 'windows-2022'
-        run: |
-          time python3 scripts/invoke.py \
-            --no-patchmatch \
-            --no-nsfw_checker \
-            --model ${{ matrix.stable-diffusion-model }} \
-            --from_file ${{ env.TEST_PROMPTS }} \
-            --root="${{ env.INVOKEAI_ROOT }}" \
-            --outdir="${{ env.INVOKEAI_ROOT }}/outputs"
+        # if: matrix.os != 'windows-2022'
+        run: python3 scripts/invoke.py --no-patchmatch --no-nsfw_checker --model ${{ matrix.stable-diffusion-model }} --from_file ${{ env.TEST_PROMPTS }} --root="${{ env.INVOKEAI_ROOT }}" --outdir="${{ env.INVOKEAI_ROOT }}/outputs"
 
       - name: Archive results
         id: archive-results
-        if: matrix.os != 'windows-2022'
+        # if: matrix.os != 'windows-2022'
         uses: actions/upload-artifact@v3
         with:
           name: results_${{ matrix.requirements-file }}_${{ matrix.python-version }}

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -26,11 +26,11 @@ jobs:
           - '3.10'
         include:
           - requirements-file: requirements-lin-cuda.txt
-            os: ubuntu-latest
+            os: ubuntu-22.04
             curl-command: curl
             github-env: $GITHUB_ENV
           - requirements-file: requirements-lin-amd.txt
-            os: ubuntu-latest
+            os: ubuntu-22.04
             curl-command: curl
             github-env: $GITHUB_ENV
           - requirements-file: requirements-mac-mps-cpu.txt
@@ -38,7 +38,7 @@ jobs:
             curl-command: curl
             github-env: $GITHUB_ENV
           - requirements-file: requirements-win-colab-cuda.txt
-            os: windows-latest
+            os: windows-2022
             curl-command: curl.exe
             github-env: $env:GITHUB_ENV
           - stable-diffusion-model: stable-diffusion-1.5
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run the tests
         id: run-tests
-        if: ${{ matrix.os }} != windows-latest
+        if: matrix.os != 'windows-2022'
         run: |
           time python3 scripts/invoke.py \
             --no-patchmatch \
@@ -121,7 +121,7 @@ jobs:
 
       - name: Archive results
         id: archive-results
-        if: ${{ matrix.os }} != windows-latest
+        if: matrix.os != 'windows-2022'
         uses: actions/upload-artifact@v3
         with:
           name: results_${{ matrix.requirements-file }}_${{ matrix.python-version }}

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - 'main'
       - 'development'
-      - 'add-windows-to-workflows'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   matrix:
     strategy:
+      fail-fast: false
       matrix:
         stable-diffusion-model:
           - stable-diffusion-1.5

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'development'
+      - 'add-windows-to-workflows'
   pull_request:
     branches:
       - 'main'
@@ -19,28 +20,33 @@ jobs:
           - requirements-lin-cuda.txt
           - requirements-lin-amd.txt
           - requirements-mac-mps-cpu.txt
+          - requirements-win-colab-cuda.txt
         python-version:
           # - '3.9'
           - '3.10'
         include:
           - requirements-file: requirements-lin-cuda.txt
             os: ubuntu-latest
-            default-shell: bash -l {0}
+            curl-command: curl
+            github-env: $GITHUB_ENV
           - requirements-file: requirements-lin-amd.txt
             os: ubuntu-latest
-            default-shell: bash -l {0}
+            curl-command: curl
+            github-env: $GITHUB_ENV
           - requirements-file: requirements-mac-mps-cpu.txt
             os: macOS-12
-            default-shell: bash -l {0}
+            curl-command: curl
+            github-env: $GITHUB_ENV
+          - requirements-file: requirements-win-colab-cuda.txt
+            os: windows-latest
+            curl-command: curl.exe
+            github-env: $env:GITHUB_ENV
           - stable-diffusion-model: stable-diffusion-1.5
             stable-diffusion-model-url: https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt
             stable-diffusion-model-dl-path: models/ldm/stable-diffusion-v1
             stable-diffusion-model-dl-name: v1-5-pruned-emaonly.ckpt
     name: ${{ matrix.requirements-file }} on ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.default-shell }}
     env:
       INVOKEAI_ROOT: '${{ github.workspace }}/invokeai'
     steps:
@@ -79,7 +85,7 @@ jobs:
       #   run: ${{ env.pythonLocation }}/bin/pip install --upgrade pip setuptools wheel
 
       - name: install requirements
-        run: ${{ env.pythonLocation }}/bin/pip install -r '${{ matrix.requirements-file }}'
+        run: pip3 install -r '${{ matrix.requirements-file }}'
 
       - name: Use Cached Stable Diffusion Model
         id: cache-sd-model
@@ -95,24 +101,17 @@ jobs:
         if: ${{ steps.cache-sd-model.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p "${{ env.INVOKEAI_ROOT }}/${{ matrix.stable-diffusion-model-dl-path }}"
-          curl \
-            -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" \
-            -o "${{ env.INVOKEAI_ROOT }}/${{ matrix.stable-diffusion-model-dl-path }}/${{ matrix.stable-diffusion-model-dl-name }}" \
-            -L ${{ matrix.stable-diffusion-model-url }}
+          ${{ matrix.curl-command }} -H "Authorization: Bearer ${{ secrets.HUGGINGFACE_TOKEN }}" -o "${{ env.INVOKEAI_ROOT }}/${{ matrix.stable-diffusion-model-dl-path }}/${{ matrix.stable-diffusion-model-dl-name }}" -L ${{ matrix.stable-diffusion-model-url }}
 
       - name: run configure_invokeai.py
         id: run-preload-models
-        run: |
-          ${{ env.pythonLocation }}/bin/python scripts/configure_invokeai.py --no-interactive --yes
-
-      - name: cat ~/.invokeai
-        id: cat-invokeai
-        run: cat ~/.invokeai
+        run: python3 scripts/configure_invokeai.py --no-interactive --yes
 
       - name: Run the tests
         id: run-tests
+        if: ${{ matrix.os }} != windows-latest
         run: |
-          time ${{ env.pythonLocation }}/bin/python scripts/invoke.py \
+          time python3 scripts/invoke.py \
             --no-patchmatch \
             --no-nsfw_checker \
             --model ${{ matrix.stable-diffusion-model }} \
@@ -122,6 +121,7 @@ jobs:
 
       - name: Archive results
         id: archive-results
+        if: ${{ matrix.os }} != windows-latest
         uses: actions/upload-artifact@v3
         with:
           name: results_${{ matrix.requirements-file }}_${{ matrix.python-version }}

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -77,8 +77,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: ${{ matrix.requirements-file }}
+          # cache: 'pip'
+          # cache-dependency-path: ${{ matrix.requirements-file }}
 
       # - name: install dependencies
       #   run: ${{ env.pythonLocation }}/bin/pip install --upgrade pip setuptools wheel

--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -33,7 +33,7 @@ torch-fidelity
 torchmetrics
 transformers==4.21.*
 picklescan
-git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.1#egg=gfpgan ; platform_system == 'Windows'
+# git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.1#egg=gfpgan ; platform_system == 'Windows'
 git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan ; platform_system != 'Windows'
 git+https://github.com/openai/CLIP.git@main#egg=clip
 git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion

--- a/environments-and-requirements/requirements-win-colab-cuda.txt
+++ b/environments-and-requirements/requirements-win-colab-cuda.txt
@@ -1,6 +1,7 @@
 -r environments-and-requirements/requirements-base.txt
 # Get hardware-appropriate torch/torchvision
 --extra-index-url https://download.pytorch.org/whl/cu116 --trusted-host https://download.pytorch.org
+gfpgan
 basicsr==1.4.1
 torch==1.12.1
 torchvision==0.13.1

--- a/environments-and-requirements/requirements-win-colab-cuda.txt
+++ b/environments-and-requirements/requirements-win-colab-cuda.txt
@@ -2,7 +2,7 @@
 # Get hardware-appropriate torch/torchvision
 --extra-index-url https://download.pytorch.org/whl/cu116 --trusted-host https://download.pytorch.org
 gfpgan
-basicsr==1.4.1
+basicsr
 torch==1.12.1
 torchvision==0.13.1
 -e .

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -119,7 +119,7 @@ PRECISION_CHOICES = [
 
 # is there a way to pick this up during git commits?
 APP_ID      = 'invoke-ai/InvokeAI'
-APP_VERSION = 'v2.2.0'
+APP_VERSION = 'v2.2.3'
 
 class ArgFormatter(argparse.RawTextHelpFormatter):
         # use defined argument order to display usage


### PR DESCRIPTION
this adds windows to the test workflows, but I disabled to run the tests themselves since for some reason the windows runners do not have enough memory (even when specs are the same as for linux https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)