### PR TITLE
Fix --embedding_directory / --embedding_path not working

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -68,6 +68,8 @@ def main():
     if opt.embeddings:
         if not os.path.isabs(opt.embedding_path):
             embedding_path = os.path.normpath(os.path.join(Globals.root,opt.embedding_path))
+        else:
+            embedding_path = opt.embedding_path
     else:
         embedding_path = None
 


### PR DESCRIPTION
It was not being assigned if the supplied path is correct crashing the app on load if loading with embeddings.