### PR TITLE
Fix Broken Link To Notebook

### DIFF
--- a/docs/installation/INSTALL_JUPYTER.md
+++ b/docs/installation/INSTALL_JUPYTER.md
@@ -2,12 +2,10 @@
 title: Running InvokeAI on Google Colab using a Jupyter Notebook
 ---
 
-# THIS DOCUMENTATION IS UNFINISHED - VOLUNTEERS GRATEFULLY ACCEPTED
-
 ## Introduction
 
 We have a [Jupyter
-notebook](https://github.com/invoke-ai/InvokeAI/blob/main/notebooks/Stable-Diffusion-local-Windows.ipynb)
+notebook](https://github.com/invoke-ai/InvokeAI/blob/main/notebooks/Stable_Diffusion_AI_Notebook.ipynb)
 with cell-by-cell installation steps. It will download the code in
 this repo as one of the steps, so instead of cloning this repo, simply
 download the notebook from the link above and load it up in VSCode
@@ -16,10 +14,19 @@ start running the cells one-by-one.
 
 !!! Note "you will need NVIDIA drivers, Python 3.10, and Git installed beforehand"
 
-## Walkthrough
+## Running Online On Google Colabotary
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/invoke-ai/InvokeAI/blob/main/notebooks/Stable_Diffusion_AI_Notebook.ipynb)
 
-## Updating to newer versions
+## Running Locally (Cloning)
 
-### Updating the stable version
+1. Install the Jupyter Notebook python library (one-time):
+pip install jupyter
 
-## Troubleshooting
+2. Clone the InvokeAI repository:
+git clone https://github.com/invoke-ai/InvokeAI.git
+cd invoke-ai
+3. Create a virtual environment using conda:
+conda create -n invoke jupyter
+4. Activate the environment and start the Jupyter notebook:
+conda activate invoke
+jupyter notebook


### PR DESCRIPTION
* The link pointed to https://github.com/invoke-ai/InvokeAI/blob/main/notebooks/Stable-Diffusion-local-Windows.ipynb which does not exist so it has been replaced with https://github.com/invoke-ai/InvokeAI/blob/main/notebooks/Stable_Diffusion_AI_Notebook.ipynb

* Add buttons for running on Colab 

* Tried adding running InvokeAI on Binder but the error was: ERROR: Ignored the following versions that require a different python version: 0.55.2 Requires-Python <3.5 ERROR: Could not find a version that satisfies the requirement clipseg (from invokeai) (from versions: none) ERROR: No matching distribution found for clipseg
Removing intermediate container 25be65428187
The command '/bin/sh -c ${KERNEL_PYTHON_PREFIX}/bin/pip install --no-cache-dir .' returned a non-zero code: 1


![Screenshot 2022-12-06 at 13-01-53 The Binder Project](https://user-images.githubusercontent.com/6527493/205849132-b8954376-1f2c-4f71-bc6c-01ddc60c3ebe.png)

`## Running Online On JupyterHub Binder
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/invoke-ai/InvokeAI/main?labpath=https%3A%2F%2Fgithub.com%2Finvoke-ai%2FInvokeAI%2Fblob%2Fmain%2Fnotebooks%2FStable_Diffusion_AI_Notebook.ipynb)`

This will have to be added for having the Launch | Binder button after it runs properly.