### PR TITLE
Update invoke.bat.in isolate environment variables

### DIFF
--- a/source_installer/invoke.bat.in
+++ b/source_installer/invoke.bat.in
@@ -1,5 +1,8 @@
 @echo off
 
+REM  isolate changes to environment variables so that this can be run again with restarting a cmd session
+setlocal
+
 PUSHD "%~dp0"
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
@@ -28,3 +31,4 @@ IF /I "%restore%" == "1" (
     pause
     exit /b
 )
+endlocal


### PR DESCRIPTION
Without locally scoped (to the script) environment variables, this script can only be run once and then you need to start a new cmd session to get a clean environment.

Surrounding the script with setlocal/endlocal achieves this.

https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setlocal https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/endlocal