### PR TITLE
Fix `docker push` github action and expand with additional metadata

### DIFF
--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
     - main
-    - development
     tags:
       - v*
+  # we will NOT push the image on pull requests, only test buildability.
+  pull_request:
+    branches:
+    - main
 
 permissions:
   contents: read
@@ -35,22 +38,37 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        # see https://github.com/docker/metadata-action
+        # will push the following tags (suffixed wit the arch):
+        # :edge
+        # :main (+ any other branches enabled in the workflow
+        # :<tag>
+        # :1.2.3 (for semver tags)
+        # :1.2 (for semver tags)
+        # :<sha>
         tags: |
+          type=edge,branch=main
           type=ref,event=branch
           type=ref,event=tag
-          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
           type=sha
+        # will su
+        flavor: |
+          latest=false
+          suffix=-${{ matrix.arch }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    # - if: github.event_name != 'pull_request'
-    #   name: Docker login
-    #   uses: docker/login-action@v2
-    #   with:
-    #     registry: ghcr.io
-    #     username: ${{ github.actor }}
-    #     password: ${{ secrets.GITHUB_TOKEN }}
+    # do not login to container registry on PRs
+    - if: github.event_name != 'pull_request'
+      name: Docker login
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push cloud image
       uses: docker/build-push-action@v3
@@ -58,7 +76,7 @@ jobs:
         context: .
         file: docker-build/Dockerfile.cloud
         platforms: Linux/${{ matrix.arch }}
-        # push: ${{ github.event_name != 'pull_request' }}
-        push: false
+        # do not push the image on PRs
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -57,8 +57,10 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=sha
+        # suffix image tags with architecture
         flavor: |
           latest=auto
+          suffix=-${{ matrix.arch }},latest=true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -26,7 +26,8 @@ jobs:
       matrix:
         arch:
         - x86_64
-        - aarch64
+        # requires resolving a patchmatch issue
+        # - aarch64
     runs-on: ubuntu-latest
     name: ${{ matrix.arch }}
     steps:

--- a/.github/workflows/build-cloud-img.yml
+++ b/.github/workflows/build-cloud-img.yml
@@ -24,14 +24,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # only x86_64 for now. aarch64+cuda isn't really a thing yet
         arch:
         - x86_64
+        - aarch64
     runs-on: ubuntu-latest
     name: ${{ matrix.arch }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      if: matrix.arch == 'aarch64'
 
     - name: Docker meta
       id: meta
@@ -39,9 +43,9 @@ jobs:
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         # see https://github.com/docker/metadata-action
-        # will push the following tags (suffixed wit the arch):
+        # will push the following tags:
         # :edge
-        # :main (+ any other branches enabled in the workflow
+        # :main (+ any other branches enabled in the workflow)
         # :<tag>
         # :1.2.3 (for semver tags)
         # :1.2 (for semver tags)
@@ -53,10 +57,8 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=sha
-        # will su
         flavor: |
-          latest=false
-          suffix=-${{ matrix.arch }}
+          latest=auto
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Modifies the cloud image build workflow;  rules are as follows:
- image will be built on all pushes to `main`, all tags starting with `v`,  and all pull requests.
- image will NOT be pushed on any pull requests.
- do NOT perform docker login on pull requests.
- PR workflows from new contributors will need approval to run. Workflows from forked repo will run in the context of the fork first, and will not have access to any secrets in this repo. Collaborators can examine them before approving workflow runs on this repo.

Image tags added as follows:
  - `:latest` for the last commit on the repo (any branch or tag, even though it's just `main` now)
  - `:edge` for every last commit on `main` (like `:latest` but *only* for `main`)
  - `:main` (or other <branch_name>, (even thouh we only run this on `main` right now)
  - `:v1.2.3`
  - `1.2.3`
  - `1.2`
  - `cdf4567` (git short SHA)

(I'm open to disabling workflow execution on PRs if that is deemed uncomfortable)