### PR TITLE
Arch Linux Specific PatchMatch Instructions & fixing conda install on linux

### DIFF
--- a/docs/installation/INSTALL_PATCHMATCH.md
+++ b/docs/installation/INSTALL_PATCHMATCH.md
@@ -26,6 +26,9 @@ it.
 Prior to installing PyPatchMatch, you need to take the following
 steps:
 
+### Debian Based Distros
+
+
 1. Install the `build-essential` tools:
 
    ```
@@ -44,6 +47,7 @@ steps:
    ```
    cd /usr/lib/x86_64-linux-gnu/pkgconfig/
    ln -sf opencv4.pc opencv.pc
+   ```
 
 4. Activate the environment you use for invokeai, either with
 `conda` or with a virtual environment.
@@ -51,7 +55,7 @@ steps:
 5. Do a "develop" install of pypatchmatch:
 
    ```
-   pip install -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.3#egg=pypatchmatch
+   pip install -e "git+https://github.com/invoke-ai/PyPatchMatch@0.1.3#egg=pypatchmatch"
    ```
 
 6. Confirm that pypatchmatch is installed.
@@ -79,8 +83,33 @@ steps:
    [link] libpatchmatch.so ...
    ```
 
+
+### Arch Based Distros
+
+1. Install the `base-devel` package:
+   ```
+   sudo pacman -Syu
+   sudo pacman -S --needed base-devel
+   ```
+
+2. Install `opencv`:
+   ```
+   sudo pacman -S opencv
+   ```
+   or for CUDA support
+   ```
+   sudo pacman -S opencv-cuda
+   ```
+
+3. Fix the naming of the `opencv` package configuration file:
+   ```
+   cd /usr/lib/pkgconfig/
+   ln -sf opencv4.pc opencv.pc
+   ```
+
+**Next, Follow Steps 4-6 from the Debian Section above**
+
+
 If you see no errors, then you're ready to go!
-
-
 
 

--- a/docs/installation/INSTALL_PATCHMATCH.md
+++ b/docs/installation/INSTALL_PATCHMATCH.md
@@ -55,7 +55,7 @@ steps:
 5. Do a "develop" install of pypatchmatch:
 
    ```
-   pip install -e "git+https://github.com/invoke-ai/PyPatchMatch@0.1.3#egg=pypatchmatch"
+   pip install "git+https://github.com/invoke-ai/PyPatchMatch@0.1.3#egg=pypatchmatch"
    ```
 
 6. Confirm that pypatchmatch is installed.

--- a/environments-and-requirements/environment-lin-aarch64.yml
+++ b/environments-and-requirements/environment-lin-aarch64.yml
@@ -42,5 +42,5 @@ dependencies:
       - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
       - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
       - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
-      - -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
+      - git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
       - -e .

--- a/environments-and-requirements/environment-lin-amd.yml
+++ b/environments-and-requirements/environment-lin-amd.yml
@@ -44,5 +44,5 @@ dependencies:
     - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion
     - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
     - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
-    - -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
+    - git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
     - -e .

--- a/environments-and-requirements/environment-lin-cuda.yml
+++ b/environments-and-requirements/environment-lin-cuda.yml
@@ -43,5 +43,5 @@ dependencies:
     - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion
     - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
     - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
-    - -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
+    - git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
     - -e .

--- a/environments-and-requirements/environment-mac.yml
+++ b/environments-and-requirements/environment-mac.yml
@@ -59,7 +59,7 @@ dependencies:
       - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion
       - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
       - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan
-      - -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
+      - git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
       - -e .
 variables:
   PYTORCH_ENABLE_MPS_FALLBACK: 1

--- a/environments-and-requirements/environment-win-cuda.yml
+++ b/environments-and-requirements/environment-win-cuda.yml
@@ -44,5 +44,5 @@ dependencies:
     - git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
     - git+https://github.com/invoke-ai/clipseg.git@relaxed-python-requirement#egg=clipseg
     - git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.1#egg=gfpgan
-    - -e git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
+    - git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch
     - -e .


### PR DESCRIPTION
* Added Arch Linux Specific Instructions to properly install Patchmatch.

* Fixed a codeblock not being properly closed in the INSTALL_PATCHMATCH.md file.

* Removed the "-e" flag on PyPatchMatch in all environment-xxx-yyy.yaml files and the INSTALL_PATCHMATCH.md file. 
  Keeping the "-e" flag appears to cause an "RemoteNotFound" Error. This may break PyPatchMatch however allows successful installation of InvokeAI via conda. 

  Screenshots before and after i made the changes:
  
![image](https://user-images.githubusercontent.com/52699291/206306677-2d3ca8ff-0964-4355-86c9-5210b751a744.png)
![image](https://user-images.githubusercontent.com/52699291/206306810-b322a291-a167-403a-aef0-e8eb229991ff.png)


* Added Quotes ( " ) around the PyPatchMatch git link.  
Reason for this is to avoid an error where ZSH sees the given link as regex, causing the command to not execute properly