### PR TITLE
Fix error when init_mask=None and invert_mask=True

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -757,7 +757,7 @@ class Generate:
         elif text_mask:
             init_mask = self._txt2mask(image, text_mask, width, height, fit=fit)
 
-        if invert_mask:
+        if init_mask and invert_mask:
             init_mask = ImageOps.invert(init_mask)
             
         return init_image,init_mask


### PR DESCRIPTION
In the event where no `init_mask` is given and `invert_mask` is set to True, the script will raise the following error:

```bash
AttributeError: 'NoneType' object has no attribute 'mode'
```

The new implementation will run image inversion only when both variables are valid.