### PR TITLE
Update transformers

### DIFF
--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -31,7 +31,7 @@ taming-transformers-rom1504
 test-tube>=0.7.5
 torch-fidelity
 torchmetrics
-transformers==4.21.*
+transformers==4.25.*
 picklescan
 git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.1#egg=gfpgan ; platform_system == 'Windows'
 git+https://github.com/invoke-ai/GFPGAN@basicsr-1.4.2#egg=gfpgan ; platform_system != 'Windows'


### PR DESCRIPTION
Getting: 
```
ImportError: `diffusers` requires transformers >= 4.25.1 to function correctly, but 4.21.3 was found in your environment. You can upgrade it with pip: `pip install transformers --upgrade`
```

System:
```
Dockerfile:		 docker-build/Dockerfile
requirements:		 requirements-lin-cuda.txt
volumename:		 invokeai_data
arch:			 x86_64
platform:		 Linux/x86_64
invokeai_tag:		 invokeai:x86_64
```