### PR TITLE
pin diffusers to 0.9.0

### DIFF
--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -1,7 +1,7 @@
 # pip will resolve the version which matches torch
 albumentations
 dependency_injector==4.40.0
-diffusers
+diffusers==0.9.0
 einops
 eventlet
 facexlib


### PR DESCRIPTION
The new diffusers update requires an update to transformers, but the transformers update causes the NSFW checker to fail in a new way. Until this is resolved, I am pinning diffusers to the older working version.