### PR TITLE
fix InvokeAI download URLs

### DIFF
--- a/installer/install.bat.in
+++ b/installer/install.bat.in
@@ -15,7 +15,7 @@ if "%1" == "use-cache" (
 @rem Config
 @rem this should be changed to the tagged release!
 @rem set INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/archive/main.zip
-set INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/refs/tags/2.2.4-rc1.zip
+set INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/archive/refs/tags/2.2.4-rc1.zip
 set INSTRUCTIONS=https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/
 set TROUBLESHOOTING=https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/#troubleshooting
 set PYTHON_URL=https://www.python.org/downloads/windows/

--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -9,7 +9,7 @@ cd "$scriptdir"
 deactivate >/dev/null 2>&1
 
 # this should be changed to the tagged release!
-INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/refs/tags/2.2.4-rc1.zip
+INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/archive/refs/tags/2.2.4-rc1.zip
 INSTRUCTIONS=https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/
 TROUBLESHOOTING=https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/#troubleshooting
 MINIMUM_PYTHON_VERSION=3.9.0


### PR DESCRIPTION
- This fixes the .bat and .sh file URLs for the installer's InvokeAI source code download and is needed for the 2.2.4 release.
