### PR TITLE
Fix GUI not working

### DIFF
--- a/backend/invoke_ai_web_server.py
+++ b/backend/invoke_ai_web_server.py
@@ -209,10 +209,9 @@ class InvokeAIWebServer:
                 FlaskUI(
                     app=self.app,
                     socketio=self.socketio,
-                    start_server="flask-socketio",
+                    server="flask_socketio",
                     width=1600,
                     height=1000,
-                    idle_interval=10,
                     port=self.port
                 ).run()
             except KeyboardInterrupt:

--- a/binary_installer/requirements.in
+++ b/binary_installer/requirements.in
@@ -8,7 +8,7 @@ diffusers
 eventlet
 flask_cors
 flask_socketio
-flaskwebgui
+flaskwebgui==1.0.3
 getpass_asterisk
 imageio-ffmpeg
 pyreadline3

--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -8,7 +8,7 @@ facexlib
 flask==2.1.3
 flask_cors==3.0.10
 flask_socketio==5.3.0
-flaskwebgui==0.3.7
+flaskwebgui==1.0.3
 getpass_asterisk
 gfpgan==1.3.8
 huggingface-hub


### PR DESCRIPTION
Fixes GUI not working on the newer versions of flaskwebgui due to a changed syntax.


@lstein I updated the version requirement for flaskwebgui to use the latest. There are 3 references in the requirement files in the binary installers that I did not update. I'm not sure if they need updating at this point. I'll let you decide on that.

If they don't, then this PR is good to go.