### PR TITLE
Fix the mistake of not importing the gc

### DIFF
--- a/ldm/invoke/generator/txt2img2img.py
+++ b/ldm/invoke/generator/txt2img2img.py
@@ -5,6 +5,7 @@ ldm.invoke.generator.txt2img inherits from ldm.invoke.generator
 import torch
 import numpy as  np
 import math
+import gc
 from ldm.invoke.generator.base import Generator
 from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.invoke.generator.omnibus import Omnibus


### PR DESCRIPTION
## Information
The "import gc" code at the top of the "ldm/invoke/generator/txt2img2img.py" file is missing, so add the import gc code.

## Reference
#1915 
