### PR TITLE
add logic for finding the root (runtime) directory

### DIFF
--- a/ldm/invoke/globals.py
+++ b/ldm/invoke/globals.py
@@ -11,12 +11,13 @@ the attributes:
 '''
 
 import os
+import os.path as osp
 from argparse import Namespace
 
 Globals = Namespace()
 
 # This is usually overwritten by the command line and/or environment variables
-Globals.root = os.path.abspath(os.environ.get('INVOKEAI_ROOT') or os.path.expanduser('~/invokeai'))
+Globals.root = osp.abspath(os.environ.get('INVOKEAI_ROOT') or osp.abspath(osp.join(os.environ.get('VIRTUAL_ENV'),'..')) or osp.expanduser('~/invokeai'))
 
 # Where to look for the initialization file
 Globals.initfile = 'invokeai.init'


### PR DESCRIPTION
This commit fixes the root search logic to be as follows:

1) The `--root_dir` command line argument
2) The contents of environment variable INVOKEAI_ROOT 
3) The VIRTUAL_ENV environment variable, plus '..' (yielding the parent of .venv, which is `invokeai`)
4) $HOME/invokeai

(3) is the new feature. Since we are now recommending to install InvokeAI and its dependencies into the .venv in the root directory, this should be a reliable choice.

This addresses multiple discord bug reports and Issue #1932 . The scenario it fixes is when the user runs `invoke.py` from outside the runtime directory, the script can't find its runtime directory and calls `configure_invoke.py` to rebuild it. Configure does this, but the `.venv` and `install.sh` are still inside the original runtime directory. Confusion ensues.