### PR TITLE
Make Dockerfile cloud ready (tested on runpod)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -70,4 +70,5 @@ jobs:
           platforms: ${{ matrix.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: pip_requirements=${{ matrix.pip-requirements }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,5 +1,3 @@
-# Building the Image without pushing to confirm it is still buildable
-# confirum functionality would unfortunately need way more resources
 name: build container image
 on:
   push:
@@ -11,28 +9,65 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pip-requirements:
-          - requirements-lin-amd.txt
-          - requirements-lin-cuda.txt
+        registry:
+          - ghcr.io
+        flavor:
+          - amd
+          - cuda
+          # - cloud
+        include:
+          - flavor: amd
+            pip-requirements: requirements-lin-amd.txt
+            dockerfile: docker-build/Dockerfile
+            platforms: linux/amd64,linux/arm64
+          - flavor: cuda
+            pip-requirements: requirements-lin-cuda.txt
+            dockerfile: docker-build/Dockerfile
+            platforms: linux/amd64,linux/arm64
+          # - flavor: cloud
+          #   pip-requirements: requirements-lin-cuda.txt
+          #   dockerfile: docker-build/Dockerfile.cloud
+          #   platforms: linux/amd64
     runs-on: ubuntu-latest
-    name: ${{ matrix.pip-requirements }} ${{ matrix.arch }}
+    name: ${{ matrix.flavor }}
     steps:
-      - name: prepare docker-tag
-        env:
-          repository: ${{ github.repository }}
-        run: echo "dockertag=${repository,,}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ matrix.registry }}/${{ github.repository }}-${{ matrix.flavor }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+          flavor: |
+            latest=true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - if: github.event_name != 'pull_request'
+        name: Docker login
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build container
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: docker-build/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: ${{ env.dockertag }}:${{ matrix.pip-requirements }}
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: pip_requirements=${{ matrix.pip-requirements }}

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -23,6 +23,12 @@ COPY . ./environments-and-requirements/${PIP_REQUIREMENTS} ./
 # install requirements
 RUN python3 -m venv .venv \
   && pip install \
+    --upgrade \
+    --no-cache-dir \
+    'pip>=22.3.1' \
+    'setuptools>=65.5.0' \
+    'wheel>=0.38.4' \
+  && pip install \
     --no-cache-dir \
     -r ${PIP_REQUIREMENTS}
 
@@ -42,6 +48,7 @@ COPY --from=builder /usr/src/app .
 
 # set Environment, Entrypoint and default CMD
 ENV INVOKEAI_ROOT /data
+ENV INVOKE_MODEL_RECONFIGURE --yes
 ENV PATH=/usr/src/app/.venv/bin:$PATH
 
 ENTRYPOINT [ "python3", "scripts/invoke.py" ]

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -30,6 +30,7 @@ RUN python3 -m venv .venv \
     'wheel>=0.38.4' \
   && pip install \
     --no-cache-dir \
+    wheel \
     -r ${PIP_REQUIREMENTS}
 
 FROM python:3.10-slim AS runtime

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -30,7 +30,6 @@ RUN python3 -m venv .venv \
     'wheel>=0.38.4' \
   && pip install \
     --no-cache-dir \
-    wheel \
     -r ${PIP_REQUIREMENTS}
 
 FROM python:3.10-slim AS runtime

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -16,4 +16,5 @@ docker run \
   --hostname="$project_name" \
   --mount="source=$volumename,target=/data" \
   --publish=9090:9090 \
+  --cap-add=sys_nice \
   "$invokeai_tag" ${1:+$@}

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -941,7 +941,11 @@ def emergency_model_reconfigure():
     print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
     print('configure_invokeai is launching....\n')
 
-    sys.argv = ['configure_invokeai','--interactive']
+    sys.argv = [
+        'configure_invokeai',
+        os.environ.get(
+            'INVOKE_MODEL_RECONFIGURE',
+            '--interactive')]
     import configure_invokeai
     configure_invokeai.main()
 


### PR DESCRIPTION
Updating the `build-container.yml` Workflow to also push images (@ebr I also already PoC'ed that it would work to push both Dockerfiles with this single Workflow)

Also introducing a new env var: INVOKE_MODEL_RECONFIGURE
With this it is possible that the container pulls necesary Model Files without Interaction. If someone wants to alter configuration he has two easy options:
- SSH into the container (tested on runpod)
- create a fork

And if someone asks "whats the difference with the cloud image" - well, I think it has a inappropriate name now and should be renamed to "patchmatch". The Difference is that it comes with patchmatch but therfore only works on amd64, while the Dockerfile is at least tested on amd64 and arm64