### PR TITLE
Potential fix for segfault on macOS in homebrew-provided Python

### DIFF
--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -110,12 +110,6 @@ if [ -z "$PYTHON" ]; then
     exit -1
 fi
 
-if [ "$OS_NAME" == "osx" ]; then
-    xcode_path=$(xcode-select --print-path)
-    _err_exit $? "xcode_path command not found"
-    export CPPFLAGS="-I$xcode_path/Library/Frameworks/Python3.framework/Versions/Current/Headers"
-    echo "Will compile wheels with CPPFLAGS=$CPPFLAGS"
-fi
 
 ROOTDIR=""
 while [ "$ROOTDIR" == "" ]


### PR DESCRIPTION
Since we moved to installing `gfpgan` and `transformers` from PyPi (as opposed to compiling them from source), we no longer need to provide a path to CPython headers. `brew` seems to be finicky when trying to use headers from an unexpected location:

https://docs.brew.sh/Homebrew-and-Python#homebrew-provided-python-bindings

> Warning! Python may crash (see [Common Issues](https://docs.brew.sh/Common-Issues)) when you import <module> from a brewed Python if you ran brew install <formula_with_python_bindings> against the system Python. If you decide to switch to the brewed Python, then reinstall all formulae with Python bindings (e.g. pyside, wxwidgets, pyqt, pygobject3, opencv, vtk and boost-python).

Notably, this list includes `opencv` as well. No idea if that's significant.

I tested this change on an M1 (Ventura) system, and was able to both install, and generate images without segfault, with both `homebrew` python (3.10) and system Python (3.9).

I did not test with `conda`, given that we no longer support it as an install method. but it's likely going to work fine because we never needed to provide header paths in `conda` envs anyway.

(Hopefully) Fixes #1941 