### PR TITLE
remove redundant tests, only do 20 steps

### DIFF
--- a/tests/preflight_prompts.txt
+++ b/tests/preflight_prompts.txt
@@ -1,9 +1,4 @@
-banana sushi -Ak_lms -S42
-banana sushi -Addim -S42
-banana sushi -Ak_lms -W640 -H480 -S42
-banana sushi -Ak_lms -S42 -G1 -U 2 0.5
-banana sushi -Ak_lms -S42 -v0.2 -n3
-banana sushi -Ak_lms -S42 -V1349749425:0.1,4145759947:0.1
-snake -I outputs/preflight/000006.4145759947.png -S42
-snake -I outputs/preflight/000006.4145759947.png -S42 -W640 -H640 --fit
-strawberry sushi -I./image-and-mask.png -S42 -f0.9 -s100 -C15
+banana sushi -Ak_lms -W640 -H480 -S42 -s20
+banana sushi -Ak_lms -S42 -G1 -U 2 0.5 -s20
+banana sushi -Ak_lms -S42 -v0.2 -n3 -s20
+banana sushi -Ak_lms -S42 -V1349749425:0.1,4145759947:0.1 -s20


### PR DESCRIPTION
- remove tests already performed in PR
- remove tests pointing to non existing files
- reduce steps to 20

This should decrease test time a lot and also "fix" failing mac tests.
I still recommend to invent why mac invoke takes so much longer!