### PR TITLE
Fix: define path as None before usage

### DIFF
--- a/ldm/invoke/generator/base.py
+++ b/ldm/invoke/generator/base.py
@@ -306,6 +306,7 @@ class Generator():
         return blurry
 
     def get_caution_img(self):
+        path = None
         if self.caution_img:
             return self.caution_img
         # Find the caution image. If we are installed in the package directory it will


### PR DESCRIPTION
path variable should be defined even before 
"if not path:"
So a small fix for python for this problem:
![image](https://user-images.githubusercontent.com/2925027/207410629-eeda0f27-f499-4c79-bec8-468ba08448c2.png)
