### PR TITLE
add concurrency to test actions

### DIFF
--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -9,6 +9,10 @@ on:
       - 'main'
       - 'development'
 
+concurrency:
+   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+   cancel-in-progress: true
+
 jobs:
   matrix:
     strategy:

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -9,6 +9,10 @@ on:
       - 'main'
       - 'development'
 
+concurrency:
+   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+   cancel-in-progress: true
+
 jobs:
   matrix:
     strategy:


### PR DESCRIPTION
configured to only cancel workflows in PRs, but not on main branch
origins in #1933, but opitmized to not cancel workflows of non PRs