### PR TITLE
add an argument that lets user specify folders to scan for weights

### DIFF
--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -432,6 +432,12 @@ class Args(object):
             help='Indicates which diffusion model to load (defaults to "default" stanza in configs/models.yaml)',
         )
         model_group.add_argument(
+            '--weight_folders',
+            nargs='+',
+            type=str,
+            help='List of folders that will be scanned for new model weights to import',
+        )
+        model_group.add_argument(
             '--png_compression','-z',
             type=int,
             default=6,

--- a/ldm/invoke/args.py
+++ b/ldm/invoke/args.py
@@ -432,10 +432,10 @@ class Args(object):
             help='Indicates which diffusion model to load (defaults to "default" stanza in configs/models.yaml)',
         )
         model_group.add_argument(
-            '--weight_folders',
+            '--weight_dirs',
             nargs='+',
             type=str,
-            help='List of folders that will be scanned for new model weights to import',
+            help='List of one or more directories that will be auto-scanned for new model weights to import',
         )
         model_group.add_argument(
             '--png_compression','-z',


### PR DESCRIPTION
This PR adds a `--weight_folders` argument to invoke.py. Using argparse, it adds a "weight_folders" attribute to the Args object. It is intended to support @blessedcoolant 's weight file autoscan feature, and can be used like this:

```
'''test.py'''
from ldm.invoke.args import Args

args = Args().parse_args()
for folder in args.weight_folders:
    print(folder)
```

Example output:

```
python test.py --weight_folders /tmp/weights /home/fred/invokeai/weights "./my folder with spaces/weight files"
/tmp/weights
/home/fred/invokeai/weights
./my folder with spaces/weight files
```