### PR TITLE
fix root-finding for conda users

### DIFF
--- a/ldm/invoke/globals.py
+++ b/ldm/invoke/globals.py
@@ -22,7 +22,7 @@ if os.environ.get('INVOKEAI_ROOT'):
 elif os.environ.get('VIRTUAL_ENV'):
     Globals.root = osp.abspath(osp.join(os.environ.get('VIRTUAL_ENV'), '..'))
 else:
-    Globals.root = osp.abspath(osp.expanduser('~/invokeai'))
+    Globals.root = osp.abspath(osp.join(__file__, '../../..'))
 
 # Where to look for the initialization file
 Globals.initfile = 'invokeai.init'


### PR DESCRIPTION
PR #1948 added logic for finding the runtime root directory relative to $VIRTUAL_ENV, but conda users dont have this env var set. This changes the default root directory to be relative to the globals.py module.

I use conda for my InvokeAI environment and after pulling `main`, I was getting errors running scripts/invoke.py because it couldn't find models at the default ~/invokeai location.

(btw, https://github.com/invoke-ai/InvokeAI/blob/main/README.md#contributing says that PRs should be against the `development` branch, but it seemed like most recent PRs were just against `main`. Is merging into `main` ok? Should `development` PRs just be used for larger/riskier changes?)