### PR TITLE
better error reporting when root directory not found

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -45,8 +45,14 @@ def main():
             print('--max_loaded_models must be >= 1; using 1')
             args.max_loaded_models = 1
 
-    # alert - setting globals here
+    # alert - setting a global here
     Globals.try_patchmatch = args.patchmatch
+
+    if not os.path.exists(os.path.join(Globals.root,'configs','models.yaml')):
+        print(f"\n** Error. The file {os.path.join(Globals.root,'configs','models.yaml')} could not be found.")
+        print(f'** Please check the location of your invokeai directory and use the --root_dir option to point to the correct path.')
+        print(f'** This script will now exit.')
+        sys.exit(-1)
 
     print(f'>> InvokeAI runtime directory is "{Globals.root}"')
 


### PR DESCRIPTION
- The invoke.py script now checks that the root (runtime) directory contains the expected config/models.yaml file and if it doesn't exits with a helpful error message about how to set the proper root.

- Formerly the script would fail with a "bad model" message and try to redownload its models, which is not helpful in the case that the root is missing or damaged.

The error message on a bad root looks like this:
```
** Error. The file /home/lstein/badroot/configs/models.yaml could not be found.
** Please check the location of your invokeai directory and use the --root_dir option to point to the correct path.
** This script will now exit.
```