### PR TITLE
avoid leaking data to HuggingFace

### DIFF
--- a/ldm/invoke/concepts_lib.py
+++ b/ldm/invoke/concepts_lib.py
@@ -46,6 +46,9 @@ class Concepts(object):
         the named concept. Returns None if invalid or cannot
         be downloaded.
         '''
+        if not concept_name in self.list_concepts():
+            print(f'This concept is not known to the Hugging Face library. Generation will continue without the concept.')
+            return None
         return self.get_concept_file(concept_name.lower(),'learned_embeds.bin')
 
     def concept_to_trigger(self, concept_name:str)->str:


### PR DESCRIPTION
Before making a concept download request to HuggingFace, the concepts library module now checks the concept name against a downloaded list of all the concepts currently known to HuggingFace.  If the requested concept is not on the list, then no download request is made.