### PR TITLE
Permit override of cmd options for docker to allow CORS customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 # InvokeAI: A Stable Diffusion Toolkit
 
+_Formerly known as lstein/stable-diffusion_
+
+![project logo](docs/assets/logo.png)
+
 [![discord badge]][discord link]
 
 [![latest release badge]][latest release link] [![github stars badge]][github stars link] [![github forks badge]][github forks link]

--- a/backend/invoke_ai_web_server.py
+++ b/backend/invoke_ai_web_server.py
@@ -81,6 +81,7 @@ class InvokeAIWebServer:
         }
 
         if opt.cors:
+            print(f">> CORS: {opt.cors}")            
             socketio_args["cors_allowed_origins"] = opt.cors
 
         frontend_path = self.find_frontend()

--- a/docker-build/env.sh
+++ b/docker-build/env.sh
@@ -5,9 +5,11 @@ volumename=${VOLUMENAME:-${project_name}_data}
 arch=${ARCH:-x86_64}
 platform=${PLATFORM:-Linux/${arch}}
 invokeai_tag=${INVOKEAI_TAG:-${project_name}:${arch}}
+gpus=${GPU_FLAGS:+--gpus=${GPU_FLAGS}}
 
 export project_name
 export volumename
 export arch
 export platform
 export invokeai_tag
+export gpus

--- a/docker-build/env.sh
+++ b/docker-build/env.sh
@@ -6,6 +6,7 @@ arch=${ARCH:-x86_64}
 platform=${PLATFORM:-Linux/${arch}}
 invokeai_tag=${INVOKEAI_TAG:-${project_name}:${arch}}
 gpus=${GPU_FLAGS:+--gpus=${GPU_FLAGS}}
+cmd_override=${CMD_OVERRIDE:-'--web --host=0.0.0.0'}
 
 export project_name
 export volumename
@@ -13,3 +14,4 @@ export arch
 export platform
 export invokeai_tag
 export gpus
+export cmd_override

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -14,6 +14,7 @@ docker run \
   --platform="$platform" \
   --name="$project_name" \
   --hostname="$project_name" \
+  --gpus all \
   --mount="source=$volumename,target=/data" \
   --publish=9090:9090 \
   --cap-add=sys_nice \

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -18,4 +18,6 @@ docker run \
   --publish=9090:9090 \
   --cap-add=sys_nice \
   $gpus \
-  "$invokeai_tag" ${1:+$@}
+  "$invokeai_tag" ${1:+$@} \
+  $cmd_override
+  

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -17,5 +17,5 @@ docker run \
   --mount="source=$volumename,target=/data" \
   --publish=9090:9090 \
   --cap-add=sys_nice \
-  $GPU_FLAGS \
+  $gpus \
   "$invokeai_tag" ${1:+$@}

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -14,8 +14,8 @@ docker run \
   --platform="$platform" \
   --name="$project_name" \
   --hostname="$project_name" \
-  --gpus all \
   --mount="source=$volumename,target=/data" \
   --publish=9090:9090 \
   --cap-add=sys_nice \
+  $GPU_FLAGS \
   "$invokeai_tag" ${1:+$@}

--- a/docs/installation/INSTALL_DOCKER.md
+++ b/docs/installation/INSTALL_DOCKER.md
@@ -127,6 +127,27 @@ also do so.
 
 ---
 
+## Running the container on your GPU
+
+If you have an Nvidia GPU, you can enable InvokeAI to run on the GPU by running the container with an extra 
+environment variable to enable GPU usage and have the process run much faster:
+
+```bash
+GPUS=all ./docker-build/run.sh
+```
+
+This passes the `--gpus all` to docker and uses the GPU.
+
+If you don't have a GPU (or your host is not yet setup to use it) you will see a message like this:
+
+`docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]].`
+
+You can use the full set of GPU combinations documented here:
+
+https://docs.docker.com/config/containers/resource_constraints/#gpu
+
+For example, use `GPUS=device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a` to choose a specific device identified by a UUID.
+
 ## Running InvokeAI in the cloud with Docker
 
 We offer an optimized Ubuntu-based image that has been well-tested in cloud deployments. Note: it also works well locally on Linux x86_64 systems with an Nvidia GPU. It *may* also work on Windows under WSL2 and on Intel Mac (not tested).

--- a/docs/installation/INSTALL_DOCKER.md
+++ b/docs/installation/INSTALL_DOCKER.md
@@ -133,7 +133,7 @@ If you have an Nvidia GPU, you can enable InvokeAI to run on the GPU by running 
 environment variable to enable GPU usage and have the process run much faster:
 
 ```bash
-GPUS=all ./docker-build/run.sh
+GPU_FLAGS=all ./docker-build/run.sh
 ```
 
 This passes the `--gpus all` to docker and uses the GPU.
@@ -146,7 +146,7 @@ You can use the full set of GPU combinations documented here:
 
 https://docs.docker.com/config/containers/resource_constraints/#gpu
 
-For example, use `GPUS=device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a` to choose a specific device identified by a UUID.
+For example, use `GPU_FLAGS=device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a` to choose a specific device identified by a UUID.
 
 ## Running InvokeAI in the cloud with Docker
 


### PR DESCRIPTION
Right now you cannot pass switches to invoke.py. If you want to add CORS, you need to modify the Dockerfile.