### PR TITLE
fix: make update.sh respect custom runtime directory

### DIFF
--- a/installer/templates/update.sh.in
+++ b/installer/templates/update.sh.in
@@ -42,7 +42,7 @@ _err_exit $? "The pip program failed to install InvokeAI's requirements."
 pip install $INVOKE_AI_SRC
 _err_exit $? "The pip program failed to install InvokeAI."
 
-python .venv/bin/configure_invoke.py
+python .venv/bin/configure_invoke.py --root .
 _err_exit $? "The configure script failed to run successfully."
 
 


### PR DESCRIPTION
This PR makes `update.sh` work in custom runtime directories instead of writing to the default (`~/invokeai`).

`update.bat` has this fix but `update.sh` does not.

https://github.com/invoke-ai/InvokeAI/blob/0439b51a26e3c227588a22897309928519ad8412/installer/templates/update.bat.in#L42