### PR TITLE
Relax Huggingface login requirement during setup

### DIFF
--- a/.github/workflows/test-invoke-conda.yml
+++ b/.github/workflows/test-invoke-conda.yml
@@ -116,7 +116,7 @@ jobs:
       - name: run configure_invokeai.py
         id: run-preload-models
         run: |
-          python scripts/configure_invokeai.py --no-interactive --yes
+          python scripts/configure_invokeai.py --skip-sd-weights --yes
 
       - name: cat invokeai.init
         id: cat-invokeai

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: run configure_invokeai.py
         id: run-preload-models
-        run: python3 scripts/configure_invokeai.py --no-interactive --yes
+        run: python3 scripts/configure_invokeai.py --skip-sd-weights --yes
 
       - name: Run the tests
         id: run-tests

--- a/docs/features/CONCEPTS.md
+++ b/docs/features/CONCEPTS.md
@@ -43,6 +43,22 @@ You can also combine styles and concepts:
 </figure>
 ## Using a Hugging Face Concept
 
+!!! warning "Authenticating to HuggingFace"
+
+    Some concepts require valid authentication to HuggingFace. Without it, they will not be downloaded
+    and will be silently ignored.
+
+    If you used an installer to install InvokeAI, you may have already set a HuggingFace token.
+    If you skipped this step, you can:
+
+    - run the InvokeAI configuration script again (if you used a manual installer): `scripts/configure_invokeai.py`
+    - set one of the `HUGGINGFACE_TOKEN` or `HUGGING_FACE_HUB_TOKEN` environment variables to contain your token
+
+    Finally, if you already used any HuggingFace library on your computer, you might already have a token
+    in your local cache. Check for a hidden `.huggingface` directory in your home folder. If it
+    contains a `token` file, then you are all set.
+
+
 Hugging Face TI concepts are downloaded and installed automatically as you
 require them. This requires your machine to be connected to the Internet. To
 find out what each concept is for, you can browse the

--- a/docs/installation/020_INSTALL_MANUAL.md
+++ b/docs/installation/020_INSTALL_MANUAL.md
@@ -459,12 +459,12 @@ greatest version, launch the Anaconda window, enter `InvokeAI` and type:
 ```bash
 git pull
 conda env update
-python scripts/configure_invokeai.py --no-interactive  #optional
+python scripts/configure_invokeai.py --skip-sd-weights #optional
 ```
 
 This will bring your local copy into sync with the remote one. The last step may
 be needed to take advantage of new features or released models. The
-`--no-interactive` flag will prevent the script from prompting you to download
+`--skip-sd-weights` flag will prevent the script from prompting you to download
 the big Stable Diffusion weights files.
 
 ## Troubleshooting

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -110,7 +110,7 @@ def main():
             max_loaded_models=opt.max_loaded_models,
             )
     except (FileNotFoundError, TypeError, AssertionError):
-        emergency_model_reconfigure()
+        emergency_model_reconfigure(opt)
         sys.exit(-1)
     except (IOError, KeyError) as e:
         print(f'{e}. Aborting.')
@@ -123,7 +123,7 @@ def main():
     try:
         gen.load_model()
     except AssertionError:
-        emergency_model_reconfigure()
+        emergency_model_reconfigure(opt)
         sys.exit(-1)
 
     # web server loops forever
@@ -939,7 +939,7 @@ def write_commands(opt, file_path:str, outfilepath:str):
             f.write('\n'.join(commands))
         print(f'>> File {outfilepath} with commands created')
 
-def emergency_model_reconfigure():
+def emergency_model_reconfigure(opt):
     print()
     print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
     print('   You appear to have a missing or misconfigured model file(s).                   ')
@@ -948,11 +948,12 @@ def emergency_model_reconfigure():
     print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
     print('configure_invokeai is launching....\n')
 
-    sys.argv = [
-        'configure_invokeai',
-        os.environ.get(
-            'INVOKE_MODEL_RECONFIGURE',
-            '--interactive')]
+    # try to match what the user has set on the CLI
+    root_dir = f"--root_dir {opt.root_dir}" if opt.root_dir is not None else None
+    config = f"--config {opt.config}" if opt.config is not None else None
+    yes_to_all = os.environ.get('INVOKE_MODEL_RECONFIGURE')
+
+    sys.argv = [ 'configure_invokeai', root_dir, config, yes_to_all ]
+
     import configure_invokeai
     configure_invokeai.main()
-

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -948,12 +948,17 @@ def emergency_model_reconfigure(opt):
     print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
     print('configure_invokeai is launching....\n')
 
-    # try to match what the user has set on the CLI
-    root_dir = f"--root_dir {opt.root_dir}" if opt.root_dir is not None else None
-    config = f"--config {opt.config}" if opt.config is not None else None
+    # Match arguments that were set on the CLI
+    # only the arguments accepted by the configuration script are parsed
+    root_dir = ["--root", opt.root_dir] if opt.root_dir is not None else []
+    config = ["--config", opt.conf] if opt.conf is not None else []
     yes_to_all = os.environ.get('INVOKE_MODEL_RECONFIGURE')
 
-    sys.argv = [ 'configure_invokeai', root_dir, config, yes_to_all ]
+    sys.argv = [ 'configure_invokeai' ]
+    sys.argv.extend(root_dir)
+    sys.argv.extend(config)
+    if yes_to_all is not None:
+        sys.argv.append(yes_to_all)
 
     import configure_invokeai
     configure_invokeai.main()

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -735,7 +735,12 @@ def main():
                         dest='interactive',
                         action=argparse.BooleanOptionalAction,
                         default=True,
-                        help='run in interactive mode (default)')
+                        help='run in interactive mode (default) - DEPRECATED')
+    parser.add_argument('--skip-sd-weights',
+                        dest='skip_sd_weights',
+                        action=argparse.BooleanOptionalAction,
+                        default=False,
+                        help='skip downloading the large Stable Diffusion weight files')
     parser.add_argument('--yes','-y',
                         dest='yes_to_all',
                         action='store_true',
@@ -768,7 +773,12 @@ def main():
         # Optimistically try to download all required assets. If any errors occur, add them and proceed anyway.
         errors=set()
 
-        if opt.interactive:
+        if not opt.interactive:
+            print("WARNING: The --(no)-interactive argument is deprecated and will be removed. Use --skip-sd-weights.")
+            opt.skip_sd_weights=True
+        if opt.skip_sd_weights:
+            print('** SKIPPING DIFFUSION WEIGHTS DOWNLOAD PER USER REQUEST **')
+        else:
             print('** DOWNLOADING DIFFUSION WEIGHTS **')
             errors.add(download_weights(opt))
         print('\n** DOWNLOADING SUPPORT MODELS **')

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -212,7 +212,7 @@ def HfLogin(access_token) -> str:
 #-------------------------------Authenticate against Hugging Face
 def authenticate(yes_to_all=False):
     print('** LICENSE AGREEMENT FOR WEIGHT FILES **')
-    print("═" * os.get_terminal_size()[0])
+    print("=" * os.get_terminal_size()[0])
     print('''
 By downloading the Stable Diffusion weight files from the official Hugging Face
 repository, you agree to have read and accepted the CreativeML Responsible AI License.
@@ -221,7 +221,7 @@ The license terms are located here:
    https://huggingface.co/spaces/CompVis/stable-diffusion-license
 
 ''')
-    print("═" * os.get_terminal_size()[0])
+    print("=" * os.get_terminal_size()[0])
 
     if not yes_to_all:
         accepted = False
@@ -237,7 +237,7 @@ The license terms are located here:
     # Authenticate to Huggingface using environment variables.
     # If successful, authentication will persist for either interactive or non-interactive use.
     # Default env var expected by HuggingFace is HUGGING_FACE_HUB_TOKEN.
-    print("═" * os.get_terminal_size()[0])
+    print("=" * os.get_terminal_size()[0])
     print('Authenticating to Huggingface')
     hf_envvars = [ "HUGGING_FACE_HUB_TOKEN", "HUGGINGFACE_TOKEN" ]
     if not (access_token := HfFolder.get_token()):
@@ -294,7 +294,7 @@ You may re-run the configuration script again in the future if you do not wish t
         print()
         print(f"Re-run the configuration script without '--yes' to set the HuggingFace token interactively, or use one of the environment variables: {', '.join(hf_envvars)}")
 
-    print("═" * os.get_terminal_size()[0])
+    print("=" * os.get_terminal_size()[0])
 
     return access_token
 

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -290,7 +290,7 @@ You may re-run the configuration script again in the future if you do not wish t
 
     elif access_token is None:
         print()
-        print("HuggingFace login did not succeed. Some functionality may be limited; see https://invoke-ai.github.io/InvokeAI/features/CONCEPTS/ for more information")
+        print("HuggingFace login did not succeed. Some functionality may be limited; see https://invoke-ai.github.io/InvokeAI/features/CONCEPTS/#using-a-hugging-face-concept for more information")
         print()
         print(f"Re-run the configuration script without '--yes' to set the HuggingFace token interactively, or use one of the environment variables: {', '.join(hf_envvars)}")
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import re
-
 from setuptools import setup, find_packages
 
 def list_files(directory):


### PR DESCRIPTION
- Fixes links to the Stable Diffusion weights license agreement. Prints a message about implicit agreement if the user used the `--yes` flag. Shortens/simplifies messaging and makes the licensing blurb more visible.
- The configuration script will no longer exit if the Huggingface token is not provided. Instead, we show a message about the purpose of the token, with a link to updated documentation, and offer to proceed with the download.
- Always caches the HF token if one is found or provided
- Prints more detailed messaging about where the token was found (or not)
- Validates the token, if exists, by logging in to HuggingFace. Offers an option to re-enter it on failure. This will prevent caching of invalid tokens which are hard for the user to reset.
- Deprecates the `--interactive[True]` flag and replaces it with `--skip-sd-weights[False]`, because: 1) its real purpose was to avoid token input when downloading the SD weights, which is no longer a blocker, and 2) avoidance of interaction is already achieved with `--yes`.