### PR TITLE
Updated to pull threshold from an existing image even if 0

### DIFF
--- a/frontend/src/features/options/store/optionsSlice.ts
+++ b/frontend/src/features/options/store/optionsSlice.ts
@@ -236,8 +236,11 @@ export const optionsSlice = createSlice({
       if (sampler) state.sampler = sampler;
       if (steps) state.steps = steps;
       if (cfg_scale) state.cfgScale = cfg_scale;
-      if (threshold) state.threshold = threshold;
-      if (typeof threshold === 'undefined') state.threshold = 0;
+      if (typeof threshold === 'undefined') {
+        state.threshold = 0;
+      } else {
+        state.threshold = threshold;
+      }
       if (perlin) state.perlin = perlin;
       if (typeof perlin === 'undefined') state.perlin = 0;
       if (typeof seamless === 'boolean') state.seamless = seamless;


### PR DESCRIPTION
Addresses #2049 but not other cases where the stored value is 0 (e.g. perlin noise). This should be investigated more thoroughly and something better put into place.