### PR TITLE
Add redirects for moved pages

### DIFF
--- a/docs/installation/010_INSTALL_AUTOMATED.md
+++ b/docs/installation/010_INSTALL_AUTOMATED.md
@@ -303,4 +303,3 @@ version as its argument. For example, this will install the old 2.2.0 release.
 ```cmd
 update.sh https://github.com/invoke-ai/InvokeAI/archive/refs/tags/v2.2.0.zip
 ```
-

--- a/docs/requirements-mkdocs.txt
+++ b/docs/requirements-mkdocs.txt
@@ -1,3 +1,5 @@
 mkdocs
 mkdocs-material>=8, <9
 mkdocs-git-revision-date-localized-plugin
+mkdocs-redirects==1.2.0
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,3 +87,11 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: true
+  - redirects:
+      redirect_maps:
+          'installation/INSTALL_AUTOMATED.md': 'installation/010_INSTALL_AUTOMATED.md'
+          'installation/INSTALL_MANUAL.md': 'installation/020_INSTALL_MANUAL.md'
+          'installation/INSTALL_SOURCE.md': 'installation/020_INSTALL_MANUAL.md'
+          'installation/INSTALL_DOCKER.md': 'installation/040_INSTALL_DOCKER.md'
+          'installation/INSTALLING_MODELS.md': 'installation/050_INSTALLING_MODELS.md'
+          'installation/INSTALL_PATCHMATCH.md': 'installation/060_INSTALL_PATCHMATCH.md'


### PR DESCRIPTION
Documentation was recently reorganized, which resulted in broken links from search engines.

This PR fixes the issue by adding a `mkdocs-redirects` plugin and a config to automatically serve redirects to new pages.