### PR TITLE
Don't crash CLI on exceptions

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -545,7 +545,7 @@ class Generate:
                 print('**Interrupted** Partial results will be returned.')
             else:
                 raise KeyboardInterrupt
-        except RuntimeError as e:
+        except (RuntimeError, Exception) as e:
             print(traceback.format_exc(), file=sys.stderr)
             print('>> Could not generate image.')
 


### PR DESCRIPTION
Prevents having to reload the model every time - speedup while debugging but also nice for users hitting minor non-critical bugs.