### PR TITLE
remove redundant code line

### DIFF
--- a/installer/create_installer.sh
+++ b/installer/create_installer.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 VERSION=$(grep ^VERSION ../setup.py | awk '{ print $3 }' | sed "s/'//g" )
-VERSION="$VERSION-p4"
+VERSION="$VERSION-p5"
 
 echo "Be certain that you're in the 'installer' directory before continuing."
 read -p "Press any key to continue, or CTRL-C to exit..."
@@ -36,8 +36,8 @@ cp WinLongPathsEnabled.reg InvokeAI-Installer/
 
 # this gets rid of the "-e ." at the end of the windows requirements file
 # because it is easier to do it now than in the .bat install script
-egrep -v '^-e .' InvokeAI-Installer/environments-and-requirements/requirements-win-colab-cuda.txt >requirements.txt
-mv requirements.txt InvokeAI-Installer/environments-and-requirements/requirements-win-colab-cuda.txt
+egrep -v '^-e .' InvokeAI-Installer/environments-and-requirements/requirements-win-colab-cuda.txt > InvokeAI-Installer/requirements.txt
+cp InvokeAI-Installer/requirements.txt InvokeAI-Installer/environments-and-requirements/requirements-win-colab-cuda.txt
 zip -r InvokeAI-installer-$VERSION-windows.zip InvokeAI-Installer
 
 # clean up

--- a/installer/create_installer.sh
+++ b/installer/create_installer.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 VERSION=$(grep ^VERSION ../setup.py | awk '{ print $3 }' | sed "s/'//g" )
-VERSION="$VERSION-p1"
+VERSION="$VERSION-p4"
 
 echo "Be certain that you're in the 'installer' directory before continuing."
 read -p "Press any key to continue, or CTRL-C to exit..."

--- a/installer/install.bat.in
+++ b/installer/install.bat.in
@@ -124,8 +124,6 @@ call "%rootdir%\.venv\Scripts\activate.bat"
 set PYTHON=%rootdir%\.venv\Scripts\python
 echo updating pip with "%PYTHON%"
 call "%PYTHON%" -mensurepip --upgrade
-
-copy environments-and-requirements\requirements-win-colab-cuda.txt .\requirements.txt
 call "%PYTHON%" -mpip install --prefer-binary -r requirements.txt
 if %errorlevel% neq 0 (
    set err_msg=Requirements installation failed. See above for errors and check %TROUBLESHOOTING% for potential solutions.

--- a/installer/templates/update.bat.in
+++ b/installer/templates/update.bat.in
@@ -27,19 +27,19 @@ echo This script will update InvokeAI and all its dependencies to !INVOKE_AI_SRC
 echo If you do not want to do this, press control-C now!
 pause
 
-call pip install -r requirements.txt
+call .venv\Scripts\python -mpip install -r requirements.txt
 if %errorlevel% neq 0 (
    echo Installation of requirements failed. See https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/#troubleshooting for suggestions.
    exit /b
 )
 
-call pip install !INVOKE_AI_SRC!
+call .venv\Scripts\python -mpip install !INVOKE_AI_SRC!
 if %errorlevel% neq 0 (
    echo Installation of InvokeAI failed. See https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/#troubleshooting for suggestions.
    exit /b
 )
 
-call .venv\Scripts\python .venv\Scripts\configure_invokeai.py --root="%rootdir%"
+call .venv\Scripts\python .venv\Scripts\configure_invokeai.py --root=.
 
 if %errorlevel% neq 0 (
    echo Configuration InvokeAI failed. See https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/#troubleshooting for suggestions.

--- a/installer/templates/update.sh.in
+++ b/installer/templates/update.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 
@@ -36,13 +36,13 @@ read -p "Press any key to continue, or CTRL-C to exit..."
 
 . .venv/bin/activate
 
-pip install -r requirements.txt
+./.venv/bin/python -mpip install -r requirements.txt
 _err_exit $? "The pip program failed to install InvokeAI's requirements."
 
-pip install $INVOKE_AI_SRC
+./.venv/bin/python -mpip install $INVOKE_AI_SRC
 _err_exit $? "The pip program failed to install InvokeAI."
 
-python .venv/bin/configure_invoke.py
+./.venv/bin/python .venv/bin/configure_invokeai.py --root .
 _err_exit $? "The configure script failed to run successfully."
 
 


### PR DESCRIPTION
install.bat was copying the requirements file into the install folder twice, causing an error message on the second try. This fixes the issue.