### PR TITLE
Revert "Don't crash CLI on exceptions"

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -545,7 +545,7 @@ class Generate:
                 print('**Interrupted** Partial results will be returned.')
             else:
                 raise KeyboardInterrupt
-        except (RuntimeError, Exception) as e:
+        except RuntimeError as e:
             print(traceback.format_exc(), file=sys.stderr)
             print('>> Could not generate image.')
 


### PR DESCRIPTION
This was put in the wrong place and appears to have broken the WebUI cancellation system.