### PR TITLE
fix python 3.9 incompatibility with dev/diffusers

### DIFF
--- a/ldm/invoke/generator/diffusers_pipeline.py
+++ b/ldm/invoke/generator/diffusers_pipeline.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import secrets
 import warnings
 from dataclasses import dataclass
-from typing import List, Optional, Union, Callable, Type, TypeVar, Generic, Any, ParamSpec
+import sys
+from typing import List, Optional, Union, Callable, Type, TypeVar, Generic, Any
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
 
 import PIL.Image
 import einops


### PR DESCRIPTION
The ParamSpec typing class is not supported on 3.9 but can be imported from `typing_extensions`. This provides a workaround so that the diffusers branch will work with Python 3.9. Note that Ubuntu 20.0.4 LTS doesn't yet support Python 3.10.