### PR TITLE
attempt to address memory issues when loading ckpt models

### DIFF
--- a/ldm/invoke/model_cache.py
+++ b/ldm/invoke/model_cache.py
@@ -230,6 +230,9 @@ class ModelCache(object):
         # merged models from auto11 merge board are flat for some reason
         if 'state_dict' in sd:
             sd = sd['state_dict']
+
+        print(f'  | Forcing garbage collection prior to loading new model')
+        gc.collect()
         model = instantiate_from_config(omega_config.model)
         model.load_state_dict(sd, strict=False)
 


### PR DESCRIPTION
- A couple of users have reported that switching back and forth between ckpt models in RAM is causing a "GPU out of memory" crash. Traceback suggests there is actually a CPU RAM issue.

See https://discord.com/channels/1020123559063990373/1048399553142984784

- This change performs a round of garbage collection just prior to the point where the crash occurs. It shouldn't actually fix anything, but at least one user with the error reports that it stopped the crash, so I'm folding it into `main`. It shouldn't break anything.