### PR TITLE
rc2.2.5 (install.sh) relative path fixes

### DIFF
--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -4,13 +4,15 @@
 scriptdir=$(dirname "$0")
 cd "$scriptdir"
 
+INVOKEAI_VERSION="2.2.5-rc1"
+
 # make sure we are not already in a venv
 # (don't need to check status)
 deactivate >/dev/null 2>&1
 
 # this should be changed to the tagged release!
 # INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/archive/main.zip
-INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/archive/refs/tags/v2.2.4.zip
+INVOKE_AI_SRC=https://github.com/invoke-ai/InvokeAI/archive/refs/tags/${INVOKEAI_VERSION}.zip
 INSTRUCTIONS=https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/
 TROUBLESHOOTING=https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/#troubleshooting
 MINIMUM_PYTHON_VERSION=3.9.0
@@ -44,7 +46,7 @@ function readinput() {
     local i="$1"
     case "$i" in
       "-i")
-        if read -i "default" 2>/dev/null <<< "test"; then 
+        if read -i "default" 2>/dev/null <<< "test"; then
           CLEAN_ARGS="$CLEAN_ARGS -i \"$2\""
         fi
         shift
@@ -94,7 +96,7 @@ echo "Installing for $OS_NAME-$OS_ARCH"
 PYTHON=""
 for candidate in python3.10 python3.9 python3 python python3.11 ; do
     if ppath=`which $candidate`; then
-	python_version=$($ppath -V | awk '{ print $2 }')    
+	python_version=$($ppath -V | awk '{ print $2 }')
 	if [ $(version $python_version) -ge $(version "$MINIMUM_PYTHON_VERSION") ]; then
 	    PYTHON=$ppath
 	    echo Python $python_version found at $PYTHON
@@ -117,6 +119,10 @@ do
     echo
     readinput -e -p "Select your preferred location for the 'invokeai' directory [$HOME]: " -i $HOME input
     ROOTDIR=${input:=$HOME}/invokeai
+
+    # This is surprisingly hard to do in plain Bash; easier in ZSH. Just running python in subshell is easiest.
+    ROOTDIR=$(python -c "from pathlib import Path; print(Path('${ROOTDIR}').expanduser().resolve())")
+
     read -e -p "InvokeAI will be installed into $ROOTDIR. OK? [y]: " input
     RESPONSE=${input:='y'}
     if [ "$RESPONSE" == 'y' ]; then
@@ -126,7 +132,7 @@ do
             RESPONSE=${input:='y'}
 	    if [ "$RESPONSE" != 'y' ]; then
 	        ROOTDIR=""
-	    fi	       
+	    fi
 	else
 	    mkdir -p "$ROOTDIR"
 	    if [ $? -ne 0 ]; then

--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -222,4 +222,13 @@ chmod a+rx "$ROOTDIR"/invoke.sh
 cp templates/update.sh.in "$ROOTDIR"/update.sh
 chmod a+rx "$ROOTDIR"/update.sh
 
-echo "You may now run InvokeAI by entering the directory $ROOTDIR and running invoke.sh"
+echo "You may now run InvokeAI by entering the directory $ROOTDIR and running invoke.sh:"
+echo
+echo "  ${ROOTDIR}/invoke.sh"
+echo
+
+read -e -p "Run InvokeAI now? [y]:" input
+RESPONSE=${input:='y'}
+if [ "$RESPONSE" == 'y' ]; then
+    exec ${ROOTDIR}/invoke.sh
+fi

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -135,7 +135,7 @@ def main():
     try:
         main_loop(gen, opt)
     except KeyboardInterrupt:
-        print("\ngoodbye!")
+        print(f'\nGoodbye!\nYou can start InvokeAI again by running the "invoke.bat" (or "invoke.sh") script from {Globals.root}')
 
 # TODO: main_loop() has gotten busy. Needs to be refactored.
 def main_loop(gen, opt):
@@ -410,7 +410,8 @@ def main_loop(gen, opt):
         output_cntr = write_log(results, log_path ,('txt', 'md'), output_cntr)
         print()
 
-    print('goodbye!')
+
+    print(f'\nGoodbye!\nYou can start InvokeAI again by running the "invoke.bat" (or "invoke.sh") script from {Globals.root}')
 
 # TO DO: remove repetitive code and the awkward command.replace() trope
 # Just do a simple parse of the command!


### PR DESCRIPTION
- Selecting `~/Data/myapps/` when prompted to choose a location would create a `./~/Data/myapps` directory (a '~' subdir in the installer directory). This is now properly expanded to the absolute path
- print out the abs path of the install location instead of relative
- point installer at `2.2.5-rc1` archive instead of `2.2.4`
- squash the double slash before `/invokeai` (if it was entered so by the user)