### PR TITLE
Fix typo to allow PyTorch run on macOS using MPS

### DIFF
--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -2,7 +2,7 @@
 
 import sys
 import os
-if sys.platform == 'Darsin':
+if sys.platform == 'Darwin':
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
 import ldm.invoke.CLI


### PR DESCRIPTION
This PR fixes a typo to allow PyTorch to run using MPS on macOS-based system.