### PR TITLE
Explicitly call python found in system

### DIFF
--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -121,7 +121,7 @@ do
     ROOTDIR=${input:=$HOME}/invokeai
 
     # This is surprisingly hard to do in plain Bash; easier in ZSH. Just running python in subshell is easiest.
-    ROOTDIR=$(python -c "from pathlib import Path; print(Path('${ROOTDIR}').expanduser().resolve())")
+    ROOTDIR=$($PYTHON -c "from pathlib import Path; print(Path('${ROOTDIR}').expanduser().resolve())")
 
     read -e -p "InvokeAI will be installed into $ROOTDIR. OK? [y]: " input
     RESPONSE=${input:='y'}


### PR DESCRIPTION
Some users are unable to run the installer because the line 124 in install.sh:
`ROOTDIR=$(python -c "from pathlib import Path; print(Path('${ROOTDIR}').expanduser().resolve())")`
expects an executable in the path named `python`, or else it will fatally crash.

Some users have python installed as `python3` on their systems and not simply `python`, thus causing the error. 
Prior sections of the installer script already find the full path to a user's python executable in a variable called `$PYTHON`, so this change simply adds that discovered python in place of the hard-coded `python` call.

This will fix #2166 