### PR TITLE
update python requirements

### DIFF
--- a/environments-and-requirements/requirements-lin-amd.txt
+++ b/environments-and-requirements/requirements-lin-amd.txt
@@ -1,6 +1,6 @@
 -r environments-and-requirements/requirements-base.txt
 # Get hardware-appropriate torch/torchvision
 --extra-index-url https://download.pytorch.org/whl/rocm5.1.1 --trusted-host https://download.pytorch.org
-torch
-torchvision
+torch>=1.13.1
+torchvision>=0.14.1
 -e .

--- a/environments-and-requirements/requirements-lin-arm64.txt
+++ b/environments-and-requirements/requirements-lin-arm64.txt
@@ -1,3 +1,0 @@
---pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
--r environments-and-requirements/requirements-base.txt
--e .

--- a/environments-and-requirements/requirements-lin-cuda.txt
+++ b/environments-and-requirements/requirements-lin-cuda.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu116 --trusted-host https://download.pytorch.org
 -r environments-and-requirements/requirements-base.txt
-torch
-torchvision
+torch>=1.13.1
+torchvision>=0.14.1
 -e .

--- a/environments-and-requirements/requirements-mac-mps-cpu.txt
+++ b/environments-and-requirements/requirements-mac-mps-cpu.txt
@@ -1,6 +1,6 @@
 -r environments-and-requirements/requirements-base.txt
 grpcio<1.51.0
-protobuf==3.19.6
-torch<1.13.0
-torchvision<0.14.0
+protobuf==3.20.3
+torch>=1.13.1
+torchvision>=0.14.1
 -e .

--- a/environments-and-requirements/requirements-win-colab-cuda.txt
+++ b/environments-and-requirements/requirements-win-colab-cuda.txt
@@ -1,6 +1,6 @@
 -r environments-and-requirements/requirements-base.txt
 # Get hardware-appropriate torch/torchvision
 --extra-index-url https://download.pytorch.org/whl/cu116 --trusted-host https://download.pytorch.org
-torch==1.12.1
-torchvision==0.13.1
+torch==1.13.1
+torchvision==0.14.1
 -e .


### PR DESCRIPTION
since torch versions <0.13.1 have a critical security issue

maybe this is the right time to get rid of the conda environments