### PR TITLE
missing text in txt2img2img.py 

### DIFF
--- a/ldm/invoke/generator/txt2img2img.py
+++ b/ldm/invoke/generator/txt2img2img.py
@@ -13,7 +13,7 @@ from ldm.invoke.generator.diffusers_pipeline import trim_to_multiple_of, StableD
 from ldm.models.diffusion.shared_invokeai_diffusion import ThresholdSettings
 
 
-class Txt2Img2Img(Generator):
+class Txt2Img2Img(CkptGenerator):
     def __init__(self, model, precision):
         super().__init__(model, precision)
         self.init_latent = None    # for get_noise()


### PR DESCRIPTION
found Ckpt was missing from line 15 in ldm/invoke/generator/txt2img2img.py