### PR TITLE
enhance the .bat installer

### DIFF
--- a/installer/create_installer.sh
+++ b/installer/create_installer.sh
@@ -9,15 +9,20 @@ VERSION="v${VERSION}${PATCH}"
 echo "Be certain that you're in the 'installer' directory before continuing."
 read -p "Press any key to continue, or CTRL-C to exit..."
 
-git commit -a
+read -e -p "Commit and tag this repo with ${VERSION} and 'latest'? [n]: " input
+RESPONSE=${input:='n'}
+if [ "$RESPONSE" == 'y' ]; then
 
-if ! git tag $VERSION ; then
-    echo "Existing/invalid tag"
-    exit -1
+    git commit -a
+
+    if ! git tag $VERSION ; then
+	echo "Existing/invalid tag"
+	exit -1
+    fi
+
+    git push origin :refs/tags/latest
+    git tag -fa latest
 fi
-
-git push origin :refs/tags/latest
-git tag -fa latest
 
 echo Building installer zip fles for InvokeAI $VERSION
 

--- a/installer/install.bat.in
+++ b/installer/install.bat.in
@@ -33,7 +33,7 @@ echo 1. Install python 3.9 or higher.
 echo 2. Double-click on the file WinLongPathsEnabled.reg in order to
 echo    enable long path support on your system.
 echo 3. Install the Visual C++ core libraries.
-echo    Pleaase download and install the libraries from:
+echo    Please download and install the libraries from:
 echo    https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170
 echo.
 echo See %INSTRUCTIONS% for more details.
@@ -78,6 +78,7 @@ set "selection="
 	set /p selection=Select the path to install InvokeAI's directory into [%UserProfile%]: 
 	if not defined selection set selection=%UserProfile%
 	set selection=%selection:"=%
+	call :Trim selection !selection!
 	set dest="%selection%\invokeai"
 	if exist %dest% (
 	   set response=y
@@ -95,6 +96,8 @@ goto :pick_rootdir
 :done
 
 set rootdir=%rootdir:"=%
+
+
 
 @rem ---------------------- Initialize the runtime directory ---------------------
 echo.
@@ -150,6 +153,7 @@ if %errorlevel% neq 0 (
    goto :err_exit
 )
 POPD
+
 copy .\templates\invoke.bat.in "%rootdir%\invoke.bat"
 copy .\templates\update.bat.in "%rootdir%\update.bat"
 
@@ -217,3 +221,10 @@ pause
 exit /b
 
 pause
+
+:Trim
+SetLocal EnableDelayedExpansion
+set Params=%*
+for /f "tokens=1*" %%a in ("!Params!") do EndLocal & set %1=%%b
+exit /b
+


### PR DESCRIPTION
Two small fixes:

1. create_installers.sh now asks before tagging and committing the current repo
2. trailing whitespace removed from user-provided location of invokeai directory in install.bat