### PR TITLE
Pin dnspython version

### DIFF
--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -3,6 +3,7 @@ accelerate
 albumentations
 datasets
 diffusers[torch]~=0.11
+dnspython==2.2.1
 einops
 eventlet
 facexlib


### PR DESCRIPTION
Fixes an issue with `configure_invokeai.py` (see https://github.com/invoke-ai/InvokeAI/issues/2323) due to [yesterday's release](https://www.dnspython.org/news/2.3.0/) of `dnspython`.