### PR TITLE
generate stable-diffusion-2.1 images without xformers

### DIFF
--- a/configs/INITIAL_MODELS.yaml
+++ b/configs/INITIAL_MODELS.yaml
@@ -1,4 +1,4 @@
-stable-diffusion-1.5:
+stable-diffusion-1_5:
    description: Stable Diffusion version 1.5 weight file (4.27 GB)
    repo_id: runwayml/stable-diffusion-v1-5
    format: diffusers
@@ -6,12 +6,13 @@ stable-diffusion-1.5:
    vae:
      repo_id: stabilityai/sd-vae-ft-mse
    default: True
-stable-diffusion-2.1:
+stable-diffusion-2_1-768:
    description: Stable Diffusion version 2.1 diffusers model (5.21 GB)
    repo_id: stabilityai/stable-diffusion-2-1
    format: diffusers
+   precision: float32
    recommended: True
-inpainting-1.5:
+inpainting-1_5:
    description: RunwayML SD 1.5 model optimized for inpainting (4.27 GB)
    repo_id: runwayml/stable-diffusion-inpainting
    config: v1-inpainting-inference.yaml
@@ -23,18 +24,18 @@ inpainting-1.5:
    recommended: True
    width: 512
    height: 512
-stable-diffusion-1.4:
+stable-diffusion-1_4:
    description: The original Stable Diffusion version 1.4 weight file (4.27 GB)
    repo_id: CompVis/stable-diffusion-v1-4
    recommended: False
    format: diffusers
    vae:
       repo_id: stabilityai/sd-vae-ft-mse
-waifu-diffusion-1.4:
+waifu-diffusion-1_4:
   description: Waifu diffusion 1.4
   format: diffusers
   repo_id: hakurei/waifu-diffusion
-waifu-diffusion-1.3:
+waifu-diffusion-1_3:
    description: Stable Diffusion 1.4 fine tuned on anime-styled images (4.27 GB)
    repo_id: hakurei/waifu-diffusion-v1-3
    config: v1-inference.yaml
@@ -46,14 +47,14 @@ waifu-diffusion-1.3:
    recommended: False
    width: 512
    height: 512
-trinart-2.0:
+trinart-2_0:
    description: An SD model finetuned with ~40,000 assorted high resolution manga/anime-style pictures (2.13 GB)
    repo_id: naclbit/trinart_stable_diffusion_v2
    format: diffusers
    recommended: False
    vae:
      repo_id: stabilityai/sd-vae-ft-mse
-trinart_characters-2.0:
+trinart_characters-2_0:
    description: An SD model finetuned with 19.2M anime/manga style images (4.27 GB)
    repo_id: naclbit/trinart_derrida_characters_v2_stable_diffusion
    config: v1-inference.yaml
@@ -65,7 +66,7 @@ trinart_characters-2.0:
    recommended: False
    width: 512
    height: 512
-papercut-1.0:
+papercut-1_0:
    description: SD 1.5 fine-tuned for papercut art (use "PaperCut" in your prompts) (2.13 GB)
    repo_id: Fictiverse/Stable_Diffusion_PaperCut_Model
    format: diffusers
@@ -74,7 +75,7 @@ papercut-1.0:
    recommended: False
    width: 512
    height: 512
-voxel_art-1.0:
+voxel_art-1_0:
    description: Stable Diffusion trained on voxel art (use "VoxelArt" in your prompts) (4.27 GB)
    repo_id: Fictiverse/Stable_Diffusion_VoxelArt_Model
    config: v1-inference.yaml

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -606,15 +606,19 @@ def import_diffuser_model(path_or_repo:str, gen, opt, completer)->str:
         model_name=default_name,
         model_description=default_description
     )
+    precision = 'auto'
+    if input('Does this model need to run in full-precision mode? [n] ').startswith(('y','Y')):
+        precision = 'float32'
 
     if not manager.import_diffuser_model(
             path_or_repo,
             model_name = model_name,
-            description = model_description):
+            description = model_description,
+            precision = precision,
+    ):
         print('** model failed to import')
         return None
-    if input('Make this the default model? [n] ').startswith(('y','Y')):
-        manager.set_default_model(model_name)
+    
     return model_name
 
 def import_ckpt_model(path_or_url:str, gen, opt, completer)->str:
@@ -772,8 +776,8 @@ def _get_model_name(existing_names,completer,default_name:str='')->str:
         model_name = input(f'Short name for this model [{default_name}]: ').strip()
         if len(model_name)==0:
             model_name = default_name
-        if not re.match('^[\w._+-]+$',model_name):
-            print('** model name must contain only words, digits and the characters "._+-" **')
+        if not re.match('^[\w_+-]+$',model_name):
+            print('** model name must contain only words, digits and the characters "_+-" **')
         elif model_name != default_name and model_name in existing_names:
             print(f'** the name {model_name} is already in use. Pick another.')
         else:

--- a/ldm/invoke/generator/base.py
+++ b/ldm/invoke/generator/base.py
@@ -22,6 +22,7 @@ from ldm.invoke.devices import choose_autocast
 from ldm.models.diffusion.cross_attention_map_saving import AttentionMapSaver
 from ldm.models.diffusion.ddpm import DiffusionWrapper
 from ldm.util import rand_perlin_2d
+from contextlib import nullcontext
 
 downsampling = 8
 CAUTION_IMG = 'assets/caution.png'
@@ -64,7 +65,9 @@ class Generator:
                  image_callback=None, step_callback=None, threshold=0.0, perlin=0.0,
                  safety_checker:dict=None,
                  **kwargs):
-        scope = choose_autocast(self.precision)
+
+        scope = self._get_scope()
+        
         self.safety_checker = safety_checker
         attention_maps_images = []
         attention_maps_callback = lambda saver: attention_maps_images.append(saver.get_stacked_maps_image())
@@ -340,4 +343,10 @@ class Generator:
             os.makedirs(dirname, exist_ok=True)
         image.save(filepath,'PNG')
 
-
+    # workaround for models that use full precision in a half-precision environment
+    # see model_manager.py _load_diffuser_model() for an illustration of when that
+    # happens
+    def _get_scope(self):
+        model_dtype = self.model.text_encoder.get_input_embeddings().weight.data[0][0].dtype
+        scope = nullcontext if model_dtype == torch.float32 else choose_autocast(self.precision)
+        return scope


### PR DESCRIPTION
This PR adds a general facility that allows the user to force a selected model to use full precision, regardless of the setting of the global precision flag.

- By adding the "precision" field to the model's entry in `models.yaml`, you can now force a model to use the specified precision. Values are "auto", "float16" and "float32". "auto" is the default, and will respect the global value of precision.

  This was designed to support SD-2.1(768 diffusers model), which must run at full precision unless xformers is installed.

- Updated !import_models to allow the precision to be set.

- While adding this feature, I realized that OmegaConf keys should not contain dots, and reworked the initial model configuration file. This will be annoying because the model names have changed, but avoids weird errors about missing keys elsewhere.