### PR TITLE
Update rocm version to match conda version

### DIFF
--- a/environments-and-requirements/requirements-lin-amd.txt
+++ b/environments-and-requirements/requirements-lin-amd.txt
@@ -1,6 +1,6 @@
 -r environments-and-requirements/requirements-base.txt
 # Get hardware-appropriate torch/torchvision
---extra-index-url https://download.pytorch.org/whl/rocm5.1.1 --trusted-host https://download.pytorch.org
+--extra-index-url https://download.pytorch.org/whl/rocm5.2 --trusted-host https://download.pytorch.org
 torch>=1.13.1
 torchvision>=0.14.1
 -e .


### PR DESCRIPTION
Note that I am still unable to get stable diffusion working on my AMD card so this is just an educated guess. The yml file for amd card's points to 5.2 as well.