### PR TITLE
Store & load 🤗 models at XDG_CACHE_HOME if HF_HOME is not set

### DIFF
--- a/ldm/invoke/globals.py
+++ b/ldm/invoke/globals.py
@@ -62,11 +62,21 @@ def global_cache_dir(subdir:Union[str,Path]='')->Path:
     '''
     Returns Path to the model cache directory. If a subdirectory
     is provided, it will be appended to the end of the path, allowing
-    for huggingface-style conventions: 
+    for huggingface-style conventions:
          global_cache_dir('diffusers')
          global_cache_dir('transformers')
     '''
-    if (home := os.environ.get('HF_HOME')):
+    home: str = os.getenv('HF_HOME')
+
+    if home is None:
+        home = os.getenv('XDG_CACHE_HOME')
+
+        if home is not None:
+            # Set `home` to $XDG_CACHE_HOME/huggingface, which is the default location mentioned in HuggingFace Hub Client Library.
+            # See: https://huggingface.co/docs/huggingface_hub/main/en/package_reference/environment_variables#xdgcachehome
+            home += os.sep + 'huggingface'
+
+    if home is not None:
         return Path(home,subdir)
     else:
         return Path(Globals.root,'models',subdir)


### PR DESCRIPTION
This commit allows InvokeAI to store & load 🤗 models at a location set by `XDG_CACHE_HOME` environment variable if `HF_HOME` is not set.

By integrating this commit, a user who either use `HF_HOME` or `XDG_CACHE_HOME` environment variables in their environment can let InvokeAI to reuse the existing cache directory used by 🤗 library by default. I happened to benefit from this commit because I have a Jupyter Notebook that uses 🤗 diffusers model stored at default location used by 🤗, i.e. `$HOME/.cache/huggingface`.

Reference: https://huggingface.co/docs/huggingface_hub/main/en/package_reference/environment_variables#xdgcachehome