### PR TITLE
[bugfix] suppress extraneous warning messages generated by diffusers

### DIFF
--- a/ldm/invoke/generator/txt2img2img.py
+++ b/ldm/invoke/generator/txt2img2img.py
@@ -3,6 +3,7 @@ ldm.invoke.generator.txt2img inherits from ldm.invoke.generator
 '''
 
 import math
+from diffusers.utils.logging import get_verbosity, set_verbosity, set_verbosity_error
 from typing import Callable, Optional
 
 import torch
@@ -66,6 +67,8 @@ class Txt2Img2Img(Generator):
 
             second_pass_noise = self.get_noise_like(resized_latents)
 
+            verbosity = get_verbosity()
+            set_verbosity_error()
             pipeline_output = pipeline.img2img_from_latents_and_embeddings(
                 resized_latents,
                 num_inference_steps=steps,
@@ -73,6 +76,7 @@ class Txt2Img2Img(Generator):
                 strength=strength,
                 noise=second_pass_noise,
                 callback=step_callback)
+            set_verbosity(verbosity)
 
             return pipeline.numpy_to_pil(pipeline_output.images)[0]
 

--- a/ldm/invoke/model_manager.py
+++ b/ldm/invoke/model_manager.py
@@ -25,6 +25,7 @@ import torch
 import safetensors
 import transformers
 from diffusers import AutoencoderKL, logging as dlogging
+from diffusers.utils.logging import get_verbosity, set_verbosity, set_verbosity_error
 from omegaconf import OmegaConf
 from omegaconf.dictconfig import DictConfig
 from picklescan.scanner import scan_file_path
@@ -827,11 +828,11 @@ class ModelManager(object):
             return model
 
         # diffusers really really doesn't like us moving a float16 model onto CPU
-        import logging
-        logging.getLogger('diffusers.pipeline_utils').setLevel(logging.CRITICAL)
+        verbosity = get_verbosity()
+        set_verbosity_error()
         model.cond_stage_model.device = 'cpu'
         model.to('cpu')
-        logging.getLogger('pipeline_utils').setLevel(logging.INFO)
+        set_verbosity(verbosity)
 
         for submodel in ('first_stage_model','cond_stage_model','model'):
             try:


### PR DESCRIPTION
This commit suppresses a few irrelevant warning messages that the diffusers module produces:

1. The warning that turning off the NSFW detector makes you an irresponsible person.
2. Warnings about running fp16 models stored in CPU (we are not running them in CPU, just caching them in CPU RAM)