### PR TITLE
fix: use pad_token for padding

### DIFF
--- a/ldm/modules/encoders/modules.py
+++ b/ldm/modules/encoders/modules.py
@@ -1,18 +1,16 @@
 import math
-import os.path
+from functools import partial
 from typing import Optional
 
+import clip
+import kornia
 import torch
 import torch.nn as nn
-from functools import partial
-import clip
-from einops import rearrange, repeat
+from einops import repeat
 from transformers import CLIPTokenizer, CLIPTextModel
-import kornia
-from ldm.invoke.devices import choose_torch_device
-from ldm.invoke.globals import Globals, global_cache_dir
-#from ldm.modules.textual_inversion_manager import TextualInversionManager
 
+from ldm.invoke.devices import choose_torch_device
+from ldm.invoke.globals import global_cache_dir
 from ldm.modules.x_transformer import (
     Encoder,
     TransformerWrapper,
@@ -663,12 +661,12 @@ class WeightedFrozenCLIPEmbedder(FrozenCLIPEmbedder):
             all_token_ids = all_token_ids[0:self.max_length]
             per_token_weights = per_token_weights[0:self.max_length]
 
-        # pad out to a 77-entry array: [eos_token, <prompt tokens>, eos_token, ..., eos_token]
+        # pad out to a 77-entry array: [bos_token, <prompt tokens>, eos_token, pad_token…]
         # (77 = self.max_length)
         all_token_ids = [self.tokenizer.bos_token_id] + all_token_ids + [self.tokenizer.eos_token_id]
         per_token_weights = [1.0] + per_token_weights + [1.0]
         pad_length = self.max_length - len(all_token_ids)
-        all_token_ids += [self.tokenizer.eos_token_id] * pad_length
+        all_token_ids += [self.tokenizer.pad_token_id] * pad_length
         per_token_weights += [1.0] * pad_length
 
         all_token_ids_tensor = torch.tensor(all_token_ids, dtype=torch.long).to(self.device)


### PR DESCRIPTION
Stable Diffusion 2 does not use the eos_token for padding.

Fixes #2378 

Before:
![v1-padding](https://user-images.githubusercontent.com/83819/213841904-b5fcacc2-5c7d-42b4-b22d-ededfac3d630.jpg)

After:
![v2-padding](https://user-images.githubusercontent.com/83819/213841909-1ba33f9c-2e1f-4565-8d15-340845500145.jpg)

<details>
<summary>metadata</summary>

```json
 {
    "model": "stable diffusion",
    "model_weights": "diffusers-2.1",
    "model_hash": "0809e3597225faf22fd48f1034d500b55aea4afffe5ae974c5818bfaadd46ea8",
    "app_id": "invoke-ai/InvokeAI",
    "app_version": "2.3.0+a0",
    "image": {
        "prompt": [
            {"prompt": "an astronaut riding a horse on mars", "weight": 1.0}
        ],
        "steps": 15,
        "cfg_scale": 7.5,
        "threshold": 0,
        "perlin": 0,
        "height": 768,
        "width": 768,
        "seed": 453168600,
        "seamless": false,
        "hires_fix": false,
        "type": "txt2img",
        "postprocessing": null,
        "sampler": "k_dpmpp_2",
        "variations": []
    }
}
```

</details>