### PR TITLE
Installer Typo: Use located $PYTHON in ROOTDIR rather than "python"

### DIFF
--- a/environments-and-requirements/requirements-base.txt
+++ b/environments-and-requirements/requirements-base.txt
@@ -1,6 +1,7 @@
 # pip will resolve the version which matches torch
 albumentations
 diffusers==0.10.*
+dnspython==2.2.1
 einops
 eventlet
 facexlib

--- a/installer/create_installer.sh
+++ b/installer/create_installer.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 VERSION=$(grep ^VERSION ../setup.py | awk '{ print $3 }' | sed "s/'//g" )
-PATCH=""
+PATCH="p2"
 VERSION="v${VERSION}${PATCH}"
 
 echo "Be certain that you're in the 'installer' directory before continuing."

--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -121,7 +121,7 @@ do
     ROOTDIR=${input:=$HOME}/invokeai
 
     # This is surprisingly hard to do in plain Bash; easier in ZSH. Just running python in subshell is easiest.
-    ROOTDIR=$(python -c "from pathlib import Path; print(Path('${ROOTDIR}').expanduser().resolve())")
+    ROOTDIR=$($PYTHON -c "from pathlib import Path; print(Path('${ROOTDIR}').expanduser().resolve())")
 
     read -e -p "InvokeAI will be installed into $ROOTDIR. OK? [y]: " input
     RESPONSE=${input:='y'}


### PR DESCRIPTION
[fixes] Install fails on macOS with `python3` binary only as the ROOTDIR line doesn't use the previously located binary