### PR TITLE
How to install opencv4 + PyPatchMatch with MacPorts

### DIFF
--- a/docs/features/TEXTUAL_INVERSION.md
+++ b/docs/features/TEXTUAL_INVERSION.md
@@ -17,7 +17,7 @@ notebooks.
 
 You will need a GPU to perform training in a reasonable length of
 time, and at least 12 GB of VRAM. We recommend using the [`xformers`
-library](../installation/070_INSTALL_XFORMERS) to accelerate the
+library](../installation/070_INSTALL_XFORMERS.md) to accelerate the
 training process further. During training, about ~8 GB is temporarily
 needed in order to store intermediate models, checkpoints and logs.
 

--- a/docs/installation/060_INSTALL_PATCHMATCH.md
+++ b/docs/installation/060_INSTALL_PATCHMATCH.md
@@ -18,13 +18,27 @@ Windows systems with no extra intervention.
 
 ## Macintosh
 
-You need to have opencv installed so that pypatchmatch can be built:
+You need to have opencv installed so that pypatchmatch can be built.
 
-```bash
+### Homebrew
+
+```sh
 brew install opencv
 ```
 
-The next time you start `invoke`, after sucesfully installing opencv, pypatchmatch will be built.
+The next time you start `invoke`, after successfully installing opencv, pypatchmatch will be built.
+
+### MacPorts
+
+MacPorts requires some extra steps to get InvokeAI to see the opencv installed files:
+
+```sh
+sudo port install py310-opencv4
+sudo ln -sf /opt/local/lib/opencv4/pkgconfig/opencv4.pc /opt/local/lib/opencv4/pkgconfig/opencv.pc
+export PKG_CONFIG_PATH=/opt/local/lib/opencv4/pkgconfig
+```
+
+Start `invoke` immediately after these steps to build pypatchmatch.
 
 ## Linux
 
@@ -56,7 +70,7 @@ Prior to installing PyPatchMatch, you need to take the following steps:
 
 5. Confirm that pypatchmatch is installed. At the command-line prompt enter
    `python`, and then at the `>>>` line type
-   `from patchmatch import patch_match`: It should look like the follwing:
+   `from patchmatch import patch_match`: It should look like the following:
 
     ```py
     Python 3.9.5 (default, Nov 23 2021, 15:27:38)
@@ -108,4 +122,4 @@ Prior to installing PyPatchMatch, you need to take the following steps:
 
 [**Next, Follow Steps 4-6 from the Debian Section above**](#linux)
 
-If you see no errors, then you're ready to go!
+If you see no errors you're ready to go!

--- a/installer/templates/update.sh.in
+++ b/installer/templates/update.sh.in
@@ -15,7 +15,7 @@ if [ $# -ge 1 ] && [ "${1:0:2}" == "-h" ]; then
 fi
 
 INVOKE_AI_VERSION=${1:-latest}
-    
+
 INVOKE_AI_SRC="https://github.com/invoke-ai/InvokeAI/archive/$INVOKE_AI_VERSION.zip"
 INVOKE_AI_DEP=https://raw.githubusercontent.com/invoke-ai/InvokeAI/$INVOKE_AI_VERSION/environments-and-requirements/requirements-base.txt
 INVOKE_AI_MODELS=https://raw.githubusercontent.com/invoke-ai/InvokeAI/$INVOKE_AI_VERSION/configs/INITIAL_MODELS.yaml


### PR DESCRIPTION
Fix some spelling and add minimal instructions for MacPorts. These steps should be sufficient to get PyPatchMatch installed if InvokeAI is started from the same shell. The [complete procedure](https://discord.com/channels/1020123559063990373/1047645643331608646/1052756909087801434) is…
```sh
sudo port install py310-opencv4
sudo ln -sf /opt/local/lib/opencv4/pkgconfig/opencv4.pc /opt/local/lib/opencv4/pkgconfig/opencv.pc

cd path/to/InvokeAI

eval "$(conda shell.zsh hook)"
conda activate invokeai
pip install "git+https://github.com/invoke-ai/PyPatchMatch@0.1.4#egg=pypatchmatch"

PKG_CONFIG_PATH=/opt/local/lib/opencv4/pkgconfig python3 scripts/invoke.py --web
```