### PR TITLE
fix dimension errors when inpainting model is used with hires-fix

### DIFF
--- a/ldm/invoke/generator/txt2img2img.py
+++ b/ldm/invoke/generator/txt2img2img.py
@@ -115,22 +115,13 @@ class Txt2Img2Img(Generator):
             scaled_width = width
             scaled_height = height
 
-        device      = self.model.device
-
+        device = self.model.device
         channels = self.latent_channels
         if channels == 9:
             channels = 4  # we don't really want noise for all the mask channels
+        shape = (1, channels,
+                 scaled_height // self.downsampling_factor, scaled_width // self.downsampling_factor)
         if self.use_mps_noise or device.type == 'mps':
-            return torch.randn([1,
-                                channels,
-                                scaled_height // self.downsampling_factor,
-                                scaled_width  // self.downsampling_factor],
-                               dtype=self.torch_dtype(),
-                               device='cpu').to(device)
+            return torch.randn(shape, dtype=self.torch_dtype(), device='cpu').to(device)
         else:
-            return torch.randn([1,
-                                channels,
-                                scaled_height // self.downsampling_factor,
-                                scaled_width  // self.downsampling_factor],
-                               dtype=self.torch_dtype(),
-                               device=device)
+            return torch.randn(shape, dtype=self.torch_dtype(), device=device)

--- a/ldm/invoke/generator/txt2img2img.py
+++ b/ldm/invoke/generator/txt2img2img.py
@@ -3,10 +3,10 @@ ldm.invoke.generator.txt2img inherits from ldm.invoke.generator
 '''
 
 import math
-from diffusers.utils.logging import get_verbosity, set_verbosity, set_verbosity_error
 from typing import Callable, Optional
 
 import torch
+from diffusers.utils.logging import get_verbosity, set_verbosity, set_verbosity_error
 
 from ldm.invoke.generator.base import Generator
 from ldm.invoke.generator.diffusers_pipeline import trim_to_multiple_of, StableDiffusionGeneratorPipeline, \
@@ -116,16 +116,20 @@ class Txt2Img2Img(Generator):
             scaled_height = height
 
         device      = self.model.device
+
+        channels = self.latent_channels
+        if channels == 9:
+            channels = 4  # we don't really want noise for all the mask channels
         if self.use_mps_noise or device.type == 'mps':
             return torch.randn([1,
-                                self.latent_channels,
+                                channels,
                                 scaled_height // self.downsampling_factor,
                                 scaled_width  // self.downsampling_factor],
                                dtype=self.torch_dtype(),
                                device='cpu').to(device)
         else:
             return torch.randn([1,
-                                self.latent_channels,
+                                channels,
                                 scaled_height // self.downsampling_factor,
                                 scaled_width  // self.downsampling_factor],
                                dtype=self.torch_dtype(),


### PR DESCRIPTION
Can test by loading an inpainting model (e.g. `--model=inpainting-1.5`) and running something like
```
naturalist illustration of a seedling sprouting --width 640 --height 832 --hires_fix
```