### PR TITLE
feat(inpaint): add solid infill for use with inpainting model

### DIFF
--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -184,6 +184,7 @@ class Inpaint(Img2Img):
                        infill_method = None,
                        inpaint_width=None,
                        inpaint_height=None,
+                       inpaint_fill:tuple(int)=(0x7F, 0x7F, 0x7F, 0xFF),
                        attention_maps_callback=None,
                        **kwargs):
         """
@@ -211,7 +212,7 @@ class Inpaint(Img2Img):
                     tile_size = tile_size
                 )
             elif infill_method == 'solid':
-                solid_bg = PIL.Image.new("RGBA", init_image.size, (0x7F, 0x7F, 0x7F, 0xFF))
+                solid_bg = PIL.Image.new("RGBA", init_image.size, inpaint_fill)
                 init_filled = PIL.Image.alpha_composite(solid_bg, init_image)
             else:
                 raise ValueError(f"Non-supported infill type {infill_method}", infill_method)

--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -19,10 +19,13 @@ from ldm.util import debug_image
 
 
 def infill_methods()->list[str]:
-    methods = list()
+    methods = [
+        "tile",
+        "solid",
+        "blur"
+    ]
     if PatchMatch.patchmatch_available():
-        methods.append('patchmatch')
-    methods.append('tile')
+        methods.insert(0, 'patchmatch')
     return methods
 
 class Inpaint(Img2Img):
@@ -202,12 +205,22 @@ class Inpaint(Img2Img):
             # Do infill
             if infill_method == 'patchmatch' and PatchMatch.patchmatch_available():
                 init_filled = self.infill_patchmatch(self.pil_image.copy())
-            else: # if infill_method == 'tile': # Only two methods right now, so always use 'tile' if not patchmatch
+            elif infill_method == 'tile':
                 init_filled = self.tile_fill_missing(
                     self.pil_image.copy(),
                     seed = self.seed,
                     tile_size = tile_size
                 )
+            elif infill_method == 'solid':
+                solid_bg = PIL.Image.new("RGBA", init_image.size, (0x7F, 0x7F, 0x7F, 0xFF))
+                init_filled = PIL.Image.alpha_composite(solid_bg, init_image)
+            elif infill_method == 'blur':
+                solid_bg = PIL.Image.new("RGBA", init_image.size, (0x7F, 0x7F, 0x7F, 0xFF))
+                non_transparent = PIL.Image.alpha_composite(solid_bg, init_image)
+                blurred = non_transparent.copy().filter(ImageFilter.GaussianBlur(radius=mask_blur_radius))
+                init_filled = PIL.Image.alpha_composite(non_transparent, blurred)
+            else:
+                raise ValueError(f"Non-supported infill type {infill_method}", infill_method)
             init_filled.paste(init_image, (0,0), init_image.split()[-1])
 
             # Resize if requested for inpainting

--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -22,7 +22,6 @@ def infill_methods()->list[str]:
     methods = [
         "tile",
         "solid",
-        "blur"
     ]
     if PatchMatch.patchmatch_available():
         methods.insert(0, 'patchmatch')
@@ -214,11 +213,6 @@ class Inpaint(Img2Img):
             elif infill_method == 'solid':
                 solid_bg = PIL.Image.new("RGBA", init_image.size, (0x7F, 0x7F, 0x7F, 0xFF))
                 init_filled = PIL.Image.alpha_composite(solid_bg, init_image)
-            elif infill_method == 'blur':
-                solid_bg = PIL.Image.new("RGBA", init_image.size, (0x7F, 0x7F, 0x7F, 0xFF))
-                non_transparent = PIL.Image.alpha_composite(solid_bg, init_image)
-                blurred = non_transparent.copy().filter(ImageFilter.GaussianBlur(radius=mask_blur_radius))
-                init_filled = PIL.Image.alpha_composite(non_transparent, blurred)
             else:
                 raise ValueError(f"Non-supported infill type {infill_method}", infill_method)
             init_filled.paste(init_image, (0,0), init_image.split()[-1])


### PR DESCRIPTION
A new infill method, **solid:** solid color. currently using middle gray.

Fixes #2417

It seems like the runwayml inpainting model specifically expects those masked areas to be blanked out like this.

I haven't tried the SD 2.0 inpainting model with it yet.