### PR TITLE
Swap codeowners for installer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@ ldm/invoke/pngwriter.py @CapableWeb
 ldm/invoke/server_legacy.py @CapableWeb
 scripts/legacy_api.py @CapableWeb
 tests/legacy_tests.sh @CapableWeb
-installer/ @tildebyte
+installer/ @ebr
 .github/workflows/ @mauwii
 docker_build/ @mauwii


### PR DESCRIPTION
This PR changes the codeowner for the installer directory from @tildebyte to @ebr due to the former's time commitments.

Further reorganization of the codeowners is pending.