### PR TITLE
Fix crash when text mask applied to img2img

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -71,6 +71,8 @@ def main():
     # when the frozen CLIP tokenizer is imported
     import transformers
     transformers.logging.set_verbosity_error()
+    import diffusers
+    diffusers.logging.set_verbosity_error()
 
     # Loading Face Restoration and ESRGAN Modules
     gfpgan,codeformer,esrgan = load_face_restoration(opt)

--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -194,7 +194,8 @@ class Inpaint(Img2Img):
         """
 
         self.enable_image_debugging = enable_image_debugging
-        self.infill_method = infill_method or infill_methods()[0], # The infill method to use
+        infill_method = infill_method or infill_methods()[0]
+        self.infill_method = infill_method
 
         self.inpaint_width = inpaint_width
         self.inpaint_height = inpaint_height


### PR DESCRIPTION
This PR fixes the crash reported at https://discord.com/channels/1020123559063990373/1031668022294884392/1071782238137630800

It also quiets-down the "NSFW is disabled" nag during img2img generation.