### PR TITLE
make Kyle the codeowner for ldm/invoke/app

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@ tests/legacy_tests.sh @CapableWeb
 installer/ @tildebyte
 .github/workflows/ @mauwii
 docker_build/ @mauwii
+ldm/invoke/app/ @Kyle0654
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,5 @@ installer/ @tildebyte
 .github/workflows/ @mauwii
 docker_build/ @mauwii
 ldm/invoke/app/ @Kyle0654
+tests/nodes/ @Kyle0654
 


### PR DESCRIPTION
This PR assigns @Kyle0654 to be the codeowner for the nodes code under `ldm/invoke/app` and `tests/nodes`