### PR TITLE
Add some paths conditions to workflows

### DIFF
--- a/.github/workflows/mkdocs-material.yml
+++ b/.github/workflows/mkdocs-material.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'main'
       - 'development'
+    paths:
+      - 'docs/**'
 
 jobs:
   mkdocs-material:

--- a/.github/workflows/mkdocs-material.yml
+++ b/.github/workflows/mkdocs-material.yml
@@ -6,6 +6,7 @@ on:
       - 'development'
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
 
 jobs:
   mkdocs-material:

--- a/.github/workflows/pyflakes.yml
+++ b/.github/workflows/pyflakes.yml
@@ -5,6 +5,9 @@ on:
       - main
       - development
       - 'release-candidate-*'
+    paths-ignore:
+      - 'docs/**'
+      - 'invokeai/frontend/**'
 
 jobs:
   pyflakes:

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -3,11 +3,17 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'invokeai/frontend/**'
+      - 'docs/**'
   pull_request:
     types:
       - 'ready_for_review'
       - 'opened'
       - 'synchronize'
+    paths-ignore:
+      - 'invokeai/frontend/**'
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Some small improvements to actions:
- `Test invoke.py pip` now ignores if all changes are in `docs/**` or `invokeai/frontent/**` as changes to these paths cannot affect generation
- `pyflakes` same change as `Test invoke.py pip`
- `mkdocs-material` now runs only if the push includes changes to `docs/**`