### PR TITLE
Switch to using max for attention slicing in all cases for the time being

### DIFF
--- a/ldm/invoke/generator/diffusers_pipeline.py
+++ b/ldm/invoke/generator/diffusers_pipeline.py
@@ -317,7 +317,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
                 # fix is in https://github.com/kulinseth/pytorch/pull/222 but no idea when it will get merged to pytorch mainline.
                 pass
             else:
-                self.enable_attention_slicing(slice_size='auto')
+                self.enable_attention_slicing(slice_size='max')
 
     def image_from_embeddings(self, latents: torch.Tensor, num_inference_steps: int,
                               conditioning_data: ConditioningData,


### PR DESCRIPTION
Justification of this change is that it enables very large image generation while imposing a *slight* performance penalty over no attention slicing. The current choice of `auto` has the same performance characteristics of `max`, and doesn't give the benefit of large image generation.

Stats on a 12GB CUDA card:

no slicing:
1280x1280
*OOM*
1024x1024
*OOM*
768x768
`>>   1 image(s) generated in 23.67s`
512x512
`>>   1 image(s) generated in 8.41s`

`auto`:
1280x1280
*OOM*
1024x1024
`>>   1 image(s) generated in 70.30s`
768x768
`>>   1 image(s) generated in 23.64s`
512x512
`>>   1 image(s) generated in 8.55s`

`max`:
1280x1280
`>>   1 image(s) generated in 147.21s`
1024x1024
`>>   1 image(s) generated in 65.62s`
768x768
`>>   1 image(s) generated in 23.19s`
512x512
`>>   1 image(s) generated in 9.06s`
