### PR TITLE
[web ui] del hotkey doesn't work after canceling

### DIFF
--- a/invokeai/frontend/src/features/gallery/components/DeleteImageModal.tsx
+++ b/invokeai/frontend/src/features/gallery/components/DeleteImageModal.tsx
@@ -89,7 +89,7 @@ const DeleteImageModal = forwardRef(
       () => {
         shouldConfirmOnDelete ? onOpen() : handleDelete();
       },
-      [image, shouldConfirmOnDelete]
+      [image, shouldConfirmOnDelete, isConnected, isProcessing]
     );
 
     const handleChangeShouldConfirmOnDelete = (


### PR DESCRIPTION
The `useHotkeys` hook for this hotkey didn't have `isConnected` or `isProcessing` in its dependencies array. This prevented `handleDelete()` from dispatching the delete request.