### PR TITLE
small change to pull esrgan denoise strength through to the generate API.

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -987,7 +987,7 @@ class Generate:
                         if len(upscale) < 2:
                             upscale.append(0.75)
                         image = self.esrgan.process(
-                            image, upscale[1], seed, int(upscale[0]), upscale_denoise_str=upscale_denoise_str)
+                            image, upscale[1], seed, int(upscale[0]), denoise_str=upscale_denoise_str)
                     else:
                         print(">> ESRGAN is disabled. Image not upscaled.")
             except Exception as e:

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -321,6 +321,7 @@ class Generate:
             codeformer_fidelity = None,
             save_original    = False,
             upscale          = None,
+            upscale_denoise_str = 0.75,
             # this is specific to inpainting and causes more extreme inpainting
             inpaint_replace  = 0.0,
             # This controls the size at which inpaint occurs (scaled up for inpaint, then back down for the result)
@@ -560,6 +561,7 @@ class Generate:
             if upscale is not None or facetool_strength > 0:
                 self.upscale_and_reconstruct(results,
                                              upscale        = upscale,
+                                             upscale_denoise_str = upscale_denoise_str,
                                              facetool       = facetool,
                                              strength       = facetool_strength,
                                              codeformer_fidelity = codeformer_fidelity,
@@ -633,6 +635,7 @@ class Generate:
             facetool_strength   = 0.0,
             codeformer_fidelity = 0.75,
             upscale             = None,
+            upscale_denoise_str = 0.75,
             out_direction       = None,
             outcrop             = [],
             save_original       = True, # to get new name
@@ -684,6 +687,7 @@ class Generate:
                 codeformer_fidelity = codeformer_fidelity,
                 save_original = save_original,
                 upscale = upscale,
+                upscale_denoise_str = upscale_denoise_str,
                 image_callback = callback,
                 prefix = prefix,
             )
@@ -952,6 +956,7 @@ class Generate:
                                 image_list,
                                 facetool      = 'gfpgan',
                                 upscale       = None,
+                                upscale_denoise_str = 0.75,
                                 strength      =  0.0,
                                 codeformer_fidelity = 0.75,
                                 save_original = False,
@@ -982,7 +987,7 @@ class Generate:
                         if len(upscale) < 2:
                             upscale.append(0.75)
                         image = self.esrgan.process(
-                            image, upscale[1], seed, int(upscale[0]))
+                            image, upscale[1], seed, int(upscale[0]), upscale_denoise_str=upscale_denoise_str)
                     else:
                         print(">> ESRGAN is disabled. Image not upscaled.")
             except Exception as e:

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -889,6 +889,7 @@ def do_postprocess (gen, opt, callback):
             codeformer_fidelity = opt.codeformer_fidelity,
             save_original       = opt.save_original,
             upscale             = opt.upscale,
+            upscale_denoise_str = opt.esrgan_denoise_str,
             out_direction       = opt.out_direction,
             outcrop             = opt.outcrop,
             callback            = callback,


### PR DESCRIPTION
I'm following the convention here of a generic "upscale" naming and thus we have "upscale_denoise_str", although this variable is currently only used with esrgan.  