### PR TITLE
Fix Incorrect Windows Environment Activation Location (Manual Installation Documentation)

### DIFF
--- a/docs/installation/020_INSTALL_MANUAL.md
+++ b/docs/installation/020_INSTALL_MANUAL.md
@@ -125,7 +125,7 @@ manager, please follow these steps:
     === "Windows"
 
         ```ps
-        .venv\script\activate
+        .venv\Scripts\activate
         ```
 
         If you get a permissions error at this point, run this command and try again
@@ -295,13 +295,12 @@ on your system, please see the [Git Installation
 Guide](https://github.com/git-guides/install-git)
 
 1. From the command line, run this command:
-
    ```bash
    git clone https://github.com/invoke-ai/InvokeAI.git
    ```
 
-This will create a directory named `InvokeAI` and populate it with the
-full source code from the InvokeAI repository.
+    This will create a directory named `InvokeAI` and populate it with the
+    full source code from the InvokeAI repository.
 
 2. Activate the InvokeAI virtual environment as per step (4) of the manual
 installation protocol (important!)
@@ -342,7 +341,7 @@ installation protocol (important!)
     repository. You can then use GitHub functions to create and submit
     pull requests to contribute improvements to the project.
 
-    Please see [Contributing](/index.md#Contributing) for hints
+    Please see [Contributing](../index.md#contributing) for hints
     on getting started.
 
 ### Unsupported Conda Install


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
* Windows location for the Python environment activate location is currently incorrect
  * Due to this, this command will fail for Windows-based users
* The contributing link within the `Developer Install` sections leads to a [404](https://invoke-ai.github.io/index.md#Contributing)
* `Developer Install`'s numbered list currently lists 1, 1, 2, . . .

## What was the solution? (How)
* Changed the location of Windows script based on actual location - [reference](https://docs.python.org/3/library/venv.html)
* Moved the link to point to one directory higher -- the main index.md
* Minor format adjustments to allow for the numbered list to appear as expected 

## How were these changes tested?
* `mkdocs serve` => Verified on local server that the changes reflected as expected

## Notes
Contributing mentions to set the upstream towards the `development` branch, but that branch has been untouched for several months, so I've pointed to the `main` branch. Let me know if we need to switch to a different one. 