### PR TITLE
Improve error messages from Textual Inversion and Merge scripts

### DIFF
--- a/ldm/invoke/merge_diffusers.py
+++ b/ldm/invoke/merge_diffusers.py
@@ -463,7 +463,7 @@ def main():
                 "** You need to have at least two diffusers models defined in models.yaml in order to merge"
             )
         else:
-            print(f"** A layout error has occurred: {str(e)}")
+            print(f"** Not enough room for the user interface. Try making this window larger.")
         sys.exit(-1)
     except Exception as e:
         print(">> An error occurred:")

--- a/ldm/invoke/training/textual_inversion.py
+++ b/ldm/invoke/training/textual_inversion.py
@@ -439,19 +439,23 @@ def main():
             do_front_end(args)
         else:
             do_textual_inversion_training(**vars(args))
-    except widget.NotEnoughSpaceForWidget as e:
-        if str(e).startswith("Height of 1 allocated"):
-            print(
-                "** You need to have at least one diffusers models defined in models.yaml in order to train"
-            )
-        else:
-            print(f"** A layout error has occurred: {str(e)}")
-        sys.exit(-1)
     except AssertionError as e:
         print(str(e))
         sys.exit(-1)
     except KeyboardInterrupt:
         pass
+    except (widget.NotEnoughSpaceForWidget, Exception) as e:
+        if str(e).startswith("Height of 1 allocated"):
+            print(
+                "** You need to have at least one diffusers models defined in models.yaml in order to train"
+            )
+        elif str(e).startswith('addwstr'):
+            print(
+                '** Not enough window space for the interface. Please make your window larger and try again.'
+            )
+        else:
+            print(f"** A layout error has occurred: {str(e)}")
+        sys.exit(-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Provide informative error messages when TI and Merge scripts have insufficient space for console UI

- The invokeai-ti and invokeai-merge scripts will crash if there is not enough space in the console to fit the user interface (even after responsive formatting).

- This PR intercepts the errors and prints a useful error message advising user to make window larger.