### PR TITLE
make --autoconvert option import .safetensors too

### DIFF
--- a/ldm/invoke/model_manager.py
+++ b/ldm/invoke/model_manager.py
@@ -712,11 +712,11 @@ class ModelManager(object):
             global_models_dir(), Globals.converted_ckpts_dir
         )
 
-        print(">> Checking for unconverted .ckpt files in {weights_directory}")
+        print(f">> Checking for unconverted .ckpt/.safetensors files in {weights_directory}")
         ckpt_files = dict()
         for root, dirs, files in os.walk(weights_directory):
             for f in files:
-                if not f.endswith(".ckpt"):
+                if not f.endswith((".ckpt",".safetensors")):
                     continue
                 basename = Path(f).stem
                 dest = Path(dest_directory, basename)
@@ -727,7 +727,7 @@ class ModelManager(object):
             return
 
         print(
-            f">> New .ckpt file(s) found in {weights_directory}. Optimizing and importing..."
+            f">> New checkpoint file(s) found in {weights_directory}. Optimizing and importing..."
         )
         for ckpt in ckpt_files:
             self.convert_and_import(ckpt, ckpt_files[ckpt])


### PR DESCRIPTION
## Automatically import .ckpt and .safetensors files from a directory at startup time (like AUTO1111)

Since 2.3.0 launching `invokeai` with `--autoconvert /path/to/directory` would recursively search for `.ckpt` files in the directory, convert them into `diffusers` models, and import into `models.yaml`. This PR adds support for `.safetensors` as well.

Note that we use brittle heuristics to distinguish inpainting models from v1.x, from v2.x models -- if the model must contain 'inpaint' in its name or path, it is treated as a 1.5 inpainting model. If the key "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight" is present in the checkpoint file and has a shape ending in 1024, then it is treated as a 2.x model.

The model's original VAE is always used. The VAE can be edited in the Web GUI and CLI, but possibly the VAE for all 1.X-derived models should be set to stability/sd-ft-vae. (comments welcome)