### PR TITLE
Fix perlin noise generator for diffusers tensors

### DIFF
--- a/ldm/invoke/generator/base.py
+++ b/ldm/invoke/generator/base.py
@@ -247,11 +247,14 @@ class Generator:
         fixdevice = 'cpu' if (self.model.device.type == 'mps') else self.model.device
         # limit noise to only the diffusion image channels, not the mask channels
         input_channels = min(self.latent_channels, 4)
+        # round up to the nearest block of 8
+        temp_width = int((width + 7) / 8) * 8
+        temp_height = int((height + 7) / 8) * 8
         noise = torch.stack([
-            rand_perlin_2d((height, width),
+            rand_perlin_2d((temp_height, temp_width),
                            (8, 8),
                            device = self.model.device).to(fixdevice) for _ in range(input_channels)], dim=0).to(self.model.device)
-        return noise
+        return noise[0:4, 0:height, 0:width]
 
     def new_seed(self):
         self.seed = random.randrange(0, np.iinfo(np.uint32).max)


### PR DESCRIPTION
Tensors with diffusers no longer have to be multiples of 8. This broke Perlin noise generation. We now generate noise for the next largest multiple of 8 and return a cropped result. Fixes #2674.