### PR TITLE
Make install.bat.in point to correct configuration script

### DIFF
--- a/binary_installer/install.bat.in
+++ b/binary_installer/install.bat.in
@@ -147,7 +147,7 @@ echo ***** Installed invoke launcher script ******
 rd /s /q binary_installer installer_files
 
 @rem preload the models
-call .venv\Scripts\python scripts\configure_invokeai.py
+call .venv\Scripts\python ldm\invoke\config\invokeai_configure.py
 set err_msg=----- model download clone failed -----
 if %errorlevel% neq 0 goto err_exit
 deactivate

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -5,5 +5,5 @@ import warnings
 from ldm.invoke.config import invokeai_configure
 
 if __name__ == '__main__':
-    warnings.warn("configure_invokeai.py is deprecated, please run 'invokai-configure'", DeprecationWarning)
-    configure_invokeai.main()
+    warnings.warn("configure_invokeai.py is deprecated, running 'invokai-configure'...", DeprecationWarning)
+    invokeai_configure.main()

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -5,5 +5,5 @@ import warnings
 from ldm.invoke.config import invokeai_configure
 
 if __name__ == '__main__':
-    warnings.warn("configure_invokeai.py is deprecated, running 'invokai-configure'...", DeprecationWarning)
+    warnings.warn("configure_invokeai.py is deprecated, running 'invokeai-configure'...", DeprecationWarning)
     invokeai_configure.main()


### PR DESCRIPTION
`install.bat.in` was pointing to a deprecated configuration script, which itself was trying to call a non-existent function as a fallback.

This PR fixes both the install.bat.in and the fallback within the deprecated script.