### PR TITLE
build: lint/format ignores stats.html

### DIFF
--- a/invokeai/frontend/.eslintignore
+++ b/invokeai/frontend/.eslintignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 patches/
 public/
+stats.html

--- a/invokeai/frontend/.prettierignore
+++ b/invokeai/frontend/.prettierignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 patches/
 public/
+stats.html


### PR DESCRIPTION
Frontend linter and formatter should ignore the build artifact `stats.html`