### PR TITLE
skip huge workflows if not needed

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,8 +5,17 @@ on:
       - 'main'
       - 'update/ci/docker/*'
       - 'update/docker/*'
+    paths:
+      - '/pyproject.toml'
+      - '/ldm/**'
+      - '/invokeai/backend/**'
+      - '/invokeai/configs/**'
+      - '/invokeai/frontend/dist/**'
+      - '/docker/Dockerfile'
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+
 
 jobs:
   docker:

--- a/.github/workflows/test-invoke-pip-skip.yml
+++ b/.github/workflows/test-invoke-pip-skip.yml
@@ -1,0 +1,67 @@
+name: Test invoke.py pip
+on:
+  pull_request:
+    paths-ignore:
+      - '/pyproject.toml'
+      - '/ldm/**'
+      - '/invokeai/backend/**'
+      - '/invokeai/configs/**'
+      - '/invokeai/frontend/dist/**'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        python-version:
+          # - '3.9'
+          - '3.10'
+        pytorch:
+          # - linux-cuda-11_6
+          - linux-cuda-11_7
+          - linux-rocm-5_2
+          - linux-cpu
+          - macos-default
+          - windows-cpu
+          # - windows-cuda-11_6
+          # - windows-cuda-11_7
+        include:
+          # - pytorch: linux-cuda-11_6
+          #   os: ubuntu-22.04
+          #   extra-index-url: 'https://download.pytorch.org/whl/cu116'
+          #   github-env: $GITHUB_ENV
+          - pytorch: linux-cuda-11_7
+            os: ubuntu-22.04
+            github-env: $GITHUB_ENV
+          - pytorch: linux-rocm-5_2
+            os: ubuntu-22.04
+            extra-index-url: 'https://download.pytorch.org/whl/rocm5.2'
+            github-env: $GITHUB_ENV
+          - pytorch: linux-cpu
+            os: ubuntu-22.04
+            extra-index-url: 'https://download.pytorch.org/whl/cpu'
+            github-env: $GITHUB_ENV
+          - pytorch: macos-default
+            os: macOS-12
+            github-env: $GITHUB_ENV
+          - pytorch: windows-cpu
+            os: windows-2022
+            github-env: $env:GITHUB_ENV
+          # - pytorch: windows-cuda-11_6
+          #   os: windows-2022
+          #   extra-index-url: 'https://download.pytorch.org/whl/cu116'
+          #   github-env: $env:GITHUB_ENV
+          # - pytorch: windows-cuda-11_7
+          #   os: windows-2022
+          #   extra-index-url: 'https://download.pytorch.org/whl/cu117'
+          #   github-env: $env:GITHUB_ENV
+    name: ${{ matrix.pytorch }} on ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -3,7 +3,19 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - '/pyproject.toml'
+      - '/ldm/**'
+      - '/invokeai/backend/**'
+      - '/invokeai/configs/**'
+      - '/invokeai/frontend/dist/**'
   pull_request:
+    paths:
+      - '/pyproject.toml'
+      - '/ldm/**'
+      - '/invokeai/backend/**'
+      - '/invokeai/configs/**'
+      - '/invokeai/frontend/dist/**'
     types:
       - 'ready_for_review'
       - 'opened'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![github open issues badge]][github open issues link] [![github open prs badge]][github open prs link]
 
 [CI checks on main badge]: https://flat.badgen.net/github/checks/invoke-ai/InvokeAI/main?label=CI%20status%20on%20main&cache=900&icon=github
-[CI checks on main link]: https://github.com/invoke-ai/InvokeAI/actions/workflows/test-invoke-conda.yml
+[CI checks on main link]:https://github.com/invoke-ai/InvokeAI/actions?query=branch%3Amain
 [discord badge]: https://flat.badgen.net/discord/members/ZmtBAhwWhy?icon=discord
 [discord link]: https://discord.gg/ZmtBAhwWhy
 [github forks badge]: https://flat.badgen.net/github/forks/invoke-ai/InvokeAI?icon=github


### PR DESCRIPTION
- filter paths for `build-container.yml` and `test-invoke-pip.yml`
  - add workflow to pass required checks on PRs with `paths-ignore`
  - this triggers if `test-invoke-pip.yml` does not
- fix "CI checks on main link" in `/README.md`