### PR TITLE
fix conversion of checkpoints into incompatible diffusers models

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -786,6 +786,7 @@ def optimize_model(model_name_or_path: Union[Path,str], gen, opt, completer):
     model_name_or_path = model_name_or_path.replace('\\','/') # windows
     manager = gen.model_manager
     ckpt_path = None
+    original_config_file=None
 
     if model_name_or_path == gen.model_name:
         print("** Can't convert the active model. !switch to another model first. **")

--- a/ldm/invoke/ckpt_to_diffuser.py
+++ b/ldm/invoke/ckpt_to_diffuser.py
@@ -53,6 +53,7 @@ from diffusers import (
 )
 from diffusers.pipelines.latent_diffusion.pipeline_latent_diffusion import LDMBertConfig, LDMBertModel
 from diffusers.pipelines.paint_by_example import PaintByExampleImageEncoder, PaintByExamplePipeline
+from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from diffusers.utils import is_safetensors_available
 from transformers import AutoFeatureExtractor, BertTokenizerFast, CLIPTextModel, CLIPTokenizer, CLIPVisionConfig
 
@@ -984,6 +985,7 @@ def load_pipeline_from_original_stable_diffusion_ckpt(
         elif model_type in ['FrozenCLIPEmbedder','WeightedFrozenCLIPEmbedder']:
             text_model = convert_ldm_clip_checkpoint(checkpoint)
             tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14",cache_dir=cache_dir)
+            safety_checker = StableDiffusionSafetyChecker.from_pretrained('CompVis/stable-diffusion-safety-checker',cache_dir=global_cache_dir("hub"))
             feature_extractor = AutoFeatureExtractor.from_pretrained("CompVis/stable-diffusion-safety-checker",cache_dir=cache_dir)
             pipe = pipeline_class(
                 vae=vae,
@@ -991,7 +993,7 @@ def load_pipeline_from_original_stable_diffusion_ckpt(
                 tokenizer=tokenizer,
                 unet=unet,
                 scheduler=scheduler,
-                safety_checker=None,
+                safety_checker=safety_checker,
                 feature_extractor=feature_extractor,
             )
         else:

--- a/ldm/invoke/merge_diffusers.py
+++ b/ldm/invoke/merge_diffusers.py
@@ -419,8 +419,7 @@ def run_gui(args: Namespace):
     mergeapp.run()
 
     args = mergeapp.merge_arguments
-    print(f'DEBUG: {args}')
-    #merge_diffusion_models_and_commit(**args)
+    merge_diffusion_models_and_commit(**args)
     print(f'>> Models merged into new model: "{args["merged_model_name"]}".')
 
 


### PR DESCRIPTION
- The checkpoint conversion script was generating diffusers models with the safety checker set to null. This resulted in models that could not be merged with ones that have the safety checker activated.

- This PR fixes the issue by incorporating the safety checker into all 1.x-derived checkpoints, regardless of user's nsfw_checker setting.