### PR TITLE
Minor Docker fixes & podman "rootless" container support (see comments)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.9
 ##################
 ##  base image  ##
 ##################
@@ -31,6 +31,9 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 # don't fall back to legacy build system
 ENV PIP_USE_PEP517=1
+# set env for next stages
+ENV APPDIR=${APPDIR}
+ENV APPNAME=${APPNAME}
 
 #######################
 ##  build pyproject  ##
@@ -43,10 +46,9 @@ RUN apt-get update \
     --no-install-recommends \
     build-essential=12.9 \
     gcc=4:10.2.* \
-    python3-dev>=${PYTHON_VERSION}
+    python3-dev=3.9.*
 
 # prepare pip for buildkit cache
-ARG APPNAME=InvokeAI
 ARG PIP_CACHE_DIR=/var/cache/buildkit/pip
 ENV PIP_CACHE_DIR ${PIP_CACHE_DIR}
 RUN mkdir -p ${PIP_CACHE_DIR}
@@ -72,8 +74,6 @@ RUN python3 -c "from patchmatch import patch_match"
 FROM python-base AS runtime
 
 # Create a new user
-ARG APPDIR=/usr/src
-ARG APPNAME=InvokeAI
 ARG UNAME=appuser
 RUN useradd \
   --no-log-init \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,7 +87,8 @@ RUN useradd \
   --no-log-init \
   -m \
   -U \
-  "${UNAME}"
+  "${UNAME}" \
+  -u 1000
 
 # create volume directory
 ARG VOLUME_DIR=/data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,10 +13,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean \
   && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
 
 # Install necessary packages
-RUN \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update \
+RUN apt-get update \
   && apt-get install -y \
     --no-install-recommends \
     libgl1-mesa-glx=20.3.* \
@@ -41,10 +38,7 @@ ENV PIP_USE_PEP517=1
 FROM python-base AS pyproject-builder
 
 # Install dependencies
-RUN \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update \
+RUN apt-get update \
   && apt-get install -y \
     --no-install-recommends \
     build-essential=12.9 \
@@ -58,18 +52,16 @@ ENV PIP_CACHE_DIR ${PIP_CACHE_DIR}
 RUN mkdir -p ${PIP_CACHE_DIR}
 
 # create virtual environment
-RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
-  python3 -m venv "${APPNAME}" \
+RUN python3 -m venv "${APPNAME}" \
   --upgrade-deps
 
 # copy sources
-COPY --link . .
+COPY . .
 
 # install pyproject.toml
 ARG PIP_EXTRA_INDEX_URL
 ENV PIP_EXTRA_INDEX_URL ${PIP_EXTRA_INDEX_URL}
-RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
-  "${APPNAME}/bin/pip" install .
+RUN "${APPNAME}/bin/pip" install .
 
 # build patchmatch
 RUN python3 -c "from patchmatch import patch_match"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN \
     python3-dev>=${PYTHON_VERSION}
 
 # prepare pip for buildkit cache
+ARG APPNAME=InvokeAI
 ARG PIP_CACHE_DIR=/var/cache/buildkit/pip
 ENV PIP_CACHE_DIR ${PIP_CACHE_DIR}
 RUN mkdir -p ${PIP_CACHE_DIR}
@@ -79,6 +80,8 @@ RUN python3 -c "from patchmatch import patch_match"
 FROM python-base AS runtime
 
 # Create a new user
+ARG APPDIR=/usr/src
+ARG APPNAME=InvokeAI
 ARG UNAME=appuser
 RUN useradd \
   --no-log-init \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHON_VERSION=3.9
+ARG PYTHON_VERSION=3.10
 ##################
 ##  base image  ##
 ##################
-FROM python:${PYTHON_VERSION}-slim AS python-base
+FROM docker.io/python:${PYTHON_VERSION}-slim AS python-base
 
 LABEL org.opencontainers.image.authors="mauwii@outlook.de"
 
@@ -49,7 +49,7 @@ RUN \
     --no-install-recommends \
     build-essential=12.9 \
     gcc=4:10.2.* \
-    python3-dev=3.9.*
+    python3-dev>=${PYTHON_VERSION}
 
 # prepare pip for buildkit cache
 ARG PIP_CACHE_DIR=/var/cache/buildkit/pip

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,5 +47,6 @@ DOCKER_BUILDKIT=1 docker build \
     ${CONTAINER_FLAVOR:+--build-arg="CONTAINER_FLAVOR=${CONTAINER_FLAVOR}"} \
     ${PIP_EXTRA_INDEX_URL:+--build-arg="PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}"} \
     ${PIP_PACKAGE:+--build-arg="PIP_PACKAGE=${PIP_PACKAGE}"} \
+    ${PYTHON_VERSION:+--build-arg="PYTHON_VERSION=${PYTHON_VERSION}" \
     --file="${DOCKERFILE}" \
     ..

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,6 +47,5 @@ DOCKER_BUILDKIT=1 docker build \
     ${CONTAINER_FLAVOR:+--build-arg="CONTAINER_FLAVOR=${CONTAINER_FLAVOR}"} \
     ${PIP_EXTRA_INDEX_URL:+--build-arg="PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}"} \
     ${PIP_PACKAGE:+--build-arg="PIP_PACKAGE=${PIP_PACKAGE}"} \
-    ${PYTHON_VERSION:+--build-arg="PYTHON_VERSION=${PYTHON_VERSION}" \
     --file="${DOCKERFILE}" \
     ..

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -50,6 +50,7 @@ DOCKER_BUILDKIT=1 "${CONTAINER_ENGINE}" build \
     --tag="${CONTAINER_IMAGE:-invokeai}" \
     ${CONTAINER_FLAVOR:+--build-arg="CONTAINER_FLAVOR=${CONTAINER_FLAVOR}"} \
     ${PIP_EXTRA_INDEX_URL:+--build-arg="PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}"} \
+    ${PYTHON_VERSION:+--build-arg="PYTHON_VERSION=${PYTHON_VERSION}"} \
     ${PIP_PACKAGE:+--build-arg="PIP_PACKAGE=${PIP_PACKAGE}"} \
     --file="${DOCKERFILE}" \
     ..

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -2,6 +2,11 @@
 
 # This file is used to set environment variables for the build.sh and run.sh scripts.
 
+# use python v3.10 by default
+if [[ -z "${PYTHON_VERSION}" ]]; then
+    PYTHON_VERSION=3.10
+fi
+
 # Try to detect the container flavor if no PIP_EXTRA_INDEX_URL got specified
 if [[ -z "$PIP_EXTRA_INDEX_URL" ]]; then
 

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -55,6 +55,10 @@ if [ $ARCH == "aarch64" ]
 then
    ARCH=arm64
 fi
+if [ $ARCH == "x86_64" ]
+then
+   ARCH=amd64
+fi
 PLATFORM="${PLATFORM-linux/${ARCH}}"
 INVOKEAI_BRANCH="${INVOKEAI_BRANCH-$(git branch --show)}"
 CONTAINER_REGISTRY="${CONTAINER_REGISTRY-"ghcr.io"}"

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -2,6 +2,11 @@
 
 # This file is used to set environment variables for the build.sh and run.sh scripts.
 
+# docker is the default container engine, but should work with "podman" (rootless) too!
+if [[ -z "${CONTAINER_ENGINE}" ]]; then
+    CONTAINER_ENGINE="docker"
+fi
+
 # use python v3.10 by default
 if [[ -z "${PYTHON_VERSION}" ]]; then
     PYTHON_VERSION=3.10

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -3,14 +3,10 @@
 # This file is used to set environment variables for the build.sh and run.sh scripts.
 
 # docker is the default container engine, but should work with "podman" (rootless) too!
-if [[ -z "${CONTAINER_ENGINE}" ]]; then
-    CONTAINER_ENGINE="docker"
-fi
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 
-# use python v3.10 by default
-if [[ -z "${PYTHON_VERSION}" ]]; then
-    PYTHON_VERSION=3.10
-fi
+# use python v3.9 by default
+PYTHON_VERSION=${PYTHON_VERSION:-3.9}
 
 # Try to detect the container flavor if no PIP_EXTRA_INDEX_URL got specified
 if [[ -z "$PIP_EXTRA_INDEX_URL" ]]; then

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -13,10 +13,10 @@ if [[ -z "$PIP_EXTRA_INDEX_URL" ]]; then
   fi
 
   # Decide which container flavor to build if not specified
-  if [[ -z "$CONTAINER_FLAVOR" ]] && python -c "import torch" &>/dev/null; then
+  if [[ -z "$CONTAINER_FLAVOR" ]] && python3 -c "import torch" &>/dev/null; then
     # Check for CUDA and ROCm
-    CUDA_AVAILABLE=$(python -c "import torch;print(torch.cuda.is_available())")
-    ROCM_AVAILABLE=$(python -c "import torch;print(torch.version.hip is not None)")
+    CUDA_AVAILABLE=$(python3 -c "import torch;print(torch.cuda.is_available())")
+    ROCM_AVAILABLE=$(python3 -c "import torch;print(torch.version.hip is not None)")
     if [[ "${CUDA_AVAILABLE}" == "True" ]]; then
       CONTAINER_FLAVOR="cuda"
     elif [[ "${ROCM_AVAILABLE}" == "True" ]]; then

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -46,6 +46,10 @@ REPOSITORY_NAME="${REPOSITORY_NAME-$(basename "$(git rev-parse --show-toplevel)"
 REPOSITORY_NAME="${REPOSITORY_NAME,,}"
 VOLUMENAME="${VOLUMENAME-"${REPOSITORY_NAME}_data"}"
 ARCH="${ARCH-$(uname -m)}"
+if [ $ARCH == "aarch64" ]
+then
+   ARCH=arm64
+fi
 PLATFORM="${PLATFORM-linux/${ARCH}}"
 INVOKEAI_BRANCH="${INVOKEAI_BRANCH-$(git branch --show)}"
 CONTAINER_REGISTRY="${CONTAINER_REGISTRY-"ghcr.io"}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,9 +8,6 @@ cd "$SCRIPTDIR" || exit 1
 
 source ./env.sh
 
-# Create outputs directory if it does not exist
-[[ -d ./outputs ]] || mkdir ./outputs
-
 echo -e "You are using these values:\n"
 echo -e "Container engine:\t${CONTAINER_ENGINE}"
 echo -e "Volumename:\t${VOLUMENAME}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -29,8 +29,8 @@ fi
   ${PLATFORM+--platform="${PLATFORM}"} \
   --name="${REPOSITORY_NAME,,}" \
   --hostname="${REPOSITORY_NAME,,}" \
-  --mount type=volume,src="${VOLUMENAME}",target=/data,rw \
-  --mount type=bind,source="$(pwd)"/outputs,target=/data/outputs,rw \
+  --mount type=volume,src="${VOLUMENAME}",target=/data \
+  --mount type=bind,source="$(pwd)"/outputs,target=/data/outputs \
   ${MODELSPATH:+--mount="type=bind,source=${MODELSPATH},target=/data/models"} \
   ${HUGGING_FACE_HUB_TOKEN:+--env="HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN}"} \
   --publish=9090:9090 \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -23,8 +23,8 @@ docker run \
   --platform="${PLATFORM}" \
   --name="${REPOSITORY_NAME,,}" \
   --hostname="${REPOSITORY_NAME,,}" \
-  --mount=source="${VOLUMENAME}",target=/data \
-  --mount type=bind,source="$(pwd)"/outputs,target=/data/outputs \
+  --mount type=volume,src="${VOLUMENAME}",target=/data,rw \
+  --mount type=bind,source="$(pwd)"/outputs,target=/data/outputs,rw \
   ${MODELSPATH:+--mount="type=bind,source=${MODELSPATH},target=/data/models"} \
   ${HUGGING_FACE_HUB_TOKEN:+--env="HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN}"} \
   --publish=9090:9090 \


### PR DESCRIPTION
I was intrigued by the Docker support and decided to try it.  When it comes to containers, I always prefer [Podman](https://podman.io/) running "rootless" rather than Docker running as root, so made a few changes to support this as well.

This was tested on both Podman and Docker. 

Notes:

* To run w/Podman, just set `CONTAINER_ENGINE="podman"`  (default is "docker") on `build.sh` and `run.sh`.  Otherwise, everything should hopefully run as before.
* For fun, it was also built on an Raspberry Pi 4 w/debian 11.  No, I couldn't generate any images as the 8GB ram quickly filled up, but at least it built and got the web interface up and running.
* I do have Podman running at full-speed with cuda on Podman on my machine, but I didn't want to dramatically break any of the current docker behavior and (and wasn't really sure how cuda was even working as-is).  My cuda Dockerfile uses the [nvidia/cuda ubuntu image](https://hub.docker.com/r/nvidia/cuda/tags) as a base, not the python base image.  If there is interest I can clean up the other Dockerfile and provide it.  I'm guessing it will work with Docker as well.)
* To support Podman, the last commit f70fb02 pulls two Docker features that I really wanted to keep but don't yet have Podman support. These changes shouldn't break Docker's build, but may make subsequent builds less-efficient. I hope Podman 4.0 will support at least some of them.  See the notes in that commit.

Could someone with podman and/or docker test it?  Even if y'all don't want ALL the commits here, hopefully some of it will be of value for Docker users too.

Enjoy!