### PR TITLE
push to pypi from branch v2.3

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -28,7 +28,7 @@ jobs:
         run: twine check dist/*
 
       - name: check PyPI versions
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v2.3'
         run: |
           pip install --upgrade requests
           python -c "\


### PR DESCRIPTION
This change will cause releases on the v2.3 branch to be pushed to PyPi.