### PR TITLE
Run garbage collection to allow the CUDA cache to completely empty.

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -650,6 +650,8 @@ class Generate:
     def clear_cuda_cache(self):
         if self._has_cuda():
             self.gather_cuda_stats()
+            # Run garbage collection prior to emptying the CUDA cache
+            gc.collect()
             torch.cuda.empty_cache()
 
     def clear_cuda_stats(self):


### PR DESCRIPTION
Some CUDA users with low VRAM were reporting OOM errors after consecutive runs. The CUDA cache wasn't being completely emptied due to python's garbage collector not running.