### PR TITLE
restore previous naming scheme for sd-2.x models:

### DIFF
--- a/invokeai/configs/INITIAL_MODELS.yaml
+++ b/invokeai/configs/INITIAL_MODELS.yaml
@@ -13,14 +13,19 @@ sd-inpainting-1.5:
   vae:
     repo_id: stabilityai/sd-vae-ft-mse
   recommended: True
-stable-diffusion-2.1:
+stable-diffusion-2.1-768:
    description: Stable Diffusion version 2.1 diffusers model, trained on 768 pixel images (5.21 GB)
    repo_id: stabilityai/stable-diffusion-2-1
    format: diffusers
    recommended: True
+stable-diffusion-2.1-base:
+   description: Stable Diffusion version 2.1 diffusers model, trained on 512 pixel images (5.21 GB)
+   repo_id: stabilityai/stable-diffusion-2-1-base
+   format: diffusers
+   recommended: False
 sd-inpainting-2.0:
    description: Stable Diffusion version 2.0 inpainting model (5.21 GB)
-   repo_id: stabilityai/stable-diffusion-2-1
+   repo_id: stabilityai/stable-diffusion-2-inpainting
    format: diffusers
    recommended: False
 analog-diffusion-1.0:

--- a/ldm/invoke/_version.py
+++ b/ldm/invoke/_version.py
@@ -1,1 +1,1 @@
-__version__='2.3.1.post1'
+__version__='2.3.1.post2'


### PR DESCRIPTION
- stable-diffusion-2.1-base base model from stabilityai/stable-diffusion-2-1-base

- stable-diffusion-2.1-768 768 pixel model from stabilityai/stable-diffusion-2-1-768

- sd-inpainting-2.0 512 pixel inpainting model from runwayml/stable-diffusion-inpainting

This PR also bumps the version number up to v2.3.1.post2