### PR TITLE
quote output, embedding and autoscan directores in invokeai.init

### DIFF
--- a/ldm/invoke/config/invokeai_configure.py
+++ b/ldm/invoke/config/invokeai_configure.py
@@ -712,8 +712,8 @@ def write_opts(opts: Namespace, init_file: Path):
                     out_file.write(line + "\n")
             out_file.write(
                 f"""
---outdir={opts.outdir}
---embedding_path={opts.embedding_path}
+--outdir="{opts.outdir}"
+--embedding_path="{opts.embedding_path}"
 --precision={opts.precision}
 --max_loaded_models={int(opts.max_loaded_models)}
 --{'no-' if not opts.safety_checker else ''}nsfw_checker

--- a/ldm/invoke/config/model_install_backend.py
+++ b/ldm/invoke/config/model_install_backend.py
@@ -126,7 +126,7 @@ def install_requested_models(
                 while line := input.readline():
                     if not line.startswith(argument):
                         output.writelines([line])
-                output.writelines([f'{argument} {directory}'])
+                output.writelines([f'{argument} "{directory}"'])
         os.replace(replacement,initfile)
 
 # -------------------------------------


### PR DESCRIPTION
This should prevent the errors that users are seeing with spaces in the file paths