### PR TITLE
prevent merge crash

### DIFF
--- a/ldm/invoke/model_manager.py
+++ b/ldm/invoke/model_manager.py
@@ -624,7 +624,7 @@ class ModelManager(object):
         self,
         repo_or_path: Union[str, Path],
         model_name: str = None,
-        model_description: str = None,
+        description: str = None,
         vae: dict = None,
         commit_to_conf: Path = None,
     ) -> bool:


### PR DESCRIPTION
- This commit corrects a crash that occurred when merging or importing diffusers models due to a misnamed argument in `model_manager.import_diffusers_model()`