### PR TITLE
Fix broken links

### DIFF
--- a/ldm/invoke/generator/inpaint.py
+++ b/ldm/invoke/generator/inpaint.py
@@ -27,7 +27,7 @@ if Globals.try_patchmatch:
         print('>> Patchmatch initialized')
         infill_methods.append('patchmatch')
     else:
-        print('>> Patchmatch not loaded, please see https://github.com/invoke-ai/InvokeAI/blob/patchmatch-install-docs/docs/installation/INSTALL_PATCHMATCH.md')
+        print('>> Patchmatch not loaded, please see https://github.com/invoke-ai/InvokeAI/blob/main/docs/installation/060_INSTALL_PATCHMATCH.md')
 else:
     print('>> Patchmatch loading disabled')
 

--- a/scripts/configure_invokeai.py
+++ b/scripts/configure_invokeai.py
@@ -98,7 +98,7 @@ def user_wants_to_download_weights()->str:
     print('''You can download and configure the weights files manually or let this
 script do it for you. Manual installation is described at:
 
-https://github.com/invoke-ai/InvokeAI/blob/main/docs/installation/INSTALLING_MODELS.md
+https://github.com/invoke-ai/InvokeAI/blob/main/docs/installation/050_INSTALLING_MODELS.md
 
 You may download the recommended models (about 10GB total), select a customized set, or
 completely skip this step.


### PR DESCRIPTION
These two links go to 404 pages on github.  Updated to the correct documentation locations