### PR TITLE
increase random number seed space 

### DIFF
--- a/invokeai/frontend/src/app/constants.ts
+++ b/invokeai/frontend/src/app/constants.ts
@@ -52,7 +52,7 @@ export const UPSCALING_LEVELS: Array<{ key: string; value: number }> = [
 
 export const NUMPY_RAND_MIN = 0;
 
-export const NUMPY_RAND_MAX = 4294967295;
+export const NUMPY_RAND_MAX = 9007199254740991;
 
 export const FACETOOL_TYPES = ['gfpgan', 'codeformer'] as const;
 

--- a/invokeai/frontend/src/features/parameters/components/MainParameters/MainCFGScale.tsx
+++ b/invokeai/frontend/src/features/parameters/components/MainParameters/MainCFGScale.tsx
@@ -17,11 +17,13 @@ export default function MainCFGScale() {
 
   const handleChangeCfgScale = (v: number) => dispatch(setCfgScale(v));
 
+  const minCfgScale = 1.0001;
+
   return shouldUseSliders ? (
     <IAISlider
       label={t('parameters.cfgScale')}
       step={0.5}
-      min={1.01}
+      min={minCfgScale}
       max={30}
       onChange={handleChangeCfgScale}
       handleReset={() => dispatch(setCfgScale(7.5))}
@@ -36,7 +38,7 @@ export default function MainCFGScale() {
     <IAINumberInput
       label={t('parameters.cfgScale')}
       step={0.5}
-      min={1.01}
+      min={minCfgScale}
       max={200}
       onChange={handleChangeCfgScale}
       value={cfgScale}

--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -23,7 +23,7 @@ from diffusers.pipeline_utils import DiffusionPipeline
 from diffusers.utils.import_utils import is_xformers_available
 from omegaconf import OmegaConf
 from PIL import Image, ImageOps
-from pytorch_lightning import logging, seed_everything
+from pytorch_lightning import logging
 
 import ldm.invoke.conditioning
 from ldm.invoke.args import metadata_from_png
@@ -973,7 +973,8 @@ class Generate:
         # uncache generators so they pick up new models
         self.generators = {}
 
-        seed_everything(random.randrange(0, np.iinfo(np.uint32).max))
+        # leave the tiny 32-bit embed seed initialization for now, users can supply larger via the UI
+        torch.manual_seed(random.randrange(0, np.iinfo(np.uint32).max))
         if self.embedding_path is not None:
             print(f'>> Loading embeddings from {self.embedding_path}')
             for root, _, files in os.walk(self.embedding_path):

--- a/ldm/invoke/ckpt_generator/base.py
+++ b/ldm/invoke/ckpt_generator/base.py
@@ -16,7 +16,6 @@ from PIL import Image, ImageFilter, ImageChops
 import cv2 as cv
 from einops import rearrange, repeat
 from pathlib import Path
-from pytorch_lightning import seed_everything
 import invokeai.assets.web as web_assets
 from ldm.invoke.devices import choose_autocast
 from ldm.models.diffusion.cross_attention_map_saving import AttentionMapSaver
@@ -88,14 +87,14 @@ class CkptGenerator():
             for n in trange(iterations, desc='Generating'):
                 x_T = None
                 if self.variation_amount > 0:
-                    seed_everything(seed)
+                    torch.manual_seed(seed)
                     target_noise = self.get_noise(width,height)
                     x_T = self.slerp(self.variation_amount, initial_noise, target_noise)
                 elif initial_noise is not None:
                     # i.e. we specified particular variations
                     x_T = initial_noise
                 else:
-                    seed_everything(seed)
+                    torch.manual_seed(seed)
                     try:
                         x_T = self.get_noise(width,height)
                     except:
@@ -211,11 +210,11 @@ class CkptGenerator():
         initial_noise = None
         if self.variation_amount > 0 or len(self.with_variations) > 0:
             # use fixed initial noise plus random noise per iteration
-            seed_everything(seed)
+            torch.manual_seed(seed)
             initial_noise = self.get_noise(width,height)
             for v_seed, v_weight in self.with_variations:
                 seed = v_seed
-                seed_everything(seed)
+                torch.manual_seed(seed)
                 next_noise = self.get_noise(width,height)
                 initial_noise = self.slerp(v_weight, initial_noise, next_noise)
             if self.variation_amount > 0:

--- a/ldm/invoke/generator/base.py
+++ b/ldm/invoke/generator/base.py
@@ -18,7 +18,6 @@ from PIL import Image, ImageFilter, ImageChops
 from diffusers import DiffusionPipeline
 from einops import rearrange
 from pathlib import Path
-from pytorch_lightning import seed_everything
 from tqdm import trange
 
 import invokeai.assets.web as web_assets
@@ -98,14 +97,14 @@ class Generator:
             for n in trange(iterations, desc='Generating'):
                 x_T = None
                 if self.variation_amount > 0:
-                    seed_everything(seed)
+                    torch.manual_seed(seed)
                     target_noise = self.get_noise(width,height)
                     x_T = self.slerp(self.variation_amount, initial_noise, target_noise)
                 elif initial_noise is not None:
                     # i.e. we specified particular variations
                     x_T = initial_noise
                 else:
-                    seed_everything(seed)
+                    torch.manual_seed(seed)
                     try:
                         x_T = self.get_noise(width,height)
                     except:
@@ -216,11 +215,11 @@ class Generator:
         initial_noise = None
         if self.variation_amount > 0 or len(self.with_variations) > 0:
             # use fixed initial noise plus random noise per iteration
-            seed_everything(seed)
+            torch.manual_seed(seed)
             initial_noise = self.get_noise(width,height)
             for v_seed, v_weight in self.with_variations:
                 seed = v_seed
-                seed_everything(seed)
+                torch.manual_seed(seed)
                 next_noise = self.get_noise(width,height)
                 initial_noise = self.slerp(v_weight, initial_noise, next_noise)
             if self.variation_amount > 0:


### PR DESCRIPTION
Increased `NUMPY_RAND_MAX`, utilized by the ui to enforce random number seed maximum to 2^53 - 1 (`9007199254740991`).
This number was chosen as it is the largest integer that Javascript can represent.

Reduce minimum value for `CfgScale` from `1.01` to `1.0001`.  There are perceptual differences between `1.01` and `1.001` for most pipeline renders.  Added an additional order of magnitude for safety.

This is the crux of the seed fix:
Refactored all use of the pytorch_lightning `seed_everything()` function to utilize the sane and predictable `torch.manual_seed` function.
https://pytorch.org/docs/stable/generated/torch.manual_seed.html
`manual_seed` will provide up to 63-bits of seed selection space.

`seed_everything()` inherits its behavior from a numpy function that conflates its single parameter with two independent functions:
* setting the random number seed to the passed parameter
*  resetting the random number seed to a unspecified, function selected number, ignoring the passed parameter. The latter behavior occurs for seed values equal to or greater than 2^32 (`4294967296`).

Tested successfully via the invokeai UI with some values up to `9007199254740991`. Tested successfully via the invokeai CLI with some values in the range `9007199254740992 ... 9223372036854775807`.

```invokeai
invoke> may I use your towel my car just hit a water buffalo -s 30 -C 7.5 -S 9007199254740992 
...
invoke> may I use your towel my car just hit a water buffalo -s 30 -C 7.5 -S 9223372036854775807
```

Was able to use seeds > 2^32 in invokeai which I had previously rendered via a vanilla StableDiffusionPipeline implementation.  Was able to obtain perceptually identical results via invokeai.  What I set out to do!

:D

![image](https://user-images.githubusercontent.com/4421199/222299887-46b5be7a-e220-40da-80df-88000c73865d.png)
