### PR TITLE
Fix for txt2img2img.py

### DIFF
--- a/invokeai/backend/generator/txt2img2img.py
+++ b/invokeai/backend/generator/txt2img2img.py
@@ -8,9 +8,9 @@ from typing import Callable, Optional
 import torch
 from diffusers.utils.logging import get_verbosity, set_verbosity, set_verbosity_error
 
-from ..models import PostprocessingSettings
+from ..stable_diffusion import PostprocessingSettings
 from .base import Generator
-from .diffusers_pipeline import (
+from ..stable_diffusion.diffusers_pipeline import (
     ConditioningData,
     StableDiffusionGeneratorPipeline,
     trim_to_multiple_of,

--- a/invokeai/backend/generator/txt2img2img.py
+++ b/invokeai/backend/generator/txt2img2img.py
@@ -10,12 +10,9 @@ from diffusers.utils.logging import get_verbosity, set_verbosity, set_verbosity_
 
 from ..stable_diffusion import PostprocessingSettings
 from .base import Generator
-from ..stable_diffusion.diffusers_pipeline import (
-    ConditioningData,
-    StableDiffusionGeneratorPipeline,
-    trim_to_multiple_of,
-)
-
+from ..stable_diffusion.diffusers_pipeline import StableDiffusionGeneratorPipeline
+from ..stable_diffusion.diffusers_pipeline import ConditioningData
+from ..stable_diffusion.diffusers_pipeline import trim_to_multiple_of
 
 class Txt2Img2Img(Generator):
     def __init__(self, model, precision):


### PR DESCRIPTION
Fix error when using txt2img 
ModuleNotFoundError: No module named 'invokeai.backend.models'
and
ModuleNotFoundError: No module named 'invokeai.backend.generator.diffusers_pipeline'