### PR TITLE
deps: upgrade to diffusers 0.14, safetensors 0.3, transformers 4.26, accelerate 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,13 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Image Processing',
 ]
 dependencies = [
-  "accelerate",
+  "accelerate~=0.16",
   "albumentations",
   "click",
   "clip_anytorch",          # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
   "compel==0.1.7",
   "datasets",
-  "diffusers[torch]~=0.13",
+  "diffusers[torch]~=0.14",
   "dnspython==2.2.1",
   "einops",
   "eventlet",
@@ -73,7 +73,7 @@ dependencies = [
   "pytorch-lightning==1.7.7",
   "realesrgan",
   "requests==2.28.2",
-  "safetensors",
+  "safetensors~=0.3.0",
   "scikit-image>=0.19",
   "send2trash",
   "streamlit",
@@ -83,7 +83,7 @@ dependencies = [
   "torch-fidelity",
   "torchvision>=0.14.1",
   "torchmetrics",
-  "transformers~=4.25",
+  "transformers~=4.26",
   "uvicorn[standard]==0.20.0",
   "windows-curses; sys_platform=='win32'",
 ]
@@ -132,7 +132,7 @@ version = { attr = "invokeai.version.__version__" }
 [tool.setuptools.packages.find]
 "where" = ["."]
 "include" = [
-    "invokeai.assets.web*","invokeai.version*", 
+    "invokeai.assets.web*","invokeai.version*",
     "invokeai.generator*","invokeai.backend*",
     "invokeai.frontend*", "invokeai.frontend.web.dist*",
     "invokeai.configs*",


### PR DESCRIPTION
Things to check for in this version:

- `diffusers` cache location is now more consistent with other huggingface-hub using code (i.e. `transformers`) as of https://github.com/huggingface/diffusers/pull/2005. I think ultimately this should make @damian0815 (and other folks with multiple diffusers-using projects) happier, but it's worth taking a look to make sure the way @lstein set things up to respect `HF_HOME` is still functioning as intended.
- I've gone ahead and updated `transformers` to the current version (4.26), but I have a vague memory that we were holding it back at some point? Need to look that up and see if that's the case and why.