### PR TITLE
build: exclude ui from `test-invoke-pip`

### DIFF
--- a/.github/workflows/test-invoke-pip-skip.yml
+++ b/.github/workflows/test-invoke-pip-skip.yml
@@ -1,12 +1,12 @@
 name: Test invoke.py pip
 on:
   pull_request:
-    paths-ignore:
-      - 'pyproject.toml'
-      - 'invokeai/**'
-      - 'invokeai/backend/**'
-      - 'invokeai/configs/**'
-      - 'invokeai/frontend/web/dist/**'
+    paths:
+      - '**'
+      - '!pyproject.toml'
+      - '!invokeai/**'
+      - 'invokeai/frontend/web/**'
+      - '!invokeai/frontend/web/dist/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -6,15 +6,13 @@ on:
     paths:
       - 'pyproject.toml'
       - 'invokeai/**'
-      - 'invokeai/backend/**'
-      - 'invokeai/configs/**'
+      - '!invokeai/frontend/web/**'
       - 'invokeai/frontend/web/dist/**'
   pull_request:
     paths:
       - 'pyproject.toml'
       - 'invokeai/**'
-      - 'invokeai/backend/**'
-      - 'invokeai/configs/**'
+      - '!invokeai/frontend/web/**'
       - 'invokeai/frontend/web/dist/**'
     types:
       - 'ready_for_review'


### PR DESCRIPTION
Prior to the folder restructure, the `paths` for `test-invoke-pip` did not include the UI's path `invokeai/frontend/`:

```yaml
    paths:
      - 'pyproject.toml'
      - 'ldm/**'
      - 'invokeai/backend/**'
      - 'invokeai/configs/**'
      - 'invokeai/frontend/dist/**'
```

After the restructure, more code was moved into the `invokeai/frontend/` folder, and `paths` was updated:

```yaml
    paths:
      - 'pyproject.toml'
      - 'invokeai/**'
      - 'invokeai/backend/**'
      - 'invokeai/configs/**'
      - 'invokeai/frontend/web/dist/**'
```

Now, the second path includes the UI. The UI now needs to be excluded, and must be excluded prior to `invokeai/frontend/web/dist/**` being included.

On `test-invoke-pip-skip`, we need to do a bit of logic juggling to invert the folder selection. First, include the web folder, then exclude everying around it and finally exclude the `dist/` folder