### PR TITLE
Make img2img strength 1 behave the same as txt2img

### DIFF
--- a/invokeai/backend/generator/base.py
+++ b/invokeai/backend/generator/base.py
@@ -99,6 +99,7 @@ class Generator:
             h_symmetry_time_pct=h_symmetry_time_pct,
             v_symmetry_time_pct=v_symmetry_time_pct,
             attention_maps_callback=attention_maps_callback,
+            seed=seed,
             **kwargs,
         )
         results = []
@@ -289,9 +290,7 @@ class Generator:
             if self.variation_amount > 0:
                 random.seed()  # reset RNG to an actually random state, so we can get a random seed for variations
                 seed = random.randrange(0, np.iinfo(np.uint32).max)
-            return (seed, initial_noise)
-        else:
-            return (seed, None)
+        return (seed, initial_noise)
 
     # returns a tensor filled with random numbers from a normal distribution
     def get_noise(self, width, height):

--- a/invokeai/backend/generator/inpaint.py
+++ b/invokeai/backend/generator/inpaint.py
@@ -223,6 +223,7 @@ class Inpaint(Img2Img):
         inpaint_height=None,
         inpaint_fill: tuple(int) = (0x7F, 0x7F, 0x7F, 0xFF),
         attention_maps_callback=None,
+        seed=None,
         **kwargs,
     ):
         """
@@ -319,6 +320,7 @@ class Inpaint(Img2Img):
                 conditioning_data=conditioning_data,
                 noise_func=self.get_noise_like,
                 callback=step_callback,
+                seed=seed
             )
 
             if (

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -731,9 +731,11 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
             device=self._model_group.device_for(self.unet),
         )
         result_latents, result_attention_maps = self.latents_from_embeddings(
-            initial_latents,
-            num_inference_steps,
-            conditioning_data,
+            latents=initial_latents if strength < 1.0 else torch.zeros_like(
+                initial_latents, device=initial_latents.device, dtype=initial_latents.dtype
+            ),
+            num_inference_steps=num_inference_steps,
+            conditioning_data=conditioning_data,
             timesteps=timesteps,
             noise=noise,
             run_id=run_id,
@@ -831,9 +833,11 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
 
         try:
             result_latents, result_attention_maps = self.latents_from_embeddings(
-                init_image_latents,
-                num_inference_steps,
-                conditioning_data,
+                latents=init_image_latents if strength < 1.0 else torch.zeros_like(
+                    init_image_latents, device=init_image_latents.device, dtype=init_image_latents.dtype
+                ),
+                num_inference_steps=num_inference_steps,
+                conditioning_data=conditioning_data,
                 noise=noise,
                 timesteps=timesteps,
                 additional_guidance=guidance,

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -690,6 +690,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         callback: Callable[[PipelineIntermediateState], None] = None,
         run_id=None,
         noise_func=None,
+        seed=None,
     ) -> InvokeAIStableDiffusionPipelineOutput:
         if isinstance(init_image, PIL.Image.Image):
             init_image = image_resized_to_grid_as_tensor(init_image.convert("RGB"))
@@ -703,7 +704,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
             device=self._model_group.device_for(self.unet),
             dtype=self.unet.dtype,
         )
-        noise = noise_func(initial_latents)
+        noise = noise_func(initial_latents, seed)
 
         return self.img2img_from_latents_and_embeddings(
             initial_latents,
@@ -781,6 +782,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         callback: Callable[[PipelineIntermediateState], None] = None,
         run_id=None,
         noise_func=None,
+        seed=None,
     ) -> InvokeAIStableDiffusionPipelineOutput:
         device = self._model_group.device_for(self.unet)
         latents_dtype = self.unet.dtype
@@ -804,7 +806,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         init_image_latents = self.non_noised_latents_from_image(
             init_image, device=device, dtype=latents_dtype
         )
-        noise = noise_func(init_image_latents)
+        noise = noise_func(init_image_latents, seed)
 
         if mask.dim() == 3:
             mask = mask.unsqueeze(0)


### PR DESCRIPTION
When the user picks a strength of 1 for img2img or inpainting, the current code slightly mixes in the initial image with random noise. Strength 1 should be a complete replacement and should yield the same results as txt2img in the img2img case.