### PR TITLE
Remove label from stale issues on comment event

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -2,6 +2,8 @@ name: Close inactive issues
 on:
   schedule:
     - cron: "00 6 * * *"
+  issue_comment:
+    types: [ "created" ]
 
 env:
   DAYS_BEFORE_ISSUE_STALE: 14
@@ -10,6 +12,7 @@ env:
 jobs:
   close-issues:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
     permissions:
       issues: write
       pull-requests: write
@@ -18,9 +21,9 @@ jobs:
         with:
           days-before-issue-stale: ${{ env.DAYS_BEFORE_ISSUE_STALE }}
           days-before-issue-close: ${{ env.DAYS_BEFORE_ISSUE_CLOSE }}
-          stale-issue-label: "Inactive Issue"
-          stale-issue-message: "There has been no activity in this issue for ${{ env.DAYS_BEFORE_ISSUE_STALE }} days. If this issue is still being experienced, please reply with an updated confirmation that the issue is still being experienced with the latest release."
-          close-issue-message: "Due to inactivity, this issue was automatically closed. If you are still experiencing the issue, please recreate the issue."
+          stale-issue-label: "stale"
+          stale-issue-message: "There has been no activity in this issue for ${{ env.DAYS_BEFORE_ISSUE_STALE }} days. Please reply with a comment to keep the issue open. We recommend testing with the latest release to make sure it hasn't been already fixed."
+          close-issue-message: "Due to inactivity, this issue was automatically closed. If you are still experiencing the issue, please open a new one and reference issue ${{ github.event.issue.number }}."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I found it to be a chore to remove labels manually in order to "un-stale" issues. This is contrary to the bot message which says commenting should remove "stale" status. On the current `cron` schedule, there may be a delay of up to 24 hours before the label is removed. This PR will trigger the workflow on issue comments in addition to the schedule.

Also adds a condition to not run this job on PRs (Github treats issues and PRs equivalently in this respect), and rewords the messages for clarity.