### PR TITLE
Disable built-in NSFW checker on models converted with --ckpt_convert

### DIFF
--- a/ldm/invoke/ckpt_to_diffuser.py
+++ b/ldm/invoke/ckpt_to_diffuser.py
@@ -1002,7 +1002,7 @@ def load_pipeline_from_original_stable_diffusion_ckpt(
                 tokenizer=tokenizer,
                 unet=unet.to(precision),
                 scheduler=scheduler,
-                safety_checker=safety_checker.to(precision),
+                safety_checker=None if return_generator_pipeline else safety_checker.to(precision),
                 feature_extractor=feature_extractor,
             )
         else:


### PR DESCRIPTION
When a legacy ckpt model was converted into diffusers in RAM, the built-in NSFW checker was not being disabled, in contrast to models converted and saved to disk. Because InvokeAI does its NSFW checking as a separate post-processing step (in order to generate blurred images rather than black ones), this defeated the
--nsfw and --no-nsfw switches.

This closes #2836 and #2580.

Note - this fix will be applied to `main` as a separate PR.