### PR TITLE
FIX bug that caused black images when converting ckpts to diffusers

### DIFF
--- a/invokeai/backend/model_management/convert_ckpt_to_diffusers.py
+++ b/invokeai/backend/model_management/convert_ckpt_to_diffusers.py
@@ -1274,7 +1274,7 @@ def load_pipeline_from_original_stable_diffusion_ckpt(
                 tokenizer=tokenizer,
                 unet=unet.to(precision),
                 scheduler=scheduler,
-                safety_checker=safety_checker.to(precision),
+                safety_checker=None if return_generator_pipeline else safety_checker.to(precision),
                 feature_extractor=feature_extractor,
             )
         else:


### PR DESCRIPTION
# Several issues noted that NSFW images were coming out black even when --no-nsfw specified

Cause of the problem was inadvertent activation of the safety checker.

When conversion occurs on disk, the safety checker is disabled during loading. However, when converting in RAM, the safety checker was not removed, resulting in it activating even when user specified --no-nsfw_checker.

This PR fixes the problem by detecting when the caller has requested the InvokeAi StableDiffusionGeneratorPipeline class to be returned and setting safety checker to None. Do not do this with diffusers models destined for disk because then they will be incompatible with the merge script!!

Closes #2836