### PR TITLE
raise operations-per-run for issue workflow to 500

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -24,3 +24,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 500


### PR DESCRIPTION
- default value is 30
- limit per hour is 1000

This should help getting the count of open issues down.