### PR TITLE
Bugfix/fix 2.3.2 upgrade path

### DIFF
--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -67,7 +67,7 @@ def main():
 
     # run any post-install patches needed
     # temporarily disabled
-    # run_patches()
+    run_patches()
 
     print(f">> Internet connectivity is {Globals.internet_available}")
 

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -66,7 +66,6 @@ def main():
     Globals.ckpt_convert = args.ckpt_convert
 
     # run any post-install patches needed
-    # temporarily disabled
     run_patches()
 
     print(f">> Internet connectivity is {Globals.internet_available}")

--- a/ldm/invoke/CLI.py
+++ b/ldm/invoke/CLI.py
@@ -66,7 +66,8 @@ def main():
     Globals.ckpt_convert = args.ckpt_convert
 
     # run any post-install patches needed
-    run_patches()
+    # temporarily disabled
+    # run_patches()
 
     print(f">> Internet connectivity is {Globals.internet_available}")
 

--- a/ldm/invoke/_version.py
+++ b/ldm/invoke/_version.py
@@ -1,2 +1,2 @@
 
-__version__='2.3.2'
+__version__='2.3.2.post1a'

--- a/ldm/invoke/_version.py
+++ b/ldm/invoke/_version.py
@@ -1,2 +1,2 @@
 
-__version__='2.3.2.post1a'
+__version__='2.3.2.post1'

--- a/ldm/invoke/config/invokeai_update.py
+++ b/ldm/invoke/config/invokeai_update.py
@@ -72,7 +72,7 @@ def main():
         tag = Prompt.ask('Enter an InvokeAI tag or branch name')
 
     print(f':crossed_fingers: Upgrading to [yellow]{tag}[/yellow]')
-    cmd = f'pip install {INVOKE_AI_SRC}/{tag}.zip --use-pep517'
+    cmd = f'pip install {INVOKE_AI_SRC}/{tag}.zip --use-pep517 --upgrade'
     print('')
     print('')
     if os.system(cmd)==0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,18 +136,18 @@ license-files = ["LICENSE"]
 version = {attr = "ldm.invoke.__version__"}
 
 [tool.setuptools.packages.find]
-"where" = ["."]
 "include" = [
-	  "invokeai.assets.web*",
-	  "invokeai.backend*",
-	  "invokeai.frontend.dist*",
-	  "invokeai.configs*",
-	  "ldm*"]
+  "invokeai.assets.web",
+  "invokeai.backend*",
+  "invokeai.configs*",
+  "invokeai.frontend.dist*",
+  "ldm*",
+]
+"where" = ["."]
 
 [tool.setuptools.package-data]
 "invokeai.assets.web" = ["**.png"]
-"invokeai.backend" = ["**.png"]
-"invokeai.configs" = ["*.example", "**/*.yaml", "*.txt"]
+"invokeai.configs" = ["**.example", "**.txt", "**.yaml", "**/*.yaml"]
 "invokeai.frontend.dist" = ["**"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,19 +136,18 @@ license-files = ["LICENSE"]
 version = {attr = "ldm.invoke.__version__"}
 
 [tool.setuptools.packages.find]
-"include" = [
-  "invokeai.assets.web",
-  "invokeai.backend*",
-  "invokeai.configs*",
-  "invokeai.configs.stable-diffusion*",
-  "invokeai.frontend.dist*",
-  "ldm*",
-]
 "where" = ["."]
+"include" = [
+	  "invokeai.assets.web*",
+	  "invokeai.backend*",
+	  "invokeai.frontend.dist*",
+	  "invokeai.configs*",
+	  "ldm*"]
 
 [tool.setuptools.package-data]
 "invokeai.assets.web" = ["**.png"]
-"invokeai.configs" = ["**.example", "**.txt", "**.yaml"]
+"invokeai.backend" = ["**.png"]
+"invokeai.configs" = ["*.example", "**/*.yaml", "*.txt"]
 "invokeai.frontend.dist" = ["**"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ version = {attr = "ldm.invoke.__version__"}
   "invokeai.assets.web",
   "invokeai.backend*",
   "invokeai.configs*",
+  "invokeai.configs.stable-diffusion*",
   "invokeai.frontend.dist*",
   "ldm*",
 ]


### PR DESCRIPTION
This is a temporary fix for #2930 . For reasons unknown, when doing a pip install from network the `configs/stable-diffusion` directory is not being installed into `.venv`, and this breaks the `run_patches()` routine in the CLI. 

This PR disables `run_patches()` until the problem can be dealt with more definitively. The only issue will be that the original checkpoint stable diffusion configuration files will not be updated with more recent versions.

[Edit]
Added line missing in `pyproject.toml` so config/stable-diffusion directory should now be created. Needs someone other than myself to test and confirm. Please don't merge till then.