### PR TITLE
fix --png_compression command line argument

### DIFF
--- a/invokeai/backend/args.py
+++ b/invokeai/backend/args.py
@@ -490,7 +490,7 @@ class Args(object):
             "-z",
             type=int,
             default=6,
-            choices=range(0, 9),
+            choices=range(0, 10),
             dest="png_compression",
             help="level of PNG compression, from 0 (none) to 9 (maximum). Default is 6.",
         )
@@ -943,7 +943,6 @@ class Args(object):
             "--png_compression",
             "-z",
             type=int,
-            default=6,
             choices=range(0, 10),
             dest="png_compression",
             help="level of PNG compression, from 0 (none) to 9 (maximum). [6]",


### PR DESCRIPTION
- The value of png_compression was always 6, despite the value provided to the --png_compression argument. This fixes the bug.
- It also fixes an inconsistency between the maximum range of png_compression and the help text.

- Closes #2945