### PR TITLE
fix(inpaint): Seam painting being broken

### DIFF
--- a/invokeai/backend/generator/inpaint.py
+++ b/invokeai/backend/generator/inpaint.py
@@ -159,6 +159,7 @@ class Inpaint(Img2Img):
         seam_size: int,
         seam_blur: int,
         prompt,
+        seed,
         sampler,
         steps,
         cfg_scale,
@@ -192,7 +193,7 @@ class Inpaint(Img2Img):
 
         seam_noise = self.get_noise(im.width, im.height)
 
-        result = make_image(seam_noise)
+        result = make_image(seam_noise, seed)
 
         return result
 
@@ -342,6 +343,7 @@ class Inpaint(Img2Img):
                     seam_size,
                     seam_blur,
                     prompt,
+                    seed,
                     sampler,
                     seam_steps,
                     cfg_scale,


### PR DESCRIPTION
After #2942, seed needs to be passed down from inpaint to seam_paint. Not doing so breaks inpainting and outpainting. This PR fixes it.