### PR TITLE
deps: upgrade to PyTorch 2.0 (replaces xformers)

### DIFF
--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -461,8 +461,7 @@ def get_torch_source() -> (Union[str, None],str):
             url = "https://download.pytorch.org/whl/cpu"
 
     if device == 'cuda':
-        url = 'https://download.pytorch.org/whl/cu117'
-        optional_modules = '[xformers]'
+        url = 'https://download.pytorch.org/whl/cu118'
 
     # in all other cases, Torch wheels should be coming from PyPi as of Torch 1.13
 

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -531,7 +531,8 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         run_id: str = None,
         additional_guidance: List[Callable] = None,
     ):
-        self._adjust_memory_efficient_attention(latents)
+        # FIXME: do we still use any slicing now that PyTorch 2.0 has scaled dot-product attention on all platforms?
+        #   self._adjust_memory_efficient_attention(latents)
         if run_id is None:
             run_id = secrets.token_urlsafe(self.ID_LENGTH)
         if additional_guidance is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,10 @@ dependencies = [
   "scikit-image>=0.19",
   "send2trash",
   "test-tube>=0.7.5",
-  "torch>=1.13.1",
+  "torch~=2.0",
   "torchvision>=0.14.1",
   "torchmetrics",
-  "transformers~=4.26",
+  "transformers~=4.27",
   "uvicorn[standard]==0.20.0",
   "windows-curses; sys_platform=='win32'",
 ]
@@ -90,10 +90,6 @@ dependencies = [
   "pudb",
 ]
 "test" = ["pytest>6.0.0", "pytest-cov"]
-"xformers" = [
-	   "xformers~=0.0.16; sys_platform!='darwin'",
-	   "triton; sys_platform=='linux'",
-]
 
 [project.scripts]
 


### PR DESCRIPTION
[PyTorch 2.0 is released!](https://pytorch.org/blog/pytorch-2.0-release/)

It provides a direct interface to several optimized implementations of [scaled dot-product attention](https://pytorch.org/blog/pytorch-2.0-release/#beta-scaled-dot-product-attention-20) so we don't need to explicitly depend on xformers or triton anymore.

Fixes #2405 

I did some quick and dirty tests here on Linux/CUDA (RTX 3060) and it works fine.

## To Do
- [ ] test on Windows
- [ ] test on MPS
- [ ] test on ROCm
- [ ] figure out what to do with our `_adjust_memory_efficient_attention` attention. Is it entirely obsolete now that pytorch has a C++ cross-platform implementation of scaled dot product attention to fall back on, or will we still need that?
- [ ] provide some interface to `torch.backends.cudnn.deterministic` as per notes on [avoiding nondeterministic algorithms](https://pytorch.org/docs/master/notes/randomness.html#avoiding-nondeterministic-algorithms).