### PR TITLE
Keep torch version at 1.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "taming-transformers-rom1504",
   "test-tube>=0.7.5",
   "torch-fidelity",
-  "torch==1.13.1",
+  "torch~=1.13.1",
   "torchmetrics",
   "torchvision>=0.14.1",
   "transformers~=4.26",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "taming-transformers-rom1504",
   "test-tube>=0.7.5",
   "torch-fidelity",
-  "torch>=1.13.1",
+  "torch==1.13.1",
   "torchmetrics",
   "torchvision>=0.14.1",
   "transformers~=4.26",


### PR DESCRIPTION
Now that torch 2.0 is out, Invoke 2.3 should lock down its version to 1.13.1 for new installs and upgrades.