### PR TITLE
prevent infinite loop when launching developer's console

### DIFF
--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -67,20 +67,20 @@ if [ "$0" != "bash" ]; then
             ;;
         7)
             invokeai-configure --root ${INVOKEAI_ROOT} --yes --default_only
-	    ;;
-	8)
-	    echo "Developer Console:"
+            ;;
+        8)
+            echo "Developer Console:"
             file_name=$(basename "${BASH_SOURCE[0]}")
             bash --init-file "$file_name"
             ;;
         9)
-	    echo "Update:"
+            echo "Update:"
             invokeai-update
             ;;
         10)
             invokeai --help
             ;;
-	[qQ])
+        [qQ])
             exit 0
             ;;
         *)

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -24,9 +24,9 @@ if [ "$(uname -s)" == "Darwin" ]; then
     export PYTORCH_ENABLE_MPS_FALLBACK=1
 fi
 
-while true
-do
 if [ "$0" != "bash" ]; then
+  while true
+  do
     echo "Do you want to generate images using the"
     echo "1. command-line interface"
     echo "2. browser-based UI"
@@ -87,9 +87,9 @@ if [ "$0" != "bash" ]; then
             echo "Invalid selection"
             exit;;
     esac
+ done
 else # in developer console
     python --version
     echo "Press ^D to exit"
     export PS1="(InvokeAI) \u@\h \w> "
 fi
-done


### PR DESCRIPTION
At some point I put a loop around the menu for the `invoke.sh` script so that users could launch the merge or textual inversion scripts and then conveniently return to the menu to select another option. However, because of poor loop termination placement, selecting option [8] for the "developer's console" created an annoying infinite loop. This fixes the problem.

The fact that nobody noticed this before is interesting and a bit sad.