### PR TITLE
fix batch generation logfile name to be compatible with Windows OS

### DIFF
--- a/ldm/invoke/dynamic_prompts.py
+++ b/ldm/invoke/dynamic_prompts.py
@@ -157,7 +157,7 @@ def _run_invoke(
 ):
     pid = os.getpid()
     logdir.mkdir(parents=True, exist_ok=True)
-    logfile = Path(logdir, f'{time.strftime("%Y-%m-%d-%H:%M:%S")}-pid={pid}.txt')
+    logfile = Path(logdir, f'{time.strftime("%Y-%m-%d_%H-%M-%S")}-pid={pid}.txt')
     print(
         f">> Process {pid} running on GPU {gpu}; logging to {logfile}", file=sys.stderr
     )


### PR DESCRIPTION
- The command `invokeai-batch --invoke` was creating a time-stamped logfile with colons in its name, which is a Windows no-no. This corrects the problem by writing the timestamp out as "13-06-2023_8-35-10"

- Closes #3005