### PR TITLE
add github API token to mkdocs workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
 # continuous integration
-/.github/workflows/ @mauwii @lstein
+/.github/workflows/ @mauwii @lstein @blessedcoolant
 
 # documentation
-/docs/ @lstein @mauwii @tildebyte
-/mkdocs.yml @lstein @mauwii
+/docs/ @lstein @mauwii @tildebyte @blessedcoolant
+/mkdocs.yml @lstein @mauwii @blessedcoolant
 
 # nodes
 /invokeai/app/ @Kyle0654 @blessedcoolant
 
 # installation and configuration
 /pyproject.toml @mauwii @lstein @blessedcoolant
-/docker/ @mauwii @lstein
+/docker/ @mauwii @lstein @blessedcoolant
 /scripts/ @ebr @lstein
 /installer/ @lstein @ebr
 /invokeai/assets @lstein @ebr

--- a/.github/workflows/mkdocs-material.yml
+++ b/.github/workflows/mkdocs-material.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: deploy to gh-pages
         if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python -m \
             mkdocs gh-deploy \


### PR DESCRIPTION
The mkdocs-workflow has been failing over the past week due to permission denied errors. I *think* this is the result of not passing the GitHub API token to the workflow, and this is a speculative fix for the issue.