### PR TITLE
fix issue with embeddings being loaded twice

### DIFF
--- a/invokeai/backend/model_management/convert_ckpt_to_diffusers.py
+++ b/invokeai/backend/model_management/convert_ckpt_to_diffusers.py
@@ -1229,15 +1229,15 @@ def load_pipeline_from_original_stable_diffusion_ckpt(
         # If a replacement VAE path was specified, we'll incorporate that into
         # the checkpoint model and then convert it
         if vae_path:
-            print(f"  | Converting VAE {vae_path}")
+            print(f"   | Converting VAE {vae_path}")
             replace_checkpoint_vae(checkpoint,vae_path)
         # otherwise we use the original VAE, provided that
         # an externally loaded diffusers VAE was not passed
         elif not vae:
-            print("  | Using checkpoint model's original VAE")
+            print("   | Using checkpoint model's original VAE")
 
         if vae:
-            print("  | Using replacement diffusers VAE")
+            print("   | Using replacement diffusers VAE")
         else:  # convert the original or replacement VAE
             vae_config = create_vae_diffusers_config(
                 original_config, image_size=image_size

--- a/invokeai/backend/model_management/model_manager.py
+++ b/invokeai/backend/model_management/model_manager.py
@@ -434,7 +434,6 @@ class ModelManager(object):
         height = width
         print(f"   | Default image dimensions = {width} x {height}")
         
-        self._add_embeddings_to_model(pipeline)
         return pipeline, width, height, model_hash
 
     def _load_ckpt_model(self, model_name, mconfig):
@@ -476,7 +475,6 @@ class ModelManager(object):
             pipeline.enable_offload_submodels(self.device)
         else:
             pipeline.to(self.device)
-
         return (
             pipeline,
             width,


### PR DESCRIPTION
This bug was causing a bunch of annoying warnings about not overwriting previously loaded tokens.

- as noted by JPPhoto