### PR TITLE
Downgrade FastAPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "einops",
   "eventlet",
   "facexlib",
-  "fastapi==0.94.1",
+  "fastapi==0.88.0",
   "fastapi-events==0.8.0",
   "fastapi-socketio==0.0.10",
   "flask==2.1.3",
@@ -160,4 +160,3 @@ output = "coverage/index.xml"
 
 [flake8]
 max-line-length = 120
-


### PR DESCRIPTION
FastAPI is broken on `main` (17d8bbf3) - any request returns a `500` type error. 

This PR downgrades `fastapi` and related packages again. I wish I had a better solution, but this at least fixes the immediate breakage.

Fixes #3038 