### PR TITLE
fix(nodes): alternative way to mark properties required

### DIFF
--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -99,6 +99,13 @@ def custom_openapi():
 
     output_schemas = schema(output_types, ref_prefix="#/components/schemas/")
     for schema_key, output_schema in output_schemas["definitions"].items():
+        # Schema generation makes output properties optional by default
+        # Manually fix this by marking them all required
+        required_properties = []
+        for prop in output_schema["properties"]:
+            required_properties.append(prop)
+        output_schema["required"] = required_properties
+
         openapi_schema["components"]["schemas"][schema_key] = output_schema
 
         # TODO: note that we assume the schema_key here is the TYPE.__name__
@@ -114,6 +121,12 @@ def custom_openapi():
         outputs_ref = {"$ref": f"#/components/schemas/{output_type_title}"}
 
         invoker_schema["output"] = outputs_ref
+
+    # Same as we did for outputs above, mark GraphExecutionState properties all required
+    required_properties = []
+    for prop in openapi_schema["components"]["schemas"]["GraphExecutionState"]["properties"]:
+        required_properties.append(prop)
+    openapi_schema["components"]["schemas"]["GraphExecutionState"]["required"] = required_properties
 
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -28,28 +28,12 @@ class ImageOutput(BaseInvocationOutput):
     image:      ImageField = Field(default=None, description="The output image")
     #fmt: on
 
-    class Config:
-        schema_extra = {
-            'required': [
-                'type',
-                'image',
-            ]
-        }
-
 class MaskOutput(BaseInvocationOutput):
     """Base class for invocations that output a mask"""
     #fmt: off
     type: Literal["mask"] = "mask"
     mask:      ImageField = Field(default=None, description="The output mask")
     #fmt: on
-
-    class Config:
-        schema_extra = {
-            'required': [
-                'type',
-                'mask',
-            ]
-        }
 
 # TODO: this isn't really necessary anymore
 class LoadImageInvocation(BaseInvocation):

--- a/invokeai/app/invocations/prompt.py
+++ b/invokeai/app/invocations/prompt.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from pydantic.fields import Field
 
-from .baseinvocation import BaseInvocationOutput
+from .baseinvocation import BaseInvocation, BaseInvocationOutput, InvocationContext
 
 
 class PromptOutput(BaseInvocationOutput):
@@ -13,10 +13,16 @@ class PromptOutput(BaseInvocationOutput):
     prompt: str = Field(default=None, description="The output prompt")
     #fmt: on
 
-    class Config:
-        schema_extra = {
-            'required': [
-                'type',
-                'prompt',
-            ]
-        }
+class SimplePromptInvocation(BaseInvocation):
+    """Simple prompt invocation."""
+    #fmt: off
+    type: Literal["simple_prompt"] = "simple_prompt"
+
+    # Inputs
+    prompt: str = Field(default=None, description="The prompt to output.")
+    #fmt: on
+
+    def invoke(self, context: InvocationContext) -> PromptOutput:
+        return PromptOutput(
+            prompt=self.prompt
+        )

--- a/invokeai/app/services/graph.py
+++ b/invokeai/app/services/graph.py
@@ -127,14 +127,6 @@ class NodeAlreadyExecutedError(Exception):
 class GraphInvocationOutput(BaseInvocationOutput):
     type: Literal["graph_output"] = "graph_output"
 
-    class Config:
-        schema_extra = {
-            'required': [
-                'type',
-                'image',
-            ]
-        }
-
 # TODO: Fill this out and move to invocations
 class GraphInvocation(BaseInvocation):
     type: Literal["graph"] = "graph"
@@ -153,14 +145,6 @@ class IterateInvocationOutput(BaseInvocationOutput):
     type: Literal["iterate_output"] = "iterate_output"
 
     item: Any = Field(description="The item being iterated over")
-
-    class Config:
-        schema_extra = {
-            'required': [
-                'type',
-                'item',
-            ]
-        }
 
 # TODO: Fill this out and move to invocations
 class IterateInvocation(BaseInvocation):
@@ -182,14 +166,6 @@ class CollectInvocationOutput(BaseInvocationOutput):
     type: Literal["collect_output"] = "collect_output"
 
     collection: list[Any] = Field(description="The collection of input items")
-
-    class Config:
-        schema_extra = {
-            'required': [
-                'type',
-                'collection',
-            ]
-        }
 
 class CollectInvocation(BaseInvocation):
     """Collects values into a collection"""
@@ -793,24 +769,6 @@ class GraphExecutionState(BaseModel):
         description="The map of original graph nodes to prepared nodes",
         default_factory=dict,
     )
-
-    # Declare all fields as required; necessary for OpenAPI schema generation build.
-    # Technically only fields without a `default_factory` need to be listed here.
-    # See: https://github.com/pydantic/pydantic/discussions/4577
-    class Config:
-        schema_extra = {
-            'required': [
-                'id',
-                'graph',
-                'execution_graph',
-                'executed',
-                'executed_history',
-                'results',
-                'errors',
-                'prepared_source_mapping',
-                'source_prepared_mapping',
-            ]
-        }
 
     def next(self) -> BaseInvocation | None:
         """Gets the next node ready to execute."""


### PR DESCRIPTION
Note: I don't think this PR is the right way to do things. The existing method of using a `Config` class is the "official" solution. See: https://docs.pydantic.dev/usage/schema/#schema-customization https://github.com/pydantic/pydantic/discussions/4577

This shouldn't interfere with pydantic; we are following the blessed path to customize a schema.

That said, here's another way to accomplish the same thing:

Instead of adding a `Config` class with `schema_extra` props, we can manipulate the schema generation directly.

Iterate over the properties of each output model to build an array of required properties.

This method requires an output actually be used by an invocation, else it is not pulled in as an output. So `PromptOutput` needs an invocation for this method to work for it.