### PR TITLE
Fix bugs in online ckpt conversion of 2.0 models

### DIFF
--- a/invokeai/backend/model_management/convert_ckpt_to_diffusers.py
+++ b/invokeai/backend/model_management/convert_ckpt_to_diffusers.py
@@ -1264,10 +1264,10 @@ def load_pipeline_from_original_stable_diffusion_ckpt(
                 cache_dir=cache_dir,
             )
             pipe = pipeline_class(
-                vae=vae,
-                text_encoder=text_model,
+                vae=vae.to(precision),
+                text_encoder=text_model.to(precision),
                 tokenizer=tokenizer,
-                unet=unet,
+                unet=unet.to(precision),
                 scheduler=scheduler,
                 safety_checker=None,
                 feature_extractor=None,


### PR DESCRIPTION
## Enable the on-the-fly conversion of models based on SD 2.0/2.1 into diffusers

This commit fixes bugs related to the on-the-fly conversion and loading of legacy checkpoint models built on SD-2.0 base.

- When legacy checkpoints built on SD-2.0 models were converted on-the-fly using --ckpt_convert, generation would crash with a precision incompatibility error. This problem has been found and fixed.