### PR TITLE
remove vestiges of non-functional autoimport code for legacy checkpoints

### DIFF
--- a/invokeai/backend/args.py
+++ b/invokeai/backend/args.py
@@ -561,7 +561,7 @@ class Args(object):
             "--autoimport",
             default=None,
             type=str,
-            help="Check the indicated directory for .ckpt/.safetensors weights files at startup and import directly",
+            help="(DEPRECATED - NONFUNCTIONAL). Check the indicated directory for .ckpt/.safetensors weights files at startup and import directly",
         )
         model_group.add_argument(
             "--autoconvert",

--- a/invokeai/backend/config/model_install_backend.py
+++ b/invokeai/backend/config/model_install_backend.py
@@ -67,7 +67,6 @@ def install_requested_models(
     scan_directory: Path = None,
     external_models: List[str] = None,
     scan_at_startup: bool = False,
-    convert_to_diffusers: bool = False,
     precision: str = "float16",
     purge_deleted: bool = False,
     config_file_path: Path = None,
@@ -113,7 +112,6 @@ def install_requested_models(
             try:
                 model_manager.heuristic_import(
                     path_url_or_repo,
-                    convert=convert_to_diffusers,
                     commit_to_conf=config_file_path,
                 )
             except KeyboardInterrupt:
@@ -122,7 +120,7 @@ def install_requested_models(
                 pass
 
     if scan_at_startup and scan_directory.is_dir():
-        argument = "--autoconvert" if convert_to_diffusers else "--autoimport"
+        argument = "--autoconvert"
         initfile = Path(Globals.root, Globals.initfile)
         replacement = Path(Globals.root, f"{Globals.initfile}.new")
         directory = str(scan_directory).replace("\\", "/")

--- a/invokeai/frontend/CLI/CLI.py
+++ b/invokeai/frontend/CLI/CLI.py
@@ -158,14 +158,9 @@ def main():
         report_model_error(opt, e)
 
     # try to autoconvert new models
-    if path := opt.autoimport:
-        gen.model_manager.heuristic_import(
-            str(path), convert=False, commit_to_conf=opt.conf
-        )
-
     if path := opt.autoconvert:
         gen.model_manager.heuristic_import(
-            str(path), convert=True, commit_to_conf=opt.conf
+            str(path), commit_to_conf=opt.conf
         )
 
     # web server loops forever


### PR DESCRIPTION
- the functionality to automatically import and run legacy checkpoint files in a designated folder has been removed from the backend but there are vestiges of the code remaining in the frontend that are causing crashes.
- This fixes the problem.

- Closes #3075