### PR TITLE
ControlNet backend first draft

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   docker:

--- a/invokeai/backend/generator/base.py
+++ b/invokeai/backend/generator/base.py
@@ -135,11 +135,7 @@ class InvokeAIGenerator(metaclass=ABCMeta):
             scheduler_name=generator_args.get('scheduler')
         )
 
-        # FIXME: doing double the work here to get conditioning info from Compel in two different ways
-        # Generators want (uc, c, extra_conditioning_info) form from get_uc_and_c_and_ec which uses Compel
-        # ControlNetModel wants output of compel(prompt)
-        # really should be able to package this up as one thing and avoid both
-        # extra arg passing and double compel calls
+        # get conditioning from prompt via Compel package
         uc, c, extra_conditioning_info = get_uc_and_c_and_ec(prompt, model=model)
 
         gen_class = self._generator_class()

--- a/invokeai/backend/generator/base.py
+++ b/invokeai/backend/generator/base.py
@@ -94,9 +94,6 @@ class InvokeAIGenerator(metaclass=ABCMeta):
         self.params=params
         self.kwargs = kwargs
 
-        # print("in InvokeAIGenerator.__init__(), kwargs: ", len(kwargs))
-        # for k,v in kwargs.items(): print("     ", k, "==>", type(v))
-
     def generate(self,
                  prompt: str='',
                  callback: Optional[Callable]=None,
@@ -104,9 +101,6 @@ class InvokeAIGenerator(metaclass=ABCMeta):
                  iterations: int=1,
                  **keyword_args,
                  )->Iterator[InvokeAIGeneratorOutput]:
-        # print("")
-        # print("in InvokeAIGenerator.generate(), keyword_args:", len(keyword_args))
-        # for k,v in keyword_args.items(): print("     ", k, "==>", type(v))
 
         '''
         Return an iterator across the indicated number of generations.
@@ -140,7 +134,6 @@ class InvokeAIGenerator(metaclass=ABCMeta):
             model=model,
             scheduler_name=generator_args.get('scheduler')
         )
-        # print("   scheduler class: ", scheduler.__class__)
 
         # FIXME: doing double the work here to get conditioning info from Compel in two different ways
         # Generators want (uc, c, extra_conditioning_info) form from get_uc_and_c_and_ec which uses Compel
@@ -148,16 +141,9 @@ class InvokeAIGenerator(metaclass=ABCMeta):
         # really should be able to package this up as one thing and avoid both
         # extra arg passing and double compel calls
         uc, c, extra_conditioning_info = get_uc_and_c_and_ec(prompt, model=model)
-        # compel = Compel(tokenizer=model.tokenizer, text_encoder=model.text_encoder)
-        # prompt_embeds = compel([prompt])
-
-
-        # print("   prompt_embeds: ", type(prompt_embeds))
-        # print("   prompt_embeds shape: ", prompt_embeds.shape)
 
         gen_class = self._generator_class()
         generator = gen_class(model, self.params.precision, **self.kwargs)
-        # print("generator class: ", type(generator))
         if self.params.variation_amount > 0:
             generator.set_variation(generator_args.get('seed'),
                                     generator_args.get('variation_amount'),
@@ -177,7 +163,6 @@ class InvokeAIGenerator(metaclass=ABCMeta):
                                     )
 
         iteration_count = range(iterations) if iterations else itertools.count(start=0, step=1)
-        # print("generator_args: ", generator_args)
         for i in iteration_count:
             results = generator.generate(prompt,
                                          conditioning=(uc, c, extra_conditioning_info),
@@ -309,8 +294,6 @@ class Generator:
     model: DiffusionPipeline
 
     def __init__(self, model: DiffusionPipeline, precision: str, **kwargs):
-        # print("Generator.__init__(), kwargs:")
-        # for k,v in kwargs.items(): print("     ", k, "==>", type(v))
         self.model = model
         self.precision = precision
         self.seed = None
@@ -358,9 +341,6 @@ class Generator:
         free_gpu_mem: bool = False,
         **kwargs,
     ):
-        # print("Generator seed: ", seed)
-        # print("Generator.generate(), kwargs:")
-        # for k,v in kwargs.items(): print("     ", k, "==>", type(v))
         scope = nullcontext
         self.safety_checker = safety_checker
         self.free_gpu_mem = free_gpu_mem

--- a/invokeai/backend/generator/txt2img.py
+++ b/invokeai/backend/generator/txt2img.py
@@ -48,7 +48,7 @@ class Txt2Img(Generator):
         """
         self.perlin = perlin
         control_image = kwargs.get("control_image", None)
-
+        do_classifier_free_guidance = cfg_scale > 1.0
 
         # noinspection PyTypeChecker
         pipeline: StableDiffusionGeneratorPipeline = self.model
@@ -70,7 +70,7 @@ class Txt2Img(Generator):
         ).add_scheduler_args_if_applicable(pipeline.scheduler, eta=ddim_eta)
 
         if control_image is not None:
-            control_image = pipeline.prepare_control_image(image=control_image)
+            control_image = pipeline.prepare_control_image(image=control_image, do_classifier_free_guidance=do_classifier_free_guidance)
             kwargs["control_image"] = control_image
 
         def make_image(x_T: torch.Tensor, _: int) -> PIL.Image.Image:

--- a/invokeai/backend/generator/txt2img.py
+++ b/invokeai/backend/generator/txt2img.py
@@ -53,6 +53,7 @@ class Txt2Img(Generator):
         """
         self.perlin = perlin
         control_image = kwargs.get("control_image", None)
+
         do_classifier_free_guidance = cfg_scale > 1.0
 
         # noinspection PyTypeChecker

--- a/invokeai/backend/generator/txt2img.py
+++ b/invokeai/backend/generator/txt2img.py
@@ -18,12 +18,6 @@ class Txt2Img(Generator):
     def __init__(self, model, precision,
                  control_model: ControlNetModel = None,
                  **kwargs):
-        # print("")
-        # print("in txt2img.Txt2Img.__init__(), model:", type(model))
-        # print("in txt2img.Txt2Img.__init__(), control_model:", type(control_model))
-        # print("in txt2img.Txt2Img.__init__(), kwargs:", len(kwargs))
-        # for k,v in kwargs.items():
-        #     print("     ", k, "==>", type(v))
         self.control_model = control_model
         super().__init__(model, precision, **kwargs)
 
@@ -76,8 +70,7 @@ class Txt2Img(Generator):
         ).add_scheduler_args_if_applicable(pipeline.scheduler, eta=ddim_eta)
 
         if control_image is not None:
-            #     print("prepping control image (converting to tensor and additional processing)")
-            control_image = pipeline.prepare_image(image=control_image)
+            control_image = pipeline.prepare_control_image(image=control_image)
             kwargs["control_image"] = control_image
 
         def make_image(x_T: torch.Tensor, _: int) -> PIL.Image.Image:

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -478,10 +478,6 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         control_image = kwargs.get("control_image", None)
         control_scale = kwargs.get("control_scale", None)
 
-        # print("in SDGPipeline.image_from_embeddings, control_prompt_embeds: ", control_prompt_embeds.shape)
-        # print("in SDGPipeline.image_from_embeddings, control_image: ", control_image.shape)
-        # print("in SDGPipeline.image_from_embeddings, control_scale: ", control_scale)
-
         result_latents, result_attention_map_saver = self.latents_from_embeddings(
             latents,
             num_inference_steps,
@@ -634,18 +630,6 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
 
         # invokeai_diffuser has batched timesteps, but diffusers schedulers expect a single value
         timestep = t[0]
-        # print("")
-        # print("in StableDiffusionGeneratorPipeline.step(), step index: " + str(step_index) +
-        #      ", total step count: " + str(total_step_count))
-        # print("t: ", str(t), " shape: ", t.shape, " type: ", type(t))
-        # print(", timestep: ", str(timestep), " shape: ", timestep.shape, " type: ", type(timestep))
-
-        #if control_image is not None:
-        #   print("control_image:   shape=", control_image.shape, "  type=", type(control_image)),
-        # print("control_scale: ", control_scale)
-        # print("control_prompt_embeds:   shape", control_prompt_embeds.shape, "  type=", type(control_prompt_embeds))
-        # print("control conditioning shape: ", control_prompt_embeds.shape if control_prompt_embeds is not None else "None")
-
 
         if additional_guidance is None:
             additional_guidance = []
@@ -653,37 +637,25 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         # FIXME: add conditional to handle NOT classifier free guidance
         # expand the latents if we are doing classifier free guidance
         # print("doing classifier free guidance: ", self.do_classifier_free_guidance)
-        # latent_model_input = latents
         # latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
-
         latent_control_input = latents
-
         latent_model_input = torch.cat([latents] * 2)
+
         # TODO: should this scaling happen here or inside self._unet_forward?
         #     i.e. before or after passing it to InvokeAIDiffuserComponent
         latent_model_input = self.scheduler.scale_model_input(latent_model_input, timestep)
-        latent_control_input = self.scheduler.scale_model_input(latent_control_input, timestep)
-
         ehs = torch.cat([conditioning_data.unconditioned_embeddings, conditioning_data.text_embeddings])
-
 
         if (self.control_model is not None) and (control_image is not None) and (control_scale is not None):
             # controlnet inference
-            # print("attempting controlnet inference")
-            # print(type(control_prompt_embeds))
-            # print(control_prompt_embeds.shape)
             down_block_res_samples, mid_block_res_sample = self.control_model(
                 latent_model_input,
-                # latent_control_input,
-                # torch.cat([latent_model_input]*2),
-                # t,
                 timestep,
                 encoder_hidden_states = ehs,
                 controlnet_cond=control_image,
                 conditioning_scale=control_scale,
                 return_dict=False,
             )
-            # print("finished ControlNetModel calls")
         else:
             down_block_res_samples, mid_block_res_sample = None, None
 
@@ -714,7 +686,6 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         noise_pred = self.invokeai_diffuser.do_diffusion_step(
             latent_model_input,
             t,
-            # timestep,
             conditioning_data.unconditioned_embeddings,
             conditioning_data.text_embeddings,
             conditioning_data.guidance_scale,
@@ -724,7 +695,6 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
             mid_block_additional_residual=mid_block_res_sample,
         )
 
-        # print("running scheduler.step()")
         # compute the previous noisy sample x_t -> x_t-1
         step_output = self.scheduler.step(
             noise_pred, timestep, latents, **conditioning_data.scheduler_args

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -473,6 +473,15 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         :param callback:
         :param run_id:
         """
+
+        # control_prompt_embeds = kwargs.get("control_prompt_embeds", None)
+        control_image = kwargs.get("control_image", None)
+        control_scale = kwargs.get("control_scale", None)
+
+        # print("in SDGPipeline.image_from_embeddings, control_prompt_embeds: ", control_prompt_embeds.shape)
+        # print("in SDGPipeline.image_from_embeddings, control_image: ", control_image.shape)
+        # print("in SDGPipeline.image_from_embeddings, control_scale: ", control_scale)
+
         result_latents, result_attention_map_saver = self.latents_from_embeddings(
             latents,
             num_inference_steps,
@@ -618,15 +627,65 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         additional_guidance: List[Callable] = None,
         **kwargs,
     ):
+
+        control_image = kwargs.get("control_image", None)   # should be a processed tensor
+        control_scale = kwargs.get("control_scale", None)
+        # control_prompt_embeds = kwargs.get("control_prompt_embeds", None)
+
         # invokeai_diffuser has batched timesteps, but diffusers schedulers expect a single value
         timestep = t[0]
+        # print("")
+        # print("in StableDiffusionGeneratorPipeline.step(), step index: " + str(step_index) +
+        #      ", total step count: " + str(total_step_count))
+        # print("t: ", str(t), " shape: ", t.shape, " type: ", type(t))
+        # print(", timestep: ", str(timestep), " shape: ", timestep.shape, " type: ", type(timestep))
+
+        #if control_image is not None:
+        #   print("control_image:   shape=", control_image.shape, "  type=", type(control_image)),
+        # print("control_scale: ", control_scale)
+        # print("control_prompt_embeds:   shape", control_prompt_embeds.shape, "  type=", type(control_prompt_embeds))
+        # print("control conditioning shape: ", control_prompt_embeds.shape if control_prompt_embeds is not None else "None")
+
 
         if additional_guidance is None:
             additional_guidance = []
 
+        # FIXME: add conditional to handle NOT classifier free guidance
+        # expand the latents if we are doing classifier free guidance
+        # print("doing classifier free guidance: ", self.do_classifier_free_guidance)
+        # latent_model_input = latents
+        # latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+
+        latent_control_input = latents
+
+        latent_model_input = torch.cat([latents] * 2)
         # TODO: should this scaling happen here or inside self._unet_forward?
         #     i.e. before or after passing it to InvokeAIDiffuserComponent
-        latent_model_input = self.scheduler.scale_model_input(latents, timestep)
+        latent_model_input = self.scheduler.scale_model_input(latent_model_input, timestep)
+        latent_control_input = self.scheduler.scale_model_input(latent_control_input, timestep)
+
+        ehs = torch.cat([conditioning_data.unconditioned_embeddings, conditioning_data.text_embeddings])
+
+
+        if (self.control_model is not None) and (control_image is not None) and (control_scale is not None):
+            # controlnet inference
+            # print("attempting controlnet inference")
+            # print(type(control_prompt_embeds))
+            # print(control_prompt_embeds.shape)
+            down_block_res_samples, mid_block_res_sample = self.control_model(
+                latent_model_input,
+                # latent_control_input,
+                # torch.cat([latent_model_input]*2),
+                # t,
+                timestep,
+                encoder_hidden_states = ehs,
+                controlnet_cond=control_image,
+                conditioning_scale=control_scale,
+                return_dict=False,
+            )
+            # print("finished ControlNetModel calls")
+        else:
+            down_block_res_samples, mid_block_res_sample = None, None
 
         if (self.control_model is not None) and (kwargs.get("control_image") is not None):
             control_image = kwargs.get("control_image") # should be a processed tensor derived from the control image
@@ -655,6 +714,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         noise_pred = self.invokeai_diffuser.do_diffusion_step(
             latent_model_input,
             t,
+            # timestep,
             conditioning_data.unconditioned_embeddings,
             conditioning_data.text_embeddings,
             conditioning_data.guidance_scale,
@@ -664,6 +724,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
             mid_block_additional_residual=mid_block_res_sample,
         )
 
+        # print("running scheduler.step()")
         # compute the previous noisy sample x_t -> x_t-1
         step_output = self.scheduler.step(
             noise_pred, timestep, latents, **conditioning_data.scheduler_args

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -15,11 +15,14 @@ import psutil
 import torch
 import torchvision.transforms as T
 from compel import EmbeddingsProvider
-from diffusers.models import AutoencoderKL, UNet2DConditionModel, ControlNetModel
+from diffusers.models import AutoencoderKL, UNet2DConditionModel
+from diffusers.models.controlnet import ControlNetModel, ControlNetOutput
 from diffusers.pipelines.stable_diffusion import StableDiffusionPipelineOutput
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import (
     StableDiffusionPipeline,
 )
+from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_controlnet import MultiControlNetModel
+
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import (
     StableDiffusionImg2ImgPipeline,
 )
@@ -474,10 +477,6 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
         :param run_id:
         """
 
-        # control_prompt_embeds = kwargs.get("control_prompt_embeds", None)
-        control_image = kwargs.get("control_image", None)
-        control_scale = kwargs.get("control_scale", None)
-
         result_latents, result_attention_map_saver = self.latents_from_embeddings(
             latents,
             num_inference_steps,
@@ -660,8 +659,12 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
             down_block_res_samples, mid_block_res_sample = None, None
 
         if (self.control_model is not None) and (kwargs.get("control_image") is not None):
-            control_image = kwargs.get("control_image") # should be a processed tensor derived from the control image
+            control_image = kwargs.get("control_image") # should be a processed tensor derived from the control image(s)
             control_scale = kwargs.get("control_scale", 1.0)  # control_scale default is 1.0
+            # handling case where using multiple control models but only specifying single control_scale
+            #     so reshape control_scale to match number of control models
+            if isinstance(self.control_model, MultiControlNetModel) and isinstance(control_scale, float):
+                control_scale = [control_scale] * len(self.control_model.nets)
             if conditioning_data.guidance_scale > 1.0:
                 # expand the latents input to control model if doing classifier free guidance
                 #    (which I think for now is always true, there is conditional elsewhere that stops execution if

--- a/invokeai/backend/stable_diffusion/diffusion/cross_attention_control.py
+++ b/invokeai/backend/stable_diffusion/diffusion/cross_attention_control.py
@@ -550,7 +550,12 @@ def get_mem_free_total(device):
 
 
 class InvokeAIDiffusersCrossAttention(
-    diffusers.models.attention.CrossAttention, InvokeAICrossAttentionMixin
+    # in diffusers v0.15, diffusers.models.attention.CrossAttention has been renamed to Attention
+    #      or alternatively can use diffusers.models.cross_attention.CrossAttention,
+    #      but that is deprecated and just a wrapper aroundr Attention
+    # diffusers.models.attention.CrossAttention, InvokeAICrossAttentionMixin
+    diffusers.models.attention.Attention, InvokeAICrossAttentionMixin
+    # diffusers.models.cross_attention.CrossAttention, InvokeAICrossAttentionMixin
 ):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/invokeai/backend/stable_diffusion/diffusion/cross_attention_control.py
+++ b/invokeai/backend/stable_diffusion/diffusion/cross_attention_control.py
@@ -329,7 +329,6 @@ class InvokeAICrossAttentionMixin:
 
     def get_invokeai_attention_mem_efficient(self, q, k, v):
         if q.device.type == "cuda":
-            # print("in get_attention_mem_efficient with q shape", q.shape, ", k shape", k.shape, ", free memory is", get_mem_free_total(q.device))
             return self.einsum_op_cuda(q, k, v)
 
         if q.device.type == "mps" or q.device.type == "cpu":

--- a/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
+++ b/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
@@ -50,7 +50,9 @@ class InvokeAIDiffuserComponent:
     """
 
     debug_thresholding = False
-    sequential_guidance = False
+    # FIXME
+    # sequential_guidance = False
+    sequential_guidance = True
 
     @dataclass
     class ExtraConditioningInfo:
@@ -354,6 +356,7 @@ class InvokeAIDiffuserComponent:
         cross_attention_control_types_to_do,
         **kwargs,
     ):
+        print("using _apply_cross_attention_controlled_conditioning__diffusers")
         context: Context = self.cross_attention_control_context
 
         cross_attn_processor_context = SwapCrossAttnContext(
@@ -393,6 +396,7 @@ class InvokeAIDiffuserComponent:
         cross_attention_control_types_to_do,
         **kwargs,
     ):
+        print("using _apply_cross_attention_controlled_conditioning__compvis")
         # print('pct', percent_through, ': doing cross attention control on', cross_attention_control_types_to_do)
         # slower non-batched path (20% slower on mac MPS)
         # We are only interested in using attention maps for conditioned_next_x, but batching them with generation of

--- a/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
+++ b/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
@@ -50,9 +50,7 @@ class InvokeAIDiffuserComponent:
     """
 
     debug_thresholding = False
-    # FIXME
-    # sequential_guidance = False
-    sequential_guidance = True
+    sequential_guidance = False
 
     @dataclass
     class ExtraConditioningInfo:
@@ -276,12 +274,7 @@ class InvokeAIDiffuserComponent:
         sigma_twice = torch.cat([sigma] * 2)
         both_conditionings = torch.cat([unconditioning, conditioning])
         both_results = self.model_forward_callback(
-            # x_twice,
-            x,
-            # sigma_twice,
-            sigma,
-            both_conditionings,
-            **kwargs,
+            x_twice, sigma_twice, both_conditionings, **kwargs,
         )
         unconditioned_next_x, conditioned_next_x = both_results.chunk(2)
         if conditioned_next_x.device.type == "mps":

--- a/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
+++ b/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
@@ -356,7 +356,6 @@ class InvokeAIDiffuserComponent:
         cross_attention_control_types_to_do,
         **kwargs,
     ):
-        print("using _apply_cross_attention_controlled_conditioning__diffusers")
         context: Context = self.cross_attention_control_context
 
         cross_attn_processor_context = SwapCrossAttnContext(
@@ -396,7 +395,6 @@ class InvokeAIDiffuserComponent:
         cross_attention_control_types_to_do,
         **kwargs,
     ):
-        print("using _apply_cross_attention_controlled_conditioning__compvis")
         # print('pct', percent_through, ': doing cross attention control on', cross_attention_control_types_to_do)
         # slower non-batched path (20% slower on mac MPS)
         # We are only interested in using attention maps for conditioned_next_x, but batching them with generation of

--- a/scripts/invokeai_controlnet_example.py
+++ b/scripts/invokeai_controlnet_example.py
@@ -1,0 +1,57 @@
+###############################
+#
+# InvokeAI ControlNet example
+#    using backend directly
+#
+###############################
+
+import os
+import torch
+import cv2
+import numpy as np
+from PIL import Image
+
+from diffusers.utils import load_image
+from diffusers.models.controlnet import ControlNetModel
+from invokeai.backend.generator import Txt2Img
+from invokeai.backend.model_management import ModelManager
+
+print("loading original 'Girl With A Pearl Earring' image")
+original_image = load_image(
+    "https://hf.co/datasets/huggingface/documentation-images/resolve/main/diffusers/input_image_vermeer.png"
+)
+
+print("Creating Canny edge detection image based on original image")
+original_image = np.array(original_image)
+canny_array = cv2.Canny(original_image,
+                        100,  # low Canny threshold
+                        200)  # high Canny threshold
+canny_image = Image.fromarray(canny_array)
+
+# using invokeai model management for base model
+print("loading base model stable-diffusion-1.5")
+model_config_path = os.getcwd() + "/../configs/models.yaml"
+model_manager = ModelManager(model_config_path)
+model = model_manager.get_model('stable-diffusion-1.5')
+
+# for now using diffusers model.from_pretrained to load ControlNetModel sidemodel
+print("loading Canny control model lllyasviel/sd-controlnet-canny")
+canny_controlnet = ControlNetModel.from_pretrained("lllyasviel/sd-controlnet-canny",
+                                                   torch_dtype=torch.float16).to("cuda")
+
+print("testing Txt2Img() constructor with ControlNet arg")
+txt2img_canny = Txt2Img(model, control_model=canny_controlnet)
+
+print("testing Txt2Img generate() using a Canny edge detection ControlNet and image")
+outputs = txt2img_canny.generate(prompt="old man",
+                                 control_image=canny_image,
+                                 seed=0,
+                                 num_steps=20,
+                                 control_scale=1.0,
+                                 precision="float16")
+generate_output = next(outputs)
+out_image = generate_output.image
+
+outname = "invokeai_controlnet_testout.png"
+print("saving generated image in home directory as: " + outname)
+out_image.save(os.path.expanduser("~") + "/" + outname)


### PR DESCRIPTION
This is a working but rough draft for adding ControlNet support to the InvokeAI backend. 
All code changes are down in invokeai.backend.generator and invokeai.backend.stable_diffusion.diffusion. 
Example of usage is in scripts/invokeai_controlnet_example.py
My basic strategy is to incorporate down in invokeai.backend.generator Generator, Txt2Img, etc. so usage in the "AI Core" looks like:
`txt2img_canny = Txt2Img(model, control_model=canny_controlnet)`
`outputs = txt2img_canny.generate(prompt="insert generic prompt", control_image=canny_image)`

I've only implemented for Txt2Img, but most of the affected code is shared by Img2Img, Inpaint, etc. as well. And the small account of code specific to Txt2Img could be copied for other Generators subclasses, or probably be pushed down into the Generator base class with a little refactoring. But I wanted to get some feedback before going any further.

Node support is not included in the current PR, but should be one of the next steps worked on.  My understanding is that building this into new Generator framework should hopefully make Node support straightforward.