### PR TITLE
[deps] bump compel version to fix crash on invalid (auto111) syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "albumentations",
   "click",
   "clip_anytorch",          # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
-  "compel==1.0.4",
+  "compel==1.0.5",
   "datasets",
   "diffusers[torch]~=0.14",
   "dnspython==2.2.1",


### PR DESCRIPTION
currently if users input eg `happy (camper:0.3)` it gets parsed incorrectly, which causes crashes if it's in the negative prompt. bump to compel 1.0.5 fixes the parser to avoid this (note the weight is parsed as plain text, it's not converted to proper invoke syntax)