### PR TITLE
fix(nodes): fix typo in `list_sessions` handler

### DIFF
--- a/invokeai/app/api/routers/sessions.py
+++ b/invokeai/app/api/routers/sessions.py
@@ -51,7 +51,7 @@ async def list_sessions(
     query: str = Query(default="", description="The query string to search for"),
 ) -> PaginatedResults[GraphExecutionState]:
     """Gets a list of sessions, optionally searching"""
-    if filter == "":
+    if query == "":
         result = ApiDependencies.invoker.services.graph_execution_manager.list(
             page, per_page
         )


### PR DESCRIPTION
The typo accidentally did not affect functionality; when `query==""`, it `search()`ed but found everything due to empty query, then paginated results, so it worked the same as `list()`.

Still fix it