### PR TITLE
chore: configure stale bot

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 28
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Please
+  update the ticket if this is still a problem on the latest release.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Due to inactivity, this issue has been automatically closed. If this is
+  still a problem on the latest release, please recreate the issue.


### PR DESCRIPTION
We are moving from the stale action to Stalebot. It allows for issues to be pinned so they are never stale.

I'll be going through our issues to mark those.

I've changed the messaging and the timings; please review and let me know if you want any changes.