### PR TITLE
[Enhancement] implement load_image and i2l invocations

### DIFF
--- a/invokeai/app/cli/commands.py
+++ b/invokeai/app/cli/commands.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 import argparse
-from typing import Any, Callable, Iterable, Literal, get_args, get_origin, get_type_hints
+from typing import Any, Callable, Iterable, Literal, get_args, get_origin, get_type_hints, Union
 from pydantic import BaseModel, Field
 import networkx as nx
 import matplotlib.pyplot as plt
@@ -21,7 +21,7 @@ def add_parsers(
     """Adds parsers for each command to the subparsers"""
 
     # Create subparsers for each command
-    for command in commands:
+    for command in sorted(commands, key=lambda x: get_args(get_type_hints(x)[command_field])[0]):
         hints = get_type_hints(command)
         cmd_name = get_args(hints[command_field])[0]
         command_parser = subparsers.add_parser(cmd_name, help=command.__doc__)

--- a/invokeai/app/cli/completer.py
+++ b/invokeai/app/cli/completer.py
@@ -4,6 +4,7 @@ You may import the global singleton `completer` to get access to the
 completer object.
 """
 import atexit
+import re
 import readline
 import shlex
 
@@ -66,6 +67,8 @@ class Completer(object):
         """
         if len(buffer)==0:
             return None, None
+        if re.search('\|\s*[a-zA-Z0-9]*$',buffer): # reset command on pipe symbol
+            return None,None
         tokens = shlex.split(buffer)
         command = None
         switch = None

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -67,6 +67,29 @@ class LoadImageInvocation(BaseInvocation):
             image=ImageField(image_type=self.image_type, image_name=self.image_name)
         )
 
+class SaveImageInvocation(BaseInvocation):
+    """Take an image as input and save it as a PNG file to a filename."""
+    #fmt: off
+    type: Literal["save_image"] = "save_image"
+
+    # Inputs
+    image: ImageField = Field(default=None, description="The image to save")
+    image_type: ImageType = Field(description="The type of the image")
+    image_name:       str = Field(description="The filename or path to save the image to")
+    #fmt: on
+
+    def invoke(self, context: InvocationContext) -> ImageOutput:
+        image = context.services.images.get(
+            self.image.image_type, self.image.image_name
+        )
+        context.services.images.save(
+            self.image_type, self.image_name, image
+        )
+        return ImageOutput(
+            image=ImageField(
+                image_type=self.image_type, image_name=self.image_name
+            )
+        )
 
 class ShowImageInvocation(BaseInvocation):
     """Displays a provided image, and passes it forward in the pipeline."""

--- a/invokeai/app/services/image_storage.py
+++ b/invokeai/app/services/image_storage.py
@@ -90,17 +90,17 @@ class DiskImageStorage(ImageStorageBase):
         return path
 
     def save(self, image_type: ImageType, image_name: str, image: Image) -> None:
-        image_subpath = os.path.join(image_type, image_name)
+        path = self.get_path(image_type, image_name)
         self.__pngWriter.save_image_and_prompt_to_png(
-            image, "", image_subpath, None
+            image, "", path, None
         )  # TODO: just pass full path to png writer
-        save_thumbnail(
-            image=image,
-            filename=image_name,
-            path=os.path.join(self.__output_folder, image_type, "thumbnails"),
-        )
-        image_path = self.get_path(image_type, image_name)
-        self.__set_cache(image_path, image)
+        # LS: Save_thumbnail() should be a separate invocation, shouldn't it?
+        # save_thumbnail(
+        #     image=image,
+        #     filename=image_name,
+        #     path=os.path.join(self.__output_folder, image_type, "thumbnails"),
+        # )
+        self.__set_cache(path, image)
 
     def delete(self, image_type: ImageType, image_name: str) -> None:
         image_path = self.get_path(image_type, image_name)

--- a/invokeai/app/services/image_storage.py
+++ b/invokeai/app/services/image_storage.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2022 Kyle Schouviller (https://github.com/kyle0654)
 
 import datetime
+import PIL
 import os
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from queue import Queue
 from typing import Dict
-
 from PIL.Image import Image
 from invokeai.app.util.save_thumbnail import save_thumbnail
 
@@ -18,7 +18,7 @@ class ImageType(str, Enum):
     RESULT = "results"
     INTERMEDIATE = "intermediates"
     UPLOAD = "uploads"
-
+    LOCAL = "local"   # a local path, relative to cwd or absolute
 
 class ImageStorageBase(ABC):
     """Responsible for storing and retrieving images."""
@@ -77,13 +77,16 @@ class DiskImageStorage(ImageStorageBase):
         if cache_item:
             return cache_item
 
-        image = Image.open(image_path)
+        image = PIL.Image.open(image_path)
         self.__set_cache(image_path, image)
         return image
 
     # TODO: make this a bit more flexible for e.g. cloud storage
     def get_path(self, image_type: ImageType, image_name: str) -> str:
-        path = os.path.join(self.__output_folder, image_type, image_name)
+        if image_type == ImageType.LOCAL:
+            path = image_name
+        else:
+            path = os.path.join(self.__output_folder, image_type, image_name)
         return path
 
     def save(self, image_type: ImageType, image_name: str, image: Image) -> None:

--- a/invokeai/app/services/model_manager_initializer.py
+++ b/invokeai/app/services/model_manager_initializer.py
@@ -72,11 +72,10 @@ def get_model_manager(config: Args) -> ModelManager:
     # try to autoconvert new models
     # autoimport new .ckpt files
     if path := config.autoconvert:
-        model_manager.autoconvert_weights(
-            conf_path=config.conf,
-            weights_directory=path,
+        model_manager.heuristic_import(
+            str(path), commit_to_conf=config.conf
         )
-
+        
     return model_manager
 
 def report_model_error(opt: Namespace, e: Exception):


### PR DESCRIPTION
# Support ability to load an image convert it into latents, and convert the latents back into an image

- `load_image` command now accepts an `--image_type` of "local", allowing it to load a local PNG file based on a relative or absolute path
- Fixed the `LatentsToImage` ("l2i") invocation to encode with the VAE directly, rather than going through the full model.
- Added a `ImageToLatents` ("i2l") invocation to decode latents into PIL Images
- Tweaked autocompleter to suggest new commands following pipe symbol.

This roundtrip now works as expected in the nodes CLI:
```
load_image --image_name ./test.png --image_type local | i2l | l2i | show_image
```
## Questions for Kyle:
- I understand how to use the pipe symbol in the CLI to pass the output of one invocation to the input of another, but how do I construct a graph to coordinate the inputs from multiple invocations? My use case would be generating an init latent with `i2l`, adding noise to it with `add_noise`, and then passing this to `t2l` with the `--noise` parameter.
- When I load or create an image or latent, the resulting object is named and stored in the session context. How do I retrieve those names so that I can use them?
- (Maybe the same question) How do I use the `--link` and `--link_node` parameters?

## To Do
There are several lines of code in the class methods `_encode_latents()` and `_decode_latents()` that are copied from `diffusers.pipelines.stable_diffusion` or `invokeai.backend.stable_diffusion.diffusers_pipeline`. These should be refactored, but I chose not to at the current time because of the risk of breaking things elsewhere.