### PR TITLE
[Bugfix] detect running invoke before updating

### DIFF
--- a/ldm/invoke/config/invokeai_update.py
+++ b/ldm/invoke/config/invokeai_update.py
@@ -4,14 +4,13 @@ pip install <path_to_git_source>.
 '''
 import os
 import platform
+import psutil
 import requests
 from rich import box, print
-from rich.console import Console, Group, group
+from rich.console import Console, group
 from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.style import Style
-from rich.syntax import Syntax
-from rich.text import Text
 
 from ldm.invoke import __version__
 
@@ -32,6 +31,16 @@ else:
 def get_versions()->dict:
     return requests.get(url=INVOKE_AI_REL).json()
 
+def invokeai_is_running()->bool:
+    for p in psutil.process_iter():
+        cmdline = p.cmdline()
+        matches = [x for x in cmdline if x.endswith('invokeai')]
+        if matches:
+            print(f':exclamation: [bold red]An InvokeAI instance appears to be running as process {p.pid}[/red bold]')
+            return True
+    return False
+        
+    
 def welcome(versions: dict):
     
     @group()
@@ -62,6 +71,10 @@ def welcome(versions: dict):
 
 def main():
     versions = get_versions()
+    if invokeai_is_running():
+        print(f':exclamation: [bold red]Please terminate all running instances of InvokeAI before updating.[/red bold]')
+        return
+
     welcome(versions)
 
     tag = None

--- a/ldm/invoke/config/invokeai_update.py
+++ b/ldm/invoke/config/invokeai_update.py
@@ -33,11 +33,14 @@ def get_versions()->dict:
 
 def invokeai_is_running()->bool:
     for p in psutil.process_iter():
-        cmdline = p.cmdline()
-        matches = [x for x in cmdline if x.endswith('invokeai')]
-        if matches:
-            print(f':exclamation: [bold red]An InvokeAI instance appears to be running as process {p.pid}[/red bold]')
-            return True
+        try:
+            cmdline = p.cmdline()
+            matches = [x for x in cmdline if x.endswith(('invokeai','invokeai.exe'))]
+            if matches:
+                print(f':exclamation: [bold red]An InvokeAI instance appears to be running as process {p.pid}[/red bold]')
+                return True
+        except psutil.AccessDenied:
+            continue
     return False
         
     


### PR DESCRIPTION
This PR addresses the issue that when `invokeai-update` is run on a Windows system, and an instance of InvokeAI is open and running, the user's `.venv` can get corrupted. 

Issue first reported here:

https://discord.com/channels/1020123559063990373/1094688269356249108/1094688434750230628