### PR TITLE
[Bugfix] make invokeai-batch work on windows

### DIFF
--- a/ldm/invoke/dynamic_prompts.py
+++ b/ldm/invoke/dynamic_prompts.py
@@ -116,7 +116,10 @@ def _get_fn_format(directory:str, sequence:int)->str:
     Get a filename that doesn't exceed filename length restrictions
     on the current platform.
     """
-    max_length = os.pathconf(directory,'PC_NAME_MAX')
+    try:
+        max_length = os.pathconf(directory,'PC_NAME_MAX')
+    except:
+        max_length = 255
     prefix = f'dp.{sequence:04}.'
     suffix = '.png'
     max_length -= len(prefix)+len(suffix)

--- a/ldm/invoke/dynamic_prompts.py
+++ b/ldm/invoke/dynamic_prompts.py
@@ -100,8 +100,8 @@ def expand_prompts(
             for command in commands:
                 sequence += 1
                 format = _get_fn_format(outdir, sequence)
-                parent_conn.send(
-                    command + f' --fnformat="{format}"'
+                parent_conn.send_bytes(
+                    (command + f' --fnformat="{format}"').encode('utf-8')
                 )
             parent_conn.close()
         else:
@@ -133,7 +133,7 @@ class MessageToStdin(object):
     def readline(self) -> str:
         try:
             if len(self.linebuffer) == 0:
-                message = self.connection.recv()
+                message = self.connection.recv_bytes().decode('utf-8')
                 self.linebuffer = message.split("\n")
             result = self.linebuffer.pop(0)
             return result


### PR DESCRIPTION
- Previous PR to truncate long filenames won't work on windows due to lack of support for os.pathconf(). This works around the limitation by hardcoding the value for PC_NAME_MAX when pathconf is unavailable.
- The `multiprocessing` send() and recv() methods weren't working properly on Windows due to issues involving `utf-8` encoding and pickling/unpickling. Changed these calls to `send_bytes()` and `recv_bytes()` , which seems to fix the issue.

Not fully tested on Windows since I lack a GPU machine to test on, but is working on CPU.