### PR TITLE
[nodes] Add subgraph library, subgraph usage in CLI, and fix subgraph execution

### DIFF
--- a/invokeai/app/api/dependencies.py
+++ b/invokeai/app/api/dependencies.py
@@ -3,12 +3,14 @@
 import os
 from argparse import Namespace
 
+from ..services.default_graphs import create_system_graphs
+
 from ..services.latent_storage import DiskLatentsStorage, ForwardCacheLatentsStorage
 
 from ...backend import Globals
 from ..services.model_manager_initializer import get_model_manager
 from ..services.restoration_services import RestorationServices
-from ..services.graph import GraphExecutionState
+from ..services.graph import GraphExecutionState, LibraryGraph
 from ..services.image_storage import DiskImageStorage
 from ..services.invocation_queue import MemoryInvocationQueue
 from ..services.invocation_services import InvocationServices
@@ -69,12 +71,17 @@ class ApiDependencies:
             latents=latents,
             images=images,
             queue=MemoryInvocationQueue(),
+            graph_library=SqliteItemStorage[LibraryGraph](
+                filename=db_location, table_name="graphs"
+            ),
             graph_execution_manager=SqliteItemStorage[GraphExecutionState](
                 filename=db_location, table_name="graph_executions"
             ),
             processor=DefaultInvocationProcessor(),
             restoration=RestorationServices(config),
         )
+
+        create_system_graphs(services.graph_library)
 
         ApiDependencies.invoker = Invoker(services)
 

--- a/invokeai/app/cli_app.py
+++ b/invokeai/app/cli_app.py
@@ -246,11 +246,12 @@ def invoke_cli():
 
         try:
             # Refresh the state of the session
-            history = list(get_graph_execution_history(context.session))
+            #history = list(get_graph_execution_history(context.session))
+            history = list(reversed(context.nodes_added))
 
             # Split the command for piping
             cmds = cmd_input.split("|")
-            start_id = len(history)
+            start_id = len(context.nodes_added)
             current_id = start_id
             new_invocations = list()
             for cmd in cmds:
@@ -277,6 +278,7 @@ def invoke_cli():
                             field = exposed_input.field
                             setattr(node, field, args[exposed_input.alias])
                     command = CliCommand(command = invocation)
+                    context.graph_nodes[invocation.id] = system_graph.id
                 else:
                     args["id"] = current_id
                     command = CliCommand(command=args)
@@ -349,10 +351,10 @@ def invoke_cli():
                 current_id = current_id + 1
 
                 # Add the node to the session
-                context.session.add_node(command.command)
+                context.add_node(command.command)
                 for edge in edges:
                     print(edge)
-                    context.session.add_edge(edge)
+                    context.add_edge(edge)
 
             # Execute all remaining nodes
             invoke_all(context)

--- a/invokeai/app/invocations/cv.py
+++ b/invokeai/app/invocations/cv.py
@@ -12,7 +12,7 @@ from .baseinvocation import BaseInvocation, InvocationContext, InvocationConfig
 from .image import ImageOutput
 
 
-class CVInvocation(BaseModel):
+class CvInvocationConfig(BaseModel):
     """Helper class to provide all OpenCV invocations with additional config"""
 
     # Schema customisation
@@ -24,7 +24,7 @@ class CVInvocation(BaseModel):
         }
 
 
-class CvInpaintInvocation(BaseInvocation, CVInvocation):
+class CvInpaintInvocation(BaseInvocation, CvInvocationConfig):
     """Simple inpaint using opencv."""
     #fmt: off
     type: Literal["cv_inpaint"] = "cv_inpaint"

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -332,7 +332,7 @@ class LatentsToLatentsInvocation(TextToLatentsInvocation):
         latent = context.services.latents.get(self.latents.latents_name)
 
         def step_callback(state: PipelineIntermediateState):
-            self.dispatch_progress(context, state.latents, state.step)
+            self.dispatch_progress(context, state)
 
         model = self.get_model(context.services.model_manager)
         conditioning_data = self.get_conditioning_data(model)

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -313,18 +313,18 @@ class LatentsToLatentsInvocation(TextToLatentsInvocation):
         )
 
 
-class LatentToLatentInvocation(TextToLatentInvocation):
-    """Generates a latent using a latent as base image."""
+class LatentsToLatentsInvocation(TextToLatentsInvocation):
+    """Generates latents using latents as base image."""
 
     type: Literal["l2l"] = "l2l"
 
     # Inputs
-    latent: Optional[LatentField] = Field(description="The latent to use as a base image")
-    strength: float = Field(default=0.5, description="The strength of the latent to use")
+    latents: Optional[LatentsField] = Field(description="The latents to use as a base image")
+    strength: float = Field(default=0.5, description="The strength of the latents to use")
 
-    def invoke(self, context: InvocationContext) -> LatentOutput:
-        noise = context.services.latents.get(self.noise.latent_name)
-        latent = context.services.latents.get(self.latent.latent_name)
+    def invoke(self, context: InvocationContext) -> LatentsOutput:
+        noise = context.services.latents.get(self.noise.latents_name)
+        latent = context.services.latents.get(self.latents.latents_name)
 
         def step_callback(state: PipelineIntermediateState):
             self.dispatch_progress(context, state.latents, state.step)
@@ -334,7 +334,7 @@ class LatentToLatentInvocation(TextToLatentInvocation):
 
         # TODO: Verify the noise is the right size
 
-        initial_latent = latent if self.strength < 1.0 else torch.zeros_like(
+        initial_latents = latent if self.strength < 1.0 else torch.zeros_like(
             latent, device=model.device, dtype=latent.dtype
         )
         
@@ -345,7 +345,7 @@ class LatentToLatentInvocation(TextToLatentInvocation):
         )
 
         result_latents, result_attention_map_saver = model.latents_from_embeddings(
-            latents=initial_latent,
+            latents=initial_latents,
             timesteps=timesteps,
             noise=noise,
             num_inference_steps=self.steps,
@@ -358,8 +358,8 @@ class LatentToLatentInvocation(TextToLatentInvocation):
 
         name = f'{context.graph_execution_state_id}__{self.id}'
         context.services.latents.set(name, result_latents)
-        return LatentOutput(
-            latent=LatentField(latent_name=name)
+        return LatentsOutput(
+            latents=LatentsField(latents_name=name)
         )
 
 

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Kyle Schouviller (https://github.com/kyle0654)
 
+import random
 from typing import Literal, Optional
 from pydantic import BaseModel, Field
 import torch
@@ -99,13 +100,17 @@ def get_noise(width:int, height:int, device:torch.device, seed:int = 0, latent_c
     return x
 
 
+def random_seed():
+    return random.randint(0, np.iinfo(np.uint32).max)
+
+
 class NoiseInvocation(BaseInvocation):
     """Generates latent noise."""
 
     type: Literal["noise"] = "noise"
 
     # Inputs
-    seed:        int = Field(default=0, ge=0, le=np.iinfo(np.uint32).max, description="The seed to use", )
+    seed:        int = Field(ge=0, le=np.iinfo(np.uint32).max, description="The seed to use", default_factory=random_seed)
     width:       int = Field(default=512, multiple_of=64, gt=0, description="The width of the resulting noise", )
     height:      int = Field(default=512, multiple_of=64, gt=0, description="The height of the resulting noise", )
 

--- a/invokeai/app/invocations/params.py
+++ b/invokeai/app/invocations/params.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Kyle Schouviller (https://github.com/kyle0654)
+
+from typing import Literal
+from pydantic import Field
+from .baseinvocation import BaseInvocation, BaseInvocationOutput, InvocationContext
+from .math import IntOutput
+
+# Pass-through parameter nodes - used by subgraphs
+
+class ParamIntInvocation(BaseInvocation):
+    """An integer parameter"""
+    #fmt: off
+    type: Literal["param_int"] = "param_int"
+    a: int = Field(default=0, description="The integer value")
+    #fmt: on
+
+    def invoke(self, context: InvocationContext) -> IntOutput:
+        return IntOutput(a=self.a)

--- a/invokeai/app/services/default_graphs.py
+++ b/invokeai/app/services/default_graphs.py
@@ -13,38 +13,39 @@ def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[Li
     graphs: list[LibraryGraph] = list()
 
     text_to_image = graph_library.get(default_text_to_image_graph_id)
-    if text_to_image is None:
-        text_to_image = LibraryGraph(
-            id=default_text_to_image_graph_id,
-            name='t2i',
-            description='Converts text to an image',
-            graph=Graph(
-                nodes={
-                    'width': ParamIntInvocation(id='width'),
-                    'height': ParamIntInvocation(id='height'),
-                    '3': NoiseInvocation(id='3'),
-                    '4': TextToLatentsInvocation(id='4'),
-                    '5': LatentsToImageInvocation(id='5')
-                },
-                edges=[
-                    Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='3', field='width')),
-                    Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='3', field='height')),
-                    Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='4', field='width')),
-                    Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='4', field='height')),
-                    Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='5', field='width')),
-                    Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='5', field='height')),
-                    Edge(source=EdgeConnection(node_id='3', field='noise'), destination=EdgeConnection(node_id='4', field='noise')),
-                    Edge(source=EdgeConnection(node_id='4', field='latents'), destination=EdgeConnection(node_id='5', field='latents')),
-                ]
-            ),
-            exposed_inputs=[
-                ExposedNodeInput(node_path='width', field='a', alias='width'),
-                ExposedNodeInput(node_path='height', field='a', alias='height')
-            ],
-            exposed_outputs=[
-                ExposedNodeOutput(node_path='5', field='image', alias='image')
-            ])
-        graph_library.set(text_to_image)
+    #if text_to_image is None:
+    text_to_image = LibraryGraph(
+        id=default_text_to_image_graph_id,
+        name='t2i',
+        description='Converts text to an image',
+        graph=Graph(
+            nodes={
+                'width': ParamIntInvocation(id='width'),
+                'height': ParamIntInvocation(id='height'),
+                '3': NoiseInvocation(id='3'),
+                '4': TextToLatentsInvocation(id='4'),
+                '5': LatentsToImageInvocation(id='5')
+            },
+            edges=[
+                Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='3', field='width')),
+                Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='3', field='height')),
+                Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='4', field='width')),
+                Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='4', field='height')),
+                Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='5', field='width')),
+                Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='5', field='height')),
+                Edge(source=EdgeConnection(node_id='3', field='noise'), destination=EdgeConnection(node_id='4', field='noise')),
+                Edge(source=EdgeConnection(node_id='4', field='latents'), destination=EdgeConnection(node_id='5', field='latents')),
+            ]
+        ),
+        exposed_inputs=[
+            ExposedNodeInput(node_path='4', field='prompt', alias='prompt'),
+            ExposedNodeInput(node_path='width', field='a', alias='width'),
+            ExposedNodeInput(node_path='height', field='a', alias='height')
+        ],
+        exposed_outputs=[
+            ExposedNodeOutput(node_path='5', field='image', alias='image')
+        ])
+    graph_library.set(text_to_image)
 
     graphs.append(text_to_image)
 

--- a/invokeai/app/services/default_graphs.py
+++ b/invokeai/app/services/default_graphs.py
@@ -7,21 +7,15 @@ from .item_storage import ItemStorageABC
 default_text_to_image_graph_id = '539b2af5-2b4d-4d8c-8071-e54a3255fc74'
 
 
-def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[LibraryGraph]:
-    """Creates the default system graphs, or adds new versions if the old ones don't match"""
-
-    graphs: list[LibraryGraph] = list()
-
-    text_to_image = graph_library.get(default_text_to_image_graph_id)
-    #if text_to_image is None:
-    text_to_image = LibraryGraph(
+def create_text_to_image() -> LibraryGraph:
+    return LibraryGraph(
         id=default_text_to_image_graph_id,
         name='t2i',
         description='Converts text to an image',
         graph=Graph(
             nodes={
-                'width': ParamIntInvocation(id='width'),
-                'height': ParamIntInvocation(id='height'),
+                'width': ParamIntInvocation(id='width', a=512),
+                'height': ParamIntInvocation(id='height', a=512),
                 '3': NoiseInvocation(id='3'),
                 '4': TextToLatentsInvocation(id='4'),
                 '5': LatentsToImageInvocation(id='5')
@@ -31,8 +25,6 @@ def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[Li
                 Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='3', field='height')),
                 Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='4', field='width')),
                 Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='4', field='height')),
-                Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='5', field='width')),
-                Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='5', field='height')),
                 Edge(source=EdgeConnection(node_id='3', field='noise'), destination=EdgeConnection(node_id='4', field='noise')),
                 Edge(source=EdgeConnection(node_id='4', field='latents'), destination=EdgeConnection(node_id='5', field='latents')),
             ]
@@ -45,6 +37,18 @@ def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[Li
         exposed_outputs=[
             ExposedNodeOutput(node_path='5', field='image', alias='image')
         ])
+
+
+def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[LibraryGraph]:
+    """Creates the default system graphs, or adds new versions if the old ones don't match"""
+
+    graphs: list[LibraryGraph] = list()
+
+    text_to_image = graph_library.get(default_text_to_image_graph_id)
+    
+    # TODO: Check if the graph is the same as the default one, and if not, update it
+    #if text_to_image is None:
+    text_to_image = create_text_to_image()
     graph_library.set(text_to_image)
 
     graphs.append(text_to_image)

--- a/invokeai/app/services/default_graphs.py
+++ b/invokeai/app/services/default_graphs.py
@@ -1,0 +1,51 @@
+from ..invocations.latent import LatentsToImageInvocation, NoiseInvocation, TextToLatentsInvocation
+from ..invocations.params import ParamIntInvocation
+from .graph import Edge, EdgeConnection, ExposedNodeInput, ExposedNodeOutput, Graph, LibraryGraph
+from .item_storage import ItemStorageABC
+
+
+default_text_to_image_graph_id = '539b2af5-2b4d-4d8c-8071-e54a3255fc74'
+
+
+def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[LibraryGraph]:
+    """Creates the default system graphs, or adds new versions if the old ones don't match"""
+
+    graphs: list[LibraryGraph] = list()
+
+    text_to_image = graph_library.get(default_text_to_image_graph_id)
+    if text_to_image is None:
+        text_to_image = LibraryGraph(
+            id=default_text_to_image_graph_id,
+            name='t2i',
+            description='Converts text to an image',
+            graph=Graph(
+                nodes={
+                    'width': ParamIntInvocation(id='width'),
+                    'height': ParamIntInvocation(id='height'),
+                    '3': NoiseInvocation(id='3'),
+                    '4': TextToLatentsInvocation(id='4'),
+                    '5': LatentsToImageInvocation(id='5')
+                },
+                edges=[
+                    Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='3', field='width')),
+                    Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='3', field='height')),
+                    Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='4', field='width')),
+                    Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='4', field='height')),
+                    Edge(source=EdgeConnection(node_id='width', field='a'), destination=EdgeConnection(node_id='5', field='width')),
+                    Edge(source=EdgeConnection(node_id='height', field='a'), destination=EdgeConnection(node_id='5', field='height')),
+                    Edge(source=EdgeConnection(node_id='3', field='noise'), destination=EdgeConnection(node_id='4', field='noise')),
+                    Edge(source=EdgeConnection(node_id='4', field='latents'), destination=EdgeConnection(node_id='5', field='latents')),
+                ]
+            ),
+            exposed_inputs=[
+                ExposedNodeInput(node_path='width', field='a', alias='width'),
+                ExposedNodeInput(node_path='height', field='a', alias='height')
+            ],
+            exposed_outputs=[
+                ExposedNodeOutput(node_path='5', field='image', alias='image')
+            ])
+        graph_library.set(text_to_image)
+
+    graphs.append(text_to_image)
+
+    return graphs

--- a/invokeai/app/services/graph.py
+++ b/invokeai/app/services/graph.py
@@ -733,7 +733,7 @@ class Graph(BaseModel):
         for sgn in (
             gn for gn in self.nodes.values() if isinstance(gn, GraphInvocation)
         ):
-            sgn.graph.nx_graph_flat(g, self._get_node_path(sgn.id, prefix))
+            g = sgn.graph.nx_graph_flat(g, self._get_node_path(sgn.id, prefix))
 
         # TODO: figure out if iteration nodes need to be expanded
 

--- a/invokeai/app/services/graph.py
+++ b/invokeai/app/services/graph.py
@@ -283,7 +283,8 @@ class Graph(BaseModel):
         :raises InvalidEdgeError: the provided edge is invalid.
         """
 
-        if self._is_edge_valid(edge) and edge not in self.edges:
+        self._validate_edge(edge)
+        if edge not in self.edges:
             self.edges.append(edge)
         else:
             raise InvalidEdgeError()
@@ -354,7 +355,7 @@ class Graph(BaseModel):
 
         return True
 
-    def _is_edge_valid(self, edge: Edge) -> bool:
+    def _validate_edge(self, edge: Edge):
         """Validates that a new edge doesn't create a cycle in the graph"""
 
         # Validate that the nodes exist (edges may contain node paths, so we can't just check for nodes directly)
@@ -362,54 +363,53 @@ class Graph(BaseModel):
             from_node = self.get_node(edge.source.node_id)
             to_node = self.get_node(edge.destination.node_id)
         except NodeNotFoundError:
-            return False
+            raise InvalidEdgeError("One or both nodes don't exist")
 
         # Validate that an edge to this node+field doesn't already exist
         input_edges = self._get_input_edges(edge.destination.node_id, edge.destination.field)
         if len(input_edges) > 0 and not isinstance(to_node, CollectInvocation):
-            return False
+            raise InvalidEdgeError(f'Edge to node {edge.destination.node_id} field {edge.destination.field} already exists')
 
         # Validate that no cycles would be created
         g = self.nx_graph_flat()
         g.add_edge(edge.source.node_id, edge.destination.node_id)
         if not nx.is_directed_acyclic_graph(g):
-            return False
+            raise InvalidEdgeError(f'Edge creates a cycle in the graph')
 
         # Validate that the field types are compatible
         if not are_connections_compatible(
             from_node, edge.source.field, to_node, edge.destination.field
         ):
-            return False
+            raise InvalidEdgeError(f'Fields are incompatible')
 
         # Validate if iterator output type matches iterator input type (if this edge results in both being set)
         if isinstance(to_node, IterateInvocation) and edge.destination.field == "collection":
             if not self._is_iterator_connection_valid(
                 edge.destination.node_id, new_input=edge.source
             ):
-                return False
+                raise InvalidEdgeError(f'Iterator input type does not match iterator output type')
 
         # Validate if iterator input type matches output type (if this edge results in both being set)
         if isinstance(from_node, IterateInvocation) and edge.source.field == "item":
             if not self._is_iterator_connection_valid(
                 edge.source.node_id, new_output=edge.destination
             ):
-                return False
+                raise InvalidEdgeError(f'Iterator output type does not match iterator input type')
 
         # Validate if collector input type matches output type (if this edge results in both being set)
         if isinstance(to_node, CollectInvocation) and edge.destination.field == "item":
             if not self._is_collector_connection_valid(
                 edge.destination.node_id, new_input=edge.source
             ):
-                return False
+                raise InvalidEdgeError(f'Collector output type does not match collector input type')
 
         # Validate if collector output type matches input type (if this edge results in both being set)
         if isinstance(from_node, CollectInvocation) and edge.source.field == "collection":
             if not self._is_collector_connection_valid(
                 edge.source.node_id, new_output=edge.destination
             ):
-                return False
+                raise InvalidEdgeError(f'Collector input type does not match collector output type')
 
-        return True
 
     def has_node(self, node_path: str) -> bool:
         """Determines whether or not a node exists in the graph."""
@@ -858,7 +858,8 @@ class GraphExecutionState(BaseModel):
 
     def is_complete(self) -> bool:
         """Returns true if the graph is complete"""
-        return self.has_error() or all((k in self.executed for k in self.graph.nodes))
+        node_ids = set(self.graph.nx_graph_flat().nodes)
+        return self.has_error() or all((k in self.executed for k in node_ids))
 
     def has_error(self) -> bool:
         """Returns true if the graph has any errors"""
@@ -946,11 +947,11 @@ class GraphExecutionState(BaseModel):
 
     def _iterator_graph(self) -> nx.DiGraph:
         """Gets a DiGraph with edges to collectors removed so an ancestor search produces all active iterators for any node"""
-        g = self.graph.nx_graph()
+        g = self.graph.nx_graph_flat()
         collectors = (
             n
             for n in self.graph.nodes
-            if isinstance(self.graph.nodes[n], CollectInvocation)
+            if isinstance(self.graph.get_node(n), CollectInvocation)
         )
         for c in collectors:
             g.remove_edges_from(list(g.in_edges(c)))
@@ -962,7 +963,7 @@ class GraphExecutionState(BaseModel):
         iterators = [
             n
             for n in nx.ancestors(g, node_id)
-            if isinstance(self.graph.nodes[n], IterateInvocation)
+            if isinstance(self.graph.get_node(n), IterateInvocation)
         ]
         return iterators
 
@@ -1098,7 +1099,9 @@ class GraphExecutionState(BaseModel):
 
     # TODO: Add API for modifying underlying graph that checks if the change will be valid given the current execution state
     def _is_edge_valid(self, edge: Edge) -> bool:
-        if not self._is_edge_valid(edge):
+        try:
+            self.graph._validate_edge(edge)
+        except InvalidEdgeError:
             return False
 
         # Invalid if destination has already been prepared or executed

--- a/invokeai/app/services/invocation_services.py
+++ b/invokeai/app/services/invocation_services.py
@@ -19,6 +19,7 @@ class InvocationServices:
     restoration: RestorationServices
 
     # NOTE: we must forward-declare any types that include invocations, since invocations can use services
+    graph_library: ItemStorageABC["LibraryGraph"]
     graph_execution_manager: ItemStorageABC["GraphExecutionState"]
     processor: "InvocationProcessorABC"
 
@@ -29,6 +30,7 @@ class InvocationServices:
             latents: LatentsStorageBase,
             images: ImageStorageBase,
             queue: InvocationQueueABC,
+            graph_library: ItemStorageABC["LibraryGraph"],
             graph_execution_manager: ItemStorageABC["GraphExecutionState"],
             processor: "InvocationProcessorABC",
             restoration: RestorationServices,
@@ -38,6 +40,7 @@ class InvocationServices:
         self.latents = latents
         self.images = images
         self.queue = queue
+        self.graph_library = graph_library
         self.graph_execution_manager = graph_execution_manager
         self.processor = processor
         self.restoration = restoration

--- a/invokeai/app/services/sqlite.py
+++ b/invokeai/app/services/sqlite.py
@@ -35,8 +35,7 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
         self._create_table()
 
     def _create_table(self):
-        try:
-            self._lock.acquire()
+        with self._lock:
             self._cursor.execute(
                 f"""CREATE TABLE IF NOT EXISTS {self._table_name} (
                 item TEXT,
@@ -45,34 +44,27 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
             self._cursor.execute(
                 f"""CREATE UNIQUE INDEX IF NOT EXISTS {self._table_name}_id ON {self._table_name}(id);"""
             )
-        finally:
-            self._lock.release()
+            self._conn.commit()
 
     def _parse_item(self, item: str) -> T:
         item_type = get_args(self.__orig_class__)[0]
         return parse_raw_as(item_type, item)
 
     def set(self, item: T):
-        try:
-            self._lock.acquire()
+        with self._lock:
             self._cursor.execute(
                 f"""INSERT OR REPLACE INTO {self._table_name} (item) VALUES (?);""",
                 (item.json(),),
             )
             self._conn.commit()
-        finally:
-            self._lock.release()
         self._on_changed(item)
 
     def get(self, id: str) -> Union[T, None]:
-        try:
-            self._lock.acquire()
+        with self._lock:
             self._cursor.execute(
                 f"""SELECT item FROM {self._table_name} WHERE id = ?;""", (str(id),)
             )
             result = self._cursor.fetchone()
-        finally:
-            self._lock.release()
 
         if not result:
             return None
@@ -80,19 +72,15 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
         return self._parse_item(result[0])
 
     def delete(self, id: str):
-        try:
-            self._lock.acquire()
+        with self._lock:
             self._cursor.execute(
                 f"""DELETE FROM {self._table_name} WHERE id = ?;""", (str(id),)
             )
             self._conn.commit()
-        finally:
-            self._lock.release()
         self._on_deleted(id)
 
     def list(self, page: int = 0, per_page: int = 10) -> PaginatedResults[T]:
-        try:
-            self._lock.acquire()
+        with self._lock:
             self._cursor.execute(
                 f"""SELECT item FROM {self._table_name} LIMIT ? OFFSET ?;""",
                 (per_page, page * per_page),
@@ -103,8 +91,6 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
 
             self._cursor.execute(f"""SELECT count(*) FROM {self._table_name};""")
             count = self._cursor.fetchone()[0]
-        finally:
-            self._lock.release()
 
         pageCount = int(count / per_page) + 1
 
@@ -115,8 +101,7 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
     def search(
         self, query: str, page: int = 0, per_page: int = 10
     ) -> PaginatedResults[T]:
-        try:
-            self._lock.acquire()
+        with self._lock:
             self._cursor.execute(
                 f"""SELECT item FROM {self._table_name} WHERE item LIKE ? LIMIT ? OFFSET ?;""",
                 (f"%{query}%", per_page, page * per_page),
@@ -130,8 +115,6 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
                 (f"%{query}%",),
             )
             count = self._cursor.fetchone()[0]
-        finally:
-            self._lock.release()
 
         pageCount = int(count / per_page) + 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "clip_anytorch",          # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
   "compel==1.0.5",
   "datasets",
-  "diffusers[torch]~=0.14",
+  "diffusers[torch]==0.14",
   "dnspython==2.2.1",
   "einops",
   "eventlet",

--- a/tests/nodes/test_graph_execution_state.py
+++ b/tests/nodes/test_graph_execution_state.py
@@ -7,7 +7,7 @@ from invokeai.app.services.processor import DefaultInvocationProcessor
 from invokeai.app.services.sqlite import SqliteItemStorage, sqlite_memory
 from invokeai.app.services.invocation_queue import MemoryInvocationQueue
 from invokeai.app.services.invocation_services import InvocationServices
-from invokeai.app.services.graph import Graph, GraphInvocation, InvalidEdgeError, NodeAlreadyInGraphError, NodeNotFoundError, are_connections_compatible, EdgeConnection, CollectInvocation, IterateInvocation, GraphExecutionState
+from invokeai.app.services.graph import Graph, GraphInvocation, InvalidEdgeError, LibraryGraph, NodeAlreadyInGraphError, NodeNotFoundError, are_connections_compatible, EdgeConnection, CollectInvocation, IterateInvocation, GraphExecutionState
 import pytest
 
 
@@ -28,6 +28,9 @@ def mock_services():
         images = None, # type: ignore
         latents = None, # type: ignore
         queue = MemoryInvocationQueue(),
+        graph_library=SqliteItemStorage[LibraryGraph](
+            filename=sqlite_memory, table_name="graphs"
+        ),
         graph_execution_manager = SqliteItemStorage[GraphExecutionState](filename = sqlite_memory, table_name = 'graph_executions'),
         processor = DefaultInvocationProcessor(),
         restoration = None, # type: ignore

--- a/tests/nodes/test_invoker.py
+++ b/tests/nodes/test_invoker.py
@@ -5,7 +5,7 @@ from invokeai.app.services.invocation_queue import MemoryInvocationQueue
 from invokeai.app.services.invoker import Invoker
 from invokeai.app.invocations.baseinvocation import BaseInvocation, BaseInvocationOutput, InvocationContext
 from invokeai.app.services.invocation_services import InvocationServices
-from invokeai.app.services.graph import Graph, GraphInvocation, InvalidEdgeError, NodeAlreadyInGraphError, NodeNotFoundError, are_connections_compatible, EdgeConnection, CollectInvocation, IterateInvocation, GraphExecutionState
+from invokeai.app.services.graph import Graph, GraphInvocation, InvalidEdgeError, LibraryGraph, NodeAlreadyInGraphError, NodeNotFoundError, are_connections_compatible, EdgeConnection, CollectInvocation, IterateInvocation, GraphExecutionState
 import pytest
 
 
@@ -26,6 +26,9 @@ def mock_services() -> InvocationServices:
         images = None, # type: ignore
         latents = None, # type: ignore
         queue = MemoryInvocationQueue(),
+        graph_library=SqliteItemStorage[LibraryGraph](
+            filename=sqlite_memory, table_name="graphs"
+        ),
         graph_execution_manager = SqliteItemStorage[GraphExecutionState](filename = sqlite_memory, table_name = 'graph_executions'),
         processor = DefaultInvocationProcessor(),
         restoration = None, # type: ignore

--- a/tests/nodes/test_node_graph.py
+++ b/tests/nodes/test_node_graph.py
@@ -1,9 +1,11 @@
-from invokeai.app.invocations.image import *
-
 from .test_nodes import ListPassThroughInvocation, PromptTestInvocation
 from invokeai.app.services.graph import Edge, Graph, GraphInvocation, InvalidEdgeError, NodeAlreadyInGraphError, NodeNotFoundError, are_connections_compatible, EdgeConnection, CollectInvocation, IterateInvocation
 from invokeai.app.invocations.generate import ImageToImageInvocation, TextToImageInvocation
 from invokeai.app.invocations.upscale import UpscaleInvocation
+from invokeai.app.invocations.image import *
+from invokeai.app.invocations.math import AddInvocation, SubtractInvocation
+from invokeai.app.invocations.params import ParamIntInvocation
+from invokeai.app.services.default_graphs import create_text_to_image
 import pytest
 
 
@@ -416,6 +418,66 @@ def test_graph_gets_subgraph_node():
     assert result is not None
     assert result.id == '1'
     assert result == n1_1
+
+
+def test_graph_expands_subgraph():
+    g = Graph()
+    n1 = GraphInvocation(id = "1")
+    n1.graph = Graph()
+
+    n1_1 = AddInvocation(id = "1", a = 1, b = 2)
+    n1_2 = SubtractInvocation(id = "2", b = 3)
+    n1.graph.add_node(n1_1)
+    n1.graph.add_node(n1_2)
+    n1.graph.add_edge(create_edge("1","a","2","a"))
+
+    g.add_node(n1)
+
+    n2 = AddInvocation(id = "2", b = 5)
+    g.add_node(n2)
+    g.add_edge(create_edge("1.2","a","2","a"))
+
+    dg = g.nx_graph_flat()
+    assert set(dg.nodes) == set(['1.1', '1.2', '2'])
+    assert set(dg.edges) == set([('1.1', '1.2'), ('1.2', '2')])
+
+
+def test_graph_subgraph_t2i():
+    g = Graph()
+    n1 = GraphInvocation(id = "1")
+
+    # Get text to image default graph
+    lg = create_text_to_image()
+    n1.graph = lg.graph
+
+    g.add_node(n1)
+
+    n2 = ParamIntInvocation(id = "2", a = 512)
+    n3 = ParamIntInvocation(id = "3", a = 256)
+
+    g.add_node(n2)
+    g.add_node(n3)
+
+    g.add_edge(create_edge("2","a","1.width","a"))
+    g.add_edge(create_edge("3","a","1.height","a"))
+    
+    n4 = ShowImageInvocation(id = "4")
+    g.add_node(n4)
+    g.add_edge(create_edge("1.5","image","4","image"))
+
+    # Validate
+    dg = g.nx_graph_flat()
+    assert set(dg.nodes) == set(['1.width', '1.height', '1.3', '1.4', '1.5', '2', '3', '4'])
+    expected_edges = [(f'1.{e.source.node_id}',f'1.{e.destination.node_id}') for e in lg.graph.edges]
+    expected_edges.extend([
+        ('2','1.width'),
+        ('3','1.height'),
+        ('1.5','4')
+    ])
+    print(expected_edges)
+    print(list(dg.edges))
+    assert set(dg.edges) == set(expected_edges)
+
 
 def test_graph_fails_to_get_missing_subgraph_node():
     g = Graph()


### PR DESCRIPTION
Subgraphs are now functional. They are stored in a graph library, and are automatically added to the CLI by name. They can expose inputs and outputs when used in the CLI (some more work will need to be done to support this in the UI - namely, storing some reference to the graph library graph somewhere on the GraphNode, or with the Graph).