### PR TITLE
Make InvocationQueueItem serializable

### DIFF
--- a/invokeai/app/services/graph.py
+++ b/invokeai/app/services/graph.py
@@ -2,7 +2,6 @@
 
 import copy
 import itertools
-import traceback
 import uuid
 from types import NoneType
 from typing import (
@@ -751,7 +750,7 @@ class GraphExecutionState(BaseModel):
     """Tracks the state of a graph execution"""
 
     id: str = Field(
-        description="The id of the execution state", default_factory=uuid.uuid4
+        description="The id of the execution state", default_factory=lambda: uuid.uuid4().__str__()
     )
 
     # TODO: Store a reference to the graph instead of the actual graph?
@@ -1171,7 +1170,7 @@ class LibraryGraph(BaseModel):
         if len(v) != len(set(i.alias for i in v)):
             raise ValueError("Duplicate exposed alias")
         return v
-    
+
     @root_validator
     def validate_exposed_nodes(cls, values):
         graph = values['graph']

--- a/invokeai/app/services/graph.py
+++ b/invokeai/app/services/graph.py
@@ -25,7 +25,6 @@ from ..invocations.baseinvocation import (
     BaseInvocationOutput,
     InvocationContext,
 )
-from .invocation_services import InvocationServices
 
 
 class EdgeConnection(BaseModel):
@@ -214,7 +213,7 @@ InvocationOutputsUnion = Union[BaseInvocationOutput.get_all_subclasses_tuple()] 
 
 
 class Graph(BaseModel):
-    id: str = Field(description="The id of this graph", default_factory=uuid.uuid4)
+    id: str = Field(description="The id of this graph", default_factory=lambda: uuid.uuid4().__str__())
     # TODO: use a list (and never use dict in a BaseModel) because pydantic/fastapi hates me
     nodes: dict[str, Annotated[InvocationsUnion, Field(discriminator="type")]] = Field(
         description="The nodes in this graph", default_factory=dict
@@ -749,9 +748,7 @@ class Graph(BaseModel):
 class GraphExecutionState(BaseModel):
     """Tracks the state of a graph execution"""
 
-    id: str = Field(
-        description="The id of the execution state", default_factory=lambda: uuid.uuid4().__str__()
-    )
+    id: str = Field(description="The id of the execution state", default_factory=lambda: uuid.uuid4().__str__())
 
     # TODO: Store a reference to the graph instead of the actual graph?
     graph: Graph = Field(description="The graph being executed")

--- a/invokeai/app/services/invocation_queue.py
+++ b/invokeai/app/services/invocation_queue.py
@@ -1,31 +1,17 @@
 # Copyright (c) 2022 Kyle Schouviller (https://github.com/kyle0654)
 
-from abc import ABC, abstractmethod
-from queue import Queue
 import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from queue import Queue
 
 
-# TODO: make this serializable
+@dataclass
 class InvocationQueueItem:
-    # session_id: str
     graph_execution_state_id: str
     invocation_id: str
     invoke_all: bool
-    timestamp: float
-
-    def __init__(
-        self,
-        # session_id: str,
-        graph_execution_state_id: str,
-        invocation_id: str,
-        invoke_all: bool = False,
-    ):
-        # self.session_id = session_id
-        self.graph_execution_state_id = graph_execution_state_id
-        self.invocation_id = invocation_id
-        self.invoke_all = invoke_all
-        self.timestamp = time.time()
-
+    timestamp: float = time.time()
 
 class InvocationQueueABC(ABC):
     """Abstract base class for all invocation queues"""

--- a/invokeai/app/services/invocation_queue.py
+++ b/invokeai/app/services/invocation_queue.py
@@ -2,16 +2,16 @@
 
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from pydantic import BaseModel, Field
 from queue import Queue
 
 
-@dataclass
-class InvocationQueueItem:
+class InvocationQueueItem(BaseModel):
     graph_execution_state_id: str
     invocation_id: str
     invoke_all: bool
-    timestamp: float = time.time()
+    timestamp: float = Field(default_factory=time.time)
+
 
 class InvocationQueueABC(ABC):
     """Abstract base class for all invocation queues"""

--- a/invokeai/app/services/invocation_queue.py
+++ b/invokeai/app/services/invocation_queue.py
@@ -3,13 +3,12 @@
 import time
 from abc import ABC, abstractmethod
 from queue import Queue
-from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 
 class InvocationQueueItem(BaseModel):
-    graph_execution_state_id: UUID
+    graph_execution_state_id: str
     invocation_id: str
     invoke_all: bool
     timestamp: float = Field(default_factory=time.time)

--- a/invokeai/app/services/invocation_queue.py
+++ b/invokeai/app/services/invocation_queue.py
@@ -2,12 +2,14 @@
 
 import time
 from abc import ABC, abstractmethod
-from pydantic import BaseModel, Field
 from queue import Queue
+from uuid import UUID
+
+from pydantic import BaseModel, Field
 
 
 class InvocationQueueItem(BaseModel):
-    graph_execution_state_id: str
+    graph_execution_state_id: UUID
     invocation_id: str
     invoke_all: bool
     timestamp: float = Field(default_factory=time.time)

--- a/invokeai/app/services/invocation_queue.py
+++ b/invokeai/app/services/invocation_queue.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 class InvocationQueueItem(BaseModel):
     graph_execution_state_id: str
     invocation_id: str
-    invoke_all: bool
+    invoke_all: bool = Field(default=False)
     timestamp: float = Field(default_factory=time.time)
 
 

--- a/invokeai/app/services/invocation_queue.py
+++ b/invokeai/app/services/invocation_queue.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel, Field
 
 
 class InvocationQueueItem(BaseModel):
-    graph_execution_state_id: str
-    invocation_id: str
+    graph_execution_state_id: str = Field(description="The ID of the graph execution state")
+    invocation_id: str = Field(description="The ID of the node being invoked")
     invoke_all: bool = Field(default=False)
     timestamp: float = Field(default_factory=time.time)
 


### PR DESCRIPTION
This is needed so that items can be pushed to an external queue, backed e.g. by Redis