### PR TITLE
Use penultimate CLIP layer on SD2 models

### DIFF
--- a/ldm/invoke/conditioning.py
+++ b/ldm/invoke/conditioning.py
@@ -15,6 +15,7 @@ from compel import Compel
 from compel.prompt_parser import FlattenedPrompt, Blend, Fragment, CrossAttentionControlSubstitute, PromptParser, \
     Conjunction
 from .devices import torch_dtype
+from .generator.diffusers_pipeline import is_penultimate_clip_trained_model
 from ..models.diffusion.shared_invokeai_diffusion import InvokeAIDiffuserComponent
 from ldm.invoke.globals import Globals
 
@@ -48,10 +49,12 @@ def get_uc_and_c_and_ec(prompt_string, model, log_tokens=False, skip_normalize_l
 
     tokenizer = get_tokenizer(model)
     text_encoder = get_text_encoder(model)
+    print("using penultimate clip layer:", is_penultimate_clip_trained_model(model))
     compel = Compel(tokenizer=tokenizer,
                     text_encoder=text_encoder,
                     textual_inversion_manager=model.textual_inversion_manager,
-                    dtype_for_device_getter=torch_dtype)
+                    dtype_for_device_getter=torch_dtype,
+                    use_penultimate_clip_layer=is_penultimate_clip_trained_model(model))
 
     # get rid of any newline characters
     prompt_string = prompt_string.replace("\n", " ")

--- a/ldm/invoke/conditioning.py
+++ b/ldm/invoke/conditioning.py
@@ -15,7 +15,7 @@ from compel import Compel
 from compel.prompt_parser import FlattenedPrompt, Blend, Fragment, CrossAttentionControlSubstitute, PromptParser, \
     Conjunction
 from .devices import torch_dtype
-from .generator.diffusers_pipeline import is_penultimate_clip_trained_model
+from .generator.diffusers_pipeline import is_sd2_model
 from ..models.diffusion.shared_invokeai_diffusion import InvokeAIDiffuserComponent
 from ldm.invoke.globals import Globals
 
@@ -49,12 +49,11 @@ def get_uc_and_c_and_ec(prompt_string, model, log_tokens=False, skip_normalize_l
 
     tokenizer = get_tokenizer(model)
     text_encoder = get_text_encoder(model)
-    print("using penultimate clip layer:", is_penultimate_clip_trained_model(model))
     compel = Compel(tokenizer=tokenizer,
                     text_encoder=text_encoder,
                     textual_inversion_manager=model.textual_inversion_manager,
                     dtype_for_device_getter=torch_dtype,
-                    use_penultimate_clip_layer=is_penultimate_clip_trained_model(model))
+                    use_penultimate_clip_layer=is_sd2_model(model))
 
     # get rid of any newline characters
     prompt_string = prompt_string.replace("\n", " ")

--- a/ldm/invoke/generator/diffusers_pipeline.py
+++ b/ldm/invoke/generator/diffusers_pipeline.py
@@ -161,7 +161,7 @@ def image_resized_to_grid_as_tensor(image: PIL.Image.Image, normalize: bool=True
 def is_inpainting_model(unet: UNet2DConditionModel):
     return unet.conv_in.in_channels == 9
 
-def is_penultimate_clip_trained_model(model: StableDiffusionPipeline):
+def is_sd2_model(model: StableDiffusionPipeline):
     # TODO there should be a better way to check this
     return model.text_encoder.config.hidden_size == 1024
 

--- a/ldm/invoke/generator/diffusers_pipeline.py
+++ b/ldm/invoke/generator/diffusers_pipeline.py
@@ -158,9 +158,12 @@ def image_resized_to_grid_as_tensor(image: PIL.Image.Image, normalize: bool=True
         tensor = tensor * 2.0 - 1.0
     return tensor
 
-
 def is_inpainting_model(unet: UNet2DConditionModel):
     return unet.conv_in.in_channels == 9
+
+def is_penultimate_clip_trained_model(model: StableDiffusionPipeline):
+    # TODO there should be a better way to check this
+    return model.text_encoder.config.hidden_size == 1024
 
 CallbackType = TypeVar('CallbackType')
 ReturnType = TypeVar('ReturnType')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "albumentations",
   "click",
   "clip_anytorch",
-  "compel~=1.1.0",
+  "compel~=1.1.3",
   "datasets",
   "diffusers[torch]==0.14",
   "dnspython==2.2.1",


### PR DESCRIPTION
According to the official release marketing text, SD2 models are "conditioned on the penultimate [second-to-last] text embeddings of a CLIP ViT-H/14 text encoder". We haven't been doing this, instead we've been using the ultimate [last] text embeddings, having inherited this behaviour from diffusers.

This pull request updates the Compel version and adds some (very bad) code to detect an SD2 model, which it uses to activate penulimate CLIP states.