### PR TITLE
Added CPU instruction for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ not supported.
     pip install InvokeAI --use-pep517 --extra-index-url https://download.pytorch.org/whl/rocm5.4.2
     ```
 
+    _For non-GPU systems:_
+    ```terminal
+    pip install InvokeAI --use-pep517 --extra-index-url https://download.pytorch.org/whl/cpu
+    ``` 
+
     _For Macintoshes, either Intel or M1/M2:_
 
     ```sh


### PR DESCRIPTION
Since the change itself is quite straight-forward, I'll just describe the context. Tried using automatic installer on my laptop, kept erroring out on line 140-something of installer.py, "ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv."
Got tired of of fighting with pip so moved on to command line install. Worked immediately, but at the time lacked instruction for CPU, so instead of opening any helpful hyperlinks in the readme, took a few minutes to grab the link from installer.py - thus this pr.