### PR TITLE
nodes-api: enforce single thread for the processor

### DIFF
--- a/invokeai/app/services/invoker.py
+++ b/invokeai/app/services/invoker.py
@@ -49,7 +49,7 @@ class Invoker:
         new_state = GraphExecutionState(graph=Graph() if graph is None else graph)
         self.services.graph_execution_manager.set(new_state)
         return new_state
-    
+
     def cancel(self, graph_execution_state_id: str) -> None:
         """Cancels the given execution state"""
         self.services.queue.cancel(graph_execution_state_id)
@@ -71,15 +71,9 @@ class Invoker:
         for service in vars(self.services):
             self.__start_service(getattr(self.services, service))
 
-        for service in vars(self.services):
-            self.__start_service(getattr(self.services, service))
-
     def stop(self) -> None:
         """Stops the invoker. A new invoker will have to be created to execute further."""
         # First stop all services
-        for service in vars(self.services):
-            self.__stop_service(getattr(self.services, service))
-
         for service in vars(self.services):
             self.__stop_service(getattr(self.services, service))
 


### PR DESCRIPTION
On hyperthreaded CPUs we get two threads operating on the queue by default on each core. This cases two threads to process queue items. This results in pytorch errors and sometimes generates garbage.

Locking this to single thread makes sense because we are bound by the number of GPUs in the system, not by CPU cores. And to parallelize across GPUs we should just start multiple processors (and use async instead of threading)

Fixes #3289