### PR TITLE
fix(ui): ignore persisted gallery state and refetch images if shouldFetchImages

### DIFF
--- a/invokeai/frontend/web/src/services/events/util/setEventListeners.ts
+++ b/invokeai/frontend/web/src/services/events/util/setEventListeners.ts
@@ -46,11 +46,11 @@ export const setEventListeners = (arg: SetEventListenersArg) => {
     const { disabledTabs } = config;
 
     // These thunks need to be dispatch in middleware; cannot handle in a reducer
-    if (!results.ids.length) {
+    if (!results.ids.length || config.shouldFetchImages) {
       dispatch(receivedResultImagesPage());
     }
 
-    if (!uploads.ids.length) {
+    if (!uploads.ids.length || config.shouldFetchImages) {
       dispatch(receivedUploadImagesPage());
     }
 


### PR DESCRIPTION
now that `results` and `uploads` are removed from the persisted blacklist, need to explicitly refetch images on page load if `shouldFetchImages` 