### PR TITLE
[Bugfix] Update check failing because process disappears

### DIFF
--- a/ldm/invoke/config/invokeai_update.py
+++ b/ldm/invoke/config/invokeai_update.py
@@ -39,7 +39,7 @@ def invokeai_is_running()->bool:
             if matches:
                 print(f':exclamation: [bold red]An InvokeAI instance appears to be running as process {p.pid}[/red bold]')
                 return True
-        except psutil.AccessDenied:
+        except (psutil.AccessDenied,psutil.NoSuchProcess):
             continue
     return False
         


### PR DESCRIPTION
Fixes #3228, where the check to see if invokeai is running fails because a process no longer exists.