### PR TITLE
Implement memory-efficient model cache

### DIFF
--- a/invokeai/backend/model_management/model_cache.py
+++ b/invokeai/backend/model_management/model_cache.py
@@ -1,0 +1,203 @@
+"""
+Manage a cache of Stable Diffusion model files for fast switching.
+They are moved between GPU and CPU as necessary. If the cache
+grows larger than a preset maximum, then the least recently used
+model will be cleared and (re)loaded from disk when next needed.
+"""
+
+import contextlib
+import hashlib
+import gc
+import time
+import os
+import psutil
+
+import safetensors
+import safetensors.torch
+import torch
+import transformers
+import warnings
+
+from pathlib import Path
+from diffusers import (
+    AutoencoderKL,
+    UNet2DConditionModel,
+    SchedulerMixin,
+    logging as diffusers_logging,
+)
+from transformers import(
+    CLIPTokenizer,
+    CLIPFeatureExtractor,
+    CLIPTextModel,
+    logging as transformers_logging,
+)    
+from huggingface_hub import scan_cache_dir
+from omegaconf import OmegaConf
+from omegaconf.dictconfig import DictConfig
+from picklescan.scanner import scan_file_path
+from typing import Sequence, Union
+
+from invokeai.backend.globals import Globals, global_cache_dir
+from diffusers.pipelines.stable_diffusion.safety_checker import (
+    StableDiffusionSafetyChecker,
+    )
+from ..stable_diffusion import (
+    StableDiffusionGeneratorPipeline,
+)
+from ..stable_diffusion.offloading import ModelGroup, FullyLoadedModelGroup
+from ..util import CUDA_DEVICE, ask_user, download_with_resume
+
+MAX_MODELS_CACHED = 4
+        
+class ModelCache(object):
+    def __init__(
+            self,
+            max_models_cached: int=MAX_MODELS_CACHED,
+            execution_device: torch.device=torch.device('cuda'),
+            precision: torch.dtype=torch.float16,
+            sequential_offload: bool=False,
+    ):
+        self.model_group: ModelGroup=FullyLoadedModelGroup(execution_device)
+        self.models: dict = dict()
+        self.stack: Sequence = list()
+        self.sequential_offload: bool=sequential_offload
+        self.precision: torch.dtype=precision
+        self.max_models_cached: int=max_models_cached
+        self.device: torch.device=execution_device
+
+    def get_model(
+            self,
+            repo_id_or_path: Union[str,Path],
+            model_class: type=StableDiffusionGeneratorPipeline,
+            subfolder: Path=None,
+            revision: str=None,
+            )->Union[
+                AutoencoderKL,
+                CLIPTokenizer,
+                CLIPFeatureExtractor,
+                CLIPTextModel,
+                UNet2DConditionModel,
+                StableDiffusionSafetyChecker,
+                StableDiffusionGeneratorPipeline,
+            ]:
+        '''
+        Load and return a HuggingFace model, with RAM caching.
+        :param repo_id_or_path: either the HuggingFace repo_id or a Path to a local model
+        :param subfolder: name of a subfolder in which the model can be found, e.g. "vae"
+        :param revision: model revision
+        :param model_class: class of model to return
+        '''
+        key = self._model_key(repo_id_or_path,model_class,revision,subfolder) # internal unique identifier for the model
+        if key in self.models: # cached - move to bottom of stack
+            previous_key = self._current_model_key
+            with contextlib.suppress(ValueError):
+                self.stack.remove(key)
+                self.stack.append(key)
+            if previous_key != key:
+                if hasattr(self.current_model,'to'):
+                    print(f'DEBUG: loading {key} into GPU')
+                    self.model_group.offload_current()
+                    self.model_group.load(self.models[key])
+
+        else:  # not cached -load
+            self._make_cache_room()
+            self.model_group.offload_current()
+            print(f'DEBUG: loading {key} from disk/net')
+            model = self._load_model_from_storage(
+                repo_id_or_path=repo_id_or_path,
+                subfolder=subfolder,
+                revision=revision,
+                model_class=model_class
+            )
+            if hasattr(model,'to'):
+                self.model_group.install(model) # register with the model group
+            self.stack.append(key)          # add to LRU cache
+            self.models[key]=model          # keep copy of model in dict
+        return self.models[key]
+
+    @staticmethod
+    def _model_key(path,model_class,revision,subfolder)->str:
+        return ':'.join([str(path),str(model_class),str(revision),str(subfolder)])
+
+    def _make_cache_room(self):
+        models_in_ram = len(self.models)
+        while models_in_ram >= self.max_models_cached:
+            if least_recently_used_key := self.stack.pop(0):
+                print(f'DEBUG: maximum cache size reached: cache_size={models_in_ram}; unloading model {least_recently_used_key}')
+                self.model_group.uninstall(self.models[least_recently_used_key])
+                del self.models[least_recently_used_key]
+            models_in_ram = len(self.models)
+        gc.collect()
+
+    @property
+    def current_model(self)->Union[
+                AutoencoderKL,
+                CLIPTokenizer,
+                CLIPFeatureExtractor,
+                CLIPTextModel,
+                UNet2DConditionModel,
+                StableDiffusionSafetyChecker,
+                StableDiffusionGeneratorPipeline,
+            ]:
+        '''
+        Returns current model.
+        '''
+        return self.models[self._current_model_key]
+
+    @property
+    def _current_model_key(self)->str:
+        '''
+        Returns key of currently loaded model.
+        '''
+        return self.stack[-1]
+
+    def _load_model_from_storage(
+            self,
+            repo_id_or_path: Union[str,Path],
+            subfolder: Path=None,
+            revision: str=None,
+            model_class: type=StableDiffusionGeneratorPipeline,
+            )->Union[
+                AutoencoderKL,
+                CLIPTokenizer,
+                CLIPFeatureExtractor,
+                CLIPTextModel,
+                UNet2DConditionModel,
+                StableDiffusionSafetyChecker,
+                StableDiffusionGeneratorPipeline,
+            ]:
+        '''
+        Load and return a HuggingFace model.
+        :param repo_id_or_path: either the HuggingFace repo_id or a Path to a local model
+        :param subfolder: name of a subfolder in which the model can be found, e.g. "vae"
+        :param revision: model revision
+        :param model_class: class of model to return
+        '''
+        # silence transformer and diffuser warnings
+        with SilenceWarnings():
+            model = model_class.from_pretrained(
+                repo_id_or_path,
+                revision=revision,
+                subfolder=subfolder or '.',
+                cache_dir=global_cache_dir('hub'),
+            )
+        if self.sequential_offload and isinstance(model,StableDiffusionGeneratorPipeline):
+            model.enable_offload_submodels(self.device)
+        elif hasattr(model,'to'):
+            model.to(self.device)
+        return model
+
+class SilenceWarnings(object):
+    def __init__(self):
+        self.transformers_verbosity = transformers_logging.get_verbosity()
+        self.diffusers_verbosity = diffusers_logging.get_verbosity()
+        
+    def __enter__(self):
+        transformers_logging.set_verbosity_error()
+        diffusers_logging.set_verbosity_error()
+        warnings.simplefilter('ignore')
+
+    def __exit__(self,type,value,traceback):
+        transformers_logging.set_verbosity(self.transformers_verbosity)
+        diffusers_logging.set_verbosity(self.diffusers_verbosity)
+        warnings.simplefilter('default')

--- a/invokeai/backend/model_management/model_cache.py
+++ b/invokeai/backend/model_management/model_cache.py
@@ -20,12 +20,14 @@ import warnings
 
 from enum import Enum
 from pathlib import Path
+from pydantic import BaseModel
 from diffusers import (
     AutoencoderKL,
     UNet2DConditionModel,
     SchedulerMixin,
     logging as diffusers_logging,
 )
+from huggingface_hub import list_repo_refs,HfApi
 from transformers import(
     CLIPTokenizer,
     CLIPFeatureExtractor,
@@ -36,10 +38,11 @@ from huggingface_hub import scan_cache_dir
 from picklescan.scanner import scan_file_path
 from typing import Sequence, Union
 
-from invokeai.backend.globals import Globals, global_cache_dir
 from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker,
     )
+from . import load_pipeline_from_original_stable_diffusion_ckpt
+from ..globals import Globals, global_cache_dir
 from ..stable_diffusion import (
     StableDiffusionGeneratorPipeline,
 )
@@ -59,8 +62,13 @@ class SDModelType(Enum):
     safety_checker=StableDiffusionSafetyChecker
     feature_extractor=CLIPFeatureExtractor
         
-# List the model classes we know how to fetch
+# The list of model classes we know how to fetch, for typechecking
 ModelClass = Union[tuple([x.value for x in SDModelType])]
+
+# Legacy information needed to load a legacy checkpoint file
+class LegacyInfo(BaseModel):
+    config_file: Path
+    vae_file: Path
 
 class ModelCache(object):
     def __init__(
@@ -69,7 +77,15 @@ class ModelCache(object):
             execution_device: torch.device=torch.device('cuda'),
             precision: torch.dtype=torch.float16,
             sequential_offload: bool=False,
+            sha_chunksize: int = 16777216,
     ):
+        '''
+        :param max_models_cached: Maximum number of models to cache in CPU RAM [4]
+        :param execution_device: Torch device to load active model into [torch.device('cuda')]
+        :param precision: Precision for loaded models [torch.float16]
+        :param sequential_offload: Conserve VRAM by loading and unloading each stage of the pipeline sequentially
+        :param sha_chunksize: Chunksize to use when calculating sha256 model hash
+        '''
         self.model_group: ModelGroup=FullyLoadedModelGroup(execution_device)
         self.models: dict = dict()
         self.stack: Sequence = list()
@@ -77,6 +93,7 @@ class ModelCache(object):
         self.precision: torch.dtype=precision
         self.max_models_cached: int=max_models_cached
         self.device: torch.device=execution_device
+        self.sha_chunksize=sha_chunksize
 
     def get_submodel(
             self,
@@ -84,7 +101,16 @@ class ModelCache(object):
             submodel: SDModelType=SDModelType.vae,
             subfolder: Path=None,
             revision: str=None,
+            legacy_info: LegacyInfo=None,
     )->ModelClass:
+        '''
+        Load and return a HuggingFace model, with RAM caching.
+        :param repo_id_or_path: either the HuggingFace repo_id or a Path to a local model
+        :param submodel: an SDModelType enum indicating the model part to return, e.g. SDModelType.vae
+        :param subfolder: name of a subfolder in which the model can be found, e.g. "vae"
+        :param revision: model revision name
+        :param legacy_info: a LegacyInfo object containing additional info needed to load a legacy ckpt
+        '''
         parent_model = self.get_model(
             repo_id_or_path=repo_id_or_path,
             subfolder=subfolder,
@@ -98,6 +124,7 @@ class ModelCache(object):
             model_type: SDModelType=SDModelType.diffusion_pipeline,
             subfolder: Path=None,
             revision: str=None,
+            legacy_info: LegacyInfo=None,
             )->ModelClass:
         '''
         Load and return a HuggingFace model, with RAM caching.
@@ -105,13 +132,14 @@ class ModelCache(object):
         :param subfolder: name of a subfolder in which the model can be found, e.g. "vae"
         :param revision: model revision
         :param model_class: class of model to return
+        :param legacy_info: a LegacyInfo object containing additional info needed to load a legacy ckpt
         '''
-        key = self._model_key(
+        key = self._model_key( # internal unique identifier for the model
             repo_id_or_path,
             model_type.value,
             revision,
             subfolder
-        ) # internal unique identifier for the model
+        ) 
         if key in self.models: # cached - move to bottom of stack
             previous_key = self._current_model_key
             with contextlib.suppress(ValueError):
@@ -119,25 +147,41 @@ class ModelCache(object):
                 self.stack.append(key)
             if previous_key != key:
                 if hasattr(self.current_model,'to'):
-                    print(f'DEBUG: loading {key} into GPU')
+                    print(f'  | loading {key} into GPU')
                     self.model_group.offload_current()
                     self.model_group.load(self.models[key])
-
         else:  # not cached -load
             self._make_cache_room()
             self.model_group.offload_current()
-            print(f'DEBUG: loading {key} from disk/net')
+            print(f'  | loading model {key} from disk/net')
             model = self._load_model_from_storage(
                 repo_id_or_path=repo_id_or_path,
                 model_class=model_type.value,
                 subfolder=subfolder,
                 revision=revision,
+                legacy_info=legacy_info,
             )
             if hasattr(model,'to'):
                 self.model_group.install(model) # register with the model group
             self.stack.append(key)          # add to LRU cache
             self.models[key]=model          # keep copy of model in dict
         return self.models[key]
+
+    @staticmethod
+    def model_hash(repo_id_or_path: Union[str,Path],
+                   revision: str=None)->str:
+        '''
+        Given the HF repo id or path to a model on disk, returns a unique
+        hash. Works for legacy checkpoint files, HF models on disk, and HF repo IDs
+        :param repo_id_or_path: repo_id string or Path to model file/directory on disk.
+        :param revision: optional revision string (if fetching a HF repo_id)
+        '''
+        if self.is_legacy_ckpt(repo_id_or_path):
+            return self._legacy_model_hash(repo_id_or_path)
+        elif Path(repo_id_or_path).is_dir():
+            return self._local_model_hash(repo_id_or_path)
+        else:
+            return self._hf_commit_hash(repo_id_or_path,revision)
 
     @staticmethod
     def _model_key(path,model_class,revision,subfolder)->str:
@@ -147,7 +191,7 @@ class ModelCache(object):
         models_in_ram = len(self.models)
         while models_in_ram >= self.max_models_cached:
             if least_recently_used_key := self.stack.pop(0):
-                print(f'DEBUG: maximum cache size reached: cache_size={models_in_ram}; unloading model {least_recently_used_key}')
+                print(f'  | maximum cache size reached: cache_size={models_in_ram}; unloading model {least_recently_used_key}')
                 self.model_group.uninstall(self.models[least_recently_used_key])
                 del self.models[least_recently_used_key]
             models_in_ram = len(self.models)
@@ -173,27 +217,134 @@ class ModelCache(object):
             subfolder: Path=None,
             revision: str=None,
             model_class: ModelClass=StableDiffusionGeneratorPipeline,
+            legacy_info: LegacyInfo=None,
             )->ModelClass:
         '''
         Load and return a HuggingFace model.
         :param repo_id_or_path: either the HuggingFace repo_id or a Path to a local model
         :param subfolder: name of a subfolder in which the model can be found, e.g. "vae"
         :param revision: model revision
-        :param model_class: class of model to return
+        :param model_class: class of model to return, defaults to StableDiffusionGeneratorPIpeline
+        :param legacy_info: a LegacyInfo object containing additional info needed to load a legacy ckpt
         '''
         # silence transformer and diffuser warnings
         with SilenceWarnings():
-            model = model_class.from_pretrained(
-                repo_id_or_path,
-                revision=revision,
-                subfolder=subfolder or '.',
-                cache_dir=global_cache_dir('hub'),
-            )
+            if self.is_legacy_ckpt(repo_id_or_path):
+                model = self._load_ckpt_from_storage(repo_id_or_path, legacy_info)
+            else:
+                model = self._load_diffusers_from_storage(
+                    repo_id_or_path,
+                    subfolder,
+                    revision,
+                    model_class,
+                )
         if self.sequential_offload and isinstance(model,StableDiffusionGeneratorPipeline):
             model.enable_offload_submodels(self.device)
         elif hasattr(model,'to'):
             model.to(self.device)
         return model
+
+    def _load_diffusers_from_storage(
+            self,
+            repo_id_or_path: Union[str,Path],
+            subfolder: Path=None,
+            revision: str=None,
+            model_class: ModelClass=StableDiffusionGeneratorPipeline,
+    )->ModelClass:
+        '''
+        Load and return a HuggingFace model using from_pretrained().
+        :param repo_id_or_path: either the HuggingFace repo_id or a Path to a local model
+        :param subfolder: name of a subfolder in which the model can be found, e.g. "vae"
+        :param revision: model revision
+        :param model_class: class of model to return, defaults to StableDiffusionGeneratorPIpeline
+        '''
+        return model_class.from_pretrained(
+            repo_id_or_path,
+            revision=revision,
+            subfolder=subfolder or '.',
+            cache_dir=global_cache_dir('hub'),
+        )
+
+    @classmethod
+    def is_legacy_ckpt(cls, repo_id_or_path: Union[str,Path])->bool:
+        '''
+        Return true if the indicated path is a legacy checkpoint
+        :param repo_id_or_path: either the HuggingFace repo_id or a Path to a local model
+        '''
+        path = Path(repo_id_or_path)
+        return path.is_file() and path.suffix in [".ckpt",".safetensors"]
+
+    def _load_ckpt_from_storage(self,
+                                ckpt_path: Union[str,Path],
+                                legacy_info:LegacyInfo)->StableDiffusionGeneratorPipeline:
+        '''
+        Load a legacy checkpoint, convert it, and return a StableDiffusionGeneratorPipeline.
+        :param ckpt_path: string or Path pointing to the weights file (.ckpt or .safetensors)
+        :param legacy_info: LegacyInfo object containing paths to legacy config file and alternate vae if required
+        '''
+        assert legacy_info is not None
+        pipeline = load_pipeline_from_original_stable_diffusion_ckpt(
+            checkpoint_path=ckpt_path,
+            original_config_file=legacy_info.config_file,
+            vae_path=legacy_info.vae_file,
+            return_generator_pipeline=True,
+            precision=self.precision,
+        )
+        return pipeline
+
+    def _legacy_model_hash(self, checkpoint_path: Union[str,Path])->str:
+        sha = hashlib.sha256()
+        path = Path(checkpoint_path)
+        assert path.is_file()
+
+        hashpath = path.parent / f"{path.name}.sha256"
+        if hashpath.exists() and path.stat().st_mtime <= hashpath.stat().st_mtime:
+            with open(hashpath) as f:
+                hash = f.read()
+            return hash
+        
+        print(f'  | computing hash of model {path.name}')
+        with open(path, "rb") as f:
+            while chunk := f.read(self.sha_chunksize):
+                sha.update(chunk)
+        hash = sha.hexdigest()
+                
+        with open(hashpath, "w") as f:
+            f.write(hash)
+        return hash
+        
+    def _local_model_hash(self, model_path: Union[str,Path])->str:
+        sha = hashlib.sha256()
+        path = Path(model_path)
+        
+        hashpath = path / "checksum.sha256"
+        if hashpath.exists() and path.stat().st_mtime <= hashpath.stat().st_mtime:
+            with open(hashpath) as f:
+                hash = f.read()
+            return hash
+        
+        print(f'  | computing hash of model {path.name}')
+        for file in list(path.rglob("*.ckpt")) \
+            + list(path.rglob("*.safetensors")) \
+            + list(path.rglob("*.pth")):
+            with open(file, "rb") as f:
+                while chunk := f.read(self.sha_chunksize):
+                    sha.update(chunk)
+        hash = sha.hexdigest()
+        with open(hashpath, "w") as f:
+            f.write(hash)
+        return hash
+    
+    def _hf_commit_hash(self, repo_id: str, revision: str='main')->str:
+        api = HfApi()
+        info = api.list_repo_refs(
+            repo_id=repo_id,
+            repo_type='model',
+        )
+        desired_revisions = [branch for branch in info.branches if branch.name==revision]
+        if not desired_revisions:
+            raise KeyError(f"Revision '{revision}' not found in {repo_id}")
+        return desired_revisions[0].target_commit
 
 class SilenceWarnings(object):
     def __init__(self):

--- a/invokeai/backend/model_management/model_manager.py
+++ b/invokeai/backend/model_management/model_manager.py
@@ -1,4 +1,4 @@
-"""enum
+"""
 Manage a cache of Stable Diffusion model files for fast switching.
 They are moved between GPU and CPU as necessary. If CPU memory falls
 below a preset minimum, the least recently used model will be
@@ -1108,11 +1108,8 @@ class ModelManager(object):
 >> invokeai/models/diffusers to invokeai/models/hub due to a change introduced by
 >> diffusers version 0.14. InvokeAI will now move all models from the "diffusers" directory
 >> into "hub" and then remove the diffusers directory. This is a quick, safe, one-time
->> operation. However if you have customized either of these directories and need to
->> make adjustments, please press ctrl-C now to abort and relaunch InvokeAI when you are ready.
->> Otherwise press <enter> to continue."""
+>> operation."""
         )
-        input("continue> ")
 
         # transformer files get moved into the hub directory
         if cls._is_huggingface_hub_directory_present():

--- a/invokeai/backend/stable_diffusion/offloading.py
+++ b/invokeai/backend/stable_diffusion/offloading.py
@@ -157,7 +157,7 @@ class LazilyLoadedModelGroup(ModelGroup):
     def offload_current(self):
         module = self._current_model_ref()
         if module is not NO_MODEL:
-            module.to(device=OFFLOAD_DEVICE)
+            module.to(OFFLOAD_DEVICE)
         self.clear_current_model()
 
     def _load(self, module: torch.nn.Module) -> torch.nn.Module:
@@ -228,7 +228,7 @@ class FullyLoadedModelGroup(ModelGroup):
     def install(self, *models: torch.nn.Module):
         for model in models:
             self._models.add(model)
-            model.to(device=self.execution_device)
+            model.to(self.execution_device)
 
     def uninstall(self, *models: torch.nn.Module):
         for model in models:
@@ -238,11 +238,11 @@ class FullyLoadedModelGroup(ModelGroup):
         self.uninstall(*self._models)
 
     def load(self, model):
-        model.to(device=self.execution_device)
+        model.to(self.execution_device)
 
     def offload_current(self):
         for model in self._models:
-            model.to(device=OFFLOAD_DEVICE)
+            model.to(OFFLOAD_DEVICE)
 
     def ready(self):
         for model in self._models:
@@ -252,7 +252,7 @@ class FullyLoadedModelGroup(ModelGroup):
         self.execution_device = device
         for model in self._models:
             if model.device != OFFLOAD_DEVICE:
-                model.to(device=device)
+                model.to(device)
 
     def device_for(self, model):
         if model not in self:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "picklescan",
   "pillow",
   "prompt-toolkit",
+  "pympler==1.0.1",
   "pypatchmatch",
   "pyreadline3",
   "python-multipart==0.0.6",

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,53 +1,84 @@
 import pytest
 import torch
 
-from invokeai.backend.model_management.model_cache import ModelCache, SDModelType
-from invokeai.backend.stable_diffusion import StableDiffusionGeneratorPipeline
+from enum import Enum
+from invokeai.backend.model_management.model_cache import ModelCache
 
-from diffusers import (
-    AutoencoderKL,
-    UNet2DConditionModel,
-    SchedulerMixin,
-)
-from transformers import (
-    CLIPTokenizer,
-    CLIPFeatureExtractor,
-    CLIPTextModel,
-)    
+class DummyModelBase(object):
+    '''Base class for dummy component of a diffusers model'''
+    def __init__(self, repo_id):
+        self.repo_id = repo_id
+        self.device = torch.device('cpu')
 
+    @classmethod
+    def from_pretrained(cls,
+                        repo_id:str,
+                        revision:str=None,
+                        subfolder:str=None,
+                        cache_dir:str=None,
+                        ):
+        return cls(repo_id)
+        
+    def to(self, device):
+        self.device = device
 
-cache = ModelCache()
+class DummyModelType1(DummyModelBase):
+    pass
+
+class DummyModelType2(DummyModelBase):
+    pass
+
+class DummyPipeline(DummyModelBase):
+    '''Dummy pipeline object is a composite of several types'''
+    def __init__(self,repo_id):
+        super().__init__(repo_id)
+        self.type1 = DummyModelType1('dummy/type1')
+        self.type2 = DummyModelType2('dummy/type2')
+
+class DMType(Enum):
+    dummy_pipeline = DummyPipeline
+    type1 = DummyModelType1
+    type2 = DummyModelType2
+
+cache = ModelCache(max_models=4)
 
 def test_pipeline_fetch():
-    model0 = cache.get_model('stabilityai/sd-vae-ft-mse',SDModelType.vae)
-    model1 = cache.get_model('stabilityai/stable-diffusion-2-1',SDModelType.diffusion_pipeline)
-    model1_2 = cache.get_model('stabilityai/stable-diffusion-2-1')
-    assert model1==model1_2
-    assert model1.device==torch.device('cuda')
-    model2 = cache.get_model('runwayml/stable-diffusion-v1-5')
-    assert model2.device==torch.device('cuda')
-    assert model1.device==torch.device('cpu')
-    model1 = cache.get_model('stabilityai/stable-diffusion-2-1')
-    assert model1.device==torch.device('cuda')
+    assert cache.cache_size()==0
+    with cache.get_model('dummy/pipeline1',DMType.dummy_pipeline) as pipeline1,\
+         cache.get_model('dummy/pipeline1',DMType.dummy_pipeline) as pipeline1a,\
+         cache.get_model('dummy/pipeline2',DMType.dummy_pipeline) as pipeline2:
+        assert pipeline1 is not None, 'get_model() should not return None'
+        assert pipeline1a is not None, 'get_model() should not return None'
+        assert pipeline2 is not None, 'get_model() should not return None'
+        assert type(pipeline1)==DMType.dummy_pipeline.value,'get_model() did not return model of expected type'
+        assert pipeline1==pipeline1a,'pipelines with the same repo_id should be the same'
+        assert pipeline1!=pipeline2,'pipelines with different repo_ids should not be the same'
+        assert cache.cache_size()==2,'cache should uniquely cache models with same identity'
+    with cache.get_model('dummy/pipeline3',DMType.dummy_pipeline) as pipeline3,\
+         cache.get_model('dummy/pipeline4',DMType.dummy_pipeline) as pipeline4:
+        assert cache.cache_size()==4,'cache did not grow as expected'
+    with cache.get_model('dummy/pipeline5',DMType.dummy_pipeline) as pipeline5:
+        assert cache.cache_size()==4,'cache did not free space as expected'
+
+def test_signatures():
+    with cache.get_model('dummy/pipeline',DMType.dummy_pipeline,revision='main') as pipeline1,\
+         cache.get_model('dummy/pipeline',DMType.dummy_pipeline,revision='fp16') as pipeline2,\
+         cache.get_model('dummy/pipeline',DMType.dummy_pipeline,revision='main',subfolder='foo') as pipeline3:
+        assert pipeline1 != pipeline2,'models are distinguished by their revision'
+        assert pipeline1 != pipeline3,'models are distinguished by their subfolder'
+
+def test_pipeline_device():
+     with cache.get_model('dummy/pipeline1',DMType.type1) as model1:
+         assert model1.device==torch.device('cuda'),'when in context, model device should be in GPU'
+     with cache.get_model('dummy/pipeline1',DMType.type1, gpu_load=False) as model1:
+         assert model1.device==torch.device('cpu'),'when gpu_load=False, model device should be CPU'
 
 def test_submodel_fetch():
-    model1_vae = cache.get_submodel('stabilityai/stable-diffusion-2-1',SDModelType.vae)
-    assert isinstance(model1_vae,AutoencoderKL)
-    model1 = cache.get_model('stabilityai/stable-diffusion-2-1',SDModelType.diffusion_pipeline)
-    assert model1_vae == model1.vae
-    model1_vae_2 = cache.get_submodel('stabilityai/stable-diffusion-2-1')
-    assert model1_vae == model1_vae_2
+    with cache.get_model(repo_id_or_path='dummy/pipeline1',model_type=DMType.dummy_pipeline) as pipeline,\
+         cache.get_model(repo_id_or_path='dummy/pipeline1',model_type=DMType.dummy_pipeline,submodel=DMType.type1) as part1,\
+         cache.get_model(repo_id_or_path='dummy/pipeline2',model_type=DMType.dummy_pipeline,submodel=DMType.type1) as part2:
+        assert type(part1)==DummyModelType1,'returned submodel is not of expected type'
+        assert part1.device==torch.device('cuda'),'returned submodel should be in the GPU when in context'
+        assert pipeline.type1==part1,'returned submodel should match the corresponding subpart of parent model'
+        assert pipeline.type1!=part2,'returned submodel should not match the subpart of a different parent'
 
-def test_transformer_fetch():
-    model4 = cache.get_model('openai/clip-vit-large-patch14',SDModelType.tokenizer)
-    assert isinstance(model4,CLIPTokenizer)
-
-    model5 = cache.get_model('openai/clip-vit-large-patch14',SDModelType.text_encoder)
-    assert isinstance(model5,CLIPTextModel)
-
-def test_subfolder_fetch():
-    model6 = cache.get_model('stabilityai/stable-diffusion-2',SDModelType.tokenizer,subfolder="tokenizer")
-    assert isinstance(model6,CLIPTokenizer)
-
-    model7 = cache.get_model('stabilityai/stable-diffusion-2',SDModelType.text_encoder,subfolder="text_encoder")
-    assert isinstance(model7,CLIPTextModel)

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from invokeai.backend.model_management.model_cache import ModelCache, SDModelType
+from invokeai.backend.stable_diffusion import StableDiffusionGeneratorPipeline
+
+from diffusers import (
+    AutoencoderKL,
+    UNet2DConditionModel,
+    SchedulerMixin,
+)
+from transformers import (
+    CLIPTokenizer,
+    CLIPFeatureExtractor,
+    CLIPTextModel,
+)    
+
+
+cache = ModelCache()
+
+def test_pipeline_fetch():
+    model0 = cache.get_model('stabilityai/sd-vae-ft-mse',SDModelType.vae)
+    model1 = cache.get_model('stabilityai/stable-diffusion-2-1',SDModelType.diffusion_pipeline)
+    model1_2 = cache.get_model('stabilityai/stable-diffusion-2-1')
+    assert model1==model1_2
+    assert model1.device==torch.device('cuda')
+    model2 = cache.get_model('runwayml/stable-diffusion-v1-5')
+    assert model2.device==torch.device('cuda')
+    assert model1.device==torch.device('cpu')
+    model1 = cache.get_model('stabilityai/stable-diffusion-2-1')
+    assert model1.device==torch.device('cuda')
+
+def test_submodel_fetch():
+    model1_vae = cache.get_submodel('stabilityai/stable-diffusion-2-1',SDModelType.vae)
+    assert isinstance(model1_vae,AutoencoderKL)
+    model1 = cache.get_model('stabilityai/stable-diffusion-2-1',SDModelType.diffusion_pipeline)
+    assert model1_vae == model1.vae
+    model1_vae_2 = cache.get_submodel('stabilityai/stable-diffusion-2-1')
+    assert model1_vae == model1_vae_2
+
+def test_transformer_fetch():
+    model4 = cache.get_model('openai/clip-vit-large-patch14',SDModelType.tokenizer)
+    assert isinstance(model4,CLIPTokenizer)
+
+    model5 = cache.get_model('openai/clip-vit-large-patch14',SDModelType.text_encoder)
+    assert isinstance(model5,CLIPTextModel)
+
+def test_subfolder_fetch():
+    model6 = cache.get_model('stabilityai/stable-diffusion-2',SDModelType.tokenizer,subfolder="tokenizer")
+    assert isinstance(model6,CLIPTokenizer)
+
+    model7 = cache.get_model('stabilityai/stable-diffusion-2',SDModelType.text_encoder,subfolder="text_encoder")
+    assert isinstance(model7,CLIPTextModel)


### PR DESCRIPTION
Manage a RAM cache of diffusion/transformer models for fast switching. They are moved between GPU VRAM and CPU RAM as necessary. If the cache grows larger than a preset maximum, then the least recently used model will be cleared and (re)loaded from disk when next needed.

## GPU management

The cache acts as a context manager that will load the model into the GPU within the context, and unload it outside the
context. Use like this:

```
cache = ModelCache(max_models=6)
with cache.get_model('runwayml/stable-diffusion-1-5') as SD1,\
     cache.get_model('stabilityai/stable-diffusion-2') as SD2:
          do_something_in_GPU(SD1,SD2)
```
Technically, get_model() returns a context manager Generator, which you can pass around to other functions:
```
sd1_context = cache.get_model('runwayml/stable-diffusion-1-5')
my_function(sd1_context)

def my_function(model_context):
   with model_context as m:
        do_something_with_torch(m)
```

## Manage any model class with `from_pretrained()`

Any type of model that has a `from_pretrained()` method can be loaded and cached with this class, allowing it to manage diffusers pipelines, VAEs, text encoders, etc. You can load a HuggingFace model using its repo_id, or a local model using its path. Legacy checkpoint .ckpt and .safetensors are converted into diffusers on the fly. Precision and the GPU type are set at cache initialization time to ensure that all models are compatible. You can also set `sequential_offload` to minimize GPU VRAM during execution of diffusers pipelines.

```
cache = ModelCache(precision=torch.float32, execution_device=torch.device('mps'), sequential_offload=True)
with cache.get_model('/usr/local/models/sd-1.5') as sd1:
   pass
```
The class of the model returned is controlled by the parameter `model_type`, which defaults to `StableDiffusionGeneratorPipeline`. For convenience, the module provides an Enum named `SDModelType` that enumerates all the model types used in a diffusers pipeline. You can subclass this or use your own Enum to add support for additional model classes.
```
with cache.get_model('openai/clip-vit-large-patch14', model_type=SDModelType.text_encoder) as clip:
   pass
```
## Load parts of models

You can selectively load a portion of a diffusers pipeline, such as its VAE or text encoder. If you know the name of the subfolder in which the part is located, you can load just that bit of the pipeline using the `subfolder` parameter:
```
with cache.get_model('stabilityai/stable-diffusion-2',
                     model_type=SDModelType.tokenizer,
                     subfolder='tokenizer') as tokenizer:
     pass
```
Alternatively, you can retrieve the entire pipeline, and return just the desired part of the model. This is useful if the parent pipeline is already loaded into RAM, or if you need multiple parts from it:
```
with cache.get_model('stabilityai/stable-diffusion-2',
                      submodel=SDModelType.vae) as vae:
   pass
```

## Support for legacy checkpoints

You can pass the path to a legacy checkpoint file (.ckpt or .safetensors) to `get_model()` and it will be converted into a diffusers model in memory. For this to work properly, you need to provide an initialized `LegacyInfo` object which provides the path to the configuration file for this checkpoint and optionally a VAE model to swap in:
```
legacy_data = LegacyInfo(config_file='./configs/v1-inference.yaml')
context = cache.get_model('/path/to/ckpt_file.ckpt',legacy_info=legacy_data)
with context as legacy_model:
    do_something(legacy_model)
```

## Misc

This class can calculate, cache and return unique hashes for diffusers repo_ids, models on disk, and legacy models. In the case of errors it propagates the error to the caller. It also provides a `scan_model()` class method which does pickle scanning on legacy checkpoints, and will raise `UnsafeModelException` and `UnscannableModelException` exceptions in the case of problems.

To write the pytest for this module, I created a dummy pipeline class that implements the minimum methods needed to be managed by the ModelCache. This might be useful for other tests. Please see `tests/test_model_cache.py`

## Relationship to the ModelManager class

I am currently modifying the ModelManager class to utilize the ModelCache and its various features. The revised ModelManager will run as a nodes service, and will be responsible for translating symbolic names in `models.yaml` into their repo_ids, versions and subfolders for passing to ModelCache.

The ModelManager work will appear in a subsequent PR.