### PR TITLE
Fix logger namespace clash in web server

### DIFF
--- a/invokeai/backend/web/invoke_ai_web_server.py
+++ b/invokeai/backend/web/invoke_ai_web_server.py
@@ -78,7 +78,6 @@ class InvokeAIWebServer:
         mimetypes.add_type("application/javascript", ".js")
         mimetypes.add_type("text/css", ".css")
         # Socket IO
-        logger = True if args.web_verbose else False
         engineio_logger = True if args.web_verbose else False
         max_http_buffer_size = 10000000
 


### PR DESCRIPTION
This PR fixes a bug that appeared in the legacy web server after the logging PR was merged.

closes #3343