### PR TITLE
add -y to the automated install instructions

### DIFF
--- a/docs/installation/010_INSTALL_AUTOMATED.md
+++ b/docs/installation/010_INSTALL_AUTOMATED.md
@@ -89,7 +89,7 @@ experimental versions later.
          sudo apt update
          sudo apt install -y software-properties-common
          sudo add-apt-repository -y ppa:deadsnakes/ppa
-         sudo apt install python3.10 python3-pip python3.10-venv
+         sudo apt install -y python3.10 python3-pip python3.10-venv
          sudo update-alternatives --install /usr/local/bin/python python /usr/bin/python3.10 3
          ```
 


### PR DESCRIPTION
hi there, love the project! i noticed a small typo when going over the install process.

when copying the automated install instructions from the docs into a terminal, the line to install the python packages failed as it was missing the `-y` flag.