### PR TITLE
Update dependencies to get deterministic image generation behavior (main branch)

### DIFF
--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -247,8 +247,8 @@ class InvokeAiInstance:
             pip[
                 "install",
                 "--require-virtualenv",
-                "torch",
-                "torchvision",
+                "torch~=2.0.0",
+                "torchvision>=0.14.1",
                 "--force-reinstall",
                 "--find-links" if find_links is not None else None,
                 find_links,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "albumentations",
   "click",
   "clip_anytorch",          # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
-  "compel~=1.1.5",
+ "compel~=1.1.5",
   "datasets",
   "diffusers[torch]~=0.16.1",
   "dnspython==2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "albumentations",
   "click",
   "clip_anytorch",          # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
-  "compel==1.0.5",
+  "compel~=1.1.5",
   "datasets",
   "diffusers[torch]~=0.16.1",
   "dnspython==2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "clip_anytorch",          # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
   "compel==1.0.5",
   "datasets",
-  "diffusers[torch]==0.15.1",
+  "diffusers[torch]~=0.16.1",
   "dnspython==2.2.1",
   "einops",
   "eventlet",
@@ -72,7 +72,7 @@ dependencies = [
   "scikit-image>=0.19",
   "send2trash",
   "test-tube>=0.7.5",
-  "torch>=1.13.1",
+  "torch~=2.0.0",
   "torchvision>=0.14.1",
   "torchmetrics",
   "transformers~=4.26",
@@ -92,7 +92,7 @@ dependencies = [
 ]
 "test" = ["pytest>6.0.0", "pytest-cov"]
 "xformers" = [
-	   "xformers~=0.0.16; sys_platform!='darwin'",
+	   "xformers~=0.0.19; sys_platform!='darwin'",
 	   "triton; sys_platform=='linux'",
 ]
 


### PR DESCRIPTION
This PR updates to `xformers ~= 0.0.19` and `torch ~= 2.0.0`, which together seem to solve the non-deterministic image generation issue that was previously seen with earlier versions of `xformers`.