### PR TITLE
Deploy documentation from v2.3 branch rather than main

### DIFF
--- a/.github/workflows/mkdocs-material.yml
+++ b/.github/workflows/mkdocs-material.yml
@@ -36,7 +36,7 @@ jobs:
             --verbose
 
       - name: deploy to gh-pages
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/v2.3' }}
         run: |
           python -m \
             mkdocs gh-deploy \


### PR DESCRIPTION
This PR instructs github to deploy documentation pages from the v2.3 branch.