### PR TITLE
Use websocket transport first for Socket.io

### DIFF
--- a/invokeai/frontend/web/src/services/events/middleware.ts
+++ b/invokeai/frontend/web/src/services/events/middleware.ts
@@ -46,6 +46,8 @@ export const socketMiddleware = () => {
       // TODO: handle providing jwt to socket.io
       socketOptions.auth = { token: OpenAPI.TOKEN };
     }
+
+    socketOptions.transports = ['websocket', 'polling'];
   }
 
   const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(


### PR DESCRIPTION
Changes transport order for the socket.io client. The `websocket` transport will be tried first, followed by the legacy `polling` transport. This helps establish persistent websocket connections.