### PR TITLE
fix(nodes): temporarily disable librarygraphs

### DIFF
--- a/invokeai/app/services/default_graphs.py
+++ b/invokeai/app/services/default_graphs.py
@@ -48,13 +48,14 @@ def create_text_to_image() -> LibraryGraph:
 
 def create_system_graphs(graph_library: ItemStorageABC[LibraryGraph]) -> list[LibraryGraph]:
     """Creates the default system graphs, or adds new versions if the old ones don't match"""
-
+    
+    # TODO: Uncomment this when we are ready to fix this up to prevent breaking changes
     graphs: list[LibraryGraph] = list()
 
     # text_to_image = graph_library.get(default_text_to_image_graph_id)
     
-    # TODO: Check if the graph is the same as the default one, and if not, update it
-    #if text_to_image is None:
+    # # TODO: Check if the graph is the same as the default one, and if not, update it
+    # #if text_to_image is None:
     text_to_image = create_text_to_image()
     graph_library.set(text_to_image)
 


### PR DESCRIPTION
- Disable for now until we resolve the issue of changing node schemas causing application to fail to start up due to invalid graphs