### PR TITLE
2.3.5 fixes to automatic updating and vae conversions

### DIFF
--- a/ldm/invoke/_version.py
+++ b/ldm/invoke/_version.py
@@ -1,2 +1,3 @@
-__version__='2.3.5.post1'
+__version__='2.3.5.post2'
+
 

--- a/ldm/invoke/config/invokeai_update.py
+++ b/ldm/invoke/config/invokeai_update.py
@@ -6,6 +6,7 @@ import os
 import platform
 import psutil
 import requests
+import pkg_resources
 from rich import box, print
 from rich.console import Console, group
 from rich.panel import Panel
@@ -72,6 +73,15 @@ def welcome(versions: dict):
     )
     console.line()
 
+def get_extras():
+    extras = ''
+    try:
+        dist = pkg_resources.get_distribution('xformers')
+        extras = '[xformers]'
+    except pkg_resources.DistributionNotFound:
+        pass
+    return extras
+
 def main():
     versions = get_versions()
     if invokeai_is_running():
@@ -94,13 +104,15 @@ def main():
     elif choice=='4':
         branch = Prompt.ask('Enter an InvokeAI branch name')
 
+    extras = get_extras()
+
     print(f':crossed_fingers: Upgrading to [yellow]{tag if tag else release}[/yellow]')
     if release:
-        cmd = f'pip install {INVOKE_AI_SRC}/{release}.zip --use-pep517 --upgrade'
+        cmd = f"pip install 'invokeai{extras} @ {INVOKE_AI_SRC}/{release}.zip' --use-pep517 --upgrade"
     elif tag:
-        cmd = f'pip install {INVOKE_AI_TAG}/{tag}.zip --use-pep517 --upgrade'
+        cmd = f"pip install 'invokeai{extras} @ {INVOKE_AI_TAG}/{tag}.zip' --use-pep517 --upgrade"
     else:
-        cmd = f'pip install {INVOKE_AI_BRANCH}/{branch}.zip --use-pep517 --upgrade'
+        cmd = f"pip install 'invokeai{extras} @ {INVOKE_AI_BRANCH}/{branch}.zip' --use-pep517 --upgrade"
     print('')
     print('')
     if os.system(cmd)==0:


### PR DESCRIPTION
# Minor fixes to the 2.3 branch:

## Updating fixed

The invokeai-update script will now recognize when the user previously installed xformers and modifies the pip install command so as to include xformers as an extra that needs to be updated. This will prevent the problems experienced during the upgrade to `2.3.5.post1` in which torch was updated but xformers wasn't.

## VAE autoconversion improved

In addition to looking for instances in which a user has entered a VAE ckpt into the "vae" field directly, the model manager now also handles the case in which the user entered a ckpt (rather than a diffusers) into the path field. These two cases now both work:

```
vae: models/ldm/stable-diffusion-1/vae-ft-mse-840000-ema-pruned.ckpt
```
and

```
vae:
      path: models/ldm/stable-diffusion-1/vae-ft-mse-840000-ema-pruned.ckpt
```
In addition, if a 32-bit checkpoint VAE is encountered and user is using half precision, the VAE is now converted to 16 bits on the fly.