### PR TITLE
[Don't Merge] Test if diffusers pre-release works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "controlnet-aux>=0.0.4",
   "timm==0.6.13",           # needed to override timm latest in controlnet_aux, see  https://github.com/isl-org/ZoeDepth/issues/26
   "datasets",
-  "diffusers[torch]~=0.16.1",
+  "diffusers[torch]==0.17.0rc0",
   "dnspython==2.2.1",
   "einops",
   "eventlet",


### PR DESCRIPTION
Hey :wave: InvokeAI team,

We will release `diffusers==0.17.0` tomorrow and already published a pre-release version. Can you test that everything works fine on your end this time? 