### PR TITLE
feat(nodes): depth-first execution

### DIFF
--- a/invokeai/app/services/graph.py
+++ b/invokeai/app/services/graph.py
@@ -1131,13 +1131,13 @@ class GraphExecutionState(BaseModel):
         """Gets the deepest node that is ready to be executed"""
         g = self.execution_graph.nx_graph()
 
-        # we need to traverse the graph in from bottom up
-        reversed_sorted_nodes = reversed(list(nx.topological_sort(g)))
+        # Depth-first search with pre-order traversal is a depth-first topological sort
+        sorted_nodes = nx.dfs_preorder_nodes(g)
         
         next_node = next(
             (
                 n
-                for n in reversed_sorted_nodes
+                for n in sorted_nodes
                 if n not in self.executed # the node must not already be executed...
                 and all((e[0] in self.executed for e in g.in_edges(n))) # ...and all its inputs must be executed
             ),

--- a/invokeai/app/services/invoker.py
+++ b/invokeai/app/services/invoker.py
@@ -22,7 +22,8 @@ class Invoker:
     def invoke(
         self, graph_execution_state: GraphExecutionState, invoke_all: bool = False
     ) -> str | None:
-        """Determines the next node to invoke and returns the id of the invoked node, or None if there are no nodes to execute"""
+        """Determines the next node to invoke and enqueues it, preparing if needed.
+        Returns the id of the queued node, or `None` if there are no nodes left to enqueue."""
 
         # Get the next invocation
         invocation = graph_execution_state.next()


### PR DESCRIPTION
There was an issue where for graphs w/ iterations, your images were output all at once, at the very end of processing. So if you canceled halfway through an execution of 10 nodes, you wouldn't get any images - even though you'd completed 5 images' worth of inference.

## Cause

Because graphs executed breadth-first (i.e. depth-by-depth), leaf nodes were necessarily processed last. For image generation graphs, your `LatentsToImage` will be leaf nodes, and be the last depth to be executed.

For example, a `TextToLatents` graph w/ 3 iterations would execute all 3 `TextToLatents` nodes fully before moving to the next depth, where the `LatentsToImage` nodes produce output images, resulting in a node execution order like this:

1. TextToLatents
2. TextToLatents
3. TextToLatents
4. LatentsToImage
5. LatentsToImage
6. LatentsToImage

## Solution

This PR makes a two changes to graph execution to execute as deeply as it can along each branch of the graph.

### Eager node preparation

We now prepare as many nodes as possible, instead of just a single node at a time.

We also need to change the conditions in which nodes are prepared. Previously, nodes were prepared only when all of their direct ancestors were executed.

The updated logic prepares nodes that:
- are *not* `Iterate` nodes whose inputs have *not* been executed
- do *not* have any unexecuted `Iterate` ancestor nodes

This results in graphs always being maximally prepared.

### Always execute the deepest prepared node

We now choose the next node to execute by traversing from the bottom of the graph instead of the top, choosing the first node whose inputs are all executed.

This means we always execute the deepest node possible.

## Result

Graphs now execute depth-first, so instead of an execution order like this:

1. TextToLatents
2. TextToLatents
3. TextToLatents
4. LatentsToImage
5. LatentsToImage
6. LatentsToImage

... we get an execution order like this:

1. TextToLatents
2. LatentsToImage
3. TextToLatents
4. LatentsToImage
5. TextToLatents
6. LatentsToImage

Immediately after inference, the image is decoded and sent to the gallery.

fixes https://github.com/invoke-ai/InvokeAI/issues/3400