### PR TITLE
refactor(minor): Image & Latent File Storage

### DIFF
--- a/invokeai/app/services/image_file_storage.py
+++ b/invokeai/app/services/image_file_storage.py
@@ -75,7 +75,7 @@ class ImageFileStorageBase(ABC):
 class DiskImageFileStorage(ImageFileStorageBase):
     """Stores images on disk"""
 
-    __output_folder: str | Path
+    __output_folder: Path
     __cache_ids: Queue  # TODO: this is an incredibly naive cache
     __cache: Dict[Path, PILImageType]
     __max_cache_size: int
@@ -89,7 +89,7 @@ class DiskImageFileStorage(ImageFileStorageBase):
         self.__thumbnails_folder = self.__output_folder / 'thumbnails'
 
         # Validate required output folders at launch
-        self.validate_storage_folders()
+        self.__validate_storage_folders()
 
     def get(self, image_name: str) -> PILImageType:
         try:
@@ -113,7 +113,7 @@ class DiskImageFileStorage(ImageFileStorageBase):
         thumbnail_size: int = 256,
     ) -> None:
         try:
-            self.validate_storage_folders()
+            self.__validate_storage_folders()
             image_path = self.get_path(image_name)
 
             if metadata is not None:
@@ -167,7 +167,7 @@ class DiskImageFileStorage(ImageFileStorageBase):
         path = path if isinstance(path, Path) else Path(path)
         return path.exists()
     
-    def validate_storage_folders(self) -> None:
+    def __validate_storage_folders(self) -> None:
         """Checks if the required output folders exist and create them if they don't"""
         folders: list[Path] = [self.__output_folder, self.__thumbnails_folder]
         for folder in folders:

--- a/invokeai/app/services/latent_storage.py
+++ b/invokeai/app/services/latent_storage.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023 Kyle Schouviller (https://github.com/kyle0654)
 
-import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from queue import Queue
@@ -70,24 +69,26 @@ class ForwardCacheLatentsStorage(LatentsStorageBase):
 class DiskLatentsStorage(LatentsStorageBase):
     """Stores latents in a folder on disk without caching"""
 
-    __output_folder: str
+    __output_folder: str | Path
 
-    def __init__(self, output_folder: str):
-        self.__output_folder = output_folder
-        Path(output_folder).mkdir(parents=True, exist_ok=True)
+    def __init__(self, output_folder: str | Path):
+        self.__output_folder = output_folder if isinstance(output_folder, Path) else Path(output_folder)
+        self.__output_folder.mkdir(parents=True, exist_ok=True)
 
     def get(self, name: str) -> torch.Tensor:
         latent_path = self.get_path(name)
         return torch.load(latent_path)
 
     def save(self, name: str, data: torch.Tensor) -> None:
+        self.__output_folder.mkdir(parents=True, exist_ok=True)
         latent_path = self.get_path(name)
         torch.save(data, latent_path)
 
     def delete(self, name: str) -> None:
         latent_path = self.get_path(name)
-        os.remove(latent_path)
+        latent_path.unlink()
+        
 
-    def get_path(self, name: str) -> str:
-        return os.path.join(self.__output_folder, name)
+    def get_path(self, name: str) -> Path:
+        return self.__output_folder / name
     


### PR DESCRIPTION
- `DiskImageStorage` and `DiskLatentsStorage` have now both been updated to exclusively work with `Path` objects and not rely on the `os` lib to handle pathing related functions.
- We now also validate the existence of the required image output folders and latent output folders to ensure that the app does not break in case the required folders get tampered with mid-session.
- Just overall general cleanup.

Tested it. Don't seem to be any thing breaking.