### PR TITLE
Quick UI Fixes

### DIFF
--- a/invokeai/frontend/web/src/app/components/ImageDnd/ImageDndContext.tsx
+++ b/invokeai/frontend/web/src/app/components/ImageDnd/ImageDndContext.tsx
@@ -9,12 +9,12 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import { PropsWithChildren, memo, useCallback, useState } from 'react';
-import OverlayDragImage from './OverlayDragImage';
-import { ImageDTO } from 'services/api';
-import { isImageDTO } from 'services/types/guards';
 import { snapCenterToCursor } from '@dnd-kit/modifiers';
 import { AnimatePresence, motion } from 'framer-motion';
+import { PropsWithChildren, memo, useCallback, useState } from 'react';
+import { ImageDTO } from 'services/api';
+import { isImageDTO } from 'services/types/guards';
+import OverlayDragImage from './OverlayDragImage';
 
 type ImageDndContextProps = PropsWithChildren;
 
@@ -40,11 +40,11 @@ const ImageDndContext = (props: ImageDndContextProps) => {
   );
 
   const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint: { delay: 150, tolerance: 5 },
+    activationConstraint: { delay: 100, tolerance: 5 },
   });
 
   const touchSensor = useSensor(TouchSensor, {
-    activationConstraint: { delay: 150, tolerance: 5 },
+    activationConstraint: { delay: 100, tolerance: 5 },
   });
   // TODO: Use KeyboardSensor - needs composition of multiple collisionDetection algos
   // Alternatively, fix `rectIntersection` collection detection to work with the drag overlay

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/AddBoardButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/AddBoardButton.tsx
@@ -1,5 +1,6 @@
-import IAIButton from 'common/components/IAIButton';
+import IAIIconButton from 'common/components/IAIIconButton';
 import { useCallback } from 'react';
+import { FaPlus } from 'react-icons/fa';
 import { useCreateBoardMutation } from 'services/apiSlice';
 
 const DEFAULT_BOARD_NAME = 'My Board';
@@ -12,15 +13,15 @@ const AddBoardButton = () => {
   }, [createBoard]);
 
   return (
-    <IAIButton
+    <IAIIconButton
+      tooltip="Add Board"
       isLoading={isLoading}
       aria-label="Add Board"
       onClick={handleCreateBoard}
-      size="sm"
-      sx={{ px: 4 }}
-    >
-      Add Board
-    </IAIButton>
+      size="xs"
+      icon={<FaPlus />}
+      sx={{ p: 2 }}
+    />
   );
 };
 

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList.tsx
@@ -1,3 +1,4 @@
+import { CloseIcon } from '@chakra-ui/icons';
 import {
   Collapse,
   Flex,
@@ -14,13 +15,12 @@ import {
   boardsSelector,
   setBoardSearchText,
 } from 'features/gallery/store/boardSlice';
-import { memo, useState } from 'react';
-import HoverableBoard from './HoverableBoard';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
+import { memo, useState } from 'react';
+import { useListAllBoardsQuery } from 'services/apiSlice';
 import AddBoardButton from './AddBoardButton';
 import AllImagesBoard from './AllImagesBoard';
-import { CloseIcon } from '@chakra-ui/icons';
-import { useListAllBoardsQuery } from 'services/apiSlice';
+import HoverableBoard from './HoverableBoard';
 
 const selector = createSelector(
   [boardsSelector],
@@ -68,7 +68,6 @@ const BoardsList = (props: Props) => {
           bg: 'base.800',
           borderRadius: 'base',
           p: 2,
-          mt: 2,
         }}
       >
         <Flex sx={{ gap: 2, alignItems: 'center' }}>

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
@@ -1,13 +1,12 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
 import { systemSelector } from 'features/system/store/systemSelectors';
-import { isEqual } from 'lodash-es';
 
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import { gallerySelector } from '../store/gallerySelectors';
 import CurrentImageButtons from './CurrentImageButtons';
 import CurrentImagePreview from './CurrentImagePreview';
-import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 
 export const currentImageDisplaySelector = createSelector(
   [systemSelector, gallerySelector],
@@ -43,6 +42,7 @@ const CurrentImageDisplay = () => {
         justifyContent: 'center',
       }}
     >
+      {hasSelectedImage && <CurrentImageButtons />}
       <Flex
         flexDirection="column"
         sx={{
@@ -51,16 +51,10 @@ const CurrentImageDisplay = () => {
           alignItems: 'center',
           justifyContent: 'center',
           gap: 4,
-          position: 'absolute',
         }}
       >
         <CurrentImagePreview />
       </Flex>
-      {hasSelectedImage && (
-        <Box sx={{ position: 'absolute', top: 0 }}>
-          <CurrentImageButtons />
-        </Box>
-      )}
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
@@ -1,12 +1,13 @@
-import { Flex } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
 import { systemSelector } from 'features/system/store/systemSelectors';
+import { isEqual } from 'lodash-es';
 
-import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import { gallerySelector } from '../store/gallerySelectors';
 import CurrentImageButtons from './CurrentImageButtons';
 import CurrentImagePreview from './CurrentImagePreview';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 
 export const currentImageDisplaySelector = createSelector(
   [systemSelector, gallerySelector],
@@ -42,7 +43,6 @@ const CurrentImageDisplay = () => {
         justifyContent: 'center',
       }}
     >
-      {hasSelectedImage && <CurrentImageButtons />}
       <Flex
         flexDirection="column"
         sx={{
@@ -51,10 +51,16 @@ const CurrentImageDisplay = () => {
           alignItems: 'center',
           justifyContent: 'center',
           gap: 4,
+          position: 'absolute',
         }}
       >
         <CurrentImagePreview />
       </Flex>
+      {hasSelectedImage && (
+        <Box sx={{ position: 'absolute', top: 0 }}>
+          <CurrentImageButtons />
+        </Box>
+      )}
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
@@ -1,13 +1,12 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
 import { systemSelector } from 'features/system/store/systemSelectors';
-import { isEqual } from 'lodash-es';
 
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import { gallerySelector } from '../store/gallerySelectors';
 import CurrentImageButtons from './CurrentImageButtons';
 import CurrentImagePreview from './CurrentImagePreview';
-import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 
 export const currentImageDisplaySelector = createSelector(
   [systemSelector, gallerySelector],
@@ -43,24 +42,8 @@ const CurrentImageDisplay = () => {
         justifyContent: 'center',
       }}
     >
-      <Flex
-        flexDirection="column"
-        sx={{
-          w: 'full',
-          h: 'full',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 4,
-          position: 'absolute',
-        }}
-      >
-        <CurrentImagePreview />
-      </Flex>
-      {hasSelectedImage && (
-        <Box sx={{ position: 'absolute', top: 0 }}>
-          <CurrentImageButtons />
-        </Box>
-      )}
+      {hasSelectedImage && <CurrentImageButtons />}
+      <CurrentImagePreview />
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
@@ -4,17 +4,17 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { uiSelector } from 'features/ui/store/uiSelectors';
 import { isEqual } from 'lodash-es';
 
+import { skipToken } from '@reduxjs/toolkit/dist/query';
+import IAIDndImage from 'common/components/IAIDndImage';
+import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
+import { systemSelector } from 'features/system/store/systemSelectors';
+import { memo, useCallback } from 'react';
+import { ImageDTO } from 'services/api';
+import { useGetImageDTOQuery } from 'services/apiSlice';
 import { gallerySelector } from '../store/gallerySelectors';
+import { imageSelected } from '../store/gallerySlice';
 import ImageMetadataViewer from './ImageMetaDataViewer/ImageMetadataViewer';
 import NextPrevImageButtons from './NextPrevImageButtons';
-import { memo, useCallback } from 'react';
-import { systemSelector } from 'features/system/store/systemSelectors';
-import { imageSelected } from '../store/gallerySlice';
-import IAIDndImage from 'common/components/IAIDndImage';
-import { ImageDTO } from 'services/api';
-import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
-import { useGetImageDTOQuery } from 'services/apiSlice';
-import { skipToken } from '@reduxjs/toolkit/dist/query';
 
 export const imagesSelector = createSelector(
   [uiSelector, gallerySelector, systemSelector],
@@ -78,7 +78,7 @@ const CurrentImagePreview = () => {
     <Flex
       sx={{
         width: 'full',
-        height: 'full',
+        height: 'calc(100vh - 10rem)',
         position: 'relative',
         alignItems: 'center',
         justifyContent: 'center',

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGalleryContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGalleryContent.tsx
@@ -13,17 +13,17 @@ import {
 } from '@chakra-ui/react';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import IAIButton from 'common/components/IAIButton';
-import IAISimpleCheckbox from 'common/components/IAISimpleCheckbox';
 import IAIIconButton from 'common/components/IAIIconButton';
 import IAIPopover from 'common/components/IAIPopover';
+import IAISimpleCheckbox from 'common/components/IAISimpleCheckbox';
 import IAISlider from 'common/components/IAISlider';
 import { gallerySelector } from 'features/gallery/store/gallerySelectors';
 import {
   setGalleryImageMinimumWidth,
   setGalleryImageObjectFit,
+  setGalleryView,
   setShouldAutoSwitchToNewImages,
   setShouldUseSingleGalleryColumn,
-  setGalleryView,
 } from 'features/gallery/store/gallerySlice';
 import { togglePinGalleryPanel } from 'features/ui/store/uiSlice';
 import { useOverlayScrollbars } from 'overlayscrollbars-react';
@@ -44,23 +44,23 @@ import { FaImage, FaServer, FaWrench } from 'react-icons/fa';
 import { MdPhotoLibrary } from 'react-icons/md';
 import HoverableImage from './HoverableImage';
 
-import { requestCanvasRescale } from 'features/canvas/store/thunks/requestCanvasScale';
+import { ChevronUpIcon } from '@chakra-ui/icons';
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from 'app/store/store';
-import { Virtuoso, VirtuosoGrid } from 'react-virtuoso';
 import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
+import { requestCanvasRescale } from 'features/canvas/store/thunks/requestCanvasScale';
 import { uiSelector } from 'features/ui/store/uiSelectors';
+import { Virtuoso, VirtuosoGrid } from 'react-virtuoso';
+import { useListAllBoardsQuery } from 'services/apiSlice';
+import { receivedPageOfImages } from 'services/thunks/image';
+import { boardsSelector } from '../store/boardSlice';
 import {
   ASSETS_CATEGORIES,
   IMAGE_CATEGORIES,
   imageCategoriesChanged,
   selectImagesAll,
 } from '../store/imagesSlice';
-import { receivedPageOfImages } from 'services/thunks/image';
 import BoardsList from './Boards/BoardsList';
-import { boardsSelector } from '../store/boardSlice';
-import { ChevronUpIcon } from '@chakra-ui/icons';
-import { useListAllBoardsQuery } from 'services/apiSlice';
 
 const itemSelector = createSelector(
   [(state: RootState) => state],
@@ -228,7 +228,14 @@ const ImageGalleryContent = () => {
         borderRadius: 'base',
       }}
     >
-      <Box sx={{ w: 'full' }}>
+      <Box
+        sx={{
+          w: 'full',
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: 2,
+        }}
+      >
         <Flex
           ref={resizeObserverRef}
           sx={{
@@ -341,7 +348,7 @@ const ImageGalleryContent = () => {
             icon={shouldPinGallery ? <BsPinAngleFill /> : <BsPinAngle />}
           />
         </Flex>
-        <Box>
+        <Box mb={isBoardListOpen ? 2 : 0}>
           <BoardsList isOpen={isBoardListOpen} />
         </Box>
       </Box>

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGalleryContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGalleryContent.tsx
@@ -262,6 +262,70 @@ const ImageGalleryContent = () => {
               icon={<FaServer />}
             />
           </ButtonGroup>
+          <Flex gap={2}>
+            <IAIPopover
+              triggerComponent={
+                <IAIIconButton
+                  tooltip={t('gallery.gallerySettings')}
+                  aria-label={t('gallery.gallerySettings')}
+                  size="sm"
+                  icon={<FaWrench />}
+                />
+              }
+            >
+              <Flex direction="column" gap={2}>
+                <IAISlider
+                  value={galleryImageMinimumWidth}
+                  onChange={handleChangeGalleryImageMinimumWidth}
+                  min={32}
+                  max={256}
+                  hideTooltip={true}
+                  label={t('gallery.galleryImageSize')}
+                  withReset
+                  handleReset={() => dispatch(setGalleryImageMinimumWidth(64))}
+                />
+                <IAISimpleCheckbox
+                  label={t('gallery.maintainAspectRatio')}
+                  isChecked={galleryImageObjectFit === 'contain'}
+                  onChange={() =>
+                    dispatch(
+                      setGalleryImageObjectFit(
+                        galleryImageObjectFit === 'contain'
+                          ? 'cover'
+                          : 'contain'
+                      )
+                    )
+                  }
+                />
+                <IAISimpleCheckbox
+                  label={t('gallery.autoSwitchNewImages')}
+                  isChecked={shouldAutoSwitchToNewImages}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    dispatch(setShouldAutoSwitchToNewImages(e.target.checked))
+                  }
+                />
+                <IAISimpleCheckbox
+                  label={t('gallery.singleColumnLayout')}
+                  isChecked={shouldUseSingleGalleryColumn}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    dispatch(setShouldUseSingleGalleryColumn(e.target.checked))
+                  }
+                />
+              </Flex>
+            </IAIPopover>
+            <IAIIconButton
+              size="sm"
+              aria-label={t('gallery.pinGallery')}
+              tooltip={`${t('gallery.pinGallery')} (Shift+G)`}
+              onClick={handleSetShouldPinGallery}
+              icon={shouldPinGallery ? <BsPinAngleFill /> : <BsPinAngle />}
+            />
+          </Flex>
+        </Flex>
+        <Box
+          mb={isBoardListOpen ? 2 : 0}
+          sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+        >
           <Flex
             as={Button}
             onClick={onToggle}
@@ -279,7 +343,11 @@ const ImageGalleryContent = () => {
           >
             <Text
               noOfLines={1}
-              sx={{ w: 'full', color: 'base.200', fontWeight: 600 }}
+              sx={{
+                w: 'full',
+                color: 'base.200',
+                fontWeight: 600,
+              }}
             >
               {selectedBoard ? selectedBoard.board_name : 'All Images'}
             </Text>
@@ -291,64 +359,6 @@ const ImageGalleryContent = () => {
               }}
             />
           </Flex>
-          <IAIPopover
-            triggerComponent={
-              <IAIIconButton
-                tooltip={t('gallery.gallerySettings')}
-                aria-label={t('gallery.gallerySettings')}
-                size="sm"
-                icon={<FaWrench />}
-              />
-            }
-          >
-            <Flex direction="column" gap={2}>
-              <IAISlider
-                value={galleryImageMinimumWidth}
-                onChange={handleChangeGalleryImageMinimumWidth}
-                min={32}
-                max={256}
-                hideTooltip={true}
-                label={t('gallery.galleryImageSize')}
-                withReset
-                handleReset={() => dispatch(setGalleryImageMinimumWidth(64))}
-              />
-              <IAISimpleCheckbox
-                label={t('gallery.maintainAspectRatio')}
-                isChecked={galleryImageObjectFit === 'contain'}
-                onChange={() =>
-                  dispatch(
-                    setGalleryImageObjectFit(
-                      galleryImageObjectFit === 'contain' ? 'cover' : 'contain'
-                    )
-                  )
-                }
-              />
-              <IAISimpleCheckbox
-                label={t('gallery.autoSwitchNewImages')}
-                isChecked={shouldAutoSwitchToNewImages}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  dispatch(setShouldAutoSwitchToNewImages(e.target.checked))
-                }
-              />
-              <IAISimpleCheckbox
-                label={t('gallery.singleColumnLayout')}
-                isChecked={shouldUseSingleGalleryColumn}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  dispatch(setShouldUseSingleGalleryColumn(e.target.checked))
-                }
-              />
-            </Flex>
-          </IAIPopover>
-
-          <IAIIconButton
-            size="sm"
-            aria-label={t('gallery.pinGallery')}
-            tooltip={`${t('gallery.pinGallery')} (Shift+G)`}
-            onClick={handleSetShouldPinGallery}
-            icon={shouldPinGallery ? <BsPinAngleFill /> : <BsPinAngle />}
-          />
-        </Flex>
-        <Box mb={isBoardListOpen ? 2 : 0}>
           <BoardsList isOpen={isBoardListOpen} />
         </Box>
       </Box>

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/ImageToImage/InitialImageDisplay.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/ImageToImage/InitialImageDisplay.tsx
@@ -1,7 +1,9 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
 import InitialImagePreview from './InitialImagePreview';
 
 const InitialImageDisplay = () => {
+  const { t } = useTranslation();
   return (
     <Flex
       sx={{
@@ -11,24 +13,25 @@ const InitialImageDisplay = () => {
         width: '100%',
         rowGap: 4,
         borderRadius: 'base',
-        alignItems: 'center',
-        justifyContent: 'center',
         bg: 'base.850',
         p: 4,
       }}
     >
-      <Flex
-        flexDirection="column"
+      <Text
         sx={{
-          w: 'full',
-          h: 'full',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 4,
+          px: 4,
+          py: 2,
+          color: 'base.300',
+          backgroundColor: 'base.750',
+          borderRadius: 4,
+          fontSize: 14,
+          fontWeight: 600,
+          textAlign: 'center',
         }}
       >
-        <InitialImagePreview />
-      </Flex>
+        {t('parameters.initialImage')}
+      </Text>
+      <InitialImagePreview />
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/ImageToImage/InitialImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/ImageToImage/InitialImagePreview.tsx
@@ -1,18 +1,18 @@
 import { Flex } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
+import { skipToken } from '@reduxjs/toolkit/dist/query';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
+import IAIDndImage from 'common/components/IAIDndImage';
+import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
+import { generationSelector } from 'features/parameters/store/generationSelectors';
 import {
   clearInitialImage,
   initialImageChanged,
 } from 'features/parameters/store/generationSlice';
 import { useCallback } from 'react';
-import { generationSelector } from 'features/parameters/store/generationSelectors';
-import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
-import IAIDndImage from 'common/components/IAIDndImage';
 import { ImageDTO } from 'services/api';
-import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
 import { useGetImageDTOQuery } from 'services/apiSlice';
-import { skipToken } from '@reduxjs/toolkit/dist/query';
 
 const selector = createSelector(
   [generationSelector],
@@ -55,10 +55,8 @@ const InitialImagePreview = () => {
       sx={{
         width: 'full',
         height: 'full',
-        position: 'absolute',
         alignItems: 'center',
         justifyContent: 'center',
-        p: 4,
       }}
     >
       <IAIDndImage

--- a/invokeai/frontend/web/src/services/apiSlice.ts
+++ b/invokeai/frontend/web/src/services/apiSlice.ts
@@ -42,7 +42,7 @@ const getModelId = ({ base_model, type, name }: ModelConfig) =>
   `${base_model}/${type}/${name}`;
 
 export const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:5173/api/v1/' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:9090/api/v1/' }),
   reducerPath: 'api',
   tagTypes,
   endpoints: (build) => ({

--- a/invokeai/frontend/web/src/services/apiSlice.ts
+++ b/invokeai/frontend/web/src/services/apiSlice.ts
@@ -42,7 +42,7 @@ const getModelId = ({ base_model, type, name }: ModelConfig) =>
   `${base_model}/${type}/${name}`;
 
 export const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:9090/api/v1/' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:5173/api/v1/' }),
   reducerPath: 'api',
   tagTypes,
   endpoints: (build) => ({


### PR DESCRIPTION
- Moved Board List title down to its own line. For a bunch of reasons --- The name was getting squished at smaller sizes. The title being right above the images feels more cohesive. The title being with the buttons was overflowing the buttons panel which was in turn offsetting the content in the unpinned drawer. Basically solves all 3 issues.
- Replaced the 'Add Board' button with a `+` button. Feels like this is more apt in this scenario. It fits better in smaller layouts and right now with the 'Add Board' text it feels like the search input next to it is the board text that we want to create. Which it ain't. This should solve both these problems together.
- Lowered DND Delay to 100. Seems to be working fine in most instances. Any lower and we start to have problems.
- Fixed the CurrentImage buttons overlaying interactive area.
- Readded the title text of initial image so the slot is descriptive to people who are unfamiliar + this also sync it up design wise with the adjacent Current Image Display panel.

KNOWN BUGS:

- DND component not recognizing state when the image is cleared. (unrelated to this PR)
- Need to figure out an alternate display to the Boards title text when the width of the gallery panel is small.