### PR TITLE
ui: fix initial image buttons, uploader functionality

### DIFF
--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -85,6 +85,7 @@
     "overlayscrollbars": "^2.1.1",
     "overlayscrollbars-react": "^0.5.0",
     "patch-package": "^7.0.0",
+    "query-string": "^8.1.0",
     "re-resizable": "^6.9.9",
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",

--- a/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
@@ -12,15 +12,14 @@ import IAIIconButton from 'common/components/IAIIconButton';
 import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
 import ImageMetadataOverlay from 'common/components/ImageMetadataOverlay';
 import { AnimatePresence } from 'framer-motion';
-import { ReactElement, SyntheticEvent, useCallback } from 'react';
+import { ReactElement, SyntheticEvent } from 'react';
 import { memo, useRef } from 'react';
-import { FaImage, FaTimes, FaUndo, FaUpload } from 'react-icons/fa';
+import { FaImage, FaUndo, FaUpload } from 'react-icons/fa';
 import { ImageDTO } from 'services/api/types';
 import { v4 as uuidv4 } from 'uuid';
 import IAIDropOverlay from './IAIDropOverlay';
-import { PostUploadAction, imageUploaded } from 'services/api/thunks/image';
-import { useDropzone } from 'react-dropzone';
-import { useAppDispatch } from 'app/store/storeHooks';
+import { PostUploadAction } from 'services/api/thunks/image';
+import { useImageUploadButton } from 'common/hooks/useImageUploadButton';
 
 type IAIDndImageProps = {
   image: ImageDTO | null | undefined;
@@ -39,6 +38,7 @@ type IAIDndImageProps = {
   minSize?: number;
   postUploadAction?: PostUploadAction;
   imageSx?: ChakraProps['sx'];
+  fitContainer?: boolean;
 };
 
 const IAIDndImage = (props: IAIDndImageProps) => {
@@ -58,8 +58,9 @@ const IAIDndImage = (props: IAIDndImageProps) => {
     minSize = 24,
     postUploadAction,
     imageSx,
+    fitContainer = false,
   } = props;
-  const dispatch = useAppDispatch();
+
   const dndId = useRef(uuidv4());
 
   const {
@@ -87,31 +88,9 @@ const IAIDndImage = (props: IAIDndImageProps) => {
     disabled: isDragDisabled || !image,
   });
 
-  const handleOnDropAccepted = useCallback(
-    (files: Array<File>) => {
-      const file = files[0];
-      if (!file) {
-        return;
-      }
-
-      dispatch(
-        imageUploaded({
-          file,
-          image_category: 'user',
-          is_intermediate: false,
-          postUploadAction,
-        })
-      );
-    },
-    [dispatch, postUploadAction]
-  );
-
-  const { getRootProps, getInputProps } = useDropzone({
-    accept: { 'image/png': ['.png'], 'image/jpeg': ['.jpg', '.jpeg', '.png'] },
-    onDropAccepted: handleOnDropAccepted,
-    noDrag: true,
-    multiple: false,
-    disabled: isUploadDisabled,
+  const { getUploadButtonProps, getUploadInputProps } = useImageUploadButton({
+    postUploadAction,
+    isDisabled: isUploadDisabled,
   });
 
   const setNodeRef = useCombinedRefs(setDroppableRef, setDraggableRef);
@@ -149,13 +128,13 @@ const IAIDndImage = (props: IAIDndImageProps) => {
           sx={{
             w: 'full',
             h: 'full',
+            position: fitContainer ? 'absolute' : 'relative',
             alignItems: 'center',
             justifyContent: 'center',
           }}
         >
           <Image
             src={image.image_url}
-            fallbackStrategy="beforeLoadOrError"
             fallback={fallback}
             onError={onError}
             objectFit="contain"
@@ -205,9 +184,9 @@ const IAIDndImage = (props: IAIDndImageProps) => {
               color: 'base.500',
               ...uploadButtonStyles,
             }}
-            {...getRootProps()}
+            {...getUploadButtonProps()}
           >
-            <input {...getInputProps()} />
+            <input {...getUploadInputProps()} />
             <Icon
               as={isUploadDisabled ? FaImage : FaUpload}
               sx={{

--- a/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
+++ b/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
@@ -1,0 +1,64 @@
+import { useAppDispatch } from 'app/store/storeHooks';
+import { useCallback } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { PostUploadAction, imageUploaded } from 'services/api/thunks/image';
+
+type UseImageUploadButtonArgs = {
+  postUploadAction?: PostUploadAction;
+  isDisabled?: boolean;
+};
+
+/**
+ * Provides image uploader functionality to any component.
+ *
+ * @example
+ * const { getUploadButtonProps, getUploadInputProps } = useImageUploadButton({
+ *   postUploadAction: {
+ *     type: 'SET_CONTROLNET_IMAGE',
+ *     controlNetId: '12345',
+ *   },
+ *   isDisabled: getIsUploadDisabled(),
+ * });
+ *
+ * // in the render function
+ * <Button {...getUploadButtonProps()} /> // will open the file dialog on click
+ * <input {...getUploadInputProps()} /> // hidden, handles native upload functionality
+ */
+export const useImageUploadButton = ({
+  postUploadAction,
+  isDisabled,
+}: UseImageUploadButtonArgs) => {
+  const dispatch = useAppDispatch();
+  const onDropAccepted = useCallback(
+    (files: File[]) => {
+      const file = files[0];
+      if (!file) {
+        return;
+      }
+
+      dispatch(
+        imageUploaded({
+          file,
+          image_category: 'user',
+          is_intermediate: false,
+          postUploadAction,
+        })
+      );
+    },
+    [dispatch, postUploadAction]
+  );
+
+  const {
+    getRootProps: getUploadButtonProps,
+    getInputProps: getUploadInputProps,
+    open: openUploader,
+  } = useDropzone({
+    accept: { 'image/png': ['.png'], 'image/jpeg': ['.jpg', '.jpeg', '.png'] },
+    onDropAccepted,
+    disabled: isDisabled,
+    noDrag: true,
+    multiple: false,
+  });
+
+  return { getUploadButtonProps, getUploadInputProps, openUploader };
+};

--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNet.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNet.tsx
@@ -172,7 +172,10 @@ const ControlNet = (props: ControlNetProps) => {
                   aspectRatio: '1/1',
                 }}
               >
-                <ControlNetImagePreview controlNet={props.controlNet} />
+                <ControlNetImagePreview
+                  controlNet={props.controlNet}
+                  height={24}
+                />
               </Flex>
             )}
           </Flex>
@@ -181,7 +184,7 @@ const ControlNet = (props: ControlNetProps) => {
               <Box mt={2}>
                 <ControlNetImagePreview
                   controlNet={props.controlNet}
-                  imageSx={expandedControlImageSx}
+                  height={96}
                 />
               </Box>
               <ParamControlNetProcessorSelect

--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
@@ -6,7 +6,7 @@ import {
   controlNetSelector,
 } from '../store/controlNetSlice';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import { Box, ChakraProps, Flex } from '@chakra-ui/react';
+import { Box, Flex, SystemStyleObject } from '@chakra-ui/react';
 import IAIDndImage from 'common/components/IAIDndImage';
 import { createSelector } from '@reduxjs/toolkit';
 import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
@@ -27,11 +27,11 @@ const selector = createSelector(
 
 type Props = {
   controlNet: ControlNetConfig;
-  imageSx?: ChakraProps['sx'];
+  height: SystemStyleObject['h'];
 };
 
 const ControlNetImagePreview = (props: Props) => {
-  const { imageSx } = props;
+  const { height } = props;
   const {
     controlNetId,
     controlImage: controlImageName,
@@ -84,10 +84,6 @@ const ControlNetImagePreview = (props: Props) => {
     setIsMouseOverImage(false);
   }, []);
 
-  const shouldShowProcessedImageBackdrop =
-    Number(controlImage?.width) > Number(processedControlImage?.width) ||
-    Number(controlImage?.height) > Number(processedControlImage?.height);
-
   const shouldShowProcessedImage =
     controlImage &&
     processedControlImage &&
@@ -96,54 +92,51 @@ const ControlNetImagePreview = (props: Props) => {
     processorType !== 'none';
 
   return (
-    <Box
+    <Flex
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      sx={{ position: 'relative', w: 'full', h: 'full' }}
+      sx={{
+        position: 'relative',
+        w: 'full',
+        h: height,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
     >
       <IAIDndImage
         image={controlImage}
         onDrop={handleDrop}
-        isDropDisabled={shouldShowProcessedImage}
+        isDropDisabled={!shouldShowProcessedImage}
         isUploadDisabled={Boolean(controlImage)}
         postUploadAction={{ type: 'SET_CONTROLNET_IMAGE', controlNetId }}
         imageSx={{
-          pointerEvents: shouldShowProcessedImage ? 'none' : 'auto',
-          ...imageSx,
+          w: 'full',
+          h: 'full',
         }}
       />
-      {shouldShowProcessedImage && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 0,
-            insetInlineStart: 0,
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 0,
+          insetInlineStart: 0,
+          w: 'full',
+          h: 'full',
+          opacity: shouldShowProcessedImage ? 1 : 0,
+          transitionProperty: 'common',
+          transitionDuration: 'normal',
+        }}
+      >
+        <IAIDndImage
+          image={processedControlImage}
+          onDrop={handleDrop}
+          payloadImage={controlImage}
+          isUploadDisabled={true}
+          imageSx={{
             w: 'full',
             h: 'full',
           }}
-        >
-          {shouldShowProcessedImageBackdrop && (
-            <Box
-              sx={{
-                position: 'absolute',
-                top: 0,
-                insetInlineStart: 0,
-                w: 'full',
-                h: 'full',
-                bg: 'base.900',
-                opacity: 0.7,
-              }}
-            />
-          )}
-          <IAIDndImage
-            image={processedControlImage}
-            onDrop={handleDrop}
-            payloadImage={controlImage}
-            isUploadDisabled={true}
-            imageSx={imageSx}
-          />
-        </Box>
-      )}
+        />
+      </Box>
       {pendingControlImages.includes(controlNetId) && (
         <Box
           sx={{
@@ -173,7 +166,7 @@ const ControlNetImagePreview = (props: Props) => {
           />
         </Flex>
       )}
-    </Box>
+    </Flex>
   );
 };
 

--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
@@ -107,7 +107,6 @@ const ControlNetImagePreview = (props: Props) => {
         image={controlImage}
         onDrop={handleDrop}
         isDropDisabled={shouldShowProcessedImage}
-        isUploadDisabled={shouldShowProcessedImage}
         postUploadAction={{ type: 'SET_CONTROLNET_IMAGE', controlNetId }}
         imageSx={{
           w: 'full',
@@ -124,6 +123,7 @@ const ControlNetImagePreview = (props: Props) => {
           opacity: shouldShowProcessedImage ? 1 : 0,
           transitionProperty: 'common',
           transitionDuration: 'normal',
+          pointerEvents: 'none',
         }}
       >
         <IAIDndImage

--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
@@ -106,8 +106,8 @@ const ControlNetImagePreview = (props: Props) => {
       <IAIDndImage
         image={controlImage}
         onDrop={handleDrop}
-        isDropDisabled={!shouldShowProcessedImage}
-        isUploadDisabled={Boolean(controlImage)}
+        isDropDisabled={shouldShowProcessedImage}
+        isUploadDisabled={shouldShowProcessedImage}
         postUploadAction={{ type: 'SET_CONTROLNET_IMAGE', controlNetId }}
         imageSx={{
           w: 'full',

--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
@@ -10,7 +10,6 @@ import { Box, ChakraProps, Flex } from '@chakra-ui/react';
 import IAIDndImage from 'common/components/IAIDndImage';
 import { createSelector } from '@reduxjs/toolkit';
 import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
-import { AnimatePresence, motion } from 'framer-motion';
 import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
 import IAIIconButton from 'common/components/IAIIconButton';
 import { FaUndo } from 'react-icons/fa';
@@ -105,64 +104,46 @@ const ControlNetImagePreview = (props: Props) => {
       <IAIDndImage
         image={controlImage}
         onDrop={handleDrop}
-        isDropDisabled={Boolean(
-          processedControlImage && processorType !== 'none'
-        )}
+        isDropDisabled={shouldShowProcessedImage}
         isUploadDisabled={Boolean(controlImage)}
         postUploadAction={{ type: 'SET_CONTROLNET_IMAGE', controlNetId }}
-        imageSx={imageSx}
+        imageSx={{
+          pointerEvents: shouldShowProcessedImage ? 'none' : 'auto',
+          ...imageSx,
+        }}
       />
-      <AnimatePresence>
-        {shouldShowProcessedImage && (
-          <motion.div
-            style={{ width: '100%' }}
-            initial={{
-              opacity: 0,
-            }}
-            animate={{
-              opacity: 1,
-              transition: { duration: 0.1 },
-            }}
-            exit={{
-              opacity: 0,
-              transition: { duration: 0.1 },
-            }}
-          >
-            <>
-              {shouldShowProcessedImageBackdrop && (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 0,
-                    insetInlineStart: 0,
-                    w: 'full',
-                    h: 'full',
-                    bg: 'base.900',
-                    opacity: 0.7,
-                  }}
-                />
-              )}
-              <Box
-                sx={{
-                  position: 'absolute',
-                  top: 0,
-                  insetInlineStart: 0,
-                  w: 'full',
-                  h: 'full',
-                }}
-              >
-                <IAIDndImage
-                  image={processedControlImage}
-                  onDrop={handleDrop}
-                  payloadImage={controlImage}
-                  isUploadDisabled={true}
-                  imageSx={imageSx}
-                />
-              </Box>
-            </>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {shouldShowProcessedImage && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            insetInlineStart: 0,
+            w: 'full',
+            h: 'full',
+          }}
+        >
+          {shouldShowProcessedImageBackdrop && (
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                insetInlineStart: 0,
+                w: 'full',
+                h: 'full',
+                bg: 'base.900',
+                opacity: 0.7,
+              }}
+            />
+          )}
+          <IAIDndImage
+            image={processedControlImage}
+            onDrop={handleDrop}
+            payloadImage={controlImage}
+            isUploadDisabled={true}
+            imageSx={imageSx}
+          />
+        </Box>
+      )}
       {pendingControlImages.includes(controlNetId) && (
         <Box
           sx={{

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImageDisplay.tsx
@@ -1,8 +1,7 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
 import { systemSelector } from 'features/system/store/systemSelectors';
-import { isEqual } from 'lodash-es';
 
 import { gallerySelector } from '../store/gallerySelectors';
 import CurrentImageButtons from './CurrentImageButtons';
@@ -22,13 +21,8 @@ export const currentImageDisplaySelector = createSelector(
   defaultSelectorOptions
 );
 
-/**
- * Displays the current image if there is one, plus associated actions.
- */
 const CurrentImageDisplay = () => {
-  const { hasSelectedImage, hasProgressImage } = useAppSelector(
-    currentImageDisplaySelector
-  );
+  const { hasSelectedImage } = useAppSelector(currentImageDisplaySelector);
 
   return (
     <Flex
@@ -43,24 +37,8 @@ const CurrentImageDisplay = () => {
         justifyContent: 'center',
       }}
     >
-      <Flex
-        flexDirection="column"
-        sx={{
-          w: 'full',
-          h: 'full',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 4,
-          position: 'absolute',
-        }}
-      >
-        <CurrentImagePreview />
-      </Flex>
-      {hasSelectedImage && (
-        <Box sx={{ position: 'absolute', top: 0 }}>
-          <CurrentImageButtons />
-        </Box>
-      )}
+      {hasSelectedImage && <CurrentImageButtons />}
+      <CurrentImagePreview />
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
@@ -51,10 +51,6 @@ const CurrentImagePreview = () => {
     shouldAntialiasProgressImage,
   } = useAppSelector(imagesSelector);
 
-  // const image = useAppSelector((state: RootState) =>
-  //   selectImagesById(state, selectedImage ?? '')
-  // );
-
   const {
     currentData: image,
     isLoading,
@@ -79,7 +75,6 @@ const CurrentImagePreview = () => {
       sx={{
         width: 'full',
         height: 'full',
-        position: 'relative',
         alignItems: 'center',
         justifyContent: 'center',
       }}
@@ -101,21 +96,13 @@ const CurrentImagePreview = () => {
           }}
         />
       ) : (
-        <Flex
-          sx={{
-            width: 'full',
-            height: 'full',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <IAIDndImage
-            image={image}
-            onDrop={handleDrop}
-            fallback={<IAIImageLoadingFallback sx={{ bg: 'none' }} />}
-            isUploadDisabled={true}
-          />
-        </Flex>
+        <IAIDndImage
+          image={image}
+          onDrop={handleDrop}
+          fallback={<IAIImageLoadingFallback sx={{ bg: 'none' }} />}
+          isUploadDisabled={true}
+          fitContainer
+        />
       )}
       {shouldShowImageDetails && image && (
         <Box

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
@@ -77,6 +77,7 @@ const CurrentImagePreview = () => {
         height: 'full',
         alignItems: 'center',
         justifyContent: 'center',
+        position: 'relative',
       }}
     >
       {progressImage && shouldShowProgressInViewer ? (

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/ImageToImage/InitialImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/ImageToImage/InitialImagePreview.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, Spacer, Text } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import {
@@ -13,6 +13,10 @@ import { ImageDTO } from 'services/api/types';
 import { IAIImageLoadingFallback } from 'common/components/IAIImageFallback';
 import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import { skipToken } from '@reduxjs/toolkit/dist/query';
+import IAIIconButton from 'common/components/IAIIconButton';
+import { FaUndo, FaUpload } from 'react-icons/fa';
+import useImageUploader from 'common/hooks/useImageUploader';
+import { useImageUploadButton } from 'common/hooks/useImageUploadButton';
 
 const selector = createSelector(
   [generationSelector],
@@ -28,6 +32,7 @@ const selector = createSelector(
 const InitialImagePreview = () => {
   const { initialImage } = useAppSelector(selector);
   const dispatch = useAppDispatch();
+  const { openUploader } = useImageUploader();
 
   const {
     currentData: image,
@@ -35,6 +40,10 @@ const InitialImagePreview = () => {
     isError,
     isSuccess,
   } = useGetImageDTOQuery(initialImage?.imageName ?? skipToken);
+
+  const { getUploadButtonProps, getUploadInputProps } = useImageUploadButton({
+    postUploadAction: { type: 'SET_INITIAL_IMAGE' },
+  });
 
   const handleDrop = useCallback(
     (droppedImage: ImageDTO) => {
@@ -50,25 +59,66 @@ const InitialImagePreview = () => {
     dispatch(clearInitialImage());
   }, [dispatch]);
 
+  const handleUpload = useCallback(() => {
+    openUploader();
+  }, [openUploader]);
+
   return (
     <Flex
       sx={{
+        flexDir: 'column',
         width: 'full',
         height: 'full',
         position: 'absolute',
         alignItems: 'center',
         justifyContent: 'center',
         p: 4,
+        gap: 4,
       }}
     >
+      <Flex
+        sx={{
+          w: 'full',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 2,
+        }}
+      >
+        <Text
+          sx={{
+            color: 'base.200',
+            fontWeight: 600,
+            fontSize: 'sm',
+            userSelect: 'none',
+          }}
+        >
+          Initial Image
+        </Text>
+        <Spacer />
+        <IAIIconButton
+          tooltip="Upload Initial Image"
+          aria-label="Upload Initial Image"
+          icon={<FaUpload />}
+          onClick={handleUpload}
+          {...getUploadButtonProps()}
+        />
+        <IAIIconButton
+          tooltip="Reset Initial Image"
+          aria-label="Reset Initial Image"
+          icon={<FaUndo />}
+          onClick={handleReset}
+          isDisabled={!initialImage}
+        />
+      </Flex>
       <IAIDndImage
         image={image}
         onDrop={handleDrop}
-        onReset={handleReset}
         fallback={<IAIImageLoadingFallback sx={{ bg: 'none' }} />}
-        postUploadAction={{ type: 'SET_INITIAL_IMAGE' }}
-        withResetIcon
+        isUploadDisabled={true}
+        fitContainer
       />
+      <input {...getUploadInputProps()} />
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/services/api/thunks/image.ts
+++ b/invokeai/frontend/web/src/services/api/thunks/image.ts
@@ -1,3 +1,4 @@
+import queryString from 'query-string';
 import { createAppAsyncThunk } from 'app/store/storeUtils';
 import { selectImagesAll } from 'features/gallery/store/imagesSlice';
 import { size } from 'lodash-es';
@@ -314,6 +315,7 @@ export const receivedPageOfImages = createAppAsyncThunk<
     params: {
       query,
     },
+    querySerializer: (q) => queryString.stringify(q, { arrayFormat: 'none' }),
   });
 
   if (error) {

--- a/invokeai/frontend/web/yarn.lock
+++ b/invokeai/frontend/web/yarn.lock
@@ -3147,6 +3147,11 @@ debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3
   dependencies:
     ms "2.1.2"
 
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
+
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
@@ -3886,6 +3891,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -5690,6 +5700,15 @@ pupa@^2.1.1:
   dependencies:
     escape-goat "^2.0.0"
 
+query-string@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-8.1.0.tgz#e7f95367737219544cd360a11a4f4ca03836e115"
+  integrity sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==
+  dependencies:
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -6382,6 +6401,11 @@ spawn-command@0.0.2-1:
   version "0.0.2-1"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
   integrity sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==
+
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
this PR is based on #3572 

[fix(ui): fix init image display buttons](https://github.com/invoke-ai/InvokeAI/commit/7025777aa29666dea730fa8932848b6876c11ca8)

- Reset and Upload buttons along top of initial image
- Also had to mess around with the control net & DnD image stuff after changing the styles
- Abstract image upload logic into hook - does not handle native HTML drag and drop upload - only the button click upload

[fix(ui): fix image fetching query string](https://github.com/invoke-ai/InvokeAI/pull/3576/commits/612a694575c12f09d2922d6478568a958df5ca2c)

- I don't understand what changed but suddenly the API didn't accept the format of query params for arrays. Added a `query-string`, a well-established lib, to serialize the query strings.