### PR TITLE
fix(docker): specify bullseye for debian 11 #3563

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.9
 ##################
 ##  base image  ##
 ##################
-FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim AS python-base
+FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-bullseye AS python-base
 
 LABEL org.opencontainers.image.authors="mauwii@outlook.de"
 


### PR DESCRIPTION
This fix specifies the Debian 11 bullseye version for the base image in the Dockerfile.

https://github.com/invoke-ai/InvokeAI/issues/3563