### PR TITLE
ui: fix ts perf

### DIFF
--- a/invokeai/frontend/web/src/i18.d.ts
+++ b/invokeai/frontend/web/src/i18.d.ts
@@ -1,17 +1,20 @@
-import 'i18next';
+// TODO: Disabled for IDE performance issues with our translation JSON
 
-import en from '../public/locales/en.json';
+// import 'i18next';
 
-declare module 'i18next' {
-  // Extend CustomTypeOptions
-  interface CustomTypeOptions {
-    // Setting Default Namespace As English
-    defaultNS: 'en';
-    // Custom Types For Resources
-    resources: {
-      en: typeof en;
-    };
-    // Never Return Null
-    returnNull: false;
-  }
-}
+// import en from '../public/locales/en.json';
+
+// declare module 'i18next' {
+//   // Extend CustomTypeOptions
+//   interface CustomTypeOptions {
+//     // Setting Default Namespace As English
+//     defaultNS: 'en';
+//     // Custom Types For Resources
+//     resources: {
+//       en: typeof en;
+//     };
+//     // Never Return Null
+//     returnNull: false;
+//   }
+// }
+export default {};

--- a/invokeai/frontend/web/src/i18n.ts
+++ b/invokeai/frontend/web/src/i18n.ts
@@ -3,6 +3,8 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import Backend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
+// TODO: Disabled for IDE performance issues with our translation JSON
+// @ts-ignore
 import translationEN from '../public/locales/en.json';
 import { LOCALSTORAGE_PREFIX } from 'app/store/constants';
 

--- a/invokeai/frontend/web/tsconfig.json
+++ b/invokeai/frontend/web/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "resolveJsonModule": true,
+    // TODO: Disabled for IDE performance issues with our translation JSON
+    // "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
The TS Language Server slows down immensely with our translation JSON, which is used to provide kinda-type-safe translation keys. I say "kinda", because you don't get autocomplete - you only get red squigglies when the key is incorrect.

To improve the performance, we can opt out of this process entirely, at the cost of no red squigglies for translation keys. Hopefully we can resolve this in the future.

It's not clear why this became an issue only recently (like past couple weeks). We've tried rolling back the app dependencies, VSCode extensions, VSCode itself, and the TS version to before the time when the issue started, but nothing seems to improve the performance.

1. Disable `resolveJsonModule` in `tsconfig.json`
2. Ignore TS in `i18n.ts` when importing the JSON
3. Comment out the custom types in `i18.d.ts` entirely

It's possible that only `3` is needed to fix the issue.

I've tested building the app and running the build - it works fine, and translation works fine.