### PR TITLE
feat(ui): gallery minSize tweak

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanel.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanel.tsx
@@ -120,7 +120,7 @@ const GalleryDrawer = () => {
       isResizable={true}
       isOpen={shouldShowGallery}
       onClose={handleCloseGallery}
-      minWidth={200}
+      minWidth={337}
     >
       <ImageGalleryContent />
     </ResizableDrawer>

--- a/invokeai/frontend/web/src/features/ui/components/InvokeTabs.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/InvokeTabs.tsx
@@ -200,7 +200,11 @@ const InvokeTabs = () => {
               onResize={handleResizeGallery}
               id="gallery"
               order={3}
-              defaultSize={galleryMinSizePct}
+              defaultSize={
+                galleryMinSizePct > DEFAULT_GALLERY_PCT
+                  ? galleryMinSizePct
+                  : DEFAULT_GALLERY_PCT
+              }
               minSize={galleryMinSizePct}
               maxSize={50}
             >


### PR DESCRIPTION
- Set min size for floating gallery panel
- Correct the default pinned width (it cannot be less than the min width and this was sometimes happening during window resize)