### PR TITLE
Make the update script work on Windows

### DIFF
--- a/invokeai/frontend/install/invokeai_update.py
+++ b/invokeai/frontend/install/invokeai_update.py
@@ -108,11 +108,11 @@ def main():
 
     print(f':crossed_fingers: Upgrading to [yellow]{tag if tag else release}[/yellow]')
     if release:
-        cmd = f"pip install 'invokeai{extras} @ {INVOKE_AI_SRC}/{release}.zip' --use-pep517 --upgrade"
+        cmd = f'pip install "invokeai{extras} @ {INVOKE_AI_SRC}/{release}.zip" --use-pep517 --upgrade'
     elif tag:
-        cmd = f"pip install 'invokeai{extras} @ {INVOKE_AI_TAG}/{tag}.zip' --use-pep517 --upgrade"
+        cmd = f'pip install "invokeai{extras} @ {INVOKE_AI_TAG}/{tag}.zip" --use-pep517 --upgrade'
     else:
-        cmd = f"pip install 'invokeai{extras} @ {INVOKE_AI_BRANCH}/{branch}.zip' --use-pep517 --upgrade"
+        cmd = f'pip install "invokeai{extras} @ {INVOKE_AI_BRANCH}/{branch}.zip" --use-pep517 --upgrade'
     print('')
     print('')
     if os.system(cmd)==0:


### PR DESCRIPTION
Windows doesn't like single quotes in its command shell causing the update script's pip command to fail. This fixes the issue.