### PR TITLE
Detect invalid model names when migrating 2.3->3.0

### DIFF
--- a/invokeai/backend/install/migrate_to_3.py
+++ b/invokeai/backend/install/migrate_to_3.py
@@ -76,6 +76,10 @@ class MigrateTo3(object):
         Create a unique name for a model for use within models.yaml.
         '''
         done = False
+        
+        # some model names have slashes in them, which really screws things up
+        name = name.replace('/','_')
+        
         key = ModelManager.create_key(name,info.base_type,info.model_type)
         unique_name = key
         counter = 1


### PR DESCRIPTION
A user discovered that 2.3 models whose symbolic names contain the "/" character are not imported properly by the `migrate-models-3` script. This fixes the issue by changing "/" to  underscore at import time.