### PR TITLE
ui: render perf fixes

### DIFF
--- a/invokeai/frontend/web/src/app/components/ImageDnd/DragPreview.tsx
+++ b/invokeai/frontend/web/src/app/components/ImageDnd/DragPreview.tsx
@@ -1,4 +1,8 @@
 import { Box, ChakraProps, Flex, Heading, Image } from '@chakra-ui/react';
+import { createSelector } from '@reduxjs/toolkit';
+import { stateSelector } from 'app/store/store';
+import { useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import { memo } from 'react';
 import { TypesafeDraggableData } from './typesafeDnd';
 
@@ -28,7 +32,24 @@ const STYLES: ChakraProps['sx'] = {
   },
 };
 
+const selector = createSelector(
+  stateSelector,
+  (state) => {
+    const gallerySelectionCount = state.gallery.selection.length;
+    const batchSelectionCount = state.batch.selection.length;
+
+    return {
+      gallerySelectionCount,
+      batchSelectionCount,
+    };
+  },
+  defaultSelectorOptions
+);
+
 const DragPreview = (props: OverlayDragImageProps) => {
+  const { gallerySelectionCount, batchSelectionCount } =
+    useAppSelector(selector);
+
   if (!props.dragData) {
     return;
   }
@@ -57,7 +78,7 @@ const DragPreview = (props: OverlayDragImageProps) => {
     );
   }
 
-  if (props.dragData.payloadType === 'IMAGE_NAMES') {
+  if (props.dragData.payloadType === 'BATCH_SELECTION') {
     return (
       <Flex
         sx={{
@@ -70,7 +91,26 @@ const DragPreview = (props: OverlayDragImageProps) => {
           ...STYLES,
         }}
       >
-        <Heading>{props.dragData.payload.imageNames.length}</Heading>
+        <Heading>{batchSelectionCount}</Heading>
+        <Heading size="sm">Images</Heading>
+      </Flex>
+    );
+  }
+
+  if (props.dragData.payloadType === 'GALLERY_SELECTION') {
+    return (
+      <Flex
+        sx={{
+          cursor: 'none',
+          userSelect: 'none',
+          position: 'relative',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDir: 'column',
+          ...STYLES,
+        }}
+      >
+        <Heading>{gallerySelectionCount}</Heading>
         <Heading size="sm">Images</Heading>
       </Flex>
     );

--- a/invokeai/frontend/web/src/app/components/ImageDnd/typesafeDnd.tsx
+++ b/invokeai/frontend/web/src/app/components/ImageDnd/typesafeDnd.tsx
@@ -77,14 +77,18 @@ export type ImageDraggableData = BaseDragData & {
   payload: { imageDTO: ImageDTO };
 };
 
-export type ImageNamesDraggableData = BaseDragData & {
-  payloadType: 'IMAGE_NAMES';
-  payload: { imageNames: string[] };
+export type GallerySelectionDraggableData = BaseDragData & {
+  payloadType: 'GALLERY_SELECTION';
+};
+
+export type BatchSelectionDraggableData = BaseDragData & {
+  payloadType: 'BATCH_SELECTION';
 };
 
 export type TypesafeDraggableData =
   | ImageDraggableData
-  | ImageNamesDraggableData;
+  | GallerySelectionDraggableData
+  | BatchSelectionDraggableData;
 
 interface UseDroppableTypesafeArguments
   extends Omit<UseDroppableArguments, 'data'> {
@@ -155,11 +159,13 @@ export const isValidDrop = (
     case 'SET_NODES_IMAGE':
       return payloadType === 'IMAGE_DTO';
     case 'SET_MULTI_NODES_IMAGE':
-      return payloadType === 'IMAGE_DTO' || 'IMAGE_NAMES';
+      return payloadType === 'IMAGE_DTO' || 'GALLERY_SELECTION';
     case 'ADD_TO_BATCH':
-      return payloadType === 'IMAGE_DTO' || 'IMAGE_NAMES';
+      return payloadType === 'IMAGE_DTO' || 'GALLERY_SELECTION';
     case 'MOVE_BOARD':
-      return payloadType === 'IMAGE_DTO' || 'IMAGE_NAMES';
+      return (
+        payloadType === 'IMAGE_DTO' || 'GALLERY_SELECTION' || 'BATCH_SELECTION'
+      );
     default:
       return false;
   }

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDropped.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDropped.ts
@@ -1,24 +1,23 @@
 import { createAction } from '@reduxjs/toolkit';
-import { startAppListening } from '../';
-import { log } from 'app/logging/useLogger';
 import {
   TypesafeDraggableData,
   TypesafeDroppableData,
 } from 'app/components/ImageDnd/typesafeDnd';
-import { imageSelected } from 'features/gallery/store/gallerySlice';
-import { initialImageChanged } from 'features/parameters/store/generationSlice';
+import { log } from 'app/logging/useLogger';
 import {
   imageAddedToBatch,
   imagesAddedToBatch,
 } from 'features/batch/store/batchSlice';
-import { controlNetImageChanged } from 'features/controlNet/store/controlNetSlice';
 import { setInitialCanvasImage } from 'features/canvas/store/canvasSlice';
+import { controlNetImageChanged } from 'features/controlNet/store/controlNetSlice';
+import { imageSelected } from 'features/gallery/store/gallerySlice';
 import {
   fieldValueChanged,
   imageCollectionFieldValueChanged,
 } from 'features/nodes/store/nodesSlice';
-import { boardsApi } from 'services/api/endpoints/boards';
+import { initialImageChanged } from 'features/parameters/store/generationSlice';
 import { boardImagesApi } from 'services/api/endpoints/boardImages';
+import { startAppListening } from '../';
 
 const moduleLog = log.child({ namespace: 'dnd' });
 
@@ -33,6 +32,7 @@ export const addImageDroppedListener = () => {
     effect: (action, { dispatch, getState }) => {
       const { activeData, overData } = action.payload;
       const { actionType } = overData;
+      const state = getState();
 
       // set current image
       if (
@@ -64,9 +64,9 @@ export const addImageDroppedListener = () => {
       // add multiple images to batch
       if (
         actionType === 'ADD_TO_BATCH' &&
-        activeData.payloadType === 'IMAGE_NAMES'
+        activeData.payloadType === 'GALLERY_SELECTION'
       ) {
-        dispatch(imagesAddedToBatch(activeData.payload.imageNames));
+        dispatch(imagesAddedToBatch(state.gallery.selection));
       }
 
       // set control image
@@ -128,14 +128,14 @@ export const addImageDroppedListener = () => {
       // set multiple nodes images (multiple images handler)
       if (
         actionType === 'SET_MULTI_NODES_IMAGE' &&
-        activeData.payloadType === 'IMAGE_NAMES'
+        activeData.payloadType === 'GALLERY_SELECTION'
       ) {
         const { fieldName, nodeId } = overData.context;
         dispatch(
           imageCollectionFieldValueChanged({
             nodeId,
             fieldName,
-            value: activeData.payload.imageNames.map((image_name) => ({
+            value: state.gallery.selection.map((image_name) => ({
               image_name,
             })),
           })

--- a/invokeai/frontend/web/src/features/batch/components/BatchImage.tsx
+++ b/invokeai/frontend/web/src/features/batch/components/BatchImage.tsx
@@ -19,7 +19,7 @@ const makeSelector = (image_name: string) =>
   createSelector(
     [stateSelector],
     (state) => ({
-      selection: state.batch.selection,
+      selectionCount: state.batch.selection.length,
       isSelected: state.batch.selection.includes(image_name),
     }),
     defaultSelectorOptions
@@ -43,7 +43,7 @@ const BatchImage = (props: BatchImageProps) => {
     [props.imageName]
   );
 
-  const { isSelected, selection } = useAppSelector(selector);
+  const { isSelected, selectionCount } = useAppSelector(selector);
 
   const handleClickRemove = useCallback(() => {
     dispatch(imageRemovedFromBatch(props.imageName));
@@ -63,13 +63,10 @@ const BatchImage = (props: BatchImageProps) => {
   );
 
   const draggableData = useMemo<TypesafeDraggableData | undefined>(() => {
-    if (selection.length > 1) {
+    if (selectionCount > 1) {
       return {
         id: 'batch',
-        payloadType: 'IMAGE_NAMES',
-        payload: {
-          imageNames: selection,
-        },
+        payloadType: 'BATCH_SELECTION',
       };
     }
 
@@ -80,7 +77,7 @@ const BatchImage = (props: BatchImageProps) => {
         payload: { imageDTO },
       };
     }
-  }, [imageDTO, selection]);
+  }, [imageDTO, selectionCount]);
 
   if (isError) {
     return <Icon as={FaExclamationCircle} />;

--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
@@ -1,25 +1,22 @@
-import { memo, useCallback, useMemo, useState } from 'react';
-import { ImageDTO } from 'services/api/types';
-import {
-  ControlNetConfig,
-  controlNetImageChanged,
-  controlNetSelector,
-} from '../store/controlNetSlice';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { Box, Flex, SystemStyleObject } from '@chakra-ui/react';
-import IAIDndImage from 'common/components/IAIDndImage';
 import { createSelector } from '@reduxjs/toolkit';
-import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
-import { IAILoadingImageFallback } from 'common/components/IAIImageFallback';
-import IAIIconButton from 'common/components/IAIIconButton';
-import { FaUndo } from 'react-icons/fa';
-import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import { skipToken } from '@reduxjs/toolkit/dist/query';
 import {
   TypesafeDraggableData,
   TypesafeDroppableData,
 } from 'app/components/ImageDnd/typesafeDnd';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
+import IAIDndImage from 'common/components/IAIDndImage';
+import { IAILoadingImageFallback } from 'common/components/IAIImageFallback';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import { PostUploadAction } from 'services/api/thunks/image';
+import {
+  ControlNetConfig,
+  controlNetImageChanged,
+  controlNetSelector,
+} from '../store/controlNetSlice';
 
 const selector = createSelector(
   controlNetSelector,

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImagePreview.tsx
@@ -1,19 +1,19 @@
 import { Box, Flex, Image } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
-import { useAppSelector } from 'app/store/storeHooks';
-import { isEqual } from 'lodash-es';
-import ImageMetadataViewer from './ImageMetaDataViewer/ImageMetadataViewer';
-import NextPrevImageButtons from './NextPrevImageButtons';
-import { memo, useMemo } from 'react';
-import IAIDndImage from 'common/components/IAIDndImage';
-import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import { skipToken } from '@reduxjs/toolkit/dist/query';
-import { stateSelector } from 'app/store/store';
-import { selectLastSelectedImage } from 'features/gallery/store/gallerySlice';
 import {
   TypesafeDraggableData,
   TypesafeDroppableData,
 } from 'app/components/ImageDnd/typesafeDnd';
+import { stateSelector } from 'app/store/store';
+import { useAppSelector } from 'app/store/storeHooks';
+import IAIDndImage from 'common/components/IAIDndImage';
+import { selectLastSelectedImage } from 'features/gallery/store/gallerySlice';
+import { isEqual } from 'lodash-es';
+import { memo, useMemo } from 'react';
+import { useGetImageDTOQuery } from 'services/api/endpoints/images';
+import ImageMetadataViewer from './ImageMetaDataViewer/ImageMetadataViewer';
+import NextPrevImageButtons from './NextPrevImageButtons';
 
 export const imagesSelector = createSelector(
   [stateSelector, selectLastSelectedImage],

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryImage.tsx
@@ -1,34 +1,35 @@
 import { Box } from '@chakra-ui/react';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import { MouseEvent, memo, useCallback, useMemo } from 'react';
-import { FaTrash } from 'react-icons/fa';
-import { useTranslation } from 'react-i18next';
 import { createSelector } from '@reduxjs/toolkit';
-import { ImageDTO } from 'services/api/types';
 import { TypesafeDraggableData } from 'app/components/ImageDnd/typesafeDnd';
 import { stateSelector } from 'app/store/store';
-import ImageContextMenu from './ImageContextMenu';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import IAIDndImage from 'common/components/IAIDndImage';
+import { imageToDeleteSelected } from 'features/imageDeletion/store/imageDeletionSlice';
+import { MouseEvent, memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaTrash } from 'react-icons/fa';
+import { ImageDTO } from 'services/api/types';
 import {
   imageRangeEndSelected,
   imageSelected,
   imageSelectionToggled,
 } from '../store/gallerySlice';
-import { imageToDeleteSelected } from 'features/imageDeletion/store/imageDeletionSlice';
+import ImageContextMenu from './ImageContextMenu';
 
-export const selector = createSelector(
-  [stateSelector, (state, { image_name }: ImageDTO) => image_name],
-  ({ gallery }, image_name) => {
-    const isSelected = gallery.selection.includes(image_name);
-    const selection = gallery.selection;
-    return {
-      isSelected,
-      selection,
-    };
-  },
-  defaultSelectorOptions
-);
+export const makeSelector = (image_name: string) =>
+  createSelector(
+    [stateSelector],
+    ({ gallery }) => {
+      const isSelected = gallery.selection.includes(image_name);
+      const selection = gallery.selection;
+      return {
+        isSelected,
+        selection,
+      };
+    },
+    defaultSelectorOptions
+  );
 
 interface HoverableImageProps {
   imageDTO: ImageDTO;
@@ -38,12 +39,12 @@ interface HoverableImageProps {
  * Gallery image component with delete/use all/use seed buttons on hover.
  */
 const GalleryImage = (props: HoverableImageProps) => {
-  const { isSelected, selection } = useAppSelector((state) =>
-    selector(state, props.imageDTO)
-  );
-
   const { imageDTO } = props;
   const { image_url, thumbnail_url, image_name } = imageDTO;
+
+  const localSelector = useMemo(() => makeSelector(image_name), [image_name]);
+
+  const { isSelected, selection } = useAppSelector(localSelector);
 
   const dispatch = useAppDispatch();
 

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryImage.tsx
@@ -22,10 +22,10 @@ export const makeSelector = (image_name: string) =>
     [stateSelector],
     ({ gallery }) => {
       const isSelected = gallery.selection.includes(image_name);
-      const selection = gallery.selection;
+      const selectionCount = gallery.selection.length;
       return {
         isSelected,
-        selection,
+        selectionCount,
       };
     },
     defaultSelectorOptions
@@ -44,7 +44,7 @@ const GalleryImage = (props: HoverableImageProps) => {
 
   const localSelector = useMemo(() => makeSelector(image_name), [image_name]);
 
-  const { isSelected, selection } = useAppSelector(localSelector);
+  const { isSelected, selectionCount } = useAppSelector(localSelector);
 
   const dispatch = useAppDispatch();
 
@@ -75,11 +75,10 @@ const GalleryImage = (props: HoverableImageProps) => {
   );
 
   const draggableData = useMemo<TypesafeDraggableData | undefined>(() => {
-    if (selection.length > 1) {
+    if (selectionCount > 1) {
       return {
         id: 'gallery-image',
-        payloadType: 'IMAGE_NAMES',
-        payload: { imageNames: selection },
+        payloadType: 'GALLERY_SELECTION',
       };
     }
 
@@ -90,7 +89,7 @@ const GalleryImage = (props: HoverableImageProps) => {
         payload: { imageDTO },
       };
     }
-  }, [imageDTO, selection]);
+  }, [imageDTO, selectionCount]);
 
   return (
     <Box sx={{ w: 'full', h: 'full', touchAction: 'none' }}>

--- a/invokeai/frontend/web/src/features/lora/components/ParamLoraList.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/ParamLoraList.tsx
@@ -1,14 +1,19 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { stateSelector } from 'app/store/store';
 import { useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import { map } from 'lodash-es';
 import ParamLora from './ParamLora';
 
-const selector = createSelector(stateSelector, ({ lora }) => {
-  const { loras } = lora;
+const selector = createSelector(
+  stateSelector,
+  ({ lora }) => {
+    const { loras } = lora;
 
-  return { loras };
-});
+    return { loras };
+  },
+  defaultSelectorOptions
+);
 
 const ParamLoraList = () => {
   const { loras } = useAppSelector(selector);

--- a/invokeai/frontend/web/src/features/nodes/components/fields/ImageInputFieldComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/fields/ImageInputFieldComponent.tsx
@@ -7,18 +7,17 @@ import {
 } from 'features/nodes/types/types';
 import { memo, useCallback, useMemo } from 'react';
 
-import { FieldComponentProps } from './types';
-import IAIDndImage from 'common/components/IAIDndImage';
-import { ImageDTO } from 'services/api/types';
 import { Flex } from '@chakra-ui/react';
-import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import { skipToken } from '@reduxjs/toolkit/dist/query';
 import {
-  NodesImageDropData,
   TypesafeDraggableData,
   TypesafeDroppableData,
 } from 'app/components/ImageDnd/typesafeDnd';
+import IAIDndImage from 'common/components/IAIDndImage';
+import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import { PostUploadAction } from 'services/api/thunks/image';
+import { ImageDTO } from 'services/api/types';
+import { FieldComponentProps } from './types';
 
 const ImageInputFieldComponent = (
   props: FieldComponentProps<ImageInputFieldValue, ImageInputFieldTemplate>

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamCFGScale.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamCFGScale.tsx
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import IAINumberInput from 'common/components/IAINumberInput';
 import IAISlider from 'common/components/IAISlider';
 import { generationSelector } from 'features/parameters/store/generationSelectors';
@@ -27,7 +28,8 @@ const selector = createSelector(
       shouldUseSliders,
       shift,
     };
-  }
+  },
+  defaultSelectorOptions
 );
 
 const ParamCFGScale = () => {

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamHeight.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamHeight.tsx
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import IAISlider, { IAIFullSliderProps } from 'common/components/IAISlider';
 import { generationSelector } from 'features/parameters/store/generationSelectors';
 import { setHeight } from 'features/parameters/store/generationSlice';
@@ -25,7 +26,8 @@ const selector = createSelector(
       inputMax,
       step,
     };
-  }
+  },
+  defaultSelectorOptions
 );
 
 type ParamHeightProps = Omit<

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamIterations.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamIterations.tsx
@@ -1,37 +1,38 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { stateSelector } from 'app/store/store';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import IAINumberInput from 'common/components/IAINumberInput';
 import IAISlider from 'common/components/IAISlider';
-import { generationSelector } from 'features/parameters/store/generationSelectors';
 import { setIterations } from 'features/parameters/store/generationSlice';
-import { configSelector } from 'features/system/store/configSelectors';
-import { hotkeysSelector } from 'features/ui/store/hotkeysSlice';
-import { uiSelector } from 'features/ui/store/uiSelectors';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const selector = createSelector([stateSelector], (state) => {
-  const { initial, min, sliderMax, inputMax, fineStep, coarseStep } =
-    state.config.sd.iterations;
-  const { iterations } = state.generation;
-  const { shouldUseSliders } = state.ui;
-  const isDisabled =
-    state.dynamicPrompts.isEnabled && state.dynamicPrompts.combinatorial;
+const selector = createSelector(
+  [stateSelector],
+  (state) => {
+    const { initial, min, sliderMax, inputMax, fineStep, coarseStep } =
+      state.config.sd.iterations;
+    const { iterations } = state.generation;
+    const { shouldUseSliders } = state.ui;
+    const isDisabled =
+      state.dynamicPrompts.isEnabled && state.dynamicPrompts.combinatorial;
 
-  const step = state.hotkeys.shift ? fineStep : coarseStep;
+    const step = state.hotkeys.shift ? fineStep : coarseStep;
 
-  return {
-    iterations,
-    initial,
-    min,
-    sliderMax,
-    inputMax,
-    step,
-    shouldUseSliders,
-    isDisabled,
-  };
-});
+    return {
+      iterations,
+      initial,
+      min,
+      sliderMax,
+      inputMax,
+      step,
+      shouldUseSliders,
+      isDisabled,
+    };
+  },
+  defaultSelectorOptions
+);
 
 const ParamIterations = () => {
   const {

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamSteps.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamSteps.tsx
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import IAINumberInput from 'common/components/IAINumberInput';
 
 import IAISlider from 'common/components/IAISlider';
@@ -33,7 +34,8 @@ const selector = createSelector(
       step,
       shouldUseSliders,
     };
-  }
+  },
+  defaultSelectorOptions
 );
 
 const ParamSteps = () => {

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamWidth.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamWidth.tsx
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import IAISlider from 'common/components/IAISlider';
-import { IAIFullSliderProps } from 'common/components/IAISlider';
+import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
+import IAISlider, { IAIFullSliderProps } from 'common/components/IAISlider';
 import { generationSelector } from 'features/parameters/store/generationSelectors';
 import { setWidth } from 'features/parameters/store/generationSlice';
 import { configSelector } from 'features/system/store/configSelectors';
@@ -26,7 +26,8 @@ const selector = createSelector(
       inputMax,
       step,
     };
-  }
+  },
+  defaultSelectorOptions
 );
 
 type ParamWidthProps = Omit<IAIFullSliderProps, 'label' | 'value' | 'onChange'>;


### PR DESCRIPTION
[fix(ui): fix selector memoization](https://github.com/invoke-ai/InvokeAI/commit/1323a45e30e95d671851b0cbbcc36d07dc4821d5)

Every `GalleryImage` was rerendering any time the app rerendered bc the selector function itself was not memoized. This resulted in the memoization cache inside the selector constantly being reset.

Same for `BatchImage`.

Also updated memoization for a few other selectors.

[fix(ui): change multi image drop to not have selection as payload](https://github.com/invoke-ai/InvokeAI/commit/4816fa9996f27b0543ecea7601ed024599e735b9)

This caused a lot of re-rendering whenever the selection changed, which caused a huge performance hit. It also made changing the current image lag a bit.

Instead of providing an array of image names as a multi-select dnd payload, there is now no multi-select dnd payload at all - instead, the payload types are used by the `imageDropped` listener to pull the selection out of redux.

Now, the only big re-renders are when the selectionCount changes. In the future I'll figure out a good way to do image names as payload without incurring re-renders.