### PR TITLE
fix: Rearrange Model Select to take full width

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamModelandVAEandScheduler.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Core/ParamModelandVAEandScheduler.tsx
@@ -10,20 +10,19 @@ const ParamModelandVAEandScheduler = () => {
 
   return (
     <Flex gap={3} w="full" flexWrap={isVaeEnabled ? 'wrap' : 'nowrap'}>
+      <Box w="full">
+        <ModelSelect />
+      </Box>
       <Flex gap={3} w="full">
-        <Box w="full">
-          <ModelSelect />
-        </Box>
-
         {isVaeEnabled && (
           <Box w="full">
             <VAESelect />
           </Box>
         )}
+        <Box w="full">
+          <ParamScheduler />
+        </Box>
       </Flex>
-      <Box w="full">
-        <ParamScheduler />
-      </Box>
     </Flex>
   );
 };


### PR DESCRIPTION
Some users want the model select to take full width coz their model names might be long. As this is a more frequently used feature, rearrange it to do that.

Followed by VAE (as it is related to the model) and the Sampler next to it.