### PR TITLE
Added class PromptsFromFileInvocation to prompt.py. 

### DIFF
--- a/invokeai/app/invocations/prompt.py
+++ b/invokeai/app/invocations/prompt.py
@@ -75,7 +75,7 @@ class PromptsFromFileInvocation(BaseInvocation):
     @validator("file_path")
     def file_path_exists(cls, v):
         if not exists(v):
-            raise ValueError("file path not found")
+            raise ValueError(FileNotFoundError)
         return v
 
     def promptsFromFile(self, file_path: str, pre_prompt: str, post_prompt: str, start_line: int, max_prompts: int):


### PR DESCRIPTION
A new PromptFromFile custom node the provides similar functionality to the old 2.3.5 --from_file CLI command.  It reads prompts from a file one line per prompt and outputs them as a prompt collection. With inputs for filename, pre_prompt, post_prompt, start line number, and max_prompts. A max_prompts of 0 will read  int32.max number of lines from the file. 

This replaces the messed up pull request I closed PR "Create prompts_fromfile.py " https://github.com/invoke-ai/InvokeAI/pull/3757
