### PR TITLE
fix: OOM crashes with SDXL

### DIFF
--- a/invokeai/app/invocations/compel.py
+++ b/invokeai/app/invocations/compel.py
@@ -147,6 +147,8 @@ class CompelInvocation(BaseInvocation):
                     tokenizer, conjunction),
                 cross_attention_control_args=options.get(
                     "cross_attention_control", None),)
+            
+        c = c.to('cpu')
 
         conditioning_data = ConditioningFieldData(
             conditionings=[
@@ -230,6 +232,10 @@ class SDXLPromptInvocationBase:
         del tokenizer_info
         del text_encoder_info
 
+        c = c.detach().to('cpu')
+        if c_pooled is not None:
+            c_pooled = c_pooled.detach().to('cpu')
+
         return c, c_pooled, None
 
     def run_clip_compel(self, context, clip_field, prompt, get_pooled):
@@ -305,6 +311,10 @@ class SDXLPromptInvocationBase:
         del text_encoder
         del tokenizer_info
         del text_encoder_info
+
+        c = c.detach().to('cpu')
+        if c_pooled is not None:
+            c_pooled = c_pooled.detach().to('cpu')
 
         return c, c_pooled, ec
 

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -503,6 +503,7 @@ class LatentsToImageInvocation(BaseInvocation):
         )
 
         with vae_info as vae:
+            latents = latents.to(vae.device)
             if self.fp32:
                 vae.to(dtype=torch.float32)
 

--- a/invokeai/app/invocations/noise.py
+++ b/invokeai/app/invocations/noise.py
@@ -48,7 +48,7 @@ def get_noise(
         dtype=torch_dtype(device),
         device=noise_device_type,
         generator=generator,
-    ).to(device)
+    ).to('cpu')
 
     return noise_tensor
 

--- a/invokeai/app/invocations/sdxl.py
+++ b/invokeai/app/invocations/sdxl.py
@@ -415,6 +415,7 @@ class SDXLTextToLatentsInvocation(BaseInvocation):
 
         #################
 
+        latents = latents.to('cpu')
         torch.cuda.empty_cache()
 
         name = f'{context.graph_execution_state_id}__{self.id}'
@@ -650,7 +651,8 @@ class SDXLLatentsToLatentsInvocation(BaseInvocation):
 
 
         #################
-
+        
+        latents = latents.to('cpu')
         torch.cuda.empty_cache()
 
         name = f'{context.graph_execution_state_id}__{self.id}'

--- a/invokeai/backend/model_management/model_cache.py
+++ b/invokeai/backend/model_management/model_cache.py
@@ -104,7 +104,7 @@ class ModelCache(object):
         :param sha_chunksize: Chunksize to use when calculating sha256 model hash
         '''
         self.model_infos: Dict[str, ModelBase] = dict()
-        self.lazy_offloading = lazy_offloading
+        self.lazy_offloading = lazy_offloading or max_vram_cache_size > 0
         self.precision: torch.dtype=precision
         self.max_cache_size: float=max_cache_size
         self.max_vram_cache_size: float=max_vram_cache_size


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization


## Have you discussed this change with the InvokeAI team?
- [x] Yes

      
## Description

SDXL was crashing on a second run for 8GB VRAM cards. With these changes it no longer does that. However you need to set your `max_vram_cache_size` setting in `invokeai.yaml` to `0` first.

Side Note: To have all of SDXL loaded into memory, you need to up your `max_cache_size` (regular RAM) to at least 6GB. This way the models boot up almost instantaneously for each generation instead of loading and unloading.