### PR TITLE
Missing def choose_torch_device

### DIFF
--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -22,7 +22,7 @@ from ...backend.stable_diffusion.diffusers_pipeline import (
 from ...backend.stable_diffusion.diffusion.shared_invokeai_diffusion import \
     PostprocessingSettings
 from ...backend.stable_diffusion.schedulers import SCHEDULER_MAP
-from ...backend.util.devices import torch_dtype
+from ...backend.util.devices import choose_torch_device, torch_dtype
 from ..models.image import ImageCategory, ImageField, ResourceOrigin
 from .baseinvocation import (BaseInvocation, BaseInvocationOutput,
                              InvocationConfig, InvocationContext)
@@ -37,10 +37,6 @@ from diffusers.models.attention_processor import (
     LoRAXFormersAttnProcessor,
     XFormersAttnProcessor,
 )
-
-def choose_torch_device() -> str:
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    return device
 
 class LatentsField(BaseModel):
     """A latents field used for passing latents between invocations"""

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -39,7 +39,6 @@ from diffusers.models.attention_processor import (
 )
 
 def choose_torch_device() -> str:
-    # Your device selection logic here
     device = "cuda" if torch.cuda.is_available() else "cpu"
     return device
 

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -38,6 +38,10 @@ from diffusers.models.attention_processor import (
     XFormersAttnProcessor,
 )
 
+def choose_torch_device() -> str:
+    # Your device selection logic here
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    return device
 
 class LatentsField(BaseModel):
     """A latents field used for passing latents between invocations"""


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because:

      
## Description
Fix for
 ```
 File "/home/invokeuser/InvokeAI/invokeai/app/services/processor.py", line 70, in __process
    outputs = invocation.invoke(
  File "/home/invokeuser/InvokeAI/invokeai/app/invocations/latent.py", line 660, in invoke
    device=choose_torch_device()
NameError: name 'choose_torch_device' is not defined
```

when using scale latents node

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
