### PR TITLE
fix v1-finetune.yaml is not in the subpath of ""

### DIFF
--- a/invokeai/app/services/config.py
+++ b/invokeai/app/services/config.py
@@ -277,7 +277,7 @@ class InvokeAISettings(BaseSettings):
     @classmethod
     def _excluded_from_yaml(self)->List[str]:
         # combination of deprecated parameters and internal ones that shouldn't be exposed as invokeai.yaml options
-        return ['type','initconf', 'gpu_mem_reserved', 'max_loaded_models', 'version', 'from_file', 'model', 'restore']
+        return ['type','initconf', 'gpu_mem_reserved', 'max_loaded_models', 'version', 'from_file', 'model', 'restore', 'root']
 
     class Config:
         env_file_encoding = 'utf-8'
@@ -446,7 +446,7 @@ setting environment variables INVOKEAI_<setting>.
         Path to the runtime root directory
         '''
         if self.root:
-            return Path(self.root).expanduser()
+            return Path(self.root).expanduser().absolute()
         else:
             return self.find_root()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Have you discussed this change with the InvokeAI team?
- [ X] Yes
- [ ] No, because:

      
## Description

This fixes the crash that occurs when fetching the configuration information of checkpoint models from a web server started by clicking on the launcher in Windows.
```
ValueError: 'C:\\Users\\foo\\Documents\\invokeai\\configs\\stable-diffusion\\v1-finetune.yaml' is not in the subpath of '' OR one path is relative and the other is absolute.
```

Very interesting edge case. Easy fix.

