### PR TITLE
CenterPadCrop node

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -60,6 +60,21 @@ class MaskOutput(BaseInvocationOutput):
         }
 
 
+class ImageMaskOutput(BaseInvocationOutput):
+    """Base class for invocations that output an image and a mask"""
+
+    # fmt: off
+    type: Literal["image_mask_output"] = "image_mask_output"
+    image:      ImageField = Field(default=None, description="The output image")
+    width:             int = Field(description="The width of the image in pixels")
+    height:            int = Field(description="The height of the image in pixels")
+    mask:       ImageField = Field(default=None, description="The output mask")
+    # fmt: on
+
+    class Config:
+        schema_extra = {"required": ["type", "image", "width", "height", "mask"]}
+
+
 class LoadImageInvocation(BaseInvocation):
     """Load an image and provide it as output."""
 
@@ -165,6 +180,65 @@ class ImageCropInvocation(BaseInvocation, PILInvocationConfig):
             image=ImageField(image_name=image_dto.image_name),
             width=image_dto.width,
             height=image_dto.height,
+        )
+
+
+class CenterPadCropInvocation(BaseInvocation, PILInvocationConfig):
+    """Pad or crop an image's sides from the center by specified pixels. Positive values are outside of the image."""
+
+    # fmt: off
+    type: Literal["img_pad_crop"] = "img_pad_crop"
+
+    # Inputs
+    image:  Optional[ImageField] = Field(default=None, description="The image to crop")
+    left:   int = Field(default=0, description="Number of pixels to pad/crop from the left (negative values crop inwards, positive values pad outwards)")
+    right:  int = Field(default=0, description="Number of pixels to pad/crop from the right (negative values crop inwards, positive values pad outwards)")
+    top:    int = Field(default=0, description="Number of pixels to pad/crop from the top (negative values crop inwards, positive values pad outwards)")
+    bottom: int = Field(default=0, description="Number of pixels to pad/crop from the bottom (negative values crop inwards, positive values pad outwards)")
+    # fmt: on
+
+    class Config(InvocationConfig):
+        schema_extra = {
+            "ui": {
+                "title": "Center Pad Crop",
+                "tags": ["image", "center", "pad", "crop"]
+            },
+        }
+
+    def invoke(self, context: InvocationContext) -> ImageMaskOutput:
+        image = context.services.images.get_pil_image(self.image.image_name)
+        imgwidth, imgheight = image.size
+
+        new_width = imgwidth + self.right + self.left
+        new_height = imgheight + self.top + self.bottom
+        image_crop = Image.new(mode="RGBA", size=(new_width, new_height), color=(0, 0, 0, 0))
+
+        image_crop.paste(image, (self.left, self.top))
+
+        white_mask = Image.new("L", image_crop.size, color=255)
+
+        image_dto = context.services.images.create(
+            image=image_crop,
+            image_origin=ResourceOrigin.INTERNAL,
+            image_category=ImageCategory.GENERAL,
+            node_id=self.id,
+            session_id=context.graph_execution_state_id,
+            is_intermediate=self.is_intermediate,
+        )
+        white_mask_dto = context.services.images.create(
+            image=white_mask,
+            image_origin=ResourceOrigin.INTERNAL,
+            image_category=ImageCategory.MASK,
+            node_id=self.id,
+            session_id=context.graph_execution_state_id,
+            is_intermediate=self.is_intermediate,
+        )
+
+        return ImageMaskOutput(
+            image=ImageField(image_name=image_dto.image_name),
+            width=image_dto.width,
+            height=image_dto.height,
+            mask=ImageField(image_name=white_mask_dto.image_name),
         )
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated relevant documentation?
- [ ] Yes
- [x] No, will do next


## Description

This node allows users to add transparent space outward around an image (pad), or crop the image inward. It is different from the Image Crop node in that it pads/crops from the center, not just the right and bottom, and also doesn't rely on a rectangular height/width box. Pixel values are given for `left`, `right`, `top`, and `bottom`. 

Similar to my FaceMask node, the node outputs the height and width of the output image, and an all-white mask the same dimensions as the output image for use with outpainting.

## QA Instructions, Screenshots, Recordings

Running Center Pad Crop into Inpaint to outpaint the new transparent area. The node's output provides the image with transparency, the white mask used by inpaint, and the height and width. Cut out the lengthy generation time:

[CenterPadCrop.webm](https://github.com/invoke-ai/InvokeAI/assets/25252829/bc99d05b-8f98-485f-bc28-6617c233ac21)

<img width="453" alt="Screenshot 2023-07-20 at 4 39 09 PM" src="https://github.com/invoke-ai/InvokeAI/assets/25252829/25e7bf57-e5fc-472e-b9f0-be918ed52d09">
