### PR TITLE
fix: No board name being displayed if it is empty

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/GalleryBoardName.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryBoardName.tsx
@@ -30,9 +30,8 @@ const GalleryBoardName = (props: Props) => {
   const numOfBoardImages = useBoardTotal(selectedBoardId);
 
   const formattedBoardName = useMemo(() => {
-    if (!boardName || !numOfBoardImages) {
-      return '';
-    }
+    if (!boardName) return '';
+    if (boardName && !numOfBoardImages) return boardName;
     if (boardName.length > 20) {
       return `${boardName.substring(0, 20)}... (${numOfBoardImages})`;
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Desc

Fixes a bug where the board name is not displayed in the header if there are no images in it.