### PR TITLE
Warn, do not crash, when duplicate models encountered

### DIFF
--- a/invokeai/backend/model_management/__init__.py
+++ b/invokeai/backend/model_management/__init__.py
@@ -3,6 +3,6 @@ Initialization file for invokeai.backend.model_management
 """
 from .model_manager import ModelManager, ModelInfo, AddModelResult, SchedulerPredictionType
 from .model_cache import ModelCache
-from .models import BaseModelType, ModelType, SubModelType, ModelVariantType, ModelNotFoundException
+from .models import BaseModelType, ModelType, SubModelType, ModelVariantType, ModelNotFoundException, DuplicateModelException
 from .model_merge import ModelMerger, MergeInterpolationMethod
 

--- a/invokeai/backend/model_management/models/__init__.py
+++ b/invokeai/backend/model_management/models/__init__.py
@@ -2,7 +2,11 @@ import inspect
 from enum import Enum
 from pydantic import BaseModel
 from typing import Literal, get_origin
-from .base import BaseModelType, ModelType, SubModelType, ModelBase, ModelConfigBase, ModelVariantType, SchedulerPredictionType, ModelError, SilenceWarnings, ModelNotFoundException, InvalidModelException
+from .base import (
+    BaseModelType, ModelType, SubModelType, ModelBase, ModelConfigBase,
+    ModelVariantType, SchedulerPredictionType, ModelError, SilenceWarnings,
+    ModelNotFoundException, InvalidModelException, DuplicateModelException
+    )
 from .stable_diffusion import StableDiffusion1Model, StableDiffusion2Model
 from .sdxl import StableDiffusionXLModel
 from .vae import VaeModel

--- a/invokeai/backend/model_management/models/base.py
+++ b/invokeai/backend/model_management/models/base.py
@@ -15,6 +15,9 @@ from contextlib import suppress
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional, Type, Literal, TypeVar, Generic, Callable, Any, Union
 
+class DuplicateModelException(Exception):
+    pass
+
 class InvalidModelException(Exception):
     pass
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ X] No  -- not needed


## Description

If a model is install twice (e.g. in the autoimprot directory and the models directory) this will warn but not crash on load.

Note starred line

```
[2023-07-21 14:12:27,677]::[InvokeAI]::INFO --> InvokeAI version 3.0.0
[2023-07-21 14:12:27,688]::[InvokeAI]::DEBUG --> Config file=/home/lstein/invokeai-main/configs/models.yaml
[2023-07-21 14:12:27,688]::[InvokeAI]::INFO --> GPU device = cuda NVIDIA GeForce RTX 4070
[2023-07-21 14:12:27,688]::[InvokeAI]::DEBUG --> Maximum RAM cache size: 6.0 GiB
[2023-07-21 14:12:27,702]::[InvokeAI]::INFO --> Scanning /home/lstein/invokeai-main/models for new models
** [2023-07-21 14:12:27,703]::[InvokeAI]::WARNING --> Model with key sd-1/main/AnalogDiffusion added twice
[2023-07-21 14:12:28,845]::[InvokeAI]::INFO --> Scanned 40 files and directories, imported 9 models
[2023-07-21 14:12:28,855]::[InvokeAI]::INFO --> Model manager service initialized
[2023-07-21 14:12:28,855]::[InvokeAI]::INFO --> InvokeAI database location is "/home/lstein/invokeai-main/databases/invokeai.db"
```
