### PR TITLE
Fix 'Del' hotkey to delete current image

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImageButtons.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImageButtons.tsx
@@ -210,6 +210,14 @@ const CurrentImageButtons = (props: CurrentImageButtonsProps) => {
     [imageDTO, shouldShowImageDetails, toaster]
   );
 
+  useHotkeys(
+    'delete',
+    () => {
+      handleDelete();
+    },
+    [dispatch, imageDTO]
+  );
+
   const handleClickProgressImagesToggle = useCallback(() => {
     dispatch(setShouldShowProgressInViewer(!shouldShowProgressInViewer));
   }, [dispatch, shouldShowProgressInViewer]);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: please see my generic explanation in #3902 (tl;dr unnecessary overhead)
      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No, bug fix, the tooltips currently say "Del" deletes the image, which it doesn't

## Description

Restore deletion of current image using the "delete" hotkey.

I'm not entirely sure this is the best approach because accidentally hitting "delete" (e.g. when you think you're typing in a prompt textarea but actually aren't) could lead to accidental deletion, especially with the "don't ask for confirmation". I'd suggest modifying the default delete key to a combo like shift+delete, but I think fixing the issue is important enough in this state.

## Related Tickets & Documents

Fixes #3846.

## QA Instructions, Screenshots, Recordings

Press delete. Rejoice upon seeing that you can quickly delete your 723 failed attempts.

## Added/updated tests?

- [ ] Yes
- [x] No
