### PR TITLE
feat: increase seed from int32 to uint32

### DIFF
--- a/invokeai/app/invocations/noise.py
+++ b/invokeai/app/invocations/noise.py
@@ -119,8 +119,8 @@ class NoiseInvocation(BaseInvocation):
 
     @validator("seed", pre=True)
     def modulo_seed(cls, v):
-        """Returns the seed modulo SEED_MAX to ensure it is within the valid range."""
-        return v % SEED_MAX
+        """Returns the seed modulo (SEED_MAX + 1) to ensure it is within the valid range."""
+        return v % (SEED_MAX + 1)
 
     def invoke(self, context: InvocationContext) -> NoiseOutput:
         noise = get_noise(

--- a/invokeai/app/util/misc.py
+++ b/invokeai/app/util/misc.py
@@ -14,7 +14,7 @@ def get_datetime_from_iso_timestamp(iso_timestamp: str) -> datetime.datetime:
     return datetime.datetime.fromisoformat(iso_timestamp)
 
 
-SEED_MAX = np.iinfo(np.int32).max
+SEED_MAX = np.iinfo(np.uint32).max
 
 
 def get_random_seed():

--- a/invokeai/frontend/web/src/app/constants.ts
+++ b/invokeai/frontend/web/src/app/constants.ts
@@ -1,2 +1,2 @@
 export const NUMPY_RAND_MIN = 0;
-export const NUMPY_RAND_MAX = 2147483647;
+export const NUMPY_RAND_MAX = 4294967295;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No: n/a


## Description

At some point I typo'd this and set the max seed to signed int32 max. It should be *un*signed int32 max.

This restored the seed range to what it was in v2.3.

Also fixed a bug in the Noise node which resulted in the max valid seed being one less than intended.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issues
#2843 is against v2.3 and increases the range of valid seeds substantially. Maybe we can explore this in the future but as of v3.0, we use numpy for a RNG in a few places, and it maxes out at the max `uint32`. I will close this PR as this supersedes it.
- Closes #3866

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

You should be able to use seeds up to and including `4294967295`.

## Added/updated tests?

- [ ] Yes
- [x] No : don't think we have any relevant tests

## [optional] Are there any post deployment tasks we need to perform?

nope!