### PR TITLE
docs generation: fix typo and remove trailing white space

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ plugins:
 
 nav:
     - Home: 'index.md'
-    - Installation: 
+    - Installation:
       - Overview: 'installation/index.md'
       - Installing with the Automated Installer: 'installation/010_INSTALL_AUTOMATED.md'
       - Installing manually: 'installation/020_INSTALL_MANUAL.md'
@@ -122,14 +122,14 @@ nav:
     - Community Nodes:
       - Community Nodes: 'nodes/communityNodes.md'
       - Overview: 'nodes/overview.md'
-    - Features: 
+    - Features:
       - Overview: 'features/index.md'
       - Concepts: 'features/CONCEPTS.md'
       - Configuration: 'features/CONFIGURATION.md'
       - ControlNet: 'features/CONTROLNET.md'
       - Image-to-Image: 'features/IMG2IMG.md'
       - Controlling Logging: 'features/LOGGING.md'
-      - Model Mergeing: 'features/MODEL_MERGING.md'
+      - Model Merging: 'features/MODEL_MERGING.md'
       - Nodes Editor (Experimental): 'features/NODES.md'
       - NSFW Checker: 'features/NSFW.md'
       - Postprocessing: 'features/POSTPROCESS.md'
@@ -140,9 +140,9 @@ nav:
       - InvokeAI Web Server: 'features/WEB.md'
       - WebUI Hotkeys: "features/WEBUIHOTKEYS.md"
       - Other: 'features/OTHER.md'
-    - Contributing: 
+    - Contributing:
       - How to Contribute: 'contributing/CONTRIBUTING.md'
-      - Development: 
+      - Development:
         - Overview: 'contributing/contribution_guides/development.md'
         - InvokeAI Architecture: 'contributing/ARCHITECTURE.md'
         - Frontend Documentation: 'contributing/contribution_guides/development_guides/contributingToFrontend.md'
@@ -161,5 +161,3 @@ nav:
     - Other:
       - Contributors: 'other/CONTRIBUTORS.md'
       - CompViz-README: 'other/README-CompViz.md'
-
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: This is a minor fix that I happened upon while reading

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

Within the `mkdocs.yml` file, there's a typo where `Model Merging` is spelled as `Model Mergeing`. I also found some unnecessary white space that I removed.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [x] No : Not big enough of a change to require tests (unless it is)

## [optional] Are there any post deployment tasks we need to perform?
Might need to re-run the yml file for docs to regenerate, but I'm hardly familiar with the codebase so 🤷
