### PR TITLE
fix: don't crash if `nsfw_methods` or `watermarking_methods` is unedfined

### DIFF
--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -139,9 +139,9 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
     useGetAppConfigQuery(undefined, {
       selectFromResult: ({ data }) => ({
         isNSFWCheckerAvailable:
-          data?.nsfw_methods.includes('nsfw_checker') ?? false,
+          data?.nsfw_methods?.includes('nsfw_checker') ?? false,
         isWatermarkerAvailable:
-          data?.watermarking_methods.includes('invisible_watermark') ?? false,
+          data?.watermarking_methods?.includes('invisible_watermark') ?? false,
       }),
     });
 


### PR DESCRIPTION
…undefined

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: it's just an ittie bittie bug fix

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description

If either `nsfw_methods` or `watermarking_methods` are undefined within the settings modal, the application blank screens. This pr fixes that by optional chaining it where it's returning as undefined.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [x] No

## [optional] Are there any post deployment tasks we need to perform?
