### PR TITLE
Restore model merge script

### DIFF
--- a/invokeai/frontend/merge/merge_diffusers.py
+++ b/invokeai/frontend/merge/merge_diffusers.py
@@ -320,7 +320,7 @@ class mergeModelsForm(npyscreen.FormMultiPageAction):
 
     def get_model_names(self, base_model: BaseModelType = None) -> List[str]:
         model_names = [
-            info["name"]
+            info["model_name"]
             for info in self.model_manager.list_models(model_type=ModelType.Main, base_model=base_model)
             if info["model_format"] == "diffusers"
         ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X ] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ X] Yes
- [ ] No

## Description

The `invokeai-merge` script was crashing at an early stage due to a misnamed dict key. This has now been fixed.

