### PR TITLE
fix: Model Manager Tab Issues

### DIFF
--- a/invokeai/frontend/web/src/features/ui/components/tabs/ModelManager/subpanels/ModelManagerPanel/ModelList.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/tabs/ModelManager/subpanels/ModelManagerPanel/ModelList.tsx
@@ -35,7 +35,7 @@ const ModelList = (props: ModelListProps) => {
   const [modelFormatFilter, setModelFormatFilter] =
     useState<CombinedModelFormat>('all');
 
-  const { filteredDiffusersModels, isDiffusersModelLoading } =
+  const { filteredDiffusersModels, isLoadingDiffusersModels } =
     useGetMainModelsQuery(ALL_BASE_MODELS, {
       selectFromResult: ({ data, isLoading }) => ({
         filteredDiffusersModels: modelsFilter(
@@ -44,11 +44,11 @@ const ModelList = (props: ModelListProps) => {
           'diffusers',
           nameFilter
         ),
-        isDiffusersModelLoading: isLoading,
+        isLoadingDiffusersModels: isLoading,
       }),
     });
 
-  const { filteredCheckpointModels, isCheckpointModelLoading } =
+  const { filteredCheckpointModels, isLoadingCheckpointModels } =
     useGetMainModelsQuery(ALL_BASE_MODELS, {
       selectFromResult: ({ data, isLoading }) => ({
         filteredCheckpointModels: modelsFilter(
@@ -57,7 +57,7 @@ const ModelList = (props: ModelListProps) => {
           'checkpoint',
           nameFilter
         ),
-        isCheckpointModelLoading: isLoading,
+        isLoadingCheckpointModels: isLoading,
       }),
     });
 

--- a/invokeai/frontend/web/src/features/ui/components/tabs/ModelManager/subpanels/ModelManagerPanel/ModelList.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/tabs/ModelManager/subpanels/ModelManagerPanel/ModelList.tsx
@@ -71,55 +71,29 @@ const ModelList = (props: ModelListProps) => {
     }
   );
 
-  const { filteredOnnxModels } = useGetOnnxModelsQuery(ALL_BASE_MODELS, {
-    selectFromResult: ({ data }) => ({
-      filteredOnnxModels: modelsFilter(data, 'onnx', 'onnx', nameFilter),
-    }),
-  });
+  const { filteredOnnxModels, isLoadingOnnxModels } = useGetOnnxModelsQuery(
+    ALL_BASE_MODELS,
+    {
+      selectFromResult: ({ data, isLoading }) => ({
+        filteredOnnxModels: modelsFilter(data, 'onnx', 'onnx', nameFilter),
+        isLoadingOnnxModels: isLoading,
+      }),
+    }
+  );
 
-  const { filteredOliveModels } = useGetOnnxModelsQuery(ALL_BASE_MODELS, {
-    selectFromResult: ({ data }) => ({
-      filteredOliveModels: modelsFilter(data, 'onnx', 'olive', nameFilter),
-    }),
-  });
+  const { filteredOliveModels, isLoadingOliveModels } = useGetOnnxModelsQuery(
+    ALL_BASE_MODELS,
+    {
+      selectFromResult: ({ data, isLoading }) => ({
+        filteredOliveModels: modelsFilter(data, 'onnx', 'olive', nameFilter),
+        isLoadingOliveModels: isLoading,
+      }),
+    }
+  );
 
   const handleSearchFilter = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setNameFilter(e.target.value);
   }, []);
-
-  const renderModelList = (
-    filterArray: Partial<CombinedModelFormat>[],
-    isLoading: boolean,
-    loadingMessage: string,
-    title: string,
-    modelList: MainModelConfigEntity[] | LoRAModelConfigEntity[]
-  ) => {
-    if (!filterArray.includes(modelFormatFilter)) return;
-
-    if (isLoading) {
-      return <FetchingModelsLoader loadingMessage={loadingMessage} />;
-    }
-
-    if (modelList.length === 0) return;
-
-    return (
-      <StyledModelContainer>
-        <Flex sx={{ gap: 2, flexDir: 'column' }}>
-          <Text variant="subtext" fontSize="sm">
-            {title}
-          </Text>
-          {modelList.map((model) => (
-            <ModelListItem
-              key={model.id}
-              model={model}
-              isSelected={selectedModelId === model.id}
-              setSelectedModelId={setSelectedModelId}
-            />
-          ))}
-        </Flex>
-      </StyledModelContainer>
-    );
-  };
 
   return (
     <Flex flexDirection="column" rowGap={4} width="50%" minWidth="50%">
@@ -181,95 +155,76 @@ const ModelList = (props: ModelListProps) => {
           maxHeight={window.innerHeight - 280}
           overflow="scroll"
         >
-          {['images', 'diffusers'].includes(modelFormatFilter) &&
+          {/* Diffusers List */}
+          {isLoadingDiffusersModels && (
+            <FetchingModelsLoader loadingMessage="Loading Diffusers..." />
+          )}
+          {['all', 'diffusers'].includes(modelFormatFilter) &&
+            !isLoadingDiffusersModels &&
             filteredDiffusersModels.length > 0 && (
-              <StyledModelContainer>
-                <Flex sx={{ gap: 2, flexDir: 'column' }}>
-                  <Text variant="subtext" fontSize="sm">
-                    Diffusers
-                  </Text>
-                  {filteredDiffusersModels.map((model) => (
-                    <ModelListItem
-                      key={model.id}
-                      model={model}
-                      isSelected={selectedModelId === model.id}
-                      setSelectedModelId={setSelectedModelId}
-                    />
-                  ))}
-                </Flex>
-              </StyledModelContainer>
+              <ModelListWrapper
+                title="Diffusers"
+                modelList={filteredDiffusersModels}
+                selected={{ selectedModelId, setSelectedModelId }}
+                key="diffusers"
+              />
             )}
-          {['images', 'checkpoint'].includes(modelFormatFilter) &&
+          {/* Checkpoints List */}
+          {isLoadingCheckpointModels && (
+            <FetchingModelsLoader loadingMessage="Loading Checkpoints..." />
+          )}
+          {['all', 'checkpoint'].includes(modelFormatFilter) &&
+            !isLoadingCheckpointModels &&
             filteredCheckpointModels.length > 0 && (
-              <StyledModelContainer>
-                <Flex sx={{ gap: 2, flexDir: 'column' }}>
-                  <Text variant="subtext" fontSize="sm">
-                    Checkpoints
-                  </Text>
-                  {filteredCheckpointModels.map((model) => (
-                    <ModelListItem
-                      key={model.id}
-                      model={model}
-                      isSelected={selectedModelId === model.id}
-                      setSelectedModelId={setSelectedModelId}
-                    />
-                  ))}
-                </Flex>
-              </StyledModelContainer>
+              <ModelListWrapper
+                title="Checkpoints"
+                modelList={filteredCheckpointModels}
+                selected={{ selectedModelId, setSelectedModelId }}
+                key="checkpoints"
+              />
             )}
-          {['images', 'olive'].includes(modelFormatFilter) &&
-            filteredOliveModels.length > 0 && (
-              <StyledModelContainer>
-                <Flex sx={{ gap: 2, flexDir: 'column' }}>
-                  <Text variant="subtext" fontSize="sm">
-                    Olives
-                  </Text>
-                  {filteredOliveModels.map((model) => (
-                    <ModelListItem
-                      key={model.id}
-                      model={model}
-                      isSelected={selectedModelId === model.id}
-                      setSelectedModelId={setSelectedModelId}
-                    />
-                  ))}
-                </Flex>
-              </StyledModelContainer>
-            )}
-          {['images', 'onnx'].includes(modelFormatFilter) &&
-            filteredOnnxModels.length > 0 && (
-              <StyledModelContainer>
-                <Flex sx={{ gap: 2, flexDir: 'column' }}>
-                  <Text variant="subtext" fontSize="sm">
-                    Onnx
-                  </Text>
-                  {filteredOnnxModels.map((model) => (
-                    <ModelListItem
-                      key={model.id}
-                      model={model}
-                      isSelected={selectedModelId === model.id}
-                      setSelectedModelId={setSelectedModelId}
-                    />
-                  ))}
-                </Flex>
-              </StyledModelContainer>
-            )}
-          {['images', 'lora'].includes(modelFormatFilter) &&
+
+          {/* LoRAs List */}
+          {isLoadingLoraModels && (
+            <FetchingModelsLoader loadingMessage="Loading LoRAs..." />
+          )}
+          {['all', 'lora'].includes(modelFormatFilter) &&
+            !isLoadingLoraModels &&
             filteredLoraModels.length > 0 && (
-              <StyledModelContainer>
-                <Flex sx={{ gap: 2, flexDir: 'column' }}>
-                  <Text variant="subtext" fontSize="sm">
-                    LoRAs
-                  </Text>
-                  {filteredLoraModels.map((model) => (
-                    <ModelListItem
-                      key={model.id}
-                      model={model}
-                      isSelected={selectedModelId === model.id}
-                      setSelectedModelId={setSelectedModelId}
-                    />
-                  ))}
-                </Flex>
-              </StyledModelContainer>
+              <ModelListWrapper
+                title="LoRAs"
+                modelList={filteredLoraModels}
+                selected={{ selectedModelId, setSelectedModelId }}
+                key="loras"
+              />
+            )}
+          {/* Olive List */}
+          {isLoadingOliveModels && (
+            <FetchingModelsLoader loadingMessage="Loading Olives..." />
+          )}
+          {['all', 'olive'].includes(modelFormatFilter) &&
+            !isLoadingOliveModels &&
+            filteredOliveModels.length > 0 && (
+              <ModelListWrapper
+                title="Olives"
+                modelList={filteredOliveModels}
+                selected={{ selectedModelId, setSelectedModelId }}
+                key="olive"
+              />
+            )}
+          {/* Onnx List */}
+          {isLoadingOnnxModels && (
+            <FetchingModelsLoader loadingMessage="Loading ONNX..." />
+          )}
+          {['all', 'onnx'].includes(modelFormatFilter) &&
+            !isLoadingOnnxModels &&
+            filteredOnnxModels.length > 0 && (
+              <ModelListWrapper
+                title="ONNX"
+                modelList={filteredOnnxModels}
+                selected={{ selectedModelId, setSelectedModelId }}
+                key="onnx"
+              />
             )}
         </Flex>
       </Flex>
@@ -330,11 +285,37 @@ const StyledModelContainer = (props: PropsWithChildren) => {
   );
 };
 
-const FetchingModelsLoader = ({
-  loadingMessage,
-}: {
-  loadingMessage?: string;
-}) => {
+type ModelListWrapperProps = {
+  title: string;
+  modelList:
+    | MainModelConfigEntity[]
+    | LoRAModelConfigEntity[]
+    | OnnxModelConfigEntity[];
+  selected: ModelListProps;
+};
+
+function ModelListWrapper(props: ModelListWrapperProps) {
+  const { title, modelList, selected } = props;
+  return (
+    <StyledModelContainer>
+      <Flex sx={{ gap: 2, flexDir: 'column' }}>
+        <Text variant="subtext" fontSize="sm">
+          {title}
+        </Text>
+        {modelList.map((model) => (
+          <ModelListItem
+            key={model.id}
+            model={model}
+            isSelected={selected.selectedModelId === model.id}
+            setSelectedModelId={selected.setSelectedModelId}
+          />
+        ))}
+      </Flex>
+    </StyledModelContainer>
+  );
+}
+
+function FetchingModelsLoader({ loadingMessage }: { loadingMessage?: string }) {
   return (
     <StyledModelContainer>
       <Flex
@@ -351,4 +332,4 @@ const FetchingModelsLoader = ({
       </Flex>
     </StyledModelContainer>
   );
-};
+}

--- a/invokeai/frontend/web/src/services/api/endpoints/models.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/models.ts
@@ -181,7 +181,7 @@ export const modelsApi = api.injectEndpoints({
       },
       providesTags: (result, error, arg) => {
         const tags: ApiFullTagDescription[] = [
-          { id: 'OnnxModel', type: LIST_TAG },
+          { type: 'OnnxModel', id: LIST_TAG },
         ];
 
         if (result) {
@@ -266,6 +266,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     importMainModels: build.mutation<
@@ -282,6 +283,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     addMainModels: build.mutation<AddMainModelResponse, AddMainModelArg>({
@@ -295,6 +297,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     deleteMainModels: build.mutation<
@@ -310,6 +313,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     convertMainModels: build.mutation<
@@ -326,6 +330,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     mergeMainModels: build.mutation<MergeMainModelResponse, MergeMainModelArg>({
@@ -339,6 +344,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     syncModels: build.mutation<SyncModelsResponse, void>({
@@ -351,6 +357,7 @@ export const modelsApi = api.injectEndpoints({
       invalidatesTags: [
         { type: 'MainModel', id: LIST_TAG },
         { type: 'SDXLRefinerModel', id: LIST_TAG },
+        { type: 'OnnxModel', id: LIST_TAG },
       ],
     }),
     getLoRAModels: build.query<EntityState<LoRAModelConfigEntity>, void>({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [?] Optimization


## Have you discussed this change with the InvokeAI team?
- [x] No

     
## Description

- Fixed filter type select using `images` instead of `all` -- Probably some merge conflict.
- Added loading state for model lists. Handy when the model list takes longer than a second for any reason to fetch. Better to show this than an empty screen.
- Refactored the render model list function so we modify the display component in one area rather than have repeated code.

### Other Issues

- The list can get a bit laggy on initial load when you have a hundreds of models / loras. This needs to be fixed. Will make another PR for this.