### PR TITLE
Refactor/cleanup root detection

### DIFF
--- a/invokeai/app/services/config.py
+++ b/invokeai/app/services/config.py
@@ -356,7 +356,6 @@ def _find_root() -> Path:
     venv = Path(os.environ.get("VIRTUAL_ENV") or ".")
     if os.environ.get("INVOKEAI_ROOT"):
         root = Path(os.environ.get("INVOKEAI_ROOT")).resolve()
-        os.environ["INVOKEAI_ROOT"] = str(root)  # absolutize it to protect against code doing a cwd()
     elif any([(venv.parent / x).exists() for x in [INIT_FILE, LEGACY_INIT_FILE]]):
         root = (venv.parent).resolve()
     else:
@@ -403,7 +402,7 @@ class InvokeAIAppConfig(InvokeAISettings):
     xformers_enabled    : bool = Field(default=True, description="Enable/disable memory-efficient attention", category='Memory/Performance')
     tiled_decode        : bool = Field(default=False, description="Whether to enable tiled VAE decode (reduces memory consumption with some performance penalty)", category='Memory/Performance')
 
-    root                : Path = Field(default=_find_root(), description='InvokeAI runtime root directory', category='Paths')
+    root                : Path = Field(default=None, description='InvokeAI runtime root directory', category='Paths')
     autoimport_dir      : Path = Field(default='autoimport', description='Path to a directory of models files to be imported on startup.', category='Paths')
     lora_dir            : Path = Field(default=None, description='Path to a directory of LoRA/LyCORIS models to be imported on startup.', category='Paths')
     embedding_dir       : Path = Field(default=None, description='Path to a directory of Textual Inversion embeddings to be imported on startup.', category='Paths')
@@ -475,6 +474,7 @@ class InvokeAIAppConfig(InvokeAISettings):
             root = Path(self.root).expanduser().absolute()
         else:
             root = self.find_root()
+        self.root = root  # insulate ourselves from relative paths that may change
         return root
 
     @property

--- a/invokeai/frontend/install/model_install.py
+++ b/invokeai/frontend/install/model_install.py
@@ -767,7 +767,9 @@ def main():
         invoke_args.extend(["--root", opt.root])
     if opt.full_precision:
         invoke_args.extend(["--precision", "float32"])
+    print(f"DEBUG: {invoke_args}")
     config.parse_args(invoke_args)
+    print(f"DEBUG: {config.root} {config.root_path}")
     logger = InvokeAILogger().getLogger(config=config)
 
     if not config.model_conf_path.exists():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,20 @@ def test_env_override():
     assert conf.max_cache_size == 20
 
 
+def test_root_resists_cwd():
+    previous = os.environ["INVOKEAI_ROOT"]
+    cwd = Path(os.getcwd()).resolve()
+
+    os.environ["INVOKEAI_ROOT"] = "."
+    conf = InvokeAIAppConfig.get_config()
+    conf.parse_args([])
+    assert conf.root_path == cwd
+
+    os.chdir(previous)
+    assert conf.root_path == cwd
+    os.environ["INVOKEAI_ROOT"] = previous
+
+
 def test_type_coercion():
     conf = InvokeAIAppConfig().get_config()
     conf.parse_args(argv=["--root=/tmp/foobar"])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ X] No, because: invisible change

      
## Have you updated all relevant documentation?
- [ X] Yes
- [ ] No


## Description

There was a problem in 3.0.1 with root resolution. If INVOKEAI_ROOT were set to "." (or any relative path), then the location of root would change if the code did an os.chdir() after config initialization. I fixed this in a quick and dirty way for 3.0.1.post3.

This PR cleans up the code with a little refactoring.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
