### PR TITLE
Fix manual installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ the command `npm install -g yarn` if needed)
 6. Configure InvokeAI and install a starting set of image generation models (you only need to do this once):
 
     ```terminal
-    invokeai-configure
+    invokeai-configure --root .
     ```
+	Don't miss the dot at the end!
 
 7. Launch the web server (do it every time you run InvokeAI):
 
@@ -193,15 +194,9 @@ the command `npm install -g yarn` if needed)
     invokeai-web
     ```
 
-8. Build Node.js assets
+8. Point your browser to http://localhost:9090 to bring up the web interface.
 
-  ```terminal
-  cd invokeai/frontend/web/
-  yarn vite build
-  ```
-
-9. Point your browser to http://localhost:9090 to bring up the web interface.
-10. Type `banana sushi` in the box on the top left and click `Invoke`.
+9. Type `banana sushi` in the box on the top left and click `Invoke`.
 
 Be sure to activate the virtual environment each time before re-launching InvokeAI,
 using `source .venv/bin/activate` or `.venv\Scripts\activate`.

--- a/docs/installation/020_INSTALL_MANUAL.md
+++ b/docs/installation/020_INSTALL_MANUAL.md
@@ -192,8 +192,10 @@ manager, please follow these steps:
     your outputs.
 
     ```terminal
-    invokeai-configure
+    invokeai-configure --root .
     ```
+	
+	Don't miss the dot at the end of the command!
 
     The script `invokeai-configure` will interactively guide you through the
     process of downloading and installing the weights files needed for InvokeAI.
@@ -225,12 +227,6 @@ manager, please follow these steps:
 
         !!! warning "Make sure that the virtual environment is activated, which should create `(.venv)` in front of your prompt!"
 
-        === "CLI"
-
-            ```bash
-            invokeai
-            ```
-
         === "local Webserver"
 
             ```bash
@@ -241,6 +237,12 @@ manager, please follow these steps:
 
             ```bash
             invokeai --web --host 0.0.0.0
+            ```
+
+        === "CLI"
+
+            ```bash
+            invokeai
             ```
 
         If you choose the run the web interface, point your browser at


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ]X Bug Fix
- [ ] Optimization
- [ X] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ X] No, because: obvious problem

      
## Have you updated all relevant documentation?
- [ X] Yes
- [ ] No


## Description

The manual installation documentation in both README.md and 020_MANUAL_INSTALL give an incomplete `invokeai-configure` command which leaves out the path to the root directory to create. As a result, the invokeai root directory gets created in the user’s home directory, even if they intended it to be placed somewhere else.

This is a fairly important issue.