### PR TITLE
fix: flake: add opencv with CUDA, new patchmatch dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,10 @@
             cudaPackages.cudnn
             cudaPackages.cuda_nvrtc
             cudatoolkit
+            pkgconfig
+            libconfig
+            cmake
+            blas
             freeglut
             glib
             gperf
@@ -42,6 +46,12 @@
             libGLU
             linuxPackages.nvidia_x11
             python
+            (opencv4.override {
+              enableGtk3 = true;
+              enableFfmpeg = true;
+              enableCuda = true;
+              enableUnfree = true;
+            })
             stdenv.cc
             stdenv.cc.cc.lib
             xorg.libX11


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

patchmatch requires build dependencies including opencv4 with CUDA. Update the flake to add them.

This fixes patchmatch not being able to be built upon startup.