### PR TITLE
fix broken civitai example link

### DIFF
--- a/docs/installation/050_INSTALLING_MODELS.md
+++ b/docs/installation/050_INSTALLING_MODELS.md
@@ -124,7 +124,7 @@ installation. Examples:
 invokeai-model-install --list controlnet
 
 # (install the model at the indicated URL)
-invokeai-model-install --add http://civitai.com/2860
+invokeai-model-install --add https://civitai.com/api/download/models/128713
 
 # (delete the named model)
 invokeai-model-install --delete sd-1/main/analog-diffusion


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ X] Documentation Update


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X ] No, because: noncontroversial

      
## Have you updated all relevant documentation?
- [ X] Yes
- [ ] No

## Description

Fixes broken Civitai example link in manual install documentation.

## Related Tickets & Documents
Closes #4152 

