### PR TITLE
Fix hue adjustment

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -667,9 +667,8 @@ class ImageHueAdjustmentInvocation(BaseInvocation):
     def invoke(self, context: InvocationContext) -> ImageOutput:
         pil_image = context.services.images.get_pil_image(self.image.image_name)
 
-        # Convert PIL image to OpenCV format (numpy array), note color channel
-        # ordering is changed from RGB to BGR
-        image = numpy.array(pil_image.convert("RGB"))[:, :, ::-1]
+        # Convert PIL image to OpenCV format (numpy array)
+        image = numpy.array(pil_image.convert("RGB"))
 
         # Convert image to HSV color space
         hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
@@ -681,7 +680,7 @@ class ImageHueAdjustmentInvocation(BaseInvocation):
         image = cv2.cvtColor(hsv_image, cv2.COLOR_HSV2BGR)
 
         # Convert back to PIL format and to original color mode
-        pil_image = Image.fromarray(image[:, :, ::-1], "RGB").convert("RGBA")
+        pil_image = Image.fromarray(image, "RGB").convert("RGBA")
 
         image_dto = context.services.images.create(
             image=pil_image,

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -661,7 +661,7 @@ class ImageHueAdjustmentInvocation(BaseInvocation):
 
     # Inputs
     image: ImageField = Field(default=None, description="The image to adjust")
-    hue: int = Field(default=0, description="The degrees by which to rotate the hue")
+    hue: int = Field(default=0, description="The degrees by which to rotate the hue, 0-360")
     # fmt: on
 
     def invoke(self, context: InvocationContext) -> ImageOutput:

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -667,20 +667,17 @@ class ImageHueAdjustmentInvocation(BaseInvocation):
     def invoke(self, context: InvocationContext) -> ImageOutput:
         pil_image = context.services.images.get_pil_image(self.image.image_name)
 
-        # Convert PIL image to OpenCV format (numpy array)
-        image = numpy.array(pil_image.convert("RGB"))
-
         # Convert image to HSV color space
-        hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        hsv_image = numpy.array(pil_image.convert("HSV"))
 
-        # Adjust the hue
-        hsv_image[:, :, 0] = (hsv_image[:, :, 0] + self.hue) % 180
+        # Convert hue from 0..360 to 0..256
+        hue = int(256 * ((self.hue % 360) / 360))
 
-        # Convert image back to BGR color space
-        image = cv2.cvtColor(hsv_image, cv2.COLOR_HSV2BGR)
+        # Increment each hue and wrap around at 255
+        hsv_image[:, :, 0] = (hsv_image[:, :, 0] + hue) % 256
 
         # Convert back to PIL format and to original color mode
-        pil_image = Image.fromarray(image, "RGB").convert("RGBA")
+        pil_image = Image.fromarray(hsv_image, mode="HSV").convert("RGBA")
 
         image_dto = context.services.images.create(
             image=pil_image,


### PR DESCRIPTION
Hue adjustment wasn't working correctly because color channels got swapped. This has now been fixed.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No; N/A


## Description

The image resulting from a hue shift had discontinuities in color. This was a result of color channels being swapped prior to the conversion to/from HSV. This PR fixes the problem.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [X] No : I tested this manually with images, comparing results to Photoshop.

## [optional] Are there any post deployment tasks we need to perform?
