### PR TITLE
Pick correct config file for sdxl models

### DIFF
--- a/invokeai/backend/model_management/model_manager.py
+++ b/invokeai/backend/model_management/model_manager.py
@@ -941,7 +941,9 @@ class ModelManager(object):
                                     raise DuplicateModelException(f"Model with key {model_key} added twice")
 
                                 model_path = self.relative_model_path(model_path)
-                                model_config: ModelConfigBase = model_class.probe_config(str(model_path))
+                                model_config: ModelConfigBase = model_class.probe_config(
+                                    str(model_path), model_base=cur_base_model
+                                )
                                 self.models[model_key] = model_config
                                 new_models_found = True
                             except DuplicateModelException as e:

--- a/invokeai/backend/model_management/models/sdxl.py
+++ b/invokeai/backend/model_management/models/sdxl.py
@@ -80,8 +80,10 @@ class StableDiffusionXLModel(DiffusersModel):
             raise Exception("Unkown stable diffusion 2.* model format")
 
         if ckpt_config_path is None:
-            # TO DO: implement picking
-            pass
+            # avoid circular import
+            from .stable_diffusion import _select_ckpt_config
+
+            ckpt_config_path = _select_ckpt_config(kwargs.get("model_base", BaseModelType.StableDiffusionXL), variant)
 
         return cls.create_config(
             path=path,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X Yes
- [ ] No


## Description

If `models.yaml` is cleared out for some reason, the model manager will repopulate it by scanning `models`. However, this would fail with a pydantic validation error if any SDXL checkpoint models were present because the lack of logic to pick the correct configuration file. This has now been added.

