### PR TITLE
api(images): allow HEAD request on image/full

### DIFF
--- a/invokeai/app/api/routers/images.py
+++ b/invokeai/app/api/routers/images.py
@@ -1,22 +1,20 @@
 import io
 from typing import Optional
 
+from PIL import Image
 from fastapi import Body, HTTPException, Path, Query, Request, Response, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.routing import APIRouter
-from PIL import Image
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from invokeai.app.invocations.metadata import ImageMetadata
 from invokeai.app.models.image import ImageCategory, ResourceOrigin
 from invokeai.app.services.image_record_storage import OffsetPaginatedResults
-from invokeai.app.services.item_storage import PaginatedResults
 from invokeai.app.services.models.image_record import (
     ImageDTO,
     ImageRecordChanges,
     ImageUrlsDTO,
 )
-
 from ..dependencies import ApiDependencies
 
 images_router = APIRouter(prefix="/v1/images", tags=["images"])
@@ -152,8 +150,9 @@ async def get_image_metadata(
         raise HTTPException(status_code=404)
 
 
-@images_router.get(
+@images_router.api_route(
     "/i/{image_name}/full",
+    methods=["GET", "HEAD"],
     operation_id="get_image_full",
     response_class=Response,
     responses={


### PR DESCRIPTION
Some clients, including whatever GIMP uses when you do "Open Location", do a HEAD request on a resource before downloading it.

Currently the image route only supports GET, so the HEAD request fails.

This lack of support for HEAD requests is something that should be addressed generally:
- https://github.com/tiangolo/fastapi/issues/1773

but in the meantime, I guess we handle it on a case-by-case basis? This PR adds HEAD to the route for `{image}/full`.


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## QA Instructions, Screenshots, Recordings

Test instructions:

- get the URL for a full image, perhaps by doing right-click _Open in New Tab_ and copying that URL.
- issue a HTTP HEAD request for that URL (maybe using [httpie](https://httpie.io/) or your other favorite HTTP test client) or with _File/Open Location_ in GIMP.
- ensure the request receives a `200 OK` response and/or the image opens.