### PR TITLE
Prevent `vae: ''` from crashing model

### DIFF
--- a/invokeai/app/api/routers/models.py
+++ b/invokeai/app/api/routers/models.py
@@ -104,8 +104,12 @@ async def update_model(
             ):  # model manager moved model path during rename - don't overwrite it
                 info.path = new_info.get("path")
 
+        # replace empty string values with None/null to avoid phenomenon of vae: ''
+        info_dict = info.dict()
+        info_dict = {x: info_dict[x] if info_dict[x] else None for x in info_dict.keys()}
+
         ApiDependencies.invoker.services.model_manager.update_model(
-            model_name=model_name, base_model=base_model, model_type=model_type, model_attributes=info.dict()
+            model_name=model_name, base_model=base_model, model_type=model_type, model_attributes=info_dict
         )
 
         model_raw = ApiDependencies.invoker.services.model_manager.list_model(

--- a/invokeai/backend/model_management/model_manager.py
+++ b/invokeai/backend/model_management/model_manager.py
@@ -526,7 +526,7 @@ class ModelManager(object):
         # Does the config explicitly override the submodel?
         if submodel_type is not None and hasattr(model_config, submodel_type):
             submodel_path = getattr(model_config, submodel_type)
-            if submodel_path is not None:
+            if submodel_path is not None and len(submodel_path) > 0:
                 model_path = getattr(model_config, submodel_type)
                 is_submodel_override = True
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -7,6 +7,7 @@ from invokeai.backend import ModelManager, BaseModelType, ModelType, SubModelTyp
 
 BASIC_MODEL_NAME = ("SDXL base", BaseModelType.StableDiffusionXL, ModelType.Main)
 VAE_OVERRIDE_MODEL_NAME = ("SDXL with VAE", BaseModelType.StableDiffusionXL, ModelType.Main)
+VAE_NULL_OVERRIDE_MODEL_NAME = ("SDXL with empty VAE", BaseModelType.StableDiffusionXL, ModelType.Main)
 
 
 @pytest.fixture
@@ -36,3 +37,11 @@ def test_get_model_path_for_overridden_vae(model_manager: ModelManager, datadir:
     expected_vae_path = datadir / "models" / "sdxl" / "vae" / "sdxl-vae-fp16-fix"
     assert vae_model_path == expected_vae_path
     assert is_override
+
+
+def test_get_model_path_for_null_overridden_vae(model_manager: ModelManager, datadir: Path):
+    model_config = model_manager._get_model_config(
+        VAE_NULL_OVERRIDE_MODEL_NAME[1], VAE_NULL_OVERRIDE_MODEL_NAME[0], VAE_NULL_OVERRIDE_MODEL_NAME[2]
+    )
+    vae_model_path, is_override = model_manager._get_model_path(model_config, SubModelType.Vae)
+    assert not is_override

--- a/tests/test_model_manager/configs/relative_sub.models.yaml
+++ b/tests/test_model_manager/configs/relative_sub.models.yaml
@@ -13,3 +13,10 @@ sdxl/main/SDXL with VAE:
   vae: sdxl/vae/sdxl-vae-fp16-fix/
   variant: normal
   format: diffusers
+
+sdxl/main/SDXL with empty VAE:
+  path: sdxl/main/SDXL base 1_0
+  description: SDXL with customized VAE
+  vae: ''
+  variant: normal
+  format: diffusers


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [X] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] Yes

      
## Have you updated all relevant documentation?
- [X] Yes

## Description

Empty model configuration fields sent by the Web Model Manager update call were sending empty strings for any field left blank, including `description` and `vae`. When the backend model manager tried to load a VAE with path `""`, it crashed.

This fixes two things:
1. If the `vae` field is an empty string, the call to `_get_model_path()` now returns `is_submodel_override` false, causing the custom VAE loading code to be bypassed. (a regression test has been added for this)
2. Added a router-level workaround to avoid writing empty strings into the model config file. These fields are replaced by None and end up not written into the config at all.

## Related Tickets & Documents

Discord bug report: https://discord.com/channels/1020123559063990373/1131987080466137219/1138829184349765652

## QA Instructions, Screenshots, Recordings

Use the web model manager to send empty fields to either `description` or `vae`. Then check `models.yaml` to see if the empty string was suppressed.

## Added/updated tests?

- [X] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_
