### PR TITLE
Bugfix: Limit RAM and VRAM cache settings to permissible values

### DIFF
--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -395,13 +395,23 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
             max_width=80,
             scroll_exit=True,
         )
-        self.max_cache_size = self.add_widget_intelligent(
-            IntTitleSlider,
+        self.nextrely += 1
+        self.add_widget_intelligent(
+            npyscreen.TitleFixedText,
             name="RAM cache size (GB). Make this at least large enough to hold a single full model.",
-            value=clip(old_opts.max_cache_size, range=(3.0, MAX_RAM)),
-            out_of=MAX_RAM,
-            lowest=3,
-            begin_entry_at=6,
+            begin_entry_at=0,
+            editable=False,
+            color="CONTROL",
+            scroll_exit=True,
+        )
+        self.nextrely -= 1
+        self.max_cache_size = self.add_widget_intelligent(
+            npyscreen.Slider,
+            value=clip(old_opts.max_cache_size, range=(3.0, MAX_RAM), step=0.5),
+            out_of=round(MAX_RAM),
+            lowest=0.0,
+            step=0.5,
+            relx=8,
             scroll_exit=True,
         )
         if HAS_CUDA:
@@ -417,7 +427,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
             self.nextrely -= 1
             self.max_vram_cache_size = self.add_widget_intelligent(
                 npyscreen.Slider,
-                value=clip(old_opts.max_vram_cache_size, range=(0, MAX_VRAM)),
+                value=clip(old_opts.max_vram_cache_size, range=(0, MAX_VRAM), step=0.25),
                 out_of=round(MAX_VRAM * 2) / 2,
                 lowest=0.0,
                 relx=8,
@@ -596,13 +606,13 @@ def default_user_selections(program_opts: Namespace) -> InstallSelections:
 
 
 # -------------------------------------
-def clip(value: float, range: tuple[float, float]) -> float:
+def clip(value: float, range: tuple[float, float], step: float) -> float:
     minimum, maximum = range
     if value < minimum:
         value = minimum
     if value > maximum:
         value = maximum
-    return value
+    return round(value / step) * step
 
 
 # -------------------------------------

--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -21,7 +21,6 @@ from argparse import Namespace
 from enum import Enum
 from pathlib import Path
 from shutil import get_terminal_size
-from typing import get_type_hints
 from urllib import request
 
 import npyscreen
@@ -399,7 +398,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
         self.max_cache_size = self.add_widget_intelligent(
             IntTitleSlider,
             name="RAM cache size (GB). Make this at least large enough to hold a single full model.",
-            value=old_opts.max_cache_size,
+            value=clip(old_opts.max_cache_size, range=(3.0, MAX_RAM)),
             out_of=MAX_RAM,
             lowest=3,
             begin_entry_at=6,
@@ -418,7 +417,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
             self.nextrely -= 1
             self.max_vram_cache_size = self.add_widget_intelligent(
                 npyscreen.Slider,
-                value=old_opts.max_vram_cache_size,
+                value=clip(old_opts.max_vram_cache_size, range=(0, MAX_VRAM)),
                 out_of=round(MAX_VRAM * 2) / 2,
                 lowest=0.0,
                 relx=8,
@@ -594,6 +593,16 @@ def default_user_selections(program_opts: Namespace) -> InstallSelections:
         if program_opts.yes_to_all
         else list(),
     )
+
+
+# -------------------------------------
+def clip(value: float, range: tuple[float, float]) -> float:
+    minimum, maximum = range
+    if value < minimum:
+        value = minimum
+    if value > maximum:
+        value = maximum
+    return value
 
 
 # -------------------------------------

--- a/invokeai/backend/install/migrate_to_3.py
+++ b/invokeai/backend/install/migrate_to_3.py
@@ -591,7 +591,6 @@ script, which will perform a full upgrade in place.""",
     # TODO: revisit - don't rely on invokeai.yaml to exist yet!
     dest_is_setup = (dest_root / "models/core").exists() and (dest_root / "databases").exists()
     if not dest_is_setup:
-        import invokeai.frontend.install.invokeai_configure
         from invokeai.backend.install.invokeai_configure import initialize_rootdir
 
         initialize_rootdir(dest_root, True)

--- a/invokeai/frontend/install/__init__.py
+++ b/invokeai/frontend/install/__init__.py
@@ -1,6 +1,3 @@
 """
 Initialization file for invokeai.frontend.config
 """
-from .invokeai_configure import main as invokeai_configure
-from .invokeai_update import main as invokeai_update
-from .model_install import main as invokeai_model_install

--- a/invokeai/frontend/install/invokeai_configure.py
+++ b/invokeai/frontend/install/invokeai_configure.py
@@ -1,4 +1,4 @@
 """
 Wrapper for invokeai.backend.configure.invokeai_configure
 """
-from ...backend.install.invokeai_configure import main
+from ...backend.install.invokeai_configure import main as invokeai_configure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
 [project.scripts]
 
 # legacy entrypoints; provided for backwards compatibility
-"configure_invokeai.py" = "invokeai.frontend.install:invokeai_configure"
+"configure_invokeai.py" = "invokeai.frontend.install.invokeai_configure:invokeai_configure"
 "textual_inversion.py" = "invokeai.frontend.training:invokeai_textual_inversion"
 
 # shortcut commands to start cli and web
@@ -130,12 +130,12 @@ dependencies = [
 "invokeai-web" = "invokeai.app.api_app:invoke_api"
 
 # full commands
-"invokeai-configure" = "invokeai.frontend.install:invokeai_configure"
+"invokeai-configure" = "invokeai.frontend.install.invokeai_configure:invokeai_configure"
 "invokeai-merge" = "invokeai.frontend.merge:invokeai_merge_diffusers"
 "invokeai-ti" = "invokeai.frontend.training:invokeai_textual_inversion"
-"invokeai-model-install" = "invokeai.frontend.install:invokeai_model_install"
+"invokeai-model-install" = "invokeai.frontend.install.model_install:main"
 "invokeai-migrate3" = "invokeai.backend.install.migrate_to_3:main"
-"invokeai-update" = "invokeai.frontend.install:invokeai_update"
+"invokeai-update" = "invokeai.frontend.install.invokeai_update:main"
 "invokeai-metadata" = "invokeai.frontend.CLI.sd_metadata:print_metadata"
 "invokeai-node-cli" = "invokeai.app.cli_app:invoke_cli"
 "invokeai-node-web" = "invokeai.app.api_app:invoke_api"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] Yes
      
## Have you updated all relevant documentation?
- [X] Yes

## Description
@JPPhoto discovered that if he had previously manually set the value of `max_ram_cache` to greater than the amount available on his system, that `configure_invokeai` would crash. This is because the UI is now reading system values to set up the maximum value for the RAM and VRAM cache sliders, but was not checking that the old setting was within range.

This fixes the issue by clipping RAM and VRAM cache settings to the maximum and minimum permissible values.

It also cleans up some unneeded import code located in `invokeai.frontend.install.__init__`, which was exacerbating circular dependency issues and had no benefit other than making some `from` statements shorter. 

## Related Tickets & Documents

See this for @JPPhoto bug report and discussion thread:
https://discord.com/channels/1020123559063990373/1042475531079262378/1138844145167892651
