### PR TITLE
Ignore unknown command-line arguments

### DIFF
--- a/invokeai/app/services/config.py
+++ b/invokeai/app/services/config.py
@@ -186,7 +186,7 @@ class InvokeAISettings(BaseSettings):
 
     def parse_args(self, argv: list = sys.argv[1:]):
         parser = self.get_parser()
-        opt = parser.parse_args(argv)
+        opt, _ = parser.parse_known_args(argv)
         for name in self.__fields__:
             if name not in self._excluded():
                 value = getattr(opt, name)


### PR DESCRIPTION
Currently, when unknown CLI arguments are encountered, `argparse` exits with an error.

This PR changes that so that unknown CLI args are silently ignored. Particularly this enables running the `uvicorn` server directly, taking advantage of hot-reloading in development, like so: `uvicorn invokeai.app.api_app:app --reload`.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No (will update the docs if this direction is deemed acceptable)

