### PR TITLE
feat: Set currently selected model back to Canvas if it exists

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/tabChanged.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/tabChanged.ts
@@ -1,6 +1,6 @@
 import { modelChanged } from 'features/parameters/store/generationSlice';
 import { setActiveTab } from 'features/ui/store/uiSlice';
-import { forEach } from 'lodash-es';
+import { find, forEach } from 'lodash-es';
 import { NON_REFINER_BASE_MODELS } from 'services/api/constants';
 import {
   MainModelConfigEntity,
@@ -37,17 +37,25 @@ export const addTabChangedListener = () => {
           }
         });
 
-        // this could still be undefined even tho TS doesn't say so
-        const firstValidCanvasModel = validCanvasModels[0];
+        // Check if current selected model exists on Canvas Models
+        const currentModel = find(
+          validCanvasModels,
+          (model) =>
+            model.model_name === getState().generation.model?.model_name
+        );
 
-        if (!firstValidCanvasModel) {
+        // If it does, set it or else set the first in list
+        const validModel = currentModel ? currentModel : validCanvasModels[0];
+
+        // Make sure the valid model exists. Can be undefined in some cases.
+        if (!validModel) {
           // uh oh, we have no models that are valid for canvas
           dispatch(modelChanged(null));
           return;
         }
 
         // only store the model name and base model in redux
-        const { base_model, model_name, model_type } = firstValidCanvasModel;
+        const { base_model, model_name, model_type } = validModel;
 
         dispatch(modelChanged({ base_model, model_name, model_type }));
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [x] Yes
      
## Description

If the currently selected model is available for canvas, then set it instead of defaulting to the first in the list.

## Related Tickets & Documents

- Closes #4215

## Post Merge

- Remember to add SDXL to this list when SDXL inpainting is merged in.