### PR TITLE
Fix maximum python version installation instructions

### DIFF
--- a/installer/readme.txt
+++ b/installer/readme.txt
@@ -8,16 +8,13 @@ Preparations:
   to work. Instructions are given here:
   https://invoke-ai.github.io/InvokeAI/installation/INSTALL_AUTOMATED/
 
-  NOTE: At this time we do not recommend Python 3.11. We recommend 
-  Version 3.10.9, which has been extensively tested with InvokeAI.
-  
   Before you start the installer, please open up your system's command
   line window (Terminal or Command) and type the commands:
 
      python --version
 
   If all is well, it will print "Python 3.X.X", where the version number
-  is at least 3.9.1, and less than 3.11.
+  is at least 3.9.*, and not higher than 3.11.*.
 
   If this works, check the version of the Python package manager, pip:
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Documentation Update


## Have you discussed this change with the InvokeAI team?
- [X] Yes

      
## Have you updated all relevant documentation?
- [X] Yes

## Description

One-line fix for the installer `readme.txt` file, which was still telling people that maximum python supported was 3.10.
Updated to indicate 3.9 through 3.11, consistent with other documentation.