### PR TITLE
Warn instead of crashing when a corrupted model is detected during startup scan

### DIFF
--- a/invokeai/backend/model_management/models/sdxl.py
+++ b/invokeai/backend/model_management/models/sdxl.py
@@ -1,6 +1,5 @@
 import os
 import json
-import invokeai.backend.util.logging as logger
 from enum import Enum
 from pydantic import Field
 from typing import Literal, Optional
@@ -12,6 +11,7 @@ from .base import (
     DiffusersModel,
     read_checkpoint_meta,
     classproperty,
+    InvalidModelException,
 )
 from omegaconf import OmegaConf
 
@@ -65,7 +65,7 @@ class StableDiffusionXLModel(DiffusersModel):
                 in_channels = unet_config["in_channels"]
 
             else:
-                raise Exception("Not supported stable diffusion diffusers format(possibly onnx?)")
+                raise InvalidModelException(f"{path} is not a recognized Stable Diffusion diffusers model")
 
         else:
             raise NotImplementedError(f"Unknown stable diffusion 2.* format: {model_format}")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [X] Bug Fix


## Have you discussed this change with the InvokeAI team?
- [X] Yes
      
## Have you updated all relevant documentation?
- [X] Yes

## Description
During directory scanning for new models, if a corrupt model was detected, InvokeAI would st

## Related Tickets & Documents

Avoids this issue: https://discord.com/channels/1020123559063990373/1133929466763161650/1139606160505319575


## QA Instructions, Screenshots, Recordings

To test:
1. Select any sdxl or sdxl-refiner model, go to its `unet` folder, and rename `config.json` to `config.json.hide`. 
2. Comment out the corresponding stanza in `models.yaml` in order to trigger a rescan of the directory.
3. Start InvokeAI

If the bug is fixed you'll get a warning that the model seems to be invalid. If not, you'll get a crash and stacktrace.
