### PR TITLE
Reimplement model config storage backend

### DIFF
--- a/invokeai/backend/model_management2/model_config.py
+++ b/invokeai/backend/model_management2/model_config.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2023 Lincoln D. Stein and the InvokeAI Development Team
+"""Configuration definitions for image generation models."""
+from enum import Enum
+from pathlib import Path
+from pydantic import BaseModel, Field, Extra
+from typing import Optional, Literal, Union
+from pydantic.error_wrappers import ValidationError
+
+class InvalidModelConfigException(Exception):
+    """
+    Exception raised when the config parser doesn't recognize the passed
+    combo of model type and format.
+    """
+
+    pass
+
+
+class BaseModelType(str, Enum):
+    """Base model type."""
+
+    StableDiffusion1 = "sd-1"
+    StableDiffusion2 = "sd-2"
+    StableDiffusionXL = "sdxl"
+    StableDiffusionXLRefiner = "sdxl-refiner"
+    # Kandinsky2_1 = "kandinsky-2.1"
+
+
+class ModelType(str, Enum):
+    """Model type."""
+
+    ONNX = "onnx"
+    Main = "main"
+    Vae = "vae"
+    Lora = "lora"
+    ControlNet = "controlnet"  # used by model_probe
+    TextualInversion = "embedding"
+
+
+class SubModelType(str, Enum):
+    """Submodel type."""
+
+    UNet = "unet"
+    TextEncoder = "text_encoder"
+    TextEncoder2 = "text_encoder_2"
+    Tokenizer = "tokenizer"
+    Tokenizer2 = "tokenizer_2"
+    Vae = "vae"
+    VaeDecoder = "vae_decoder"
+    VaeEncoder = "vae_encoder"
+    Scheduler = "scheduler"
+    SafetyChecker = "safety_checker"
+
+
+class ModelVariantType(str, Enum):
+    """Variant type."""
+
+    Normal = "normal"
+    Inpaint = "inpaint"
+    Depth = "depth"
+
+
+class ModelFormat(str, Enum):
+    """Storage format of model."""
+
+    Diffusers = "diffusers"
+    Checkpoint = "checkpoint"
+    Lycoris = "lycoris"
+    Onnx = "onnx"
+    Olive = "olive"
+    EmbeddingFile = "embedding_file"
+    EmbeddingFolder = "embedding_folder"
+
+
+class SchedulerPredictionType(str, Enum):
+    """Scheduler prediction type."""
+
+    Epsilon = "epsilon"
+    VPrediction = "v_prediction"
+    Sample = "sample"
+
+
+class ModelConfigBase(BaseModel):
+    """Base class for model configuration information."""
+
+    path: Path
+    name: str
+    base_model: BaseModelType
+    model_type: ModelType
+    model_format: ModelFormat
+    description: Optional[str] = Field(None)
+    author: Optional[str] = Field(description="Model author")
+    thumbnail_url: Optional[str] = Field(description="URL of thumbnail image")
+    license_url: Optional[str] = Field(description="URL of license")
+    source_url: Optional[str] = Field(description="Model download source")
+
+    class Config:
+        """Pydantic configuration hint."""
+
+        use_enum_values = True
+        extra = Extra.forbid
+        validate_assignment = True
+
+class CheckpointConfig(ModelConfigBase):
+    """Model config for checkpoint-style models."""
+
+    model_format: Literal[ModelFormat.Checkpoint] = ModelFormat.Checkpoint
+    config: Path = Field(
+        description="path to the checkpoint model config file"
+    )
+
+
+class DiffusersConfig(ModelConfigBase):
+    """Model config for diffusers-style models."""
+
+    model_format: Literal[ModelFormat.Diffusers] = ModelFormat.Diffusers
+
+
+class LoRAConfig(ModelConfigBase):
+    """Model config for LoRA/Lycoris models."""
+
+    model_format: Literal[ModelFormat.Lycoris, ModelFormat.Diffusers]
+
+
+class TextualInversionConfig(ModelConfigBase):
+    """Model config for textual inversion embeddings."""
+
+    model_format: Literal[
+        ModelFormat.EmbeddingFile,
+        ModelFormat.EmbeddingFolder
+    ]
+
+
+class MainConfig(ModelConfigBase):
+    """Model config for main models."""
+
+    vae: Optional[Path] = Field(None)
+    model_variant: ModelVariantType
+
+
+class MainCheckpointConfig(CheckpointConfig, MainConfig):
+    """Model config for main checkpoint models."""
+
+    pass
+
+
+class MainDiffusersConfig(DiffusersConfig, MainConfig):
+    """Model config for main diffusers models."""
+
+    pass
+
+
+class ONNXSD1Config(MainConfig):
+    """Model config for ONNX format models based on sd-1."""
+
+    model_format: Literal[ModelFormat.Onnx, ModelFormat.Olive]
+
+class ONNXSD2Config(MainConfig):
+    """Model config for ONNX format models based on sd-2."""
+
+    model_format: Literal[ModelFormat.Onnx, ModelFormat.Olive]
+    # No yaml config file for ONNX, so these are part of config
+    prediction_type: SchedulerPredictionType
+    upcast_attention: bool
+
+class ModelConfig(object):
+    """Class for parsing config dicts into StableDiffusion*Config obects."""
+
+    _class_map: dict = {
+        ModelFormat.Checkpoint: {
+            ModelType.Main: MainCheckpointConfig,
+        },
+        ModelFormat.Diffusers: {
+            ModelType.Main: MainDiffusersConfig,
+            ModelType.Lora: LoRAConfig,
+        },
+        ModelFormat.Lycoris: {
+            ModelType.Lora: LoRAConfig,
+        },
+        ModelFormat.Onnx: {
+            ModelType.ONNX: {
+                BaseModelType.StableDiffusion1: ONNXSD1Config,
+                BaseModelType.StableDiffusion2: ONNXSD2Config,
+            },
+        },
+        ModelFormat.Olive: {
+            ModelType.ONNX: {
+                BaseModelType.StableDiffusion1: ONNXSD1Config,
+                BaseModelType.StableDiffusion2: ONNXSD2Config,
+            },
+        },
+        ModelFormat.EmbeddingFile: {
+            ModelType.TextualInversion: TextualInversionConfig,
+        },
+        ModelFormat.EmbeddingFolder: {
+            ModelType.TextualInversion: TextualInversionConfig,
+        },
+    }
+
+    @classmethod
+    def parse_obj(cls, raw_data: dict) -> Union[
+            MainCheckpointConfig,
+            MainDiffusersConfig,
+            LoRAConfig,
+            TextualInversionConfig,
+            ONNXSD1Config,
+            ONNXSD2Config,
+    ]:
+        """Return the appropriate config object from raw dict values."""
+        try:
+            model_format = raw_data.get('model_format')
+            model_type = raw_data.get('model_type')
+            model_base = raw_data.get('base_model')
+            class_to_return = cls._class_map[model_format][model_type]
+            if isinstance(class_to_return,dict): # additional level allowed
+                class_to_return = class_to_return[model_base]
+            return class_to_return.parse_obj(raw_data)
+        except KeyError:
+            raise InvalidModelConfigException(
+                f"Unknown combination of model_format '{model_format}' and model_type '{model_type}'"
+            )
+        except ValidationError as e:
+            raise InvalidModelConfigException(
+                f"Invalid model configuration passed: {str(e)}"
+            ) from e

--- a/invokeai/backend/model_management2/model_config.py
+++ b/invokeai/backend/model_management2/model_config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, Extra
 from typing import Optional, Literal, Union
 from pydantic.error_wrappers import ValidationError
 
+
 class InvalidModelConfigException(Exception):
     """
     Exception raised when the config parser doesn't recognize the passed
@@ -100,13 +101,12 @@ class ModelConfigBase(BaseModel):
         extra = Extra.forbid
         validate_assignment = True
 
+
 class CheckpointConfig(ModelConfigBase):
     """Model config for checkpoint-style models."""
 
     model_format: Literal[ModelFormat.Checkpoint] = ModelFormat.Checkpoint
-    config: Path = Field(
-        description="path to the checkpoint model config file"
-    )
+    config: Path = Field(description="path to the checkpoint model config file")
 
 
 class DiffusersConfig(ModelConfigBase):
@@ -124,10 +124,7 @@ class LoRAConfig(ModelConfigBase):
 class TextualInversionConfig(ModelConfigBase):
     """Model config for textual inversion embeddings."""
 
-    model_format: Literal[
-        ModelFormat.EmbeddingFile,
-        ModelFormat.EmbeddingFolder
-    ]
+    model_format: Literal[ModelFormat.EmbeddingFile, ModelFormat.EmbeddingFolder]
 
 
 class MainConfig(ModelConfigBase):
@@ -154,6 +151,7 @@ class ONNXSD1Config(MainConfig):
 
     model_format: Literal[ModelFormat.Onnx, ModelFormat.Olive]
 
+
 class ONNXSD2Config(MainConfig):
     """Model config for ONNX format models based on sd-2."""
 
@@ -161,6 +159,7 @@ class ONNXSD2Config(MainConfig):
     # No yaml config file for ONNX, so these are part of config
     prediction_type: SchedulerPredictionType
     upcast_attention: bool
+
 
 class ModelConfig(object):
     """Class for parsing config dicts into StableDiffusion*Config obects."""
@@ -197,21 +196,23 @@ class ModelConfig(object):
     }
 
     @classmethod
-    def parse_obj(cls, raw_data: dict) -> Union[
-            MainCheckpointConfig,
-            MainDiffusersConfig,
-            LoRAConfig,
-            TextualInversionConfig,
-            ONNXSD1Config,
-            ONNXSD2Config,
+    def parse_obj(
+        cls, raw_data: dict
+    ) -> Union[
+        MainCheckpointConfig,
+        MainDiffusersConfig,
+        LoRAConfig,
+        TextualInversionConfig,
+        ONNXSD1Config,
+        ONNXSD2Config,
     ]:
         """Return the appropriate config object from raw dict values."""
         try:
-            model_format = raw_data.get('model_format')
-            model_type = raw_data.get('model_type')
-            model_base = raw_data.get('base_model')
+            model_format = raw_data.get("model_format")
+            model_type = raw_data.get("model_type")
+            model_base = raw_data.get("base_model")
             class_to_return = cls._class_map[model_format][model_type]
-            if isinstance(class_to_return,dict): # additional level allowed
+            if isinstance(class_to_return, dict):  # additional level allowed
                 class_to_return = class_to_return[model_base]
             return class_to_return.parse_obj(raw_data)
         except KeyError:
@@ -219,6 +220,4 @@ class ModelConfig(object):
                 f"Unknown combination of model_format '{model_format}' and model_type '{model_type}'"
             )
         except ValidationError as e:
-            raise InvalidModelConfigException(
-                f"Invalid model configuration passed: {str(e)}"
-            ) from e
+            raise InvalidModelConfigException(f"Invalid model configuration passed: {str(e)}") from e

--- a/tests/test_model_config2.py
+++ b/tests/test_model_config2.py
@@ -1,0 +1,155 @@
+"""
+Test the refactored model config classes.
+"""
+
+from pathlib import Path
+
+from invokeai.backend.model_management2.model_config import(
+    ModelConfig,
+    InvalidModelConfigException,
+    MainCheckpointConfig,
+    MainDiffusersConfig,
+    LoRAConfig,
+    TextualInversionConfig,
+    ONNXSD1Config,
+    ONNXSD2Config,
+    ValidationError,
+)
+
+def test_checkpoints():
+    raw = dict(path='/tmp/foo.ckpt',
+               name='foo',
+               base_model='sd-1',
+               model_type='main',
+               config='/tmp/foo.yaml',
+               model_variant='normal',
+               model_format='checkpoint'
+            )
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config, MainCheckpointConfig)
+    assert config.model_format == "checkpoint"
+    assert config.base_model == "sd-1"
+    assert config.vae is None
+
+def test_diffusers():
+    raw = dict(path='/tmp/foo',
+               name='foo',
+               base_model='sd-2',
+               model_type='main',
+               model_variant='inpaint',
+               model_format='diffusers',
+               vae='/tmp/foobar/vae.pt',
+            )
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config, MainDiffusersConfig)
+    assert config.model_format == "diffusers"
+    assert config.base_model == "sd-2"
+    assert config.model_variant == "inpaint"
+    assert config.vae == Path('/tmp/foobar/vae.pt')
+    assert isinstance(config.vae, Path)
+
+def test_invalid_diffusers():
+    raw = dict(path='/tmp/foo',
+               name='foo',
+               base_model='sd-2',
+               model_type='main',
+               model_variant='inpaint',
+               config='/tmp/foo.ckpt',
+               model_format='diffusers'
+               )
+    # This is expected to fail with a validation error, because
+    # diffusers format does not have a `config` field
+    try:
+        ModelConfig.parse_obj(raw)
+        assert False, "Validation should have failed"
+    except InvalidModelConfigException:
+        assert True
+
+
+def test_lora():
+    raw = dict(path='/tmp/foo',
+               name='foo',
+               base_model='sdxl',
+               model_type='lora',
+               model_format='lycoris',
+               )
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config, LoRAConfig)
+    assert config.model_format == 'lycoris'
+    raw['model_format'] = 'diffusers'
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config, LoRAConfig)
+    assert config.model_format == 'diffusers'
+
+def test_embedding():
+    raw = dict(path='/tmp/foo',
+               name='foo',
+               base_model='sdxl-refiner',
+               model_type='embedding',
+               model_format='embedding_file',
+               )
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config,TextualInversionConfig)
+    assert config.model_format == 'embedding_file'
+
+def test_onnx():
+    raw = dict(path='/tmp/foo.ckpt',
+               name='foo',
+               base_model='sd-1',
+               model_type='onnx',
+               model_variant='normal',
+               model_format='onnx'
+               )
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config, ONNXSD1Config)
+    assert config.model_format == 'onnx'
+
+    raw['base_model'] = 'sd-2'
+    # this should not validate without the upcast_attention field
+    try:
+        ModelConfig.parse_obj(raw)
+        assert False, 'Config should not have validated without upcast_attention'
+    except InvalidModelConfigException:
+        assert True
+
+    raw['upcast_attention'] = True
+    raw['prediction_type'] = 'epsilon'
+    config = ModelConfig.parse_obj(raw)
+    assert isinstance(config, ONNXSD2Config)
+    assert config.upcast_attention
+
+def test_assignment():
+    raw = dict(path='/tmp/foo.ckpt',
+               name='foo',
+               base_model='sd-2',
+               model_type='onnx',
+               model_variant='normal',
+               model_format='onnx',
+               upcast_attention = True,
+               prediction_type = 'epsilon',
+               )
+    config = ModelConfig.parse_obj(raw)
+    config.upcast_attention = False
+    assert not config.upcast_attention
+    try:
+        config.prediction_type = 'not valid'
+        assert False, 'Config should not have accepted invalid assignment'
+    except ValidationError:
+        assert True
+
+def test_invalid_combination():
+    raw = dict(path='/tmp/foo.ckpt',
+               name='foo',
+               base_model='sd-2',
+               model_type='main',
+               model_variant='normal',
+               model_format='onnx',
+               upcast_attention = True,
+               prediction_type = 'epsilon',
+               )
+    try:
+        ModelConfig.parse_obj(raw)
+        assert False, "This should have raised an InvalidModelConfigException"
+    except InvalidModelConfigException:
+        assert True
+

--- a/tests/test_model_config2.py
+++ b/tests/test_model_config2.py
@@ -4,7 +4,7 @@ Test the refactored model config classes.
 
 from pathlib import Path
 
-from invokeai.backend.model_management2.model_config import(
+from invokeai.backend.model_management2.model_config import (
     ModelConfig,
     InvalidModelConfigException,
     MainCheckpointConfig,
@@ -16,47 +16,53 @@ from invokeai.backend.model_management2.model_config import(
     ValidationError,
 )
 
+
 def test_checkpoints():
-    raw = dict(path='/tmp/foo.ckpt',
-               name='foo',
-               base_model='sd-1',
-               model_type='main',
-               config='/tmp/foo.yaml',
-               model_variant='normal',
-               model_format='checkpoint'
-            )
+    raw = dict(
+        path="/tmp/foo.ckpt",
+        name="foo",
+        base_model="sd-1",
+        model_type="main",
+        config="/tmp/foo.yaml",
+        model_variant="normal",
+        model_format="checkpoint",
+    )
     config = ModelConfig.parse_obj(raw)
     assert isinstance(config, MainCheckpointConfig)
     assert config.model_format == "checkpoint"
     assert config.base_model == "sd-1"
     assert config.vae is None
 
+
 def test_diffusers():
-    raw = dict(path='/tmp/foo',
-               name='foo',
-               base_model='sd-2',
-               model_type='main',
-               model_variant='inpaint',
-               model_format='diffusers',
-               vae='/tmp/foobar/vae.pt',
-            )
+    raw = dict(
+        path="/tmp/foo",
+        name="foo",
+        base_model="sd-2",
+        model_type="main",
+        model_variant="inpaint",
+        model_format="diffusers",
+        vae="/tmp/foobar/vae.pt",
+    )
     config = ModelConfig.parse_obj(raw)
     assert isinstance(config, MainDiffusersConfig)
     assert config.model_format == "diffusers"
     assert config.base_model == "sd-2"
     assert config.model_variant == "inpaint"
-    assert config.vae == Path('/tmp/foobar/vae.pt')
+    assert config.vae == Path("/tmp/foobar/vae.pt")
     assert isinstance(config.vae, Path)
 
+
 def test_invalid_diffusers():
-    raw = dict(path='/tmp/foo',
-               name='foo',
-               base_model='sd-2',
-               model_type='main',
-               model_variant='inpaint',
-               config='/tmp/foo.ckpt',
-               model_format='diffusers'
-               )
+    raw = dict(
+        path="/tmp/foo",
+        name="foo",
+        base_model="sd-2",
+        model_type="main",
+        model_variant="inpaint",
+        config="/tmp/foo.ckpt",
+        model_format="diffusers",
+    )
     # This is expected to fail with a validation error, because
     # diffusers format does not have a `config` field
     try:
@@ -67,89 +73,97 @@ def test_invalid_diffusers():
 
 
 def test_lora():
-    raw = dict(path='/tmp/foo',
-               name='foo',
-               base_model='sdxl',
-               model_type='lora',
-               model_format='lycoris',
-               )
+    raw = dict(
+        path="/tmp/foo",
+        name="foo",
+        base_model="sdxl",
+        model_type="lora",
+        model_format="lycoris",
+    )
     config = ModelConfig.parse_obj(raw)
     assert isinstance(config, LoRAConfig)
-    assert config.model_format == 'lycoris'
-    raw['model_format'] = 'diffusers'
+    assert config.model_format == "lycoris"
+    raw["model_format"] = "diffusers"
     config = ModelConfig.parse_obj(raw)
     assert isinstance(config, LoRAConfig)
-    assert config.model_format == 'diffusers'
+    assert config.model_format == "diffusers"
+
 
 def test_embedding():
-    raw = dict(path='/tmp/foo',
-               name='foo',
-               base_model='sdxl-refiner',
-               model_type='embedding',
-               model_format='embedding_file',
-               )
+    raw = dict(
+        path="/tmp/foo",
+        name="foo",
+        base_model="sdxl-refiner",
+        model_type="embedding",
+        model_format="embedding_file",
+    )
     config = ModelConfig.parse_obj(raw)
-    assert isinstance(config,TextualInversionConfig)
-    assert config.model_format == 'embedding_file'
+    assert isinstance(config, TextualInversionConfig)
+    assert config.model_format == "embedding_file"
+
 
 def test_onnx():
-    raw = dict(path='/tmp/foo.ckpt',
-               name='foo',
-               base_model='sd-1',
-               model_type='onnx',
-               model_variant='normal',
-               model_format='onnx'
-               )
+    raw = dict(
+        path="/tmp/foo.ckpt",
+        name="foo",
+        base_model="sd-1",
+        model_type="onnx",
+        model_variant="normal",
+        model_format="onnx",
+    )
     config = ModelConfig.parse_obj(raw)
     assert isinstance(config, ONNXSD1Config)
-    assert config.model_format == 'onnx'
+    assert config.model_format == "onnx"
 
-    raw['base_model'] = 'sd-2'
+    raw["base_model"] = "sd-2"
     # this should not validate without the upcast_attention field
     try:
         ModelConfig.parse_obj(raw)
-        assert False, 'Config should not have validated without upcast_attention'
+        assert False, "Config should not have validated without upcast_attention"
     except InvalidModelConfigException:
         assert True
 
-    raw['upcast_attention'] = True
-    raw['prediction_type'] = 'epsilon'
+    raw["upcast_attention"] = True
+    raw["prediction_type"] = "epsilon"
     config = ModelConfig.parse_obj(raw)
     assert isinstance(config, ONNXSD2Config)
     assert config.upcast_attention
 
+
 def test_assignment():
-    raw = dict(path='/tmp/foo.ckpt',
-               name='foo',
-               base_model='sd-2',
-               model_type='onnx',
-               model_variant='normal',
-               model_format='onnx',
-               upcast_attention = True,
-               prediction_type = 'epsilon',
-               )
+    raw = dict(
+        path="/tmp/foo.ckpt",
+        name="foo",
+        base_model="sd-2",
+        model_type="onnx",
+        model_variant="normal",
+        model_format="onnx",
+        upcast_attention=True,
+        prediction_type="epsilon",
+    )
     config = ModelConfig.parse_obj(raw)
     config.upcast_attention = False
     assert not config.upcast_attention
     try:
-        config.prediction_type = 'not valid'
-        assert False, 'Config should not have accepted invalid assignment'
+        config.prediction_type = "not valid"
+        assert False, "Config should not have accepted invalid assignment"
     except ValidationError:
         assert True
 
+
 def test_invalid_combination():
-    raw = dict(path='/tmp/foo.ckpt',
-               name='foo',
-               base_model='sd-2',
-               model_type='main',
-               model_variant='normal',
-               model_format='onnx',
-               upcast_attention = True,
-               prediction_type = 'epsilon',
-               )
+    raw = dict(
+        path="/tmp/foo.ckpt",
+        name="foo",
+        base_model="sd-2",
+        model_type="main",
+        model_variant="normal",
+        model_format="onnx",
+        upcast_attention=True,
+        prediction_type="epsilon",
+    )
     try:
         ModelConfig.parse_obj(raw)
         assert False, "This should have raised an InvalidModelConfigException"
     except InvalidModelConfigException:
         assert True
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This part of an implementation of the model manager refactors proposed in #4071 and #4043 , which will together allow model configurations to be fetched and stored in a modular backend (file or DBMS). For the time being, I am placing the code in `invokeai/backend/model_management2` to avoid breaking the current code.

Tasks to implement:
- [X] Refactor model configuration objects into a separate dedicated module
- [] Abstract base class for model config save, retrieve, update and delete: `ModelConfigStorageABC`
- [] File-based storage backend implementation: `ModelConfigStorageYAML`
- [] Db-based storage backend implementation: `ModelConfigStorageDb`

That's enough for this PR. Model downloading, type probing and installation will be in a separate PR.
Instantiating the model from the config is a third PR.
 