### PR TITLE
fix: Change refinerStart default to 0.8

### DIFF
--- a/invokeai/frontend/web/src/features/sdxl/components/SDXLRefiner/ParamSDXLRefinerStart.tsx
+++ b/invokeai/frontend/web/src/features/sdxl/components/SDXLRefiner/ParamSDXLRefinerStart.tsx
@@ -28,7 +28,7 @@ const ParamSDXLRefinerStart = () => {
   );
 
   const handleReset = useCallback(
-    () => dispatch(setRefinerStart(0.7)),
+    () => dispatch(setRefinerStart(0.8)),
     [dispatch]
   );
 

--- a/invokeai/frontend/web/src/features/sdxl/store/sdxlSlice.ts
+++ b/invokeai/frontend/web/src/features/sdxl/store/sdxlSlice.ts
@@ -33,7 +33,7 @@ const sdxlInitialState: SDXLInitialState = {
   refinerScheduler: 'euler',
   refinerPositiveAestheticScore: 6,
   refinerNegativeAestheticScore: 2.5,
-  refinerStart: 0.7,
+  refinerStart: 0.8,
 };
 
 const sdxlSlice = createSlice({


### PR DESCRIPTION
This is the recommended value according to the paper.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [x] Yes
      
## Description

Change the defaults of `refinerStart` to 0.8 -- the recommended value from the paper because the refiner was trained to deal with denoising the final 20% of the process.

https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl