### PR TITLE
make session_list api return a raw dict rather than pydantic object

### DIFF
--- a/invokeai/app/api/routers/sessions.py
+++ b/invokeai/app/api/routers/sessions.py
@@ -40,7 +40,7 @@ async def create_session(
 @session_router.get(
     "/",
     operation_id="list_sessions",
-    responses={200: {"model": PaginatedResults[GraphExecutionState]}},
+    responses={200: {"model": PaginatedResults[dict]}},
 )
 async def list_sessions(
     page: int = Query(default=0, description="The page of results to get"),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix


## Have you discussed this change with the InvokeAI team?
- [X] Yes - with @psychedelicious 

     
## Have you updated all relevant documentation?
- [X] Yes

## Description

The `list_sessions` api (`GET /api/v1/sessions`) generates a Pydantic validation error when it tries to retrieve a session from an earlier version of the pydantic execution_graph schema. This retrieves the session as a raw dict without attempting to parse it, allowing the user to recover the image metadata.


## Related Tickets & Documents

- Related Issue #4293 
- Closes #

## QA Instructions, Screenshots, Recordings

To test:

```
curl -X 'GET' \
  'http://localhost:9090/api/v1/sessions/?page=0&per_page=10' \
  -H 'accept: application/json'
```

Or use `localhost:9090/docs`
