### PR TITLE
feat: add itemstorage retrieval as dict (skip pydantic)

### DIFF
--- a/invokeai/app/services/images.py
+++ b/invokeai/app/services/images.py
@@ -35,7 +35,7 @@ from invokeai.app.services.models.image_record import (
 )
 from invokeai.app.services.resource_name import NameServiceBase
 from invokeai.app.services.urls import UrlServiceBase
-from invokeai.app.util.metadata import get_metadata_graph_from_raw_session
+from invokeai.app.util.metadata import get_metadata_graph_from_session_dict
 
 if TYPE_CHECKING:
     from invokeai.app.services.graph import GraphExecutionState
@@ -190,10 +190,10 @@ class ImageService(ImageServiceABC):
         graph = None
 
         if session_id is not None:
-            session_raw = self._services.graph_execution_manager.get_raw(session_id)
+            session_raw = self._services.graph_execution_manager.get_as_dict(session_id)
             if session_raw is not None:
                 try:
-                    graph = get_metadata_graph_from_raw_session(session_raw)
+                    graph = get_metadata_graph_from_session_dict(session_raw)
                 except Exception as e:
                     self._services.logger.warn(f"Failed to parse session graph: {e}")
                     graph = None
@@ -294,12 +294,12 @@ class ImageService(ImageServiceABC):
             if not image_record.session_id:
                 return ImageMetadata(metadata=metadata)
 
-            session_raw = self._services.graph_execution_manager.get_raw(image_record.session_id)
+            session_raw = self._services.graph_execution_manager.get_as_dict(image_record.session_id)
             graph = None
 
             if session_raw:
                 try:
-                    graph = get_metadata_graph_from_raw_session(session_raw)
+                    graph = get_metadata_graph_from_session_dict(session_raw)
                 except Exception as e:
                     self._services.logger.warn(f"Failed to parse session graph: {e}")
                     graph = None

--- a/invokeai/app/services/item_storage.py
+++ b/invokeai/app/services/item_storage.py
@@ -19,6 +19,18 @@ class PaginatedResults(GenericModel, Generic[T]):
     # fmt: on
 
 
+class PaginatedDictResults(BaseModel):
+    """Paginated raw results (dict)"""
+
+    # fmt: off
+    items: list[dict] = Field(description="Items")
+    page: int = Field(description="Current Page")
+    pages: int = Field(description="Total number of pages")
+    per_page: int = Field(description="Number of items per page")
+    total: int = Field(description="Total number of items in result")
+    # fmt: on
+
+
 class ItemStorageABC(ABC, Generic[T]):
     _on_changed_callbacks: list[Callable[[T], None]]
     _on_deleted_callbacks: list[Callable[[str], None]]
@@ -35,8 +47,8 @@ class ItemStorageABC(ABC, Generic[T]):
         pass
 
     @abstractmethod
-    def get_raw(self, item_id: str) -> Optional[str]:
-        """Gets the raw item as a string, skipping Pydantic parsing"""
+    def get_as_dict(self, item_id: str) -> Optional[dict]:
+        """Gets the item as a dict, skipping Pydantic parsing"""
         pass
 
     @abstractmethod
@@ -50,7 +62,16 @@ class ItemStorageABC(ABC, Generic[T]):
         pass
 
     @abstractmethod
+    def list_as_dict(self, page: int = 0, per_page: int = 10) -> PaginatedDictResults:
+        """Gets a paginated list of items, skipping Pydantic parsing"""
+        pass
+
+    @abstractmethod
     def search(self, query: str, page: int = 0, per_page: int = 10) -> PaginatedResults[T]:
+        pass
+
+    @abstractmethod
+    def search_as_dict(self, query: str, page: int = 0, per_page: int = 10) -> PaginatedDictResults:
         pass
 
     def on_changed(self, on_changed: Callable[[T], None]) -> None:

--- a/invokeai/app/util/metadata.py
+++ b/invokeai/app/util/metadata.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 from invokeai.app.services.graph import Edge
 
 
-def get_metadata_graph_from_raw_session(session_raw: str) -> Optional[dict]:
+def get_metadata_graph_from_session_dict(session_dict: dict) -> Optional[dict]:
     """
     Parses raw session string, returning a dict of the graph.
 
@@ -17,7 +17,7 @@ def get_metadata_graph_from_raw_session(session_raw: str) -> Optional[dict]:
     Any validation failure will return None.
     """
 
-    graph = json.loads(session_raw).get("graph", None)
+    graph = session_dict.get("graph", None)
 
     # sanity check make sure the graph is at least reasonably shaped
     if (

--- a/invokeai/frontend/web/src/services/api/schema.d.ts
+++ b/invokeai/frontend/web/src/services/api/schema.d.ts
@@ -4755,15 +4755,15 @@ export type components = {
       image_resolution?: number;
     };
     /**
-     * PaginatedResults[GraphExecutionState] 
-     * @description Paginated results
+     * PaginatedDictResults 
+     * @description Paginated raw results (dict)
      */
-    PaginatedResults_GraphExecutionState_: {
+    PaginatedDictResults: {
       /**
        * Items 
        * @description Items
        */
-      items: (components["schemas"]["GraphExecutionState"])[];
+      items: (Record<string, never>)[];
       /**
        * Page 
        * @description Current Page
@@ -6194,12 +6194,6 @@ export type components = {
       ui_type?: components["schemas"]["UIType"];
     };
     /**
-     * StableDiffusionOnnxModelFormat 
-     * @description An enumeration. 
-     * @enum {string}
-     */
-    StableDiffusionOnnxModelFormat: "olive" | "onnx";
-    /**
      * StableDiffusion1ModelFormat 
      * @description An enumeration. 
      * @enum {string}
@@ -6217,6 +6211,12 @@ export type components = {
      * @enum {string}
      */
     StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
+    /**
+     * StableDiffusionOnnxModelFormat 
+     * @description An enumeration. 
+     * @enum {string}
+     */
+    StableDiffusionOnnxModelFormat: "olive" | "onnx";
     /**
      * StableDiffusionXLModelFormat 
      * @description An enumeration. 
@@ -6254,7 +6254,7 @@ export type operations = {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["PaginatedResults_GraphExecutionState_"];
+          "application/json": components["schemas"]["PaginatedDictResults"];
         };
       };
       /** @description Validation Error */
@@ -6307,7 +6307,7 @@ export type operations = {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["GraphExecutionState"];
+          "application/json": Record<string, never>;
         };
       };
       /** @description Session not found */


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

- Create `PaginatedDictResults`, a non-type-safe, non-generic version of `PaginatedResults`. (because `PaginatedResults` is a `pydantic.GenericlModel`, it requires a pydantic model as the generic type and is not suitable)
- Add `ItemStorageABC` and `SqliteItemStorage` methods to return the dict representation of items
- The existing methods are unchanged in what they output, but now they use the `dict` methods to retrieve items before parsing them
- `ImagesService` and some metadata stuff is updated to use the appropriate methods
- Sessions router updated to use the dict versions
- Client types regenerated

## QA Instructions, Screenshots, Recordings

If `http://localhost:9090/docs#/sessions/list_sessions` does not give you a 422 error normally, you will need to render old graphs invalid by changing a node model.

### Creating a fail state

Easy way (do this on `main`, not this PR):
- consider making a backup of your `invokeai.db` first
- generate an image on linear ui with Randomize Seed enabled
- `type: Literal["rand_int"] = "rand_int"` in `math.py` to something else eg `type: Literal["broken"] = "broken"`
- restart the server
- hit the endpoint, should 422 now

Then switch to this PR.

### Testing

- Both the get and list sessions routes should return sessions where the session is no longer valid
- Test generation - everything should work as before

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->