### PR TITLE
stats: handle exceptions

### DIFF
--- a/invokeai/app/services/invocation_stats.py
+++ b/invokeai/app/services/invocation_stats.py
@@ -268,8 +268,14 @@ class InvocationStatsService(InvocationStatsServiceBase):
         is complete.
         """
         completed = set()
+        errored = set()
         for graph_id, node_log in self._stats.items():
-            current_graph_state = self.graph_execution_manager.get(graph_id)
+            try:
+                current_graph_state = self.graph_execution_manager.get(graph_id)
+            except Exception:
+                errored.add(graph_id)
+                continue
+
             if not current_graph_state.is_complete():
                 continue
 
@@ -300,5 +306,9 @@ class InvocationStatsService(InvocationStatsServiceBase):
             completed.add(graph_id)
 
         for graph_id in completed:
+            del self._stats[graph_id]
+            del self._cache_stats[graph_id]
+
+        for graph_id in errored:
             del self._stats[graph_id]
             del self._cache_stats[graph_id]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

[fix(stats): fix fail case when previous graph is invalid](https://github.com/invoke-ai/InvokeAI/commit/d1d2d5a47d7cdfdb06b83d49ac090978b978f9ec)

When retrieving a graph, it is parsed through pydantic. It is possible that this graph is invalid, and an error is thrown.

Handle this by deleting the failed graph from the stats if this occurs.

[fix(stats): fix InvocationStatsService types](https://github.com/invoke-ai/InvokeAI/commit/1b70bd13804737e2980486a4e9069d149b38b9b9)

- move docstrings to ABC
- `start_time: int` -> `start_time: float`
- remove class attribute assignments in `StatsContext`
- add `update_mem_stats()` to ABC
- add class attributes to ABC, because they are referenced in instances of the class. if they should not be on the ABC, then maybe there needs to be some restructuring

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

On `main` (not this PR), create a situation in which an graph is valid but will be rendered invalid on invoke. Easy way in node editor:
- create an `Integer Primitive` node, set value to 3
- create a `Resize Image` node and add an image to it
- route the output of `Integer Primitive` to the `width` of `Resize Image`
- Invoke - this will cause first a `Validation Error` (expected), and if you inspect the error in the JS console, you'll see it is a "session retrieval error"
- Invoke again - this will also cause a `Validation Error`, but if you inspect the error you should see it originates in the stats module (this is the error this PR fixes)
- Fix the graph by setting the `Integer Primitive` to 512
- Invoke again - you get the same `Validation Error` originating from stats, even tho there are no issues

Switch to this PR, and then you should only ever get the `Validation Error` that that is classified as a "session retrieval error".