### PR TITLE
fix crash that occurs when no invokeai.yaml is present

### DIFF
--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -50,7 +50,6 @@ from invokeai.frontend.install.model_install import addModelsForm, process_and_e
 
 # TO DO - Move all the frontend code into invokeai.frontend.install
 from invokeai.frontend.install.widgets import (
-    SingleSelectColumns,
     SingleSelectColumnsSimple,
     MultiSelectColumns,
     CenteredButtonPress,
@@ -409,7 +408,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
             SingleSelectColumnsSimple,
             columns=len(DEVICE_CHOICES),
             values=DEVICE_CHOICES,
-            value=DEVICE_CHOICES.index(device),
+            value=[DEVICE_CHOICES.index(device)],
             begin_entry_at=3,
             relx=30,
             max_height=2,
@@ -429,7 +428,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
             SingleSelectColumnsSimple,
             columns=len(ATTENTION_CHOICES),
             values=ATTENTION_CHOICES,
-            value=ATTENTION_CHOICES.index(attention_type),
+            value=[ATTENTION_CHOICES.index(attention_type)],
             begin_entry_at=3,
             max_height=2,
             relx=30,
@@ -451,14 +450,13 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
             SingleSelectColumnsSimple,
             columns=len(ATTENTION_SLICE_CHOICES),
             values=ATTENTION_SLICE_CHOICES,
-            value=ATTENTION_SLICE_CHOICES.index(attention_slice_size),
+            value=[ATTENTION_SLICE_CHOICES.index(attention_slice_size)],
             relx=30,
             hidden=attention_type != "sliced",
             max_height=2,
             max_width=110,
             scroll_exit=True,
         )
-
         self.add_widget_intelligent(
             npyscreen.TitleFixedText,
             name="Model RAM cache size (GB). Make this at least large enough to hold a single full model.",
@@ -609,13 +607,7 @@ https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENS
         new_opts.precision = PRECISION_CHOICES[self.precision.value[0]]
         new_opts.device = DEVICE_CHOICES[self.device.value[0]]
         new_opts.attention_type = ATTENTION_CHOICES[self.attention_type.value[0]]
-
-        # some sort of bug in npyscreen?
-        attention_slice_value = self.attention_slice_size.value
-        if type(attention_slice_value) == list:
-            attention_slice_value = attention_slice_value[0]
-        new_opts.attention_slice_size = ATTENTION_SLICE_CHOICES[attention_slice_value]
-
+        new_opts.attention_slice_size = ATTENTION_SLICE_CHOICES[self.attention_slice_size.value[0]]
         generation_options = [GENERATION_OPT_CHOICES[x] for x in self.generation_options.value]
         for v in GENERATION_OPT_CHOICES:
             setattr(new_opts, v, v in generation_options)

--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -608,13 +608,13 @@ https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENS
         new_opts.precision = PRECISION_CHOICES[self.precision.value[0]]
         new_opts.device = DEVICE_CHOICES[self.device.value[0]]
         new_opts.attention_type = ATTENTION_CHOICES[self.attention_type.value[0]]
-        
+
         # some sort of bug in npyscreen?
         attention_slice_value = self.attention_slice_size.value
         if type(attention_slice_value) == list:
             attention_slice_value = attention_slice_value[0]
         new_opts.attention_slice_size = ATTENTION_SLICE_CHOICES[attention_slice_value]
-        
+
         generation_options = [GENERATION_OPT_CHOICES[x] for x in self.generation_options.value]
         for v in GENERATION_OPT_CHOICES:
             setattr(new_opts, v, v in generation_options)

--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -354,7 +354,6 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
         device = old_opts.device
         attention_type = old_opts.attention_type
         attention_slice_size = old_opts.attention_slice_size
-
         self.nextrely += 1
         self.add_widget_intelligent(
             npyscreen.TitleFixedText,
@@ -609,7 +608,13 @@ https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENS
         new_opts.precision = PRECISION_CHOICES[self.precision.value[0]]
         new_opts.device = DEVICE_CHOICES[self.device.value[0]]
         new_opts.attention_type = ATTENTION_CHOICES[self.attention_type.value[0]]
-        new_opts.attention_slice_size = ATTENTION_SLICE_CHOICES[self.attention_slice_size.value[0]]
+        
+        # some sort of bug in npyscreen?
+        attention_slice_value = self.attention_slice_size.value
+        if type(attention_slice_value) == list:
+            attention_slice_value = attention_slice_value[0]
+        new_opts.attention_slice_size = ATTENTION_SLICE_CHOICES[attention_slice_value]
+        
         generation_options = [GENERATION_OPT_CHOICES[x] for x in self.generation_options.value]
         for v in GENERATION_OPT_CHOICES:
             setattr(new_opts, v, v in generation_options)
@@ -706,8 +711,6 @@ def initialize_rootdir(root: Path, yes_to_all: bool = False):
             path.mkdir(parents=True, exist_ok=True)
     path = dest / "core"
     path.mkdir(parents=True, exist_ok=True)
-
-    maybe_create_models_yaml(root)
 
 
 def maybe_create_models_yaml(root: Path):

--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -51,6 +51,7 @@ from invokeai.frontend.install.model_install import addModelsForm, process_and_e
 # TO DO - Move all the frontend code into invokeai.frontend.install
 from invokeai.frontend.install.widgets import (
     SingleSelectColumns,
+    SingleSelectColumnsSimple,
     MultiSelectColumns,
     CenteredButtonPress,
     FileBox,
@@ -384,7 +385,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
         )
         self.nextrely -= 2
         self.precision = self.add_widget_intelligent(
-            SingleSelectColumns,
+            SingleSelectColumnsSimple,
             columns=len(PRECISION_CHOICES),
             name="Precision",
             values=PRECISION_CHOICES,
@@ -405,7 +406,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
         )
         self.nextrely -= 2
         self.device = self.add_widget_intelligent(
-            SingleSelectColumns,
+            SingleSelectColumnsSimple,
             columns=len(DEVICE_CHOICES),
             values=DEVICE_CHOICES,
             value=DEVICE_CHOICES.index(device),
@@ -425,7 +426,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
         )
         self.nextrely -= 2
         self.attention_type = self.add_widget_intelligent(
-            SingleSelectColumns,
+            SingleSelectColumnsSimple,
             columns=len(ATTENTION_CHOICES),
             values=ATTENTION_CHOICES,
             value=ATTENTION_CHOICES.index(attention_type),
@@ -447,7 +448,7 @@ Use cursor arrows to make a checkbox selection, and space to toggle.
         )
         self.nextrely -= 2
         self.attention_slice_size = self.add_widget_intelligent(
-            SingleSelectColumns,
+            SingleSelectColumnsSimple,
             columns=len(ATTENTION_SLICE_CHOICES),
             values=ATTENTION_SLICE_CHOICES,
             value=ATTENTION_SLICE_CHOICES.index(attention_slice_size),

--- a/invokeai/frontend/install/widgets.py
+++ b/invokeai/frontend/install/widgets.py
@@ -264,15 +264,14 @@ class SingleSelectWithChanged(npyscreen.SelectOne):
 
 
 class SingleSelectColumnsSimple(SelectColumnBase, SingleSelectWithChanged):
+    """Row of radio buttons. Spacebar to select."""
+
     def __init__(self, screen, columns: int = 1, values: list = [], **keywords):
         self.columns = columns
         self.value_cnt = len(values)
         self.rows = math.ceil(self.value_cnt / self.columns)
         self.on_changed = None
         super().__init__(screen, values=values, **keywords)
-
-    def when_value_edited(self):
-        self.h_select(self.cursor_line)
 
     def h_cursor_line_right(self, ch):
         self.h_exit_down("bye bye")
@@ -282,6 +281,8 @@ class SingleSelectColumnsSimple(SelectColumnBase, SingleSelectWithChanged):
 
 
 class SingleSelectColumns(SingleSelectColumnsSimple):
+    """Row of radio buttons. When tabbing over a selection, it is auto selected."""
+
     def when_cursor_moved(self):
         self.h_select(self.cursor_line)
 

--- a/invokeai/frontend/install/widgets.py
+++ b/invokeai/frontend/install/widgets.py
@@ -177,6 +177,8 @@ class FloatTitleSlider(npyscreen.TitleText):
 
 
 class SelectColumnBase:
+    """Base class for selection widget arranged in columns."""
+
     def make_contained_widgets(self):
         self._my_widgets = []
         column_width = self.width // self.columns
@@ -253,6 +255,7 @@ class MultiSelectColumns(SelectColumnBase, npyscreen.MultiSelect):
 class SingleSelectWithChanged(npyscreen.SelectOne):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.on_changed = None
 
     def h_select(self, ch):
         super().h_select(ch)
@@ -260,7 +263,7 @@ class SingleSelectWithChanged(npyscreen.SelectOne):
             self.on_changed(self.value)
 
 
-class SingleSelectColumns(SelectColumnBase, SingleSelectWithChanged):
+class SingleSelectColumnsSimple(SelectColumnBase, SingleSelectWithChanged):
     def __init__(self, screen, columns: int = 1, values: list = [], **keywords):
         self.columns = columns
         self.value_cnt = len(values)
@@ -271,14 +274,16 @@ class SingleSelectColumns(SelectColumnBase, SingleSelectWithChanged):
     def when_value_edited(self):
         self.h_select(self.cursor_line)
 
-    def when_cursor_moved(self):
-        self.h_select(self.cursor_line)
-
     def h_cursor_line_right(self, ch):
         self.h_exit_down("bye bye")
 
     def h_cursor_line_left(self, ch):
         self.h_exit_up("bye bye")
+
+
+class SingleSelectColumns(SingleSelectColumnsSimple):
+    def when_cursor_moved(self):
+        self.h_select(self.cursor_line)
 
 
 class TextBoxInner(npyscreen.MultiLineEdit):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix


## Have you discussed this change with the InvokeAI team?
- [X] Yes

      
## Have you updated all relevant documentation?
- [X] n/a


## Description

This corrects a config script crash that occurred when `attention_slice_size` was set to `auto` and no previous `invokeai.yaml` file present.

