### PR TITLE
fix: Controlnet Prepreocessed Image Save Icon Missing

### DIFF
--- a/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ControlNetImagePreview.tsx
@@ -180,11 +180,19 @@ const ControlNetImagePreview = ({ isSmall, controlNet }: Props) => {
           isUploadDisabled={true}
           isDropDisabled={!isEnabled}
         >
-          <IAIDndImageIcon
-            onClick={handleResetControlImage}
-            icon={controlImage ? <FaUndo /> : undefined}
-            tooltip="Reset Control Image"
-          />
+          <>
+            <IAIDndImageIcon
+              onClick={handleResetControlImage}
+              icon={controlImage ? <FaUndo /> : undefined}
+              tooltip="Reset Control Image"
+            />
+            <IAIDndImageIcon
+              onClick={handleSaveControlImage}
+              icon={controlImage ? <FaSave size={16} /> : undefined}
+              tooltip="Save Control Image"
+              styleOverrides={{ marginTop: 6 }}
+            />
+          </>
         </IAIDndImage>
       </Box>
       {pendingControlImages.includes(controlNetId) && (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
