### PR TITLE
Fix/various

### DIFF
--- a/invokeai/app/invocations/compel.py
+++ b/invokeai/app/invocations/compel.py
@@ -302,6 +302,29 @@ class SDXLCompelPromptInvocation(BaseInvocation, SDXLPromptInvocationBase):
 
         add_time_ids = torch.tensor([original_size + crop_coords + target_size])
 
+        # [1, 77, 768], [1, 154, 1280]
+        if c1.shape[1] < c2.shape[1]:
+            c1 = torch.cat(
+                [
+                    c1,
+                    torch.zeros(
+                        (c1.shape[0], c2.shape[1] - c1.shape[1], c1.shape[2]), device=c1.device, dtype=c1.dtype
+                    ),
+                ],
+                dim=1,
+            )
+
+        elif c1.shape[1] > c2.shape[1]:
+            c2 = torch.cat(
+                [
+                    c2,
+                    torch.zeros(
+                        (c2.shape[0], c1.shape[1] - c2.shape[1], c2.shape[2]), device=c2.device, dtype=c2.dtype
+                    ),
+                ],
+                dim=1,
+            )
+
         conditioning_data = ConditioningFieldData(
             conditionings=[
                 SDXLConditioningInfo(

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -445,8 +445,14 @@ class DenoiseLatentsInvocation(BaseInvocation):
                 latents = context.services.latents.get(self.latents.latents_name)
                 if seed is None:
                     seed = self.latents.seed
-            else:
+
+                if noise is not None and noise.shape[1:] != latents.shape[1:]:
+                    raise Exception(f"Incompatable 'noise' and 'latents' shapes: {latents.shape=} {noise.shape=}")
+
+            elif noise is not None:
                 latents = torch.zeros_like(noise)
+            else:
+                raise Exception("'latents' or 'noise' must be provided!")
 
             if seed is None:
                 seed = 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because:


## Description
Pad tensors in compel-sdxl node when user provided different long-prompts in prompt and style fields.
Check and throw error if noise and latents passed to denoise have different shapes.
