### PR TITLE
Remove `main` choice from the InvokeAI update script

### DIFF
--- a/invokeai/frontend/install/invokeai_update.py
+++ b/invokeai/frontend/install/invokeai_update.py
@@ -54,13 +54,15 @@ def welcome(versions: dict):
     def text():
         yield f"InvokeAI Version: [bold yellow]{__version__}"
         yield ""
-        yield "This script will update InvokeAI to the latest release, or to a development version of your choice."
+        yield "This script will update InvokeAI to the latest release, or to the development version of your choice."
+        yield ""
+        yield "When updating to an arbitrary tag or branch, be aware that the front end may be mismatched to the backend,"
+        yield "making the web frontend unusable. Please downgrade to the latest release if this happens."
         yield ""
         yield "[bold yellow]Options:"
         yield f"""[1] Update to the latest official release ([italic]{versions[0]['tag_name']}[/italic])
-[2] Update to the bleeding-edge development version ([italic]main[/italic])
-[3] Manually enter the [bold]tag name[/bold] for the version you wish to update to
-[4] Manually enter the [bold]branch name[/bold] for the version you wish to update to"""
+[2] Manually enter the [bold]tag name[/bold] for the version you wish to update to
+[3] Manually enter the [bold]branch name[/bold] for the version you wish to update to"""
 
     console.rule()
     print(
@@ -104,11 +106,11 @@ def main():
     if choice == "1":
         release = versions[0]["tag_name"]
     elif choice == "2":
-        release = "main"
+        while not tag:
+            tag = Prompt.ask("Enter an InvokeAI tag name")
     elif choice == "3":
-        tag = Prompt.ask("Enter an InvokeAI tag name")
-    elif choice == "4":
-        branch = Prompt.ask("Enter an InvokeAI branch name")
+        while not branch:
+            branch = Prompt.ask("Enter an InvokeAI branch name")
 
     extras = get_extras()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] Yes

## Description

The InvokeAI updater offers to update to the latest `main` branch. However, many times the front end has not been rebuilt, causing the web UI to break. This PR removes the option to update to main, adds a warning that frontend breakage can occur when updating to an arbitrary tag or branch, and tells users to downgrade in case the frontend breaks.

## Related Tickets & Documents

See discord discussion at: https://discord.com/channels/1020123559063990373/1037879444897017887/1148531778764685322
