### PR TITLE
Remove Background Node

### DIFF
--- a/invokeai/app/invocations/removebackground.py
+++ b/invokeai/app/invocations/removebackground.py
@@ -39,7 +39,7 @@ class RemoveBackgroundInvocation(BaseInvocation):
 
             session = new_session(self.model_name)
             image = remove(image, session=session)
-        except:
+        except ImportError:
             context.services.logger.warning(
                 "Remove Background --> To use this node, please quit InvokeAI and execute 'pip install rembg' from outside your InvokeAI folder with your InvokeAI virtual environment activated."
             )

--- a/invokeai/app/invocations/removebackground.py
+++ b/invokeai/app/invocations/removebackground.py
@@ -1,0 +1,53 @@
+from typing import Literal
+from invokeai.app.models.image import (ImageCategory, ResourceOrigin)
+from invokeai.app.invocations.primitives import ImageField, ImageOutput
+from invokeai.app.invocations.baseinvocation import (
+    BaseInvocation,
+    InvocationContext,
+    InputField,
+    invocation,
+    )
+
+rembg_models = Literal[
+    "isnet-anime",
+    #"isnet-general-use", # on the github page but not shipped with pip it seems
+    "silueta",
+    "u2net_cloth_seg",
+    "u2net_human_seg",
+    "u2net",
+    "u2netp",
+]
+
+@invocation("remove_background", title="Remove Background", tags=["image", "remove", "background", "rembg"], category="image", version="1.0.0")
+class RemoveBackgroundInvocation(BaseInvocation):
+    """Outputs an image with the background removed behind the subject using rembg."""
+
+    image:       ImageField  = InputField(description="Image to remove background from")
+    model_name:  rembg_models = InputField(default="u2net", description="Model to use to remove background")
+
+    def invoke(self, context: InvocationContext) -> ImageOutput:
+        image = context.services.images.get_pil_image(self.image.image_name)
+
+        try:
+            from rembg import remove, new_session
+            session = new_session(self.model_name)
+            image = remove(image, session=session)
+        except:
+            context.services.logger.warning("Remove Background --> To use this node, please quit InvokeAI and execute 'pip install rembg' from outside your InvokeAI folder with your InvokeAI virtual environment activated.")
+            context.services.logger.warning("Remove Background --> rembg package not found. Passing through unaltered image!")
+
+        image_dto = context.services.images.create(
+            image=image,
+            image_origin=ResourceOrigin.INTERNAL,
+            image_category=ImageCategory.GENERAL,
+            node_id=self.id,
+            session_id=context.graph_execution_state_id,
+            is_intermediate=self.is_intermediate,
+            workflow=self.workflow,
+        )
+
+        return ImageOutput(
+            image=ImageField(image_name=image_dto.image_name),
+            width=image_dto.width,
+            height=image_dto.height,
+        )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description

Remove Background outputs an image with the background removed behind the subject using `rembg`. Requires the `rembg `Python package.

It currently checks if `rembg` is installed or not. If not, it passes through the original unaltered image (so as to not raise an exception and disrupt a workflow).

## Issues

`rembg` installs its onnx models to a hidden u2net directory in the user's home folder. I've made an [issue](https://github.com/danielgatis/rembg/issues/517) on the project's GitHub to change this behaviour. Hopefully they'll eventually be installed into the site-packages folder. I've made the PR draft as a result.

`isnet-general-use.onnx` is an offered model on GitHub but doesn't ship in the `pip` package. Mentioned this to the author in the above issue, as well, so the model is commented out in the dropdown literal list for now. It's not that exceptional compared to the default model.

## QA Instructions, Screenshots, Recordings

Some screenshots at https://github.com/ymgenesis/NodeUtilities
