### PR TITLE
Update lora hotfix to new diffusers version(scale argument added)

### DIFF
--- a/invokeai/backend/util/hotfixes.py
+++ b/invokeai/backend/util/hotfixes.py
@@ -772,11 +772,13 @@ diffusers.models.controlnet.ControlNetModel = ControlNetModel
 # NOTE: with this patch, torch.compile crashes on 2.0 torch(already fixed in nightly)
 # https://github.com/huggingface/diffusers/pull/4315
 # https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/lora.py#L96C18-L96C18
-def new_LoRACompatibleConv_forward(self, x):
+def new_LoRACompatibleConv_forward(self, hidden_states, scale: float = 1.0):
     if self.lora_layer is None:
-        return super(diffusers.models.lora.LoRACompatibleConv, self).forward(x)
+        return super(diffusers.models.lora.LoRACompatibleConv, self).forward(hidden_states)
     else:
-        return super(diffusers.models.lora.LoRACompatibleConv, self).forward(x) + self.lora_layer(x)
+        return super(diffusers.models.lora.LoRACompatibleConv, self).forward(hidden_states) + (
+            scale * self.lora_layer(hidden_states)
+        )
 
 
 diffusers.models.lora.LoRACompatibleConv.forward = new_LoRACompatibleConv_forward


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
In 0.21.0 diffusers in lora-conv forward function `scale` argument added.
!!! Check someone before merge as I can't run it now to test.
