### PR TITLE
Adding excludes to flake8 config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,13 @@ output = "coverage/index.xml"
 max-line-length = 120
 ignore = ["E203", "E266", "E501", "W503"]
 select = ["B", "C", "E", "F", "W", "T4"]
+exclude = [
+  ".git",
+  "__pycache__",
+  "build",
+  "dist",
+  "invokeai/frontend/web/node_modules/"
+]
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: very minor fix

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description

Building invoke-ai's web with yarn adds python files that do not pass with flake8.
This only affect devs who run flake8 on the whole code base after having run yarn.
The added python files are outside the scope of this repo and so should not be checked with flake8.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [x] No : N/A

## [optional] Are there any post deployment tasks we need to perform?
None