### PR TITLE
feat(nodes): add invocation cache

### DIFF
--- a/invokeai/app/api/dependencies.py
+++ b/invokeai/app/api/dependencies.py
@@ -9,6 +9,7 @@ from invokeai.app.services.boards import BoardService, BoardServiceDependencies
 from invokeai.app.services.config import InvokeAIAppConfig
 from invokeai.app.services.image_record_storage import SqliteImageRecordStorage
 from invokeai.app.services.images import ImageService, ImageServiceDependencies
+from invokeai.app.services.invocation_cache.invocation_cache_memory import MemoryInvocationCache
 from invokeai.app.services.resource_name import SimpleNameService
 from invokeai.app.services.urls import LocalUrlService
 from invokeai.backend.util.logging import InvokeAILogger
@@ -126,6 +127,7 @@ class ApiDependencies:
             configuration=config,
             performance_statistics=InvocationStatsService(graph_execution_manager),
             logger=logger,
+            invocation_cache=MemoryInvocationCache(max_cache_size=config.node_cache_size),
         )
 
         create_system_graphs(services.graph_library)

--- a/invokeai/app/cli_app.py
+++ b/invokeai/app/cli_app.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2022 Kyle Schouviller (https://github.com/kyle0654)
 
+from invokeai.app.services.invocation_cache.invocation_cache_memory import MemoryInvocationCache
+
 from .services.config import InvokeAIAppConfig
 
 # parse_args() must be called before any other imports. if it is not called first, consumers of the config
@@ -309,6 +311,7 @@ def invoke_cli():
         performance_statistics=InvocationStatsService(graph_execution_manager),
         logger=logger,
         configuration=config,
+        invocation_cache=MemoryInvocationCache(max_cache_size=config.node_cache_size),
     )
 
     system_graphs = create_system_graphs(services.graph_library)

--- a/invokeai/app/invocations/collections.py
+++ b/invokeai/app/invocations/collections.py
@@ -56,6 +56,7 @@ class RangeOfSizeInvocation(BaseInvocation):
     tags=["range", "integer", "random", "collection"],
     category="collections",
     version="1.0.0",
+    use_cache=False,
 )
 class RandomRangeInvocation(BaseInvocation):
     """Creates a collection of random numbers"""

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -965,3 +965,42 @@ class ImageChannelMultiplyInvocation(BaseInvocation):
             width=image_dto.width,
             height=image_dto.height,
         )
+
+
+@invocation(
+    "save_image",
+    title="Save Image",
+    tags=["primitives", "image"],
+    category="primitives",
+    version="1.0.0",
+    use_cache=False,
+)
+class SaveImageInvocation(BaseInvocation):
+    """Saves an image. Unlike an image primitive, this invocation stores a copy of the image."""
+
+    image: ImageField = InputField(description="The image to load")
+    metadata: CoreMetadata = InputField(
+        default=None,
+        description=FieldDescriptions.core_metadata,
+        ui_hidden=True,
+    )
+
+    def invoke(self, context: InvocationContext) -> ImageOutput:
+        image = context.services.images.get_pil_image(self.image.image_name)
+
+        image_dto = context.services.images.create(
+            image=image,
+            image_origin=ResourceOrigin.INTERNAL,
+            image_category=ImageCategory.GENERAL,
+            node_id=self.id,
+            session_id=context.graph_execution_state_id,
+            is_intermediate=self.is_intermediate,
+            metadata=self.metadata.dict() if self.metadata else None,
+            workflow=self.workflow,
+        )
+
+        return ImageOutput(
+            image=ImageField(image_name=image_dto.image_name),
+            width=image_dto.width,
+            height=image_dto.height,
+        )

--- a/invokeai/app/invocations/math.py
+++ b/invokeai/app/invocations/math.py
@@ -54,7 +54,14 @@ class DivideInvocation(BaseInvocation):
         return IntegerOutput(value=int(self.a / self.b))
 
 
-@invocation("rand_int", title="Random Integer", tags=["math", "random"], category="math", version="1.0.0")
+@invocation(
+    "rand_int",
+    title="Random Integer",
+    tags=["math", "random"],
+    category="math",
+    version="1.0.0",
+    use_cache=False,
+)
 class RandomIntInvocation(BaseInvocation):
     """Outputs a single random integer."""
 

--- a/invokeai/app/invocations/prompt.py
+++ b/invokeai/app/invocations/prompt.py
@@ -10,7 +10,14 @@ from invokeai.app.invocations.primitives import StringCollectionOutput
 from .baseinvocation import BaseInvocation, InputField, InvocationContext, UIComponent, invocation
 
 
-@invocation("dynamic_prompt", title="Dynamic Prompt", tags=["prompt", "collection"], category="prompt", version="1.0.0")
+@invocation(
+    "dynamic_prompt",
+    title="Dynamic Prompt",
+    tags=["prompt", "collection"],
+    category="prompt",
+    version="1.0.0",
+    use_cache=False,
+)
 class DynamicPromptInvocation(BaseInvocation):
     """Parses a prompt using adieyal/dynamicprompts' random or combinatorial generator"""
 

--- a/invokeai/app/services/config/invokeai_config.py
+++ b/invokeai/app/services/config/invokeai_config.py
@@ -253,6 +253,7 @@ class InvokeAIAppConfig(InvokeAISettings):
     attention_type      : Literal[tuple(["auto", "normal", "xformers", "sliced", "torch-sdp"])] = Field(default="auto", description="Attention type", category="Generation", )
     attention_slice_size: Literal[tuple(["auto", "balanced", "max", 1, 2, 3, 4, 5, 6, 7, 8])] = Field(default="auto", description='Slice size, valid when attention_type=="sliced"', category="Generation", )
     force_tiled_decode: bool = Field(default=False, description="Whether to enable tiled VAE decode (reduces memory consumption with some performance penalty)", category="Generation",)
+    node_cache_size     : int = Field(default=512, description="How many cached nodes to keep in memory", category="Generation", )
 
     # NODES
     allow_nodes         : Optional[List[str]] = Field(default=None, description="List of nodes to allow. Omit to allow all.", category="Nodes")

--- a/invokeai/app/services/invocation_cache/invocation_cache_base.py
+++ b/invokeai/app/services/invocation_cache/invocation_cache_base.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+from invokeai.app.invocations.baseinvocation import BaseInvocation, BaseInvocationOutput
+
+
+class InvocationCacheBase(ABC):
+    """Base class for invocation caches."""
+
+    @abstractmethod
+    def get(self, key: Union[int, str]) -> Optional[BaseInvocationOutput]:
+        """Retrieves and invocation output from the cache"""
+        pass
+
+    @abstractmethod
+    def save(self, key: Union[int, str], value: BaseInvocationOutput) -> None:
+        """Stores an invocation output in the cache"""
+        pass
+
+    @abstractmethod
+    def delete(self, key: Union[int, str]) -> None:
+        """Deleted an invocation output from the cache"""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_key(cls, value: BaseInvocation) -> Union[int, str]:
+        """Creates the cache key for an invocation"""
+        pass

--- a/invokeai/app/services/invocation_cache/invocation_cache_memory.py
+++ b/invokeai/app/services/invocation_cache/invocation_cache_memory.py
@@ -1,0 +1,34 @@
+from queue import Queue
+from typing import Optional, Union
+
+from invokeai.app.invocations.baseinvocation import BaseInvocation, BaseInvocationOutput
+from invokeai.app.services.invocation_cache.invocation_cache_base import InvocationCacheBase
+
+
+class MemoryInvocationCache(InvocationCacheBase):
+    __cache: dict[Union[int, str], BaseInvocationOutput]
+    __max_cache_size: int
+    __cache_ids: Queue
+
+    def __init__(self, max_cache_size: int = 512) -> None:
+        self.__cache = dict()
+        self.__max_cache_size = max_cache_size
+        self.__cache_ids = Queue()
+
+    def get(self, key: Union[int, str]) -> Optional[BaseInvocationOutput]:
+        return self.__cache.get(key, None)
+
+    def save(self, key: Union[int, str], value: BaseInvocationOutput) -> None:
+        if key not in self.__cache:
+            self.__cache[key] = value
+            self.__cache_ids.put(key)
+            if self.__cache_ids.qsize() > self.__max_cache_size:
+                self.__cache.pop(self.__cache_ids.get())
+
+    def delete(self, key: Union[int, str]) -> None:
+        if key in self.__cache:
+            del self.__cache[key]
+
+    @classmethod
+    def create_key(cls, value: BaseInvocation) -> Union[int, str]:
+        return hash(value.json(exclude={"id"}))

--- a/invokeai/app/services/invocation_services.py
+++ b/invokeai/app/services/invocation_services.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from invokeai.app.services.events import EventServiceBase
     from invokeai.app.services.graph import GraphExecutionState, LibraryGraph
     from invokeai.app.services.images import ImageServiceABC
+    from invokeai.app.services.invocation_cache.invocation_cache_base import InvocationCacheBase
     from invokeai.app.services.invocation_queue import InvocationQueueABC
     from invokeai.app.services.invocation_stats import InvocationStatsServiceBase
     from invokeai.app.services.invoker import InvocationProcessorABC
@@ -37,6 +38,7 @@ class InvocationServices:
     processor: "InvocationProcessorABC"
     performance_statistics: "InvocationStatsServiceBase"
     queue: "InvocationQueueABC"
+    invocation_cache: "InvocationCacheBase"
 
     def __init__(
         self,
@@ -53,6 +55,7 @@ class InvocationServices:
         processor: "InvocationProcessorABC",
         performance_statistics: "InvocationStatsServiceBase",
         queue: "InvocationQueueABC",
+        invocation_cache: "InvocationCacheBase",
     ):
         self.board_images = board_images
         self.boards = boards
@@ -68,3 +71,4 @@ class InvocationServices:
         self.processor = processor
         self.performance_statistics = performance_statistics
         self.queue = queue
+        self.invocation_cache = invocation_cache

--- a/invokeai/frontend/web/src/app/store/nanostores/store.ts
+++ b/invokeai/frontend/web/src/app/store/nanostores/store.ts
@@ -1,0 +1,5 @@
+import { Store } from '@reduxjs/toolkit';
+import { atom } from 'nanostores';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const $store = atom<Store<any> | undefined>();

--- a/invokeai/frontend/web/src/app/store/store.ts
+++ b/invokeai/frontend/web/src/app/store/store.ts
@@ -31,6 +31,7 @@ import { actionSanitizer } from './middleware/devtools/actionSanitizer';
 import { actionsDenylist } from './middleware/devtools/actionsDenylist';
 import { stateSanitizer } from './middleware/devtools/stateSanitizer';
 import { listenerMiddleware } from './middleware/listenerMiddleware';
+import { $store } from './nanostores/store';
 
 const allReducers = {
   canvas: canvasReducer,
@@ -121,3 +122,4 @@ export type RootState = ReturnType<typeof store.getState>;
 export type AppThunkDispatch = ThunkDispatch<RootState, any, AnyAction>;
 export type AppDispatch = typeof store.dispatch;
 export const stateSelector = (state: RootState) => state;
+$store.set(store);

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/EmbedWorkflowCheckbox.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/EmbedWorkflowCheckbox.tsx
@@ -27,7 +27,7 @@ const EmbedWorkflowCheckbox = ({ nodeId }: { nodeId: string }) => {
 
   return (
     <FormControl as={Flex} sx={{ alignItems: 'center', gap: 2, w: 'auto' }}>
-      <FormLabel sx={{ fontSize: 'xs', mb: '1px' }}>Embed Workflow</FormLabel>
+      <FormLabel sx={{ fontSize: 'xs', mb: '1px' }}>Workflow</FormLabel>
       <Checkbox
         className="nopan"
         size="sm"

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNode.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNode.tsx
@@ -1,14 +1,13 @@
 import { Flex, Grid, GridItem } from '@chakra-ui/react';
+import { useAnyOrDirectInputFieldNames } from 'features/nodes/hooks/useAnyOrDirectInputFieldNames';
+import { useConnectionInputFieldNames } from 'features/nodes/hooks/useConnectionInputFieldNames';
+import { useOutputFieldNames } from 'features/nodes/hooks/useOutputFieldNames';
 import { memo } from 'react';
+import NodeWrapper from '../common/NodeWrapper';
 import InvocationNodeFooter from './InvocationNodeFooter';
 import InvocationNodeHeader from './InvocationNodeHeader';
-import NodeWrapper from '../common/NodeWrapper';
-import OutputField from './fields/OutputField';
 import InputField from './fields/InputField';
-import { useOutputFieldNames } from 'features/nodes/hooks/useOutputFieldNames';
-import { useWithFooter } from 'features/nodes/hooks/useWithFooter';
-import { useConnectionInputFieldNames } from 'features/nodes/hooks/useConnectionInputFieldNames';
-import { useAnyOrDirectInputFieldNames } from 'features/nodes/hooks/useAnyOrDirectInputFieldNames';
+import OutputField from './fields/OutputField';
 
 type Props = {
   nodeId: string;
@@ -22,7 +21,6 @@ const InvocationNode = ({ nodeId, isOpen, label, type, selected }: Props) => {
   const inputConnectionFieldNames = useConnectionInputFieldNames(nodeId);
   const inputAnyOrDirectFieldNames = useAnyOrDirectInputFieldNames(nodeId);
   const outputFieldNames = useOutputFieldNames(nodeId);
-  const withFooter = useWithFooter(nodeId);
 
   return (
     <NodeWrapper nodeId={nodeId} selected={selected}>
@@ -43,7 +41,7 @@ const InvocationNode = ({ nodeId, isOpen, label, type, selected }: Props) => {
               h: 'full',
               py: 2,
               gap: 1,
-              borderBottomRadius: withFooter ? 0 : 'base',
+              borderBottomRadius: 0,
             }}
           >
             <Flex sx={{ flexDir: 'column', px: 2, w: 'full', h: 'full' }}>
@@ -76,7 +74,7 @@ const InvocationNode = ({ nodeId, isOpen, label, type, selected }: Props) => {
               ))}
             </Flex>
           </Flex>
-          {withFooter && <InvocationNodeFooter nodeId={nodeId} />}
+          <InvocationNodeFooter nodeId={nodeId} />
         </>
       )}
     </NodeWrapper>

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeFooter.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeFooter.tsx
@@ -3,12 +3,15 @@ import { DRAG_HANDLE_CLASSNAME } from 'features/nodes/types/constants';
 import { memo } from 'react';
 import EmbedWorkflowCheckbox from './EmbedWorkflowCheckbox';
 import SaveToGalleryCheckbox from './SaveToGalleryCheckbox';
+import UseCacheCheckbox from './UseCacheCheckbox';
+import { useHasImageOutput } from 'features/nodes/hooks/useHasImageOutput';
 
 type Props = {
   nodeId: string;
 };
 
 const InvocationNodeFooter = ({ nodeId }: Props) => {
+  const hasImageOutput = useHasImageOutput(nodeId);
   return (
     <Flex
       className={DRAG_HANDLE_CLASSNAME}
@@ -22,8 +25,9 @@ const InvocationNodeFooter = ({ nodeId }: Props) => {
         justifyContent: 'space-between',
       }}
     >
-      <EmbedWorkflowCheckbox nodeId={nodeId} />
-      <SaveToGalleryCheckbox nodeId={nodeId} />
+      {hasImageOutput && <EmbedWorkflowCheckbox nodeId={nodeId} />}
+      <UseCacheCheckbox nodeId={nodeId} />
+      {hasImageOutput && <SaveToGalleryCheckbox nodeId={nodeId} />}
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/UseCacheCheckbox.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/UseCacheCheckbox.tsx
@@ -1,0 +1,35 @@
+import { Checkbox, Flex, FormControl, FormLabel } from '@chakra-ui/react';
+import { useAppDispatch } from 'app/store/storeHooks';
+import { useUseCache } from 'features/nodes/hooks/useUseCache';
+import { nodeUseCacheChanged } from 'features/nodes/store/nodesSlice';
+import { ChangeEvent, memo, useCallback } from 'react';
+
+const UseCacheCheckbox = ({ nodeId }: { nodeId: string }) => {
+  const dispatch = useAppDispatch();
+  const useCache = useUseCache(nodeId);
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      dispatch(
+        nodeUseCacheChanged({
+          nodeId,
+          useCache: e.target.checked,
+        })
+      );
+    },
+    [dispatch, nodeId]
+  );
+
+  return (
+    <FormControl as={Flex} sx={{ alignItems: 'center', gap: 2, w: 'auto' }}>
+      <FormLabel sx={{ fontSize: 'xs', mb: '1px' }}>Use Cache</FormLabel>
+      <Checkbox
+        className="nopan"
+        size="sm"
+        onChange={handleChange}
+        isChecked={useCache}
+      />
+    </FormControl>
+  );
+};
+
+export default memo(UseCacheCheckbox);

--- a/invokeai/frontend/web/src/features/nodes/hooks/useBuildNodeData.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useBuildNodeData.ts
@@ -146,6 +146,7 @@ export const useBuildNodeData = () => {
           isIntermediate: true,
           inputs,
           outputs,
+          useCache: template.useCache,
         },
       };
 

--- a/invokeai/frontend/web/src/features/nodes/hooks/useUseCache.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useUseCache.ts
@@ -2,12 +2,10 @@ import { createSelector } from '@reduxjs/toolkit';
 import { stateSelector } from 'app/store/store';
 import { useAppSelector } from 'app/store/storeHooks';
 import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
-import { some } from 'lodash-es';
 import { useMemo } from 'react';
-import { FOOTER_FIELDS } from '../types/constants';
 import { isInvocationNode } from '../types/types';
 
-export const useHasImageOutputs = (nodeId: string) => {
+export const useUseCache = (nodeId: string) => {
   const selector = useMemo(
     () =>
       createSelector(
@@ -17,15 +15,15 @@ export const useHasImageOutputs = (nodeId: string) => {
           if (!isInvocationNode(node)) {
             return false;
           }
-          return some(node.data.outputs, (output) =>
-            FOOTER_FIELDS.includes(output.type)
-          );
+          // cast to boolean to support older workflows that didn't have useCache
+          // TODO: handle this better somehow
+          return node.data.useCache;
         },
         defaultSelectorOptions
       ),
     [nodeId]
   );
 
-  const withFooter = useAppSelector(selector);
-  return withFooter;
+  const useCache = useAppSelector(selector);
+  return useCache;
 };

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -260,6 +260,20 @@ const nodesSlice = createSlice({
       }
       node.data.embedWorkflow = embedWorkflow;
     },
+    nodeUseCacheChanged: (
+      state,
+      action: PayloadAction<{ nodeId: string; useCache: boolean }>
+    ) => {
+      const { nodeId, useCache } = action.payload;
+      const nodeIndex = state.nodes.findIndex((n) => n.id === nodeId);
+
+      const node = state.nodes?.[nodeIndex];
+
+      if (!isInvocationNode(node)) {
+        return;
+      }
+      node.data.useCache = useCache;
+    },
     nodeIsIntermediateChanged: (
       state,
       action: PayloadAction<{ nodeId: string; isIntermediate: boolean }>
@@ -904,6 +918,7 @@ export const {
   nodeIsIntermediateChanged,
   mouseOverNodeChanged,
   nodeExclusivelySelected,
+  nodeUseCacheChanged,
 } = nodesSlice.actions;
 
 export default nodesSlice.reducer;

--- a/invokeai/frontend/web/src/features/nodes/types/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/types.ts
@@ -1,3 +1,4 @@
+import { $store } from 'app/store/nanostores/store';
 import {
   SchedulerParam,
   zBaseModel,
@@ -7,7 +8,8 @@ import {
   zSDXLRefinerModel,
   zScheduler,
 } from 'features/parameters/types/parameterSchemas';
-import { keyBy } from 'lodash-es';
+import i18n from 'i18next';
+import { has, keyBy } from 'lodash-es';
 import { OpenAPIV3 } from 'openapi-types';
 import { RgbaColor } from 'react-colorful';
 import { Node } from 'reactflow';
@@ -20,7 +22,6 @@ import {
 import { O } from 'ts-toolbelt';
 import { JsonObject } from 'type-fest';
 import { z } from 'zod';
-import i18n from 'i18next';
 
 export type NonNullableGraph = O.Required<Graph, 'nodes' | 'edges'>;
 
@@ -57,6 +58,10 @@ export type InvocationTemplate = {
    * The invocation's version.
    */
   version?: string;
+  /**
+   * Whether or not this node should use the cache
+   */
+  useCache: boolean;
 };
 
 export type FieldUIConfig = {
@@ -976,6 +981,9 @@ export type InvocationSchemaExtra = {
     type: Omit<OpenAPIV3.SchemaObject, 'default'> & {
       default: AnyInvocationType;
     };
+    use_cache: Omit<OpenAPIV3.SchemaObject, 'default'> & {
+      default: boolean;
+    };
   };
 };
 
@@ -1139,9 +1147,37 @@ export const zInvocationNodeData = z.object({
   version: zSemVer.optional(),
 });
 
+export const zInvocationNodeDataV2 = z.preprocess(
+  (arg) => {
+    try {
+      const data = zInvocationNodeData.parse(arg);
+      if (!has(data, 'useCache')) {
+        const nodeTemplates = $store.get()?.getState().nodes.nodeTemplates as
+          | Record<string, InvocationTemplate>
+          | undefined;
+
+        const template = nodeTemplates?.[data.type];
+
+        let useCache = true;
+        if (template) {
+          useCache = template.useCache;
+        }
+
+        Object.assign(data, { useCache });
+      }
+      return data;
+    } catch {
+      return arg;
+    }
+  },
+  zInvocationNodeData.extend({
+    useCache: z.boolean(),
+  })
+);
+
 // Massage this to get better type safety while developing
 export type InvocationNodeData = Omit<
-  z.infer<typeof zInvocationNodeData>,
+  z.infer<typeof zInvocationNodeDataV2>,
   'type'
 > & {
   type: AnyInvocationType;
@@ -1169,7 +1205,7 @@ const zDimension = z.number().gt(0).nullish();
 export const zWorkflowInvocationNode = z.object({
   id: z.string().trim().min(1),
   type: z.literal('invocation'),
-  data: zInvocationNodeData,
+  data: zInvocationNodeDataV2,
   width: zDimension,
   height: zDimension,
   position: zPosition,
@@ -1231,6 +1267,8 @@ export type WorkflowWarning = {
   data: JsonObject;
 };
 
+const CURRENT_WORKFLOW_VERSION = '1.0.0';
+
 export const zWorkflow = z.object({
   name: z.string().default(''),
   author: z.string().default(''),
@@ -1246,7 +1284,7 @@ export const zWorkflow = z.object({
     .object({
       version: zSemVer,
     })
-    .default({ version: '1.0.0' }),
+    .default({ version: CURRENT_WORKFLOW_VERSION }),
 });
 
 export const zValidatedWorkflow = zWorkflow.transform((workflow) => {

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addNSFWCheckerToGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addNSFWCheckerToGraph.ts
@@ -1,33 +1,18 @@
 import { RootState } from 'app/store/store';
 import { NonNullableGraph } from 'features/nodes/types/types';
-import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
 import {
   ImageNSFWBlurInvocation,
   LatentsToImageInvocation,
-  MetadataAccumulatorInvocation,
 } from 'services/api/types';
-import {
-  LATENTS_TO_IMAGE,
-  METADATA_ACCUMULATOR,
-  NSFW_CHECKER,
-} from './constants';
+import { LATENTS_TO_IMAGE, NSFW_CHECKER } from './constants';
 
 export const addNSFWCheckerToGraph = (
   state: RootState,
   graph: NonNullableGraph,
   nodeIdToAddTo = LATENTS_TO_IMAGE
 ): void => {
-  const activeTabName = activeTabNameSelector(state);
-
-  const is_intermediate =
-    activeTabName === 'unifiedCanvas' ? !state.canvas.shouldAutoSave : false;
-
   const nodeToAddTo = graph.nodes[nodeIdToAddTo] as
     | LatentsToImageInvocation
-    | undefined;
-
-  const metadataAccumulator = graph.nodes[METADATA_ACCUMULATOR] as
-    | MetadataAccumulatorInvocation
     | undefined;
 
   if (!nodeToAddTo) {
@@ -36,11 +21,12 @@ export const addNSFWCheckerToGraph = (
   }
 
   nodeToAddTo.is_intermediate = true;
+  nodeToAddTo.use_cache = true;
 
   const nsfwCheckerNode: ImageNSFWBlurInvocation = {
     id: NSFW_CHECKER,
     type: 'img_nsfw',
-    is_intermediate,
+    is_intermediate: true,
   };
 
   graph.nodes[NSFW_CHECKER] = nsfwCheckerNode as ImageNSFWBlurInvocation;
@@ -54,17 +40,4 @@ export const addNSFWCheckerToGraph = (
       field: 'image',
     },
   });
-
-  if (metadataAccumulator) {
-    graph.edges.push({
-      source: {
-        node_id: METADATA_ACCUMULATOR,
-        field: 'metadata',
-      },
-      destination: {
-        node_id: NSFW_CHECKER,
-        field: 'metadata',
-      },
-    });
-  }
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addSaveImageNode.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addSaveImageNode.ts
@@ -1,0 +1,92 @@
+import { NonNullableGraph } from 'features/nodes/types/types';
+import {
+  CANVAS_OUTPUT,
+  LATENTS_TO_IMAGE,
+  METADATA_ACCUMULATOR,
+  NSFW_CHECKER,
+  SAVE_IMAGE,
+  WATERMARKER,
+} from './constants';
+import {
+  MetadataAccumulatorInvocation,
+  SaveImageInvocation,
+} from 'services/api/types';
+import { RootState } from 'app/store/store';
+import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
+
+/**
+ * Set the `use_cache` field on the linear/canvas graph's final image output node to False.
+ */
+export const addSaveImageNode = (
+  state: RootState,
+  graph: NonNullableGraph
+): void => {
+  const activeTabName = activeTabNameSelector(state);
+  const is_intermediate =
+    activeTabName === 'unifiedCanvas' ? !state.canvas.shouldAutoSave : false;
+
+  const saveImageNode: SaveImageInvocation = {
+    id: SAVE_IMAGE,
+    type: 'save_image',
+    is_intermediate,
+    use_cache: false,
+  };
+
+  graph.nodes[SAVE_IMAGE] = saveImageNode;
+
+  const metadataAccumulator = graph.nodes[METADATA_ACCUMULATOR] as
+    | MetadataAccumulatorInvocation
+    | undefined;
+
+  if (metadataAccumulator) {
+    graph.edges.push({
+      source: {
+        node_id: METADATA_ACCUMULATOR,
+        field: 'metadata',
+      },
+      destination: {
+        node_id: SAVE_IMAGE,
+        field: 'metadata',
+      },
+    });
+  }
+
+  const destination = {
+    node_id: SAVE_IMAGE,
+    field: 'image',
+  };
+
+  if (WATERMARKER in graph.nodes) {
+    graph.edges.push({
+      source: {
+        node_id: WATERMARKER,
+        field: 'image',
+      },
+      destination,
+    });
+  } else if (NSFW_CHECKER in graph.nodes) {
+    graph.edges.push({
+      source: {
+        node_id: NSFW_CHECKER,
+        field: 'image',
+      },
+      destination,
+    });
+  } else if (CANVAS_OUTPUT in graph.nodes) {
+    graph.edges.push({
+      source: {
+        node_id: CANVAS_OUTPUT,
+        field: 'image',
+      },
+      destination,
+    });
+  } else if (LATENTS_TO_IMAGE in graph.nodes) {
+    graph.edges.push({
+      source: {
+        node_id: LATENTS_TO_IMAGE,
+        field: 'image',
+      },
+      destination,
+    });
+  }
+};

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addWatermarkerToGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addWatermarkerToGraph.ts
@@ -51,6 +51,7 @@ export const addWatermarkerToGraph = (
 
   // no matter the situation, we want the l2i node to be intermediate
   nodeToAddTo.is_intermediate = true;
+  nodeToAddTo.use_cache = true;
 
   if (nsfwCheckerNode) {
     // if we are using NSFW checker, we need to "disable" it output by marking it intermediate,

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildCanvasSDXLOutpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildCanvasSDXLOutpaintGraph.ts
@@ -48,6 +48,7 @@ import {
   SEAMLESS,
 } from './constants';
 import { craftSDXLStylePrompt } from './helpers/craftSDXLStylePrompt';
+import { addSaveImageNode } from './addSaveImageNode';
 
 /**
  * Builds the Canvas tab's Outpaint graph.
@@ -98,14 +99,10 @@ export const buildCanvasSDXLOutpaintGraph = (
   const { width, height } = state.canvas.boundingBoxDimensions;
 
   // We may need to set the inpaint width and height to scale the image
-  const {
-    scaledBoundingBoxDimensions,
-    boundingBoxScaleMethod,
-    shouldAutoSave,
-  } = state.canvas;
+  const { scaledBoundingBoxDimensions, boundingBoxScaleMethod } = state.canvas;
 
   const fp32 = vaePrecision === 'fp32';
-
+  const is_intermediate = true;
   const isUsingScaledDimensions = ['auto', 'manual'].includes(
     boundingBoxScaleMethod
   );
@@ -143,37 +140,37 @@ export const buildCanvasSDXLOutpaintGraph = (
       [MASK_FROM_ALPHA]: {
         type: 'tomask',
         id: MASK_FROM_ALPHA,
-        is_intermediate: true,
+        is_intermediate,
         image: canvasInitImage,
       },
       [MASK_COMBINE]: {
         type: 'mask_combine',
         id: MASK_COMBINE,
-        is_intermediate: true,
+        is_intermediate,
         mask2: canvasMaskImage,
       },
       [INPAINT_IMAGE]: {
         type: 'i2l',
         id: INPAINT_IMAGE,
-        is_intermediate: true,
+        is_intermediate,
         fp32,
       },
       [NOISE]: {
         type: 'noise',
         id: NOISE,
         use_cpu,
-        is_intermediate: true,
+        is_intermediate,
       },
       [INPAINT_CREATE_MASK]: {
         type: 'create_denoise_mask',
         id: INPAINT_CREATE_MASK,
-        is_intermediate: true,
+        is_intermediate,
         fp32,
       },
       [SDXL_DENOISE_LATENTS]: {
         type: 'denoise_latents',
         id: SDXL_DENOISE_LATENTS,
-        is_intermediate: true,
+        is_intermediate,
         steps: steps,
         cfg_scale: cfg_scale,
         scheduler: scheduler,
@@ -186,18 +183,18 @@ export const buildCanvasSDXLOutpaintGraph = (
         type: 'noise',
         id: NOISE,
         use_cpu,
-        is_intermediate: true,
+        is_intermediate,
       },
       [CANVAS_COHERENCE_NOISE_INCREMENT]: {
         type: 'add',
         id: CANVAS_COHERENCE_NOISE_INCREMENT,
         b: 1,
-        is_intermediate: true,
+        is_intermediate,
       },
       [CANVAS_COHERENCE_DENOISE_LATENTS]: {
         type: 'denoise_latents',
         id: CANVAS_COHERENCE_DENOISE_LATENTS,
-        is_intermediate: true,
+        is_intermediate,
         steps: canvasCoherenceSteps,
         cfg_scale: cfg_scale,
         scheduler: scheduler,
@@ -207,18 +204,18 @@ export const buildCanvasSDXLOutpaintGraph = (
       [LATENTS_TO_IMAGE]: {
         type: 'l2i',
         id: LATENTS_TO_IMAGE,
-        is_intermediate: true,
+        is_intermediate,
         fp32,
       },
       [CANVAS_OUTPUT]: {
         type: 'color_correct',
         id: CANVAS_OUTPUT,
-        is_intermediate: !shouldAutoSave,
+        is_intermediate,
       },
       [RANGE_OF_SIZE]: {
         type: 'range_of_size',
         id: RANGE_OF_SIZE,
-        is_intermediate: true,
+        is_intermediate,
         // seed - must be connected manually
         // start: 0,
         size: iterations,
@@ -227,7 +224,7 @@ export const buildCanvasSDXLOutpaintGraph = (
       [ITERATE]: {
         type: 'iterate',
         id: ITERATE,
-        is_intermediate: true,
+        is_intermediate,
       },
     },
     edges: [
@@ -487,7 +484,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[INPAINT_INFILL] = {
       type: 'infill_patchmatch',
       id: INPAINT_INFILL,
-      is_intermediate: true,
+      is_intermediate,
       downscale: infillPatchmatchDownscaleSize,
     };
   }
@@ -496,7 +493,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[INPAINT_INFILL] = {
       type: 'infill_lama',
       id: INPAINT_INFILL,
-      is_intermediate: true,
+      is_intermediate,
     };
   }
 
@@ -504,7 +501,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[INPAINT_INFILL] = {
       type: 'infill_cv2',
       id: INPAINT_INFILL,
-      is_intermediate: true,
+      is_intermediate,
     };
   }
 
@@ -512,7 +509,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[INPAINT_INFILL] = {
       type: 'infill_tile',
       id: INPAINT_INFILL,
-      is_intermediate: true,
+      is_intermediate,
       tile_size: infillTileSize,
     };
   }
@@ -526,7 +523,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[INPAINT_IMAGE_RESIZE_UP] = {
       type: 'img_resize',
       id: INPAINT_IMAGE_RESIZE_UP,
-      is_intermediate: true,
+      is_intermediate,
       width: scaledWidth,
       height: scaledHeight,
       image: canvasInitImage,
@@ -534,28 +531,28 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[MASK_RESIZE_UP] = {
       type: 'img_resize',
       id: MASK_RESIZE_UP,
-      is_intermediate: true,
+      is_intermediate,
       width: scaledWidth,
       height: scaledHeight,
     };
     graph.nodes[INPAINT_IMAGE_RESIZE_DOWN] = {
       type: 'img_resize',
       id: INPAINT_IMAGE_RESIZE_DOWN,
-      is_intermediate: true,
+      is_intermediate,
       width: width,
       height: height,
     };
     graph.nodes[INPAINT_INFILL_RESIZE_DOWN] = {
       type: 'img_resize',
       id: INPAINT_INFILL_RESIZE_DOWN,
-      is_intermediate: true,
+      is_intermediate,
       width: width,
       height: height,
     };
     graph.nodes[MASK_RESIZE_DOWN] = {
       type: 'img_resize',
       id: MASK_RESIZE_DOWN,
-      is_intermediate: true,
+      is_intermediate,
       width: width,
       height: height,
     };
@@ -715,7 +712,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     graph.nodes[CANVAS_COHERENCE_INPAINT_CREATE_MASK] = {
       type: 'create_denoise_mask',
       id: CANVAS_COHERENCE_INPAINT_CREATE_MASK,
-      is_intermediate: true,
+      is_intermediate,
       fp32,
     };
 
@@ -762,7 +759,7 @@ export const buildCanvasSDXLOutpaintGraph = (
       graph.nodes[CANVAS_COHERENCE_MASK_EDGE] = {
         type: 'mask_edge',
         id: CANVAS_COHERENCE_MASK_EDGE,
-        is_intermediate: true,
+        is_intermediate,
         edge_blur: maskBlur,
         edge_size: maskBlur * 2,
         low_threshold: 100,
@@ -878,6 +875,8 @@ export const buildCanvasSDXLOutpaintGraph = (
     // must add after nsfw checker!
     addWatermarkerToGraph(state, graph, CANVAS_OUTPUT);
   }
+
+  addSaveImageNode(state, graph);
 
   return graph;
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearImageToImageGraph.ts
@@ -27,6 +27,7 @@ import {
   RESIZE,
   SEAMLESS,
 } from './constants';
+import { addSaveImageNode } from './addSaveImageNode';
 
 /**
  * Builds the Image to Image tab graph.
@@ -85,6 +86,7 @@ export const buildLinearImageToImageGraph = (
   }
 
   const fp32 = vaePrecision === 'fp32';
+  const is_intermediate = true;
 
   let modelLoaderNodeId = MAIN_MODEL_LOADER;
 
@@ -100,31 +102,37 @@ export const buildLinearImageToImageGraph = (
         type: 'main_model_loader',
         id: modelLoaderNodeId,
         model,
+        is_intermediate,
       },
       [CLIP_SKIP]: {
         type: 'clip_skip',
         id: CLIP_SKIP,
         skipped_layers: clipSkip,
+        is_intermediate,
       },
       [POSITIVE_CONDITIONING]: {
         type: 'compel',
         id: POSITIVE_CONDITIONING,
         prompt: positivePrompt,
+        is_intermediate,
       },
       [NEGATIVE_CONDITIONING]: {
         type: 'compel',
         id: NEGATIVE_CONDITIONING,
         prompt: negativePrompt,
+        is_intermediate,
       },
       [NOISE]: {
         type: 'noise',
         id: NOISE,
         use_cpu,
+        is_intermediate,
       },
       [LATENTS_TO_IMAGE]: {
         type: 'l2i',
         id: LATENTS_TO_IMAGE,
         fp32,
+        is_intermediate,
       },
       [DENOISE_LATENTS]: {
         type: 'denoise_latents',
@@ -134,6 +142,7 @@ export const buildLinearImageToImageGraph = (
         steps,
         denoising_start: 1 - strength,
         denoising_end: 1,
+        is_intermediate,
       },
       [IMAGE_TO_LATENTS]: {
         type: 'i2l',
@@ -143,6 +152,7 @@ export const buildLinearImageToImageGraph = (
         //   image_name: initialImage.image_name,
         // },
         fp32,
+        is_intermediate,
       },
     },
     edges: [
@@ -374,6 +384,8 @@ export const buildLinearImageToImageGraph = (
     // must add after nsfw checker!
     addWatermarkerToGraph(state, graph);
   }
+
+  addSaveImageNode(state, graph);
 
   return graph;
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearSDXLImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearSDXLImageToImageGraph.ts
@@ -29,6 +29,7 @@ import {
   SEAMLESS,
 } from './constants';
 import { craftSDXLStylePrompt } from './helpers/craftSDXLStylePrompt';
+import { addSaveImageNode } from './addSaveImageNode';
 
 /**
  * Builds the Image to Image tab graph.
@@ -85,6 +86,7 @@ export const buildLinearSDXLImageToImageGraph = (
   }
 
   const fp32 = vaePrecision === 'fp32';
+  const is_intermediate = true;
 
   // Model Loader ID
   let modelLoaderNodeId = SDXL_MODEL_LOADER;
@@ -105,28 +107,33 @@ export const buildLinearSDXLImageToImageGraph = (
         type: 'sdxl_model_loader',
         id: modelLoaderNodeId,
         model,
+        is_intermediate,
       },
       [POSITIVE_CONDITIONING]: {
         type: 'sdxl_compel_prompt',
         id: POSITIVE_CONDITIONING,
         prompt: positivePrompt,
         style: craftedPositiveStylePrompt,
+        is_intermediate,
       },
       [NEGATIVE_CONDITIONING]: {
         type: 'sdxl_compel_prompt',
         id: NEGATIVE_CONDITIONING,
         prompt: negativePrompt,
         style: craftedNegativeStylePrompt,
+        is_intermediate,
       },
       [NOISE]: {
         type: 'noise',
         id: NOISE,
         use_cpu,
+        is_intermediate,
       },
       [LATENTS_TO_IMAGE]: {
         type: 'l2i',
         id: LATENTS_TO_IMAGE,
         fp32,
+        is_intermediate,
       },
       [SDXL_DENOISE_LATENTS]: {
         type: 'denoise_latents',
@@ -138,6 +145,7 @@ export const buildLinearSDXLImageToImageGraph = (
           ? Math.min(refinerStart, 1 - strength)
           : 1 - strength,
         denoising_end: shouldUseSDXLRefiner ? refinerStart : 1,
+        is_intermediate,
       },
       [IMAGE_TO_LATENTS]: {
         type: 'i2l',
@@ -147,6 +155,7 @@ export const buildLinearSDXLImageToImageGraph = (
         //   image_name: initialImage.image_name,
         // },
         fp32,
+        is_intermediate,
       },
     },
     edges: [
@@ -397,6 +406,8 @@ export const buildLinearSDXLImageToImageGraph = (
     // must add after nsfw checker!
     addWatermarkerToGraph(state, graph);
   }
+
+  addSaveImageNode(state, graph);
 
   return graph;
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearTextToImageGraph.ts
@@ -143,6 +143,7 @@ export const buildLinearTextToImageGraph = (
         type: isUsingOnnxModel ? 'l2i_onnx' : 'l2i',
         id: LATENTS_TO_IMAGE,
         fp32,
+        is_intermediate,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearTextToImageGraph.ts
@@ -26,6 +26,7 @@ import {
   SEAMLESS,
   TEXT_TO_IMAGE_GRAPH,
 } from './constants';
+import { addSaveImageNode } from './addSaveImageNode';
 
 export const buildLinearTextToImageGraph = (
   state: RootState
@@ -58,7 +59,7 @@ export const buildLinearTextToImageGraph = (
   }
 
   const fp32 = vaePrecision === 'fp32';
-
+  const is_intermediate = true;
   const isUsingOnnxModel = model.model_type === 'onnx';
 
   let modelLoaderNodeId = isUsingOnnxModel
@@ -74,7 +75,7 @@ export const buildLinearTextToImageGraph = (
       ? {
           type: 't2l_onnx',
           id: DENOISE_LATENTS,
-          is_intermediate: true,
+          is_intermediate,
           cfg_scale,
           scheduler,
           steps,
@@ -82,7 +83,7 @@ export const buildLinearTextToImageGraph = (
       : {
           type: 'denoise_latents',
           id: DENOISE_LATENTS,
-          is_intermediate: true,
+          is_intermediate,
           cfg_scale,
           scheduler,
           steps,
@@ -108,26 +109,26 @@ export const buildLinearTextToImageGraph = (
       [modelLoaderNodeId]: {
         type: modelLoaderNodeType,
         id: modelLoaderNodeId,
-        is_intermediate: true,
+        is_intermediate,
         model,
       },
       [CLIP_SKIP]: {
         type: 'clip_skip',
         id: CLIP_SKIP,
         skipped_layers: clipSkip,
-        is_intermediate: true,
+        is_intermediate,
       },
       [POSITIVE_CONDITIONING]: {
         type: isUsingOnnxModel ? 'prompt_onnx' : 'compel',
         id: POSITIVE_CONDITIONING,
         prompt: positivePrompt,
-        is_intermediate: true,
+        is_intermediate,
       },
       [NEGATIVE_CONDITIONING]: {
         type: isUsingOnnxModel ? 'prompt_onnx' : 'compel',
         id: NEGATIVE_CONDITIONING,
         prompt: negativePrompt,
-        is_intermediate: true,
+        is_intermediate,
       },
       [NOISE]: {
         type: 'noise',
@@ -135,7 +136,7 @@ export const buildLinearTextToImageGraph = (
         width,
         height,
         use_cpu,
-        is_intermediate: true,
+        is_intermediate,
       },
       [t2lNode.id]: t2lNode,
       [LATENTS_TO_IMAGE]: {
@@ -292,6 +293,8 @@ export const buildLinearTextToImageGraph = (
     // must add after nsfw checker!
     addWatermarkerToGraph(state, graph);
   }
+
+  addSaveImageNode(state, graph);
 
   return graph;
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildNodesGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildNodesGraph.ts
@@ -55,6 +55,9 @@ export const buildNodesGraph = (nodesState: NodesState): Graph => {
         {} as Record<Exclude<string, 'id' | 'type'>, unknown>
       );
 
+      // add reserved use_cache
+      transformedInputs['use_cache'] = node.data.useCache;
+
       // Build this specific node
       const graphNode = {
         type,

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/constants.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/constants.ts
@@ -3,6 +3,7 @@ export const POSITIVE_CONDITIONING = 'positive_conditioning';
 export const NEGATIVE_CONDITIONING = 'negative_conditioning';
 export const DENOISE_LATENTS = 'denoise_latents';
 export const LATENTS_TO_IMAGE = 'latents_to_image';
+export const SAVE_IMAGE = 'save_image';
 export const NSFW_CHECKER = 'nsfw_checker';
 export const WATERMARKER = 'invisible_watermark';
 export const NOISE = 'noise';

--- a/invokeai/frontend/web/src/features/nodes/util/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/parseSchema.ts
@@ -16,7 +16,7 @@ import {
 } from '../types/types';
 import { buildInputFieldTemplate, getFieldType } from './fieldTemplateBuilders';
 
-const RESERVED_INPUT_FIELD_NAMES = ['id', 'type', 'metadata'];
+const RESERVED_INPUT_FIELD_NAMES = ['id', 'type', 'metadata', 'use_cache'];
 const RESERVED_OUTPUT_FIELD_NAMES = ['type'];
 const RESERVED_FIELD_TYPES = [
   'WorkflowField',
@@ -235,6 +235,8 @@ export const parseSchema = (
       {} as Record<string, OutputFieldTemplate>
     );
 
+    const useCache = schema.properties.use_cache.default;
+
     const invocation: InvocationTemplate = {
       title,
       type,
@@ -244,6 +246,7 @@ export const parseSchema = (
       outputType,
       inputs,
       outputs,
+      useCache,
     };
 
     Object.assign(invocationsAccumulator, { [type]: invocation });

--- a/invokeai/frontend/web/src/services/api/schema.d.ts
+++ b/invokeai/frontend/web/src/services/api/schema.d.ts
@@ -341,6 +341,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * A
        * @description The first number
        * @default 0
@@ -424,6 +430,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Width
        * @description The width of the image
        * @default 512
@@ -481,6 +493,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Latents A
        * @description Latents tensor
@@ -701,6 +719,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Collection
        * @description The collection of boolean values
        */
@@ -750,6 +774,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Value
        * @description The boolean value
@@ -802,6 +832,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to infill
        */
@@ -834,6 +870,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -903,6 +945,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * CLIP
        * @description CLIP (tokenizer, text encoder, LoRAs) and skipped layer count
        */
@@ -958,6 +1006,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Collection Item
        * @description The item to collect (all inputs must be of the same type)
@@ -1034,6 +1088,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to color-correct
        */
@@ -1109,6 +1169,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Color
        * @description The color value
        * @default {
@@ -1165,6 +1231,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Prompt
        * @description Prompt to be parsed by Compel to create a conditioning tensor
        * @default
@@ -1203,6 +1275,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Collection
        * @description The collection of conditioning tensors
@@ -1265,6 +1343,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Conditioning
        * @description Conditioning tensor
        */
@@ -1314,6 +1398,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -1422,6 +1512,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The control image
@@ -1553,7 +1649,7 @@ export type components = {
       /**
        * App Version
        * @description The version of InvokeAI used to generate this image
-       * @default 3.1.1rc1
+       * @default 3.1.1
        */
       app_version?: string;
       /**
@@ -1714,6 +1810,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Vae
        * @description VAE
        */
@@ -1768,6 +1870,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to inpaint
@@ -1829,6 +1937,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Noise
        * @description Noise tensor
@@ -1957,6 +2071,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * A
        * @description The first number
        * @default 0
@@ -1996,6 +2116,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default false
+       */
+      use_cache?: boolean;
       /**
        * Prompt
        * @description The prompt to parse with dynamicprompts
@@ -2041,6 +2167,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The input image
@@ -2108,6 +2240,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Collection
        * @description The collection of float values
        */
@@ -2158,6 +2296,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Value
        * @description The float value
        * @default 0
@@ -2191,6 +2335,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Start
        * @description The first value of the range
@@ -2237,6 +2387,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Operation
        * @description The operation to perform
@@ -2302,6 +2458,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Value
        * @description The value to round
        * @default 0
@@ -2339,7 +2501,7 @@ export type components = {
        * @description The nodes in this graph
        */
       nodes?: {
-        [key: string]: components["schemas"]["BooleanInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ImageProcessorInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"];
+        [key: string]: components["schemas"]["BooleanInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ImageProcessorInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["SaveImageInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["StringSplitNegInvocation"] | components["schemas"]["StringSplitInvocation"] | components["schemas"]["StringJoinInvocation"] | components["schemas"]["StringJoinThreeInvocation"] | components["schemas"]["StringReplaceInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"];
       };
       /**
        * Edges
@@ -2382,7 +2544,7 @@ export type components = {
        * @description The results of node executions
        */
       results: {
-        [key: string]: components["schemas"]["BooleanOutput"] | components["schemas"]["BooleanCollectionOutput"] | components["schemas"]["IntegerOutput"] | components["schemas"]["IntegerCollectionOutput"] | components["schemas"]["FloatOutput"] | components["schemas"]["FloatCollectionOutput"] | components["schemas"]["StringOutput"] | components["schemas"]["StringCollectionOutput"] | components["schemas"]["ImageOutput"] | components["schemas"]["ImageCollectionOutput"] | components["schemas"]["DenoiseMaskOutput"] | components["schemas"]["LatentsOutput"] | components["schemas"]["LatentsCollectionOutput"] | components["schemas"]["ColorOutput"] | components["schemas"]["ColorCollectionOutput"] | components["schemas"]["ConditioningOutput"] | components["schemas"]["ConditioningCollectionOutput"] | components["schemas"]["ControlOutput"] | components["schemas"]["ModelLoaderOutput"] | components["schemas"]["LoraLoaderOutput"] | components["schemas"]["SDXLLoraLoaderOutput"] | components["schemas"]["VaeLoaderOutput"] | components["schemas"]["SeamlessModeOutput"] | components["schemas"]["MetadataAccumulatorOutput"] | components["schemas"]["SDXLModelLoaderOutput"] | components["schemas"]["SDXLRefinerModelLoaderOutput"] | components["schemas"]["ClipSkipInvocationOutput"] | components["schemas"]["SchedulerOutput"] | components["schemas"]["ONNXModelLoaderOutput"] | components["schemas"]["NoiseOutput"] | components["schemas"]["GraphInvocationOutput"] | components["schemas"]["IterateInvocationOutput"] | components["schemas"]["CollectInvocationOutput"];
+        [key: string]: components["schemas"]["BooleanOutput"] | components["schemas"]["BooleanCollectionOutput"] | components["schemas"]["IntegerOutput"] | components["schemas"]["IntegerCollectionOutput"] | components["schemas"]["FloatOutput"] | components["schemas"]["FloatCollectionOutput"] | components["schemas"]["StringOutput"] | components["schemas"]["StringCollectionOutput"] | components["schemas"]["ImageOutput"] | components["schemas"]["ImageCollectionOutput"] | components["schemas"]["DenoiseMaskOutput"] | components["schemas"]["LatentsOutput"] | components["schemas"]["LatentsCollectionOutput"] | components["schemas"]["ColorOutput"] | components["schemas"]["ColorCollectionOutput"] | components["schemas"]["ConditioningOutput"] | components["schemas"]["ConditioningCollectionOutput"] | components["schemas"]["ControlOutput"] | components["schemas"]["ModelLoaderOutput"] | components["schemas"]["LoraLoaderOutput"] | components["schemas"]["SDXLLoraLoaderOutput"] | components["schemas"]["VaeLoaderOutput"] | components["schemas"]["SeamlessModeOutput"] | components["schemas"]["MetadataAccumulatorOutput"] | components["schemas"]["SDXLModelLoaderOutput"] | components["schemas"]["SDXLRefinerModelLoaderOutput"] | components["schemas"]["ClipSkipInvocationOutput"] | components["schemas"]["SchedulerOutput"] | components["schemas"]["ONNXModelLoaderOutput"] | components["schemas"]["NoiseOutput"] | components["schemas"]["StringPosNegOutput"] | components["schemas"]["String2Output"] | components["schemas"]["GraphInvocationOutput"] | components["schemas"]["IterateInvocationOutput"] | components["schemas"]["CollectInvocationOutput"];
       };
       /**
        * Errors
@@ -2427,6 +2589,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Graph
        * @description The graph to run
@@ -2480,6 +2648,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to process
        */
@@ -2530,6 +2704,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to blur
@@ -2589,6 +2769,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to get the channel from
        */
@@ -2628,6 +2814,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to adjust
@@ -2680,6 +2872,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to adjust
        */
@@ -2724,6 +2922,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Collection
        * @description The collection of image values
@@ -2775,6 +2979,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to convert
        */
@@ -2814,6 +3024,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to crop
@@ -2958,6 +3174,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to adjust
        */
@@ -2996,6 +3218,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to lerp
@@ -3042,6 +3270,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to load
        */
@@ -3074,6 +3308,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to lerp
@@ -3136,6 +3376,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image1
        * @description The first image to multiply
        */
@@ -3173,6 +3419,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Metadata
        * @description Optional core metadata to be written to image
@@ -3239,6 +3491,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Base Image
        * @description The base image
        */
@@ -3265,6 +3523,12 @@ export type components = {
        * @default 0
        */
       y?: number;
+      /**
+       * Crop
+       * @description Crop to base image dimensions
+       * @default false
+       */
+      crop?: boolean;
       /**
        * Type
        * @default img_paste
@@ -3293,6 +3557,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -3356,6 +3626,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to resize
        */
@@ -3413,6 +3689,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to scale
        */
@@ -3458,6 +3740,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to encode
@@ -3530,6 +3818,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to check
        */
@@ -3582,6 +3876,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to infill
        */
@@ -3625,6 +3925,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to infill
@@ -3672,6 +3978,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to infill
        */
@@ -3715,6 +4027,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Collection
        * @description The collection of integer values
@@ -3766,6 +4084,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Value
        * @description The integer value
        * @default 0
@@ -3799,6 +4123,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Operation
        * @description The operation to perform
@@ -3864,6 +4194,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Collection
        * @description The list of items to iterate over
        */
@@ -3920,6 +4256,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to infill
        */
@@ -3952,6 +4294,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Collection
        * @description The collection of latents tensors
@@ -4019,6 +4367,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Latents
        * @description The latents tensor
        */
@@ -4079,6 +4433,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Tiled
        * @description Processing using overlapping tiles (reduce memory consumption)
        * @default false
@@ -4133,6 +4493,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -4197,6 +4563,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to process
        */
@@ -4241,6 +4613,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -4370,6 +4748,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * LoRA
        * @description LoRA model to load
        */
@@ -4456,6 +4840,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Model
        * @description Main model (UNet, VAE, CLIP) to load
        */
@@ -4488,6 +4878,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Mask1
        * @description The first mask to combine
@@ -4526,6 +4922,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to apply the mask to
@@ -4580,6 +4982,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to create the mask from
        */
@@ -4618,6 +5026,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -4669,6 +5083,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Generation Mode
        * @description The generation mode that output this image
@@ -4845,6 +5265,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to process
        */
@@ -4889,6 +5315,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -5011,6 +5443,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * A
        * @description The first number
        * @default 0
@@ -5050,6 +5488,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Seed
        * @description Seed for random number generation
@@ -5129,6 +5573,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to process
        */
@@ -5173,6 +5623,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Latents
        * @description Denoised latents tensor
@@ -5251,6 +5707,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Prompt
        * @description Raw prompt text (no parsing)
@@ -5337,6 +5799,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Positive Conditioning
        * @description Positive conditioning tensor
@@ -5484,6 +5952,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Model
        * @description ONNX Main model (UNet, VAE, CLIP) to load
        */
@@ -5516,6 +5990,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -5599,6 +6079,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to process
        */
@@ -5656,6 +6142,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * File Path
        * @description Path to prompt text file
        */
@@ -5711,6 +6203,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default false
+       */
+      use_cache?: boolean;
+      /**
        * Low
        * @description The inclusive low value
        * @default 0
@@ -5750,6 +6248,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default false
+       */
+      use_cache?: boolean;
       /**
        * Low
        * @description The inclusive low value
@@ -5802,6 +6306,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Start
        * @description The start of the range
        * @default 0
@@ -5828,7 +6338,7 @@ export type components = {
     };
     /**
      * Integer Range of Size
-     * @description Creates a range from start to start + size with step
+     * @description Creates a range from start to start + (size * step) incremented by step
      */
     RangeOfSizeInvocation: {
       /**
@@ -5847,6 +6357,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Start
        * @description The start of the range
@@ -5901,6 +6417,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Latents
        * @description Latents tensor
@@ -5968,6 +6490,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Value
        * @description The float value
        * @default 0
@@ -6007,6 +6535,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Prompt
        * @description Prompt to be parsed by Compel to create a conditioning tensor
@@ -6087,6 +6621,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * LoRA
        * @description LoRA model to load
@@ -6169,6 +6709,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Model
        * @description SDXL Main model (UNet, VAE, CLIP1, CLIP2) to load
        */
@@ -6233,6 +6779,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Style
        * @description Prompt to be parsed by Compel to create a conditioning tensor
@@ -6299,6 +6851,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Model
        * @description SDXL Refiner Main Modde (UNet, VAE, CLIP2) to load
        */
@@ -6338,6 +6896,50 @@ export type components = {
       type: "sdxl_refiner_model_loader_output";
     };
     /**
+     * Save Image
+     * @description Saves an image. Unlike an image primitive, this invocation stores a copy of the image.
+     */
+    SaveImageInvocation: {
+      /**
+       * Id
+       * @description The id of this instance of an invocation. Must be unique among all instances of invocations.
+       */
+      id: string;
+      /**
+       * Is Intermediate
+       * @description Whether or not this is an intermediate invocation.
+       * @default false
+       */
+      is_intermediate?: boolean;
+      /**
+       * Workflow
+       * @description The workflow to save with the image
+       */
+      workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default false
+       */
+      use_cache?: boolean;
+      /**
+       * Image
+       * @description The image to load
+       */
+      image?: components["schemas"]["ImageField"];
+      /**
+       * Metadata
+       * @description Optional core metadata to be written to image
+       */
+      metadata?: components["schemas"]["CoreMetadata"];
+      /**
+       * Type
+       * @default save_image
+       * @enum {string}
+       */
+      type: "save_image";
+    };
+    /**
      * Scale Latents
      * @description Scales latents by a given factor.
      */
@@ -6358,6 +6960,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Latents
        * @description Latents tensor
@@ -6409,6 +7017,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Scheduler
        * @description Scheduler to use during inference
@@ -6470,6 +7084,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * UNet
        * @description UNet (scheduler, LoRAs)
@@ -6543,6 +7163,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Image
        * @description The image to process
        */
@@ -6575,6 +7201,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to show
@@ -6759,6 +7391,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Easing
        * @description The easing function to use
        * @default Linear
@@ -6825,6 +7463,28 @@ export type components = {
       type: "step_param_easing";
     };
     /**
+     * String2Output
+     * @description Base class for invocations that output two strings
+     */
+    String2Output: {
+      /**
+       * String 1
+       * @description string 1
+       */
+      string_1: string;
+      /**
+       * String 2
+       * @description string 2
+       */
+      string_2: string;
+      /**
+       * Type
+       * @default string_2_output
+       * @enum {string}
+       */
+      type: "string_2_output";
+    };
+    /**
      * String Collection Primitive
      * @description A collection of string primitive values
      */
@@ -6845,6 +7505,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Collection
        * @description The collection of string values
@@ -6896,6 +7562,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * Value
        * @description The string value
        * @default
@@ -6907,6 +7579,104 @@ export type components = {
        * @enum {string}
        */
       type: "string";
+    };
+    /**
+     * String Join
+     * @description Joins string left to string right
+     */
+    StringJoinInvocation: {
+      /**
+       * Id
+       * @description The id of this instance of an invocation. Must be unique among all instances of invocations.
+       */
+      id: string;
+      /**
+       * Is Intermediate
+       * @description Whether or not this is an intermediate invocation.
+       * @default false
+       */
+      is_intermediate?: boolean;
+      /**
+       * Workflow
+       * @description The workflow to save with the image
+       */
+      workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
+       * String Left
+       * @description String Left
+       * @default
+       */
+      string_left?: string;
+      /**
+       * String Right
+       * @description String Right
+       * @default
+       */
+      string_right?: string;
+      /**
+       * Type
+       * @default string_join
+       * @enum {string}
+       */
+      type: "string_join";
+    };
+    /**
+     * String Join Three
+     * @description Joins string left to string middle to string right
+     */
+    StringJoinThreeInvocation: {
+      /**
+       * Id
+       * @description The id of this instance of an invocation. Must be unique among all instances of invocations.
+       */
+      id: string;
+      /**
+       * Is Intermediate
+       * @description Whether or not this is an intermediate invocation.
+       * @default false
+       */
+      is_intermediate?: boolean;
+      /**
+       * Workflow
+       * @description The workflow to save with the image
+       */
+      workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
+       * String Left
+       * @description String Left
+       * @default
+       */
+      string_left?: string;
+      /**
+       * String Middle
+       * @description String Middle
+       * @default
+       */
+      string_middle?: string;
+      /**
+       * String Right
+       * @description String Right
+       * @default
+       */
+      string_right?: string;
+      /**
+       * Type
+       * @default string_join_three
+       * @enum {string}
+       */
+      type: "string_join_three";
     };
     /**
      * StringOutput
@@ -6924,6 +7694,172 @@ export type components = {
        * @enum {string}
        */
       type: "string_output";
+    };
+    /**
+     * StringPosNegOutput
+     * @description Base class for invocations that output a positive and negative string
+     */
+    StringPosNegOutput: {
+      /**
+       * Positive String
+       * @description Positive string
+       */
+      positive_string: string;
+      /**
+       * Negative String
+       * @description Negative string
+       */
+      negative_string: string;
+      /**
+       * Type
+       * @default string_pos_neg_output
+       * @enum {string}
+       */
+      type: "string_pos_neg_output";
+    };
+    /**
+     * String Replace
+     * @description Replaces the search string with the replace string
+     */
+    StringReplaceInvocation: {
+      /**
+       * Id
+       * @description The id of this instance of an invocation. Must be unique among all instances of invocations.
+       */
+      id: string;
+      /**
+       * Is Intermediate
+       * @description Whether or not this is an intermediate invocation.
+       * @default false
+       */
+      is_intermediate?: boolean;
+      /**
+       * Workflow
+       * @description The workflow to save with the image
+       */
+      workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
+       * String
+       * @description String to work on
+       * @default
+       */
+      string?: string;
+      /**
+       * Search String
+       * @description String to search for
+       * @default
+       */
+      search_string?: string;
+      /**
+       * Replace String
+       * @description String to replace the search
+       * @default
+       */
+      replace_string?: string;
+      /**
+       * Use Regex
+       * @description Use search string as a regex expression (non regex is case insensitive)
+       * @default false
+       */
+      use_regex?: boolean;
+      /**
+       * Type
+       * @default string_replace
+       * @enum {string}
+       */
+      type: "string_replace";
+    };
+    /**
+     * String Split
+     * @description Splits string into two strings, based on the first occurance of the delimiter. The delimiter will be removed from the string
+     */
+    StringSplitInvocation: {
+      /**
+       * Id
+       * @description The id of this instance of an invocation. Must be unique among all instances of invocations.
+       */
+      id: string;
+      /**
+       * Is Intermediate
+       * @description Whether or not this is an intermediate invocation.
+       * @default false
+       */
+      is_intermediate?: boolean;
+      /**
+       * Workflow
+       * @description The workflow to save with the image
+       */
+      workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
+       * String
+       * @description String to split
+       * @default
+       */
+      string?: string;
+      /**
+       * Delimiter
+       * @description Delimiter to spilt with. blank will split on the first whitespace
+       * @default
+       */
+      delimiter?: string;
+      /**
+       * Type
+       * @default string_split
+       * @enum {string}
+       */
+      type: "string_split";
+    };
+    /**
+     * String Split Negative
+     * @description Splits string into two strings, inside [] goes into negative string everthing else goes into positive string. Each [ and ] character is replaced with a space
+     */
+    StringSplitNegInvocation: {
+      /**
+       * Id
+       * @description The id of this instance of an invocation. Must be unique among all instances of invocations.
+       */
+      id: string;
+      /**
+       * Is Intermediate
+       * @description Whether or not this is an intermediate invocation.
+       * @default false
+       */
+      is_intermediate?: boolean;
+      /**
+       * Workflow
+       * @description The workflow to save with the image
+       */
+      workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
+       * String
+       * @description String to split
+       * @default
+       */
+      string?: string;
+      /**
+       * Type
+       * @default string_split_neg
+       * @enum {string}
+       */
+      type: "string_split_neg";
     };
     /**
      * SubModelType
@@ -6952,6 +7888,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * A
        * @description The first number
@@ -7010,6 +7952,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -7112,6 +8060,12 @@ export type components = {
        */
       workflow?: string;
       /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
+      /**
        * VAE
        * @description VAE model to load
        */
@@ -7193,6 +8147,12 @@ export type components = {
        * @description The workflow to save with the image
        */
       workflow?: string;
+      /**
+       * Use Cache
+       * @description Whether or not to use the cache
+       * @default true
+       */
+      use_cache?: boolean;
       /**
        * Image
        * @description The image to process
@@ -7291,11 +8251,11 @@ export type components = {
       ui_order?: number;
     };
     /**
-     * StableDiffusion1ModelFormat
+     * StableDiffusion2ModelFormat
      * @description An enumeration.
      * @enum {string}
      */
-    StableDiffusion1ModelFormat: "checkpoint" | "diffusers";
+    StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
     /**
      * StableDiffusionOnnxModelFormat
      * @description An enumeration.
@@ -7309,17 +8269,17 @@ export type components = {
      */
     ControlNetModelFormat: "checkpoint" | "diffusers";
     /**
+     * StableDiffusion1ModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    StableDiffusion1ModelFormat: "checkpoint" | "diffusers";
+    /**
      * StableDiffusionXLModelFormat
      * @description An enumeration.
      * @enum {string}
      */
     StableDiffusionXLModelFormat: "checkpoint" | "diffusers";
-    /**
-     * StableDiffusion2ModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
   };
   responses: never;
   parameters: never;
@@ -7436,7 +8396,7 @@ export type operations = {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["BooleanInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ImageProcessorInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"];
+        "application/json": components["schemas"]["BooleanInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ImageProcessorInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["SaveImageInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["StringSplitNegInvocation"] | components["schemas"]["StringSplitInvocation"] | components["schemas"]["StringJoinInvocation"] | components["schemas"]["StringJoinThreeInvocation"] | components["schemas"]["StringReplaceInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"];
       };
     };
     responses: {
@@ -7477,7 +8437,7 @@ export type operations = {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["BooleanInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ImageProcessorInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"];
+        "application/json": components["schemas"]["BooleanInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ImageProcessorInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["SaveImageInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["StringSplitNegInvocation"] | components["schemas"]["StringSplitInvocation"] | components["schemas"]["StringJoinInvocation"] | components["schemas"]["StringJoinThreeInvocation"] | components["schemas"]["StringReplaceInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"];
       };
     };
     responses: {

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -132,6 +132,7 @@ export type DivideInvocation = s['DivideInvocation'];
 export type ImageNSFWBlurInvocation = s['ImageNSFWBlurInvocation'];
 export type ImageWatermarkInvocation = s['ImageWatermarkInvocation'];
 export type SeamlessModeInvocation = s['SeamlessModeInvocation'];
+export type SaveImageInvocation = s['SaveImageInvocation'];
 
 // ControlNet Nodes
 export type ControlNetInvocation = s['ControlNetInvocation'];

--- a/tests/nodes/test_graph_execution_state.py
+++ b/tests/nodes/test_graph_execution_state.py
@@ -1,4 +1,8 @@
+import logging
+
 import pytest
+
+from invokeai.app.services.invocation_cache.invocation_cache_memory import MemoryInvocationCache
 
 # This import must happen before other invoke imports or test in other files(!!) break
 from .test_nodes import (  # isort: split
@@ -42,7 +46,7 @@ def mock_services() -> InvocationServices:
     return InvocationServices(
         model_manager=None,  # type: ignore
         events=TestEventService(),
-        logger=None,  # type: ignore
+        logger=logging,  # type: ignore
         images=None,  # type: ignore
         latents=None,  # type: ignore
         boards=None,  # type: ignore
@@ -53,6 +57,7 @@ def mock_services() -> InvocationServices:
         performance_statistics=InvocationStatsService(graph_execution_manager),
         processor=DefaultInvocationProcessor(),
         configuration=None,  # type: ignore
+        invocation_cache=MemoryInvocationCache(),  # type: ignore
     )
 
 

--- a/tests/nodes/test_invoker.py
+++ b/tests/nodes/test_invoker.py
@@ -1,6 +1,9 @@
+import logging
+
 import pytest
 
 from invokeai.app.services.graph import Graph, GraphExecutionState, LibraryGraph
+from invokeai.app.services.invocation_cache.invocation_cache_memory import MemoryInvocationCache
 from invokeai.app.services.invocation_queue import MemoryInvocationQueue
 from invokeai.app.services.invocation_services import InvocationServices
 from invokeai.app.services.invocation_stats import InvocationStatsService
@@ -39,7 +42,7 @@ def mock_services() -> InvocationServices:
     return InvocationServices(
         model_manager=None,  # type: ignore
         events=TestEventService(),
-        logger=None,  # type: ignore
+        logger=logging,  # type: ignore
         images=None,  # type: ignore
         latents=None,  # type: ignore
         boards=None,  # type: ignore
@@ -50,6 +53,7 @@ def mock_services() -> InvocationServices:
         processor=DefaultInvocationProcessor(),
         performance_statistics=InvocationStatsService(graph_execution_manager),
         configuration=None,  # type: ignore
+        invocation_cache=MemoryInvocationCache(),
     )
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description

The invocation cache provides simple node memoization functionality. Nodes that use the cache are memoized and not re-executed if their inputs haven't changed. Instead, the stored output is returned.

## Results

This feature provides anywhere some significant to massive performance improvement.

The improvement is most marked on large batches of generations where you only change a couple things (e.g. different seed or prompt for each iteration) and low-VRAM systems, where skipping an extraneous model load is a big deal.

## Overview

A new `invocation_cache` service is added to handle the caching. There's not much to it.

All nodes now inherit a boolean `use_cache` field from `BaseInvocation`. This is a node field and not a class attribute, because specific instances of nodes may want to opt in or out of caching.

The recently-added `invoke_internal()` method on `BaseInvocation` is used as an entrypoint for the cache logic.

To create a cache key, the invocation is first serialized using pydantic's provided `json()` method, skipping the unique `id` field. Then python's very fast builtin `hash()` is used to create an integer key. All implementations of `InvocationCacheBase` must provide a class method `create_key()` which accepts an invocation and outputs a string or integer key.

## In-Memory Implementation

An in-memory implementation is provided. In this implementation, the node outputs are stored in memory as python classes. The in-memory cache does not persist application restarts.

Max node cache size is added as `node_cache_size` under the `Generation` config category.

It defaults to 512 - this number is up for discussion, but given that these are relatively lightweight pydantic models, I think it's safe to up this even higher.

Note that the cache isn't storing the big stuff - tensors and images are store on disk, and outputs include only references to them.

## Node Definition

The default for all nodes is to use the cache. The `@invocation` decorator now accepts an optional `use_cache: bool` argument to override the default of `True`.

Non-deterministic nodes, however, should set this to `False`. Currently, all random-stuff nodes, including `dynamic_prompt`, are set to `False`.

The field name `use_cache` is now effectively a reserved field name and possibly a breaking change if any community nodes use this as a field name. In hindsight, all our reserved field names should have been prefixed with underscores or something.

## One Gotcha

Leaf nodes probably want to opt out of the cache, because if they are not cached, their outputs are not saved again.

If you run the same graph multiple times, you only end up with a single image output, because the image storage side-effects are in the `invoke()` method, which is bypassed if we have a cache hit.

## Linear UI

The linear graphs _almost_ just work, but due to the gotcha, we need to be careful about the final image-outputting node. To resolve this, a `SaveImageInvocation` node is added and used in the linear graphs.

This node is similar to `ImagePrimitive`, except it saves a copy of its input image, and has `use_cache` set to `False` by default.

This is now the leaf node in all linear graphs, and is the only node in those graphs with `use_cache == False` _and_ the only node with `is_intermedate == False`.

## Workflow Editor

All nodes now have a footer with a new `Use Cache [ ]` checkbox. It defaults to the value set by the invocation in its python definition, but can be changed by the user.

The workflow/node validation logic has been updated to migrate old workflows to use the new default values for `use_cache`. Users may still want to review the settings that have been chosen. In the event of catastrophic failure when running this migration, the default value of `True` is applied, as this is correct for most nodes.

Users should consider saving their workflows after loading them in and having them updated.

## Future Enhancements - Callback

A future enhancement would be to provide a callback to the `use_cache` flag that would be run as the node is executed to determine, based on its own internal state, if the cache should be used or not.

This would be useful for `DynamicPromptInvocation`, where the deterministic behaviour is determined by the `combinatorial: bool` field.

## Future Enhancements - Persisted Cache

Similar to how the latents storage is backed by disk, the invocation cache could be persisted to the database or disk. We'd need to be very careful about deserializing outputs, but it's perhaps worth exploring in the future.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue # https://discord.com/channels/1020123559063990373/1130288930319761428/1153011770517110985

## QA Instructions, Screenshots, Recordings

Set your log level to debug in `invokeai.yaml` (not the UI). If you look carefully, you should see messages about cache hits, misses and skips.

Test linear UI & canvas. All modes should work, and if you run the same graph 2x in a row (manual seed), the second run should complete *very* fast, skipping progress images.

SDXL on low-vram should be substantially faster.

Old workflows should just work, except you probably want to add a Save Image node on to the end of the workflow.

## Added/updated tests?

- [x] Yes (made sure the existing tests work)
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
