### PR TITLE
fix case where controlnet + is sometimes disabled

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/ControlNet/ParamControlNetCollapse.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/ControlNet/ParamControlNetCollapse.tsx
@@ -15,12 +15,9 @@ import {
 import { getValidControlNets } from 'features/controlNet/util/getValidControlNets';
 import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
 import { map } from 'lodash-es';
-import { Fragment, memo, useCallback } from 'react';
+import { Fragment, memo, useCallback, useMemo } from 'react';
 import { FaPlus } from 'react-icons/fa';
-import {
-  controlNetModelsAdapter,
-  useGetControlNetModelsQuery,
-} from 'services/api/endpoints/models';
+import { useGetControlNetModelsQuery } from 'services/api/endpoints/models';
 import { v4 as uuidv4 } from 'uuid';
 
 const selector = createSelector(
@@ -53,16 +50,22 @@ const ParamControlNetCollapse = () => {
   const { controlNetsArray, activeLabel } = useAppSelector(selector);
   const isControlNetDisabled = useFeatureStatus('controlNet').isFeatureDisabled;
   const dispatch = useAppDispatch();
-  const { firstModel } = useGetControlNetModelsQuery(undefined, {
-    selectFromResult: (result) => {
-      const firstModel = result.data
-        ? controlNetModelsAdapter.getSelectors().selectAll(result.data)[0]
-        : undefined;
-      return {
-        firstModel,
-      };
-    },
-  });
+  const { data: controlnetModels } = useGetControlNetModelsQuery();
+
+  const firstModel = useMemo(() => {
+    if (!controlnetModels || !Object.keys(controlnetModels.entities).length) {
+      return undefined;
+    }
+    const firstModelId = Object.keys(controlnetModels.entities)[0];
+
+    if (!firstModelId) {
+      return undefined;
+    }
+
+    const firstModel = controlnetModels.entities[firstModelId];
+
+    return firstModel ? firstModel : undefined;
+  }, [controlnetModels]);
 
   const handleClickedAddControlNet = useCallback(() => {
     if (!firstModel) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
I wasn't able to pin down exact steps to replicate but frequently the `+` icon for adding a controlnet was disabled and I think it was because the store did not realize that there were any response. I also noticed that the UI is making each model (and some board requests) twice on page load, but the controlnet one _was_ omitted from the second batch without this change. We should probably fix the double requests but I'm not even sure where to start on that.

Double requests (with this change, you can see controlnet request in second batch)
![Screenshot 2023-09-20 at 11 42 51 AM](https://github.com/invoke-ai/InvokeAI/assets/6750888/24ebef91-14dd-4418-bcf4-d8571d0101f8)

Double requests (without this change, no controlnet request in second batch)
![Screenshot 2023-09-20 at 11 43 27 AM](https://github.com/invoke-ai/InvokeAI/assets/6750888/707bdb29-e509-443e-85f3-bee2c9003322)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
