### PR TITLE
fix(ui): workflow editor side panel remembers positioning

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/NodeEditorPanelGroup.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/NodeEditorPanelGroup.tsx
@@ -45,6 +45,7 @@ const NodeEditorPanelGroup = () => {
       <PanelGroup
         ref={panelGroupRef}
         id="workflow-panel-group"
+        autoSaveId="workflow-panel-group"
         direction="vertical"
         style={{ height: '100%', width: '100%' }}
         storage={panelStorage}


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
fix(ui): workflow editor side panel remembers positioning
closes #4402