### PR TITLE
Add missing python-socketio dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
   'pyperclip',
   "pyreadline3",
   "python-multipart",
+  "python-socketio",
   "pytorch-lightning",
   "realesrgan",
   "requests~=2.28.2",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: It's mandatory

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
Since https://github.com/invoke-ai/InvokeAI/pull/4552 python-socketio is required as a dependency. It was a dependancy of fastapi-socketio before it got removed.

This resolves the issue of "ModuleNotFoundError: No module named 'socketio'" on a fresh .venv on 3.2.0RC1 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
