### PR TITLE
Respect INVOKEAI_ prefix on environment variables

### DIFF
--- a/invokeai/app/services/config/invokeai_config.py
+++ b/invokeai/app/services/config/invokeai_config.py
@@ -277,6 +277,7 @@ class InvokeAIAppConfig(InvokeAISettings):
 
     class Config:
         validate_assignment = True
+        env_prefix = "INVOKEAI"
 
     def parse_args(self, argv: Optional[list[str]] = None, conf: Optional[DictConfig] = None, clobber=False):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,6 +121,12 @@ def test_env_override(patch_rootdir):
     conf.parse_args(conf=init1, argv=[])
     assert conf.max_cache_size == 20
 
+    # make sure that prefix is respected
+    del os.environ["INVOKEAI_always_use_cpu"]
+    os.environ["always_use_cpu"] = "True"
+    conf.parse_args(conf=init1, argv=[])
+    assert conf.always_use_cpu is False
+
 
 def test_root_resists_cwd(patch_rootdir):
     from invokeai.app.services.config import InvokeAIAppConfig


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [X] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] Yes

## Have you updated all relevant documentation?
- [ ] Yes
- [X] N/A


## Description

Pedantic was misconfigured and was not picking up the INVOKEAI_ prefix on environment variables. Therefore, if the system had an unrelated environment variable such as `version`, this caused pedantic validation errors.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #4098 

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [X] Yes — regression tests run; new regression test added.