### PR TITLE
feat: save workflow to images db

### DIFF
--- a/invokeai/app/api/routers/images.py
+++ b/invokeai/app/api/routers/images.py
@@ -45,13 +45,17 @@ async def upload_image(
     if not file.content_type.startswith("image"):
         raise HTTPException(status_code=415, detail="Not an image")
 
-    contents = await file.read()
+    metadata: Optional[str] = None
+    workflow: Optional[str] = None
 
+    contents = await file.read()
     try:
         pil_image = Image.open(io.BytesIO(contents))
         if crop_visible:
             bbox = pil_image.getbbox()
             pil_image = pil_image.crop(bbox)
+        metadata = pil_image.info.get("invokeai_metadata", None)
+        workflow = pil_image.info.get("invokeai_workflow", None)
     except Exception:
         # Error opening the image
         raise HTTPException(status_code=415, detail="Failed to read image")
@@ -63,6 +67,8 @@ async def upload_image(
             image_category=image_category,
             session_id=session_id,
             board_id=board_id,
+            metadata=metadata,
+            workflow=workflow,
             is_intermediate=is_intermediate,
         )
 

--- a/invokeai/app/invocations/metadata.py
+++ b/invokeai/app/invocations/metadata.py
@@ -85,11 +85,8 @@ class CoreMetadata(BaseModelExcludeNull):
 class ImageMetadata(BaseModelExcludeNull):
     """An image's generation metadata"""
 
-    metadata: Optional[dict] = Field(
-        default=None,
-        description="The image's core metadata, if it was created in the Linear or Canvas UI",
-    )
-    graph: Optional[dict] = Field(default=None, description="The graph that created the image")
+    metadata: Optional[dict] = Field(default=None, description="The metadata associated with the image")
+    workflow: Optional[dict] = Field(default=None, description="The workflow associated with the image")
 
 
 @invocation_output("metadata_accumulator_output")

--- a/invokeai/app/services/image_file_storage.py
+++ b/invokeai/app/services/image_file_storage.py
@@ -59,7 +59,7 @@ class ImageFileStorageBase(ABC):
         self,
         image: PILImageType,
         image_name: str,
-        metadata: Optional[dict] = None,
+        metadata: Optional[Union[str, dict]] = None,
         workflow: Optional[str] = None,
         thumbnail_size: int = 256,
     ) -> None:
@@ -109,7 +109,7 @@ class DiskImageFileStorage(ImageFileStorageBase):
         self,
         image: PILImageType,
         image_name: str,
-        metadata: Optional[dict] = None,
+        metadata: Optional[Union[str, dict]] = None,
         workflow: Optional[str] = None,
         thumbnail_size: int = 256,
     ) -> None:
@@ -119,20 +119,10 @@ class DiskImageFileStorage(ImageFileStorageBase):
 
             pnginfo = PngImagePlugin.PngInfo()
 
-            if metadata is not None or workflow is not None:
-                if metadata is not None:
-                    pnginfo.add_text("invokeai_metadata", json.dumps(metadata))
-                if workflow is not None:
-                    pnginfo.add_text("invokeai_workflow", workflow)
-            else:
-                # For uploaded images, we want to retain metadata. PIL strips it on save; manually add it back
-                # TODO: retain non-invokeai metadata on save...
-                original_metadata = image.info.get("invokeai_metadata", None)
-                if original_metadata is not None:
-                    pnginfo.add_text("invokeai_metadata", original_metadata)
-                original_workflow = image.info.get("invokeai_workflow", None)
-                if original_workflow is not None:
-                    pnginfo.add_text("invokeai_workflow", original_workflow)
+            if metadata is not None:
+                pnginfo.add_text("invokeai_metadata", json.dumps(metadata) if type(metadata) is dict else metadata)
+            if workflow is not None:
+                pnginfo.add_text("invokeai_workflow", workflow)
 
             image.save(image_path, "PNG", pnginfo=pnginfo)
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
@@ -1,8 +1,9 @@
 import { Flex, MenuItem, Spinner } from '@chakra-ui/react';
 import { useStore } from '@nanostores/react';
+import { skipToken } from '@reduxjs/toolkit/dist/query';
 import { useAppToaster } from 'app/components/Toaster';
 import { $customStarUI } from 'app/store/nanostores/customStarUI';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { useAppDispatch } from 'app/store/storeHooks';
 import { setInitialCanvasImage } from 'features/canvas/store/canvasSlice';
 import {
   imagesToChangeSelected,
@@ -32,12 +33,12 @@ import {
 import { FaCircleNodes } from 'react-icons/fa6';
 import { MdStar, MdStarBorder } from 'react-icons/md';
 import {
-  useGetImageMetadataFromFileQuery,
+  useGetImageMetadataQuery,
   useStarImagesMutation,
   useUnstarImagesMutation,
 } from 'services/api/endpoints/images';
 import { ImageDTO } from 'services/api/types';
-import { configSelector } from '../../../system/store/configSelectors';
+import { useDebounce } from 'use-debounce';
 import { sentImageToCanvas, sentImageToImg2Img } from '../../store/actions';
 
 type SingleSelectionMenuItemsProps = {
@@ -53,11 +54,12 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
   const toaster = useAppToaster();
 
   const isCanvasEnabled = useFeatureStatus('unifiedCanvas').isFeatureEnabled;
-  const { shouldFetchMetadataFromApi } = useAppSelector(configSelector);
   const customStarUi = useStore($customStarUI);
 
-  const { metadata, workflow, isLoading } = useGetImageMetadataFromFileQuery(
-    { image: imageDTO, shouldFetchMetadataFromApi },
+  const [debouncedImageName] = useDebounce(imageDTO.image_name, 300);
+
+  const { metadata, workflow, isLoading } = useGetImageMetadataQuery(
+    debouncedImageName ?? skipToken,
     {
       selectFromResult: (res) => ({
         isLoading: res.isFetching,

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
@@ -9,15 +9,15 @@ import {
   Tabs,
   Text,
 } from '@chakra-ui/react';
+import { skipToken } from '@reduxjs/toolkit/dist/query';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import { memo } from 'react';
-import { useGetImageMetadataFromFileQuery } from 'services/api/endpoints/images';
+import { useTranslation } from 'react-i18next';
+import { useGetImageMetadataQuery } from 'services/api/endpoints/images';
 import { ImageDTO } from 'services/api/types';
+import { useDebounce } from 'use-debounce';
 import DataViewer from './DataViewer';
 import ImageMetadataActions from './ImageMetadataActions';
-import { useAppSelector } from '../../../../app/store/storeHooks';
-import { configSelector } from '../../../system/store/configSelectors';
-import { useTranslation } from 'react-i18next';
 
 type ImageMetadataViewerProps = {
   image: ImageDTO;
@@ -31,10 +31,10 @@ const ImageMetadataViewer = ({ image }: ImageMetadataViewerProps) => {
   // });
   const { t } = useTranslation();
 
-  const { shouldFetchMetadataFromApi } = useAppSelector(configSelector);
+  const [debouncedImageName] = useDebounce(image.image_name, 300);
 
-  const { metadata, workflow } = useGetImageMetadataFromFileQuery(
-    { image, shouldFetchMetadataFromApi },
+  const { metadata, workflow } = useGetImageMetadataQuery(
+    debouncedImageName ?? skipToken,
     {
       selectFromResult: (res) => ({
         metadata: res?.currentData?.metadata,

--- a/invokeai/frontend/web/src/services/api/schema.d.ts
+++ b/invokeai/frontend/web/src/services/api/schema.d.ts
@@ -1288,6 +1288,11 @@ export type components = {
        */
       use_cache?: boolean;
       /**
+       * CLIP
+       * @description CLIP (tokenizer, text encoder, LoRAs) and skipped layer count
+       */
+      clip?: components["schemas"]["ClipField"];
+      /**
        * Skipped Layers
        * @description Number of layers to skip in text encoder
        * @default 0
@@ -1299,11 +1304,6 @@ export type components = {
        * @enum {string}
        */
       type: "clip_skip";
-      /**
-       * CLIP
-       * @description CLIP (tokenizer, text encoder, LoRAs) and skipped layer count
-       */
-      clip?: components["schemas"]["ClipField"];
     };
     /**
      * ClipSkipInvocationOutput
@@ -3916,14 +3916,14 @@ export type components = {
     ImageMetadata: {
       /**
        * Metadata
-       * @description The image's core metadata, if it was created in the Linear or Canvas UI
+       * @description The metadata associated with the image
        */
       metadata?: Record<string, never>;
       /**
-       * Graph
-       * @description The graph that created the image
+       * Workflow
+       * @description The workflow associated with the image
        */
-      graph?: Record<string, never>;
+      workflow?: Record<string, never>;
     };
     /**
      * Multiply Images
@@ -7551,6 +7551,11 @@ export type components = {
        */
       use_cache?: boolean;
       /**
+       * Image
+       * @description The image to load
+       */
+      image?: components["schemas"]["ImageField"];
+      /**
        * Metadata
        * @description Optional core metadata to be written to image
        */
@@ -7561,11 +7566,6 @@ export type components = {
        * @enum {string}
        */
       type: "save_image";
-      /**
-       * Image
-       * @description The image to load
-       */
-      image?: components["schemas"]["ImageField"];
     };
     /**
      * Scale Latents
@@ -7863,16 +7863,6 @@ export type components = {
        */
       session_id: string;
       /**
-       * Field Values
-       * @description The field values that were used for this queue item
-       */
-      field_values?: components["schemas"]["NodeFieldValue"][];
-      /**
-       * Queue Id
-       * @description The id of the queue with which this item is associated
-       */
-      queue_id: string;
-      /**
        * Error
        * @description The error message if this queue item errored
        */
@@ -7897,6 +7887,16 @@ export type components = {
        * @description When this queue item was completed
        */
       completed_at?: string;
+      /**
+       * Queue Id
+       * @description The id of the queue with which this item is associated
+       */
+      queue_id: string;
+      /**
+       * Field Values
+       * @description The field values that were used for this queue item
+       */
+      field_values?: components["schemas"]["NodeFieldValue"][];
       /**
        * Session
        * @description The fully-populated session to be executed
@@ -7937,16 +7937,6 @@ export type components = {
        */
       session_id: string;
       /**
-       * Field Values
-       * @description The field values that were used for this queue item
-       */
-      field_values?: components["schemas"]["NodeFieldValue"][];
-      /**
-       * Queue Id
-       * @description The id of the queue with which this item is associated
-       */
-      queue_id: string;
-      /**
        * Error
        * @description The error message if this queue item errored
        */
@@ -7971,6 +7961,16 @@ export type components = {
        * @description When this queue item was completed
        */
       completed_at?: string;
+      /**
+       * Queue Id
+       * @description The id of the queue with which this item is associated
+       */
+      queue_id: string;
+      /**
+       * Field Values
+       * @description The field values that were used for this queue item
+       */
+      field_values?: components["schemas"]["NodeFieldValue"][];
     };
     /** SessionQueueStatus */
     SessionQueueStatus: {
@@ -9096,6 +9096,12 @@ export type components = {
       ui_order?: number;
     };
     /**
+     * ControlNetModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    ControlNetModelFormat: "checkpoint" | "diffusers";
+    /**
      * StableDiffusionOnnxModelFormat
      * @description An enumeration.
      * @enum {string}
@@ -9108,17 +9114,17 @@ export type components = {
      */
     StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
     /**
-     * CLIPVisionModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    CLIPVisionModelFormat: "diffusers";
-    /**
      * StableDiffusion1ModelFormat
      * @description An enumeration.
      * @enum {string}
      */
     StableDiffusion1ModelFormat: "checkpoint" | "diffusers";
+    /**
+     * CLIPVisionModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    CLIPVisionModelFormat: "diffusers";
     /**
      * StableDiffusionXLModelFormat
      * @description An enumeration.
@@ -9131,12 +9137,6 @@ export type components = {
      * @enum {string}
      */
     IPAdapterModelFormat: "invokeai";
-    /**
-     * ControlNetModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    ControlNetModelFormat: "checkpoint" | "diffusers";
   };
   responses: never;
   parameters: never;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

 
## Description

feat: save workflow to images db
- Add `workflow` column to `images` table
- Revise image saving and uploading logic to save workflow and metadata to db
- Update UI queries to fetch metadata and workflow from db instead of file

## Related Tickets & Documents

This resolves the performance issues related to extracting workflows and metadata from the image directly. The workflows and metadata are still stored in the image, but we only read them from the db.

Uploaded images' workflow and metadata are written to the db, if they exist.

Unfortunately, because we've only been storing workflows in the image itself, images with embedded workflows won't load their workflows. A migration script to import the workflows into the db will be required.

## QA Instructions, Screenshots, Recordings

- Back up your database
- Check out the PR
- Start up the app
- Metadata should still load, but old images' workflows won't be accessible
- Generate an image in linear ui & confirm the metadata loads
- Generate an image in workflow editor w/ workflow ticked & confirm the workflow loads
- Generate a really, really big image and confirm there is no lag
- Cruise through your gallery and confirm the 300ms debounce prevents a gajillion network requests from firing to load the workflows for all the images as you go by
