### PR TITLE
Unpin Safetensors dependency, safeguard against future breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
   "realesrgan",
   "requests~=2.28.2",
   "rich~=13.3",
-  "safetensors==0.3.1",
+  "safetensors~=0.3.1",
   "scikit-image~=0.21.0",
   "semver~=3.0.1",
   "send2trash",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes, partially
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
Since https://github.com/invoke-ai/InvokeAI/commit/c82da330dbbbbb1eb1f9271f445e0ac45c32e8c5 the Safetensors package is pinned to version 0.3.1 because at the time no ARM64 builds for MacOSX were available. This has since changed and the most recent version (0.3.3) has all packages available. https://pypi.org/project/safetensors/0.3.3/#files (also for 0.3.2 now)

Safetensors is a core dependency for Diffusers and Transformers and part of the Huggingface ecosystem. In the release notes for version 0.3.3 the developers announce breaking changes for version 0.4.0.
https://github.com/huggingface/safetensors/releases

This small little change makes sure:
1) That we use the most recent version of Safetensors again, since the reason for pinning it has been solved.
2) We safeguard against breaking changes in Safetensors 0.4.0. Once it hits, we have plenty of time to assess it and make necessary changes.
3) Diffusers 0.21 and Transformers require at least version 0.3.1 according to their setup.py. We make sure that the user has at least 0.3.1 but also allow higher versions up to 0.3.3 since they are compatible and include bugfixes.
4) Housekeeping. In my opinion, we should try and use recent versions of dependencies unless they make things worse or something breaks. I would argue that we don't let some parts of the huggingface ecosystem age while the others are on bleeding edge especially when there is no more reason for it.

I hope my arguing sounds reasonable. Thank you version much.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
