### PR TITLE
Re-enable button for seeds set to zero

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImageButtons.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImageButtons.tsx
@@ -287,7 +287,7 @@ const CurrentImageButtons = (props: CurrentImageButtonsProps) => {
             icon={<FaSeedling />}
             tooltip={`${t('parameters.useSeed')} (S)`}
             aria-label={`${t('parameters.useSeed')} (S)`}
-            isDisabled={!metadata?.seed}
+            isDisabled={metadata?.seed === null || metadata?.seed === undefined}
             onClick={handleUseSeed}
           />
           <IAIIconButton


### PR DESCRIPTION
Change the statement to explicitly look for null and undefined so it doesn't fail to re-enable the button on images with seeds set to zero.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: Fixing a minor documented issue.

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No, doesn't require documentation update.


## Description


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #4156

## QA Instructions, Screenshots, Recordings
Its only a small line change, and I have tested it to make sure the button still disables when there's no metadata on the image and that it still works for zero and non-zero seed images. However, another set of eyes to make sure I didn't overlook something breaking with the change would be nice.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [x] No : This is a minor change

## [optional] Are there any post deployment tasks we need to perform?
