### PR TITLE
Add installer support for ip-adapters

### DIFF
--- a/invokeai/backend/install/model_install_backend.py
+++ b/invokeai/backend/install/model_install_backend.py
@@ -70,14 +70,6 @@ LEGACY_CONFIGS = {
 
 
 @dataclass
-class ModelInstallList:
-    """Class for listing models to be installed/removed"""
-
-    install_models: List[str] = field(default_factory=list)
-    remove_models: List[str] = field(default_factory=list)
-
-
-@dataclass
 class InstallSelections:
     install_models: List[str] = field(default_factory=list)
     remove_models: List[str] = field(default_factory=list)
@@ -94,7 +86,7 @@ class ModelLoadInfo:
     installed: bool = False
     recommended: bool = False
     default: bool = False
-
+    requires: Optional[List[str]] = field(default_factory=list)
 
 class ModelInstall(object):
     def __init__(
@@ -131,8 +123,6 @@ class ModelInstall(object):
 
         # supplement with entries in models.yaml
         installed_models = [x for x in self.mgr.list_models()]
-        # suppresses autoloaded models
-        # installed_models = [x for x in self.mgr.list_models() if not self._is_autoloaded(x)]
 
         for md in installed_models:
             base = md["base_model"]
@@ -164,9 +154,12 @@ class ModelInstall(object):
 
     def list_models(self, model_type):
         installed = self.mgr.list_models(model_type=model_type)
+        print()
         print(f"Installed models of type `{model_type}`:")
+        print(f"{'Model Key':50} Model Path")
         for i in installed:
-            print(f"{i['model_name']}\t{i['base_model']}\t{i['path']}")
+            print(f"{'/'.join([i['base_model'],i['model_type'],i['model_name']]):50} {i['path']}")
+        print()
 
     # logic here a little reversed to maintain backward compatibility
     def starter_models(self, all_models: bool = False) -> Set[str]:
@@ -204,6 +197,8 @@ class ModelInstall(object):
             job += 1
 
         # add requested models
+        self._remove_installed(selections.install_models)
+        self._add_required_models(selections.install_models)
         for path in selections.install_models:
             logger.info(f"Installing {path} [{job}/{jobs}]")
             try:
@@ -262,6 +257,26 @@ class ModelInstall(object):
             raise KeyError(f"{str(model_path_id_or_url)} is not recognized as a local path, repo ID or URL. Skipping")
 
         return models_installed
+
+    def _remove_installed(self, model_list: List[str]):
+        all_models = self.all_models()
+        for path in model_list:
+            key = self.reverse_paths.get(path) 
+            if key and all_models[key].installed:
+                logger.warning(f"{path} already installed. Skipping.")
+                model_list.remove(path)
+
+    def _add_required_models(self, model_list: List[str]):
+        additional_models = []
+        all_models = self.all_models()
+        for path in model_list:
+            if not(key := self.reverse_paths.get(path)):
+                continue
+            for requirement in all_models[key].requires:
+                requirement_key = self.reverse_paths.get(requirement)
+                if not all_models[requirement_key].installed:
+                    additional_models.append(requirement)
+        model_list.extend(additional_models)
 
     # install a model from a local path. The optional info parameter is there to prevent
     # the model from being probed twice in the event that it has already been probed.

--- a/invokeai/backend/install/model_install_backend.py
+++ b/invokeai/backend/install/model_install_backend.py
@@ -88,6 +88,7 @@ class ModelLoadInfo:
     default: bool = False
     requires: Optional[List[str]] = field(default_factory=list)
 
+
 class ModelInstall(object):
     def __init__(
         self,
@@ -261,7 +262,7 @@ class ModelInstall(object):
     def _remove_installed(self, model_list: List[str]):
         all_models = self.all_models()
         for path in model_list:
-            key = self.reverse_paths.get(path) 
+            key = self.reverse_paths.get(path)
             if key and all_models[key].installed:
                 logger.warning(f"{path} already installed. Skipping.")
                 model_list.remove(path)
@@ -270,7 +271,7 @@ class ModelInstall(object):
         additional_models = []
         all_models = self.all_models()
         for path in model_list:
-            if not(key := self.reverse_paths.get(path)):
+            if not (key := self.reverse_paths.get(path)):
                 continue
             for requirement in all_models[key].requires:
                 requirement_key = self.reverse_paths.get(requirement)

--- a/invokeai/configs/INITIAL_MODELS.yaml
+++ b/invokeai/configs/INITIAL_MODELS.yaml
@@ -103,28 +103,35 @@ sd-1/lora/LowRA:
    recommended: True
 sd-1/lora/Ink scenery:
    path: https://civitai.com/api/download/models/83390
-# any/clip_vision/ip_adapter_sd_image_encoder:
-#    repo_id: InvokeAI/ip_adapter_sd_image_encoder
-#    recommended: True
-#    description: Required model for using IP-Adapters with SD-1/2 models
-# any/clip_vision/ip_adapter_sdxl_image_encoder:
-#    repo_id: InvokeAI/ip_adapter_sdxl_image_encoder
-#    recommended: True
-#    description: Required model for using IP-Adapters with SDXL models
 sd-1/ip_adapter/ip_adapter_sd15:
    repo_id: InvokeAI/ip_adapter_sd15
    recommended: True
+   requires:
+      - InvokeAI/ip_adapter_sd_image_encoder
    description: IP-Adapter for SD 1.5 models
 sd-1/ip_adapter/ip_adapter_plus_sd15:
    repo_id: InvokeAI/ip_adapter_plus_sd15
    recommended: False
+   requires:
+      - InvokeAI/ip_adapter_sd_image_encoder
    description: Refined IP-Adapter for SD 1.5 models
 sd-1/ip_adapter/ip_adapter_plus_face_sd15:
    repo_id: InvokeAI/ip_adapter_plus_face_sd15
    recommended: False
+   requires:
+      - InvokeAI/ip_adapter_sd_image_encoder
    description: Refined IP-Adapter for SD 1.5 models, adapted for faces
 sdxl/ip_adapter/ip_adapter_sdxl:
    repo_id: InvokeAI/ip_adapter_sdxl
    recommended: False
+   requires:
+      - InvokeAI/ip_adapter_sdxl_image_encoder
    description: IP-Adapter for SDXL models
-
+any/clip_vision/ip_adapter_sd_image_encoder:
+   repo_id: InvokeAI/ip_adapter_sd_image_encoder
+   recommended: False
+   description: Required model for using IP-Adapters with SD-1/2 models
+any/clip_vision/ip_adapter_sdxl_image_encoder:
+   repo_id: InvokeAI/ip_adapter_sdxl_image_encoder
+   recommended: False
+   description: Required model for using IP-Adapters with SDXL models

--- a/invokeai/configs/INITIAL_MODELS.yaml
+++ b/invokeai/configs/INITIAL_MODELS.yaml
@@ -103,3 +103,28 @@ sd-1/lora/LowRA:
    recommended: True
 sd-1/lora/Ink scenery:
    path: https://civitai.com/api/download/models/83390
+# any/clip_vision/ip_adapter_sd_image_encoder:
+#    repo_id: InvokeAI/ip_adapter_sd_image_encoder
+#    recommended: True
+#    description: Required model for using IP-Adapters with SD-1/2 models
+# any/clip_vision/ip_adapter_sdxl_image_encoder:
+#    repo_id: InvokeAI/ip_adapter_sdxl_image_encoder
+#    recommended: True
+#    description: Required model for using IP-Adapters with SDXL models
+sd-1/ip_adapter/ip_adapter_sd15:
+   repo_id: InvokeAI/ip_adapter_sd15
+   recommended: True
+   description: IP-Adapter for SD 1.5 models
+sd-1/ip_adapter/ip_adapter_plus_sd15:
+   repo_id: InvokeAI/ip_adapter_plus_sd15
+   recommended: False
+   description: Refined IP-Adapter for SD 1.5 models
+sd-1/ip_adapter/ip_adapter_plus_face_sd15:
+   repo_id: InvokeAI/ip_adapter_plus_face_sd15
+   recommended: False
+   description: Refined IP-Adapter for SD 1.5 models, adapted for faces
+sdxl/ip_adapter/ip_adapter_sdxl:
+   repo_id: InvokeAI/ip_adapter_sdxl
+   recommended: False
+   description: IP-Adapter for SDXL models
+

--- a/invokeai/frontend/install/model_install.py
+++ b/invokeai/frontend/install/model_install.py
@@ -563,23 +563,24 @@ class addModelsForm(CyclingForm, npyscreen.FormMultiPage):
             if downloads := section.get("download_ids"):
                 selections.install_models.extend(downloads.value.split())
 
-        # special case for the ipadapter_models. If any of the adapters are
-        # chosen, then we add the corresponding encoder(s) to the install list.
-        section = self.ipadapter_models
-        if section.get("models_selected"):
-            selected_adapters = [
-                self.all_models[section["models"][x]].name for x in section.get("models_selected").value
-            ]
-            encoders = []
-            if any(["sdxl" in x for x in selected_adapters]):
-                encoders.append("ip_adapter_sdxl_image_encoder")
-            if any(["sd15" in x for x in selected_adapters]):
-                encoders.append("ip_adapter_sd_image_encoder")
-            for encoder in encoders:
-                key = f"any/clip_vision/{encoder}"
-                repo_id = f"InvokeAI/{encoder}"
-                if key not in self.all_models:
-                    selections.install_models.append(repo_id)
+        # NOT NEEDED - DONE IN BACKEND NOW
+        # # special case for the ipadapter_models. If any of the adapters are
+        # # chosen, then we add the corresponding encoder(s) to the install list.
+        # section = self.ipadapter_models
+        # if section.get("models_selected"):
+        #     selected_adapters = [
+        #         self.all_models[section["models"][x]].name for x in section.get("models_selected").value
+        #     ]
+        #     encoders = []
+        #     if any(["sdxl" in x for x in selected_adapters]):
+        #         encoders.append("ip_adapter_sdxl_image_encoder")
+        #     if any(["sd15" in x for x in selected_adapters]):
+        #         encoders.append("ip_adapter_sd_image_encoder")
+        #     for encoder in encoders:
+        #         key = f"any/clip_vision/{encoder}"
+        #         repo_id = f"InvokeAI/{encoder}"
+        #         if key not in self.all_models:
+        #             selections.install_models.append(repo_id)
 
 
 class AddModelApplication(npyscreen.NPSAppManaged):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature


## Have you discussed this change with the InvokeAI team?
- [X] Yes

      
## Have you updated all relevant documentation?
- [X] Yes

## Description

This PR adds support for selecting and installing IP-Adapters at configure time. The user is offered the four existing InvokeAI IP Adapters in the UI as shown below. The matching image encoders are selected and installed behind the scenes. That is, if the user selects one of the three sd15 adapters, then the SD encoder will be installed. If they select the sdxl adapter, then the SDXL encoder will be installed.

![image](https://github.com/invoke-ai/InvokeAI/assets/111189/19f46401-99fb-4f7b-9a5e-8f2efd0a5b77)

Note that the automatic selection of the encoder does not work when the installer is run in headless mode. I may be able to fix that soon, but I'm out of time today.
