### PR TITLE
Add blend_noise node for use in variation generation

### DIFF
--- a/invokeai/app/invocations/noise.py
+++ b/invokeai/app/invocations/noise.py
@@ -129,7 +129,7 @@ class NoiseInvocation(BaseInvocation):
     "blend_noise", title="Blend Noise", tags=["latents", "noise", "variations"], category="latents", version="1.0.0"
 )
 class BlendNoiseInvocation(BaseInvocation):
-    """Blend two noise tensors according to a proportion. Useful for generating variations."""
+    """Blend two noise tensors proportionately. Useful for generating variations."""
 
     noise_A: LatentsField = InputField(description=FieldDescriptions.noise, input=Input.Connection, ui_order=0)
     noise_B: LatentsField = InputField(description=FieldDescriptions.noise, input=Input.Connection, ui_order=1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Have you discussed this change with the InvokeAI team?
- [X] Yes

## Have you updated all relevant documentation?
- [X] Yes

## Description

This PR adds a new `blend_noise` node. It takes two noise tensors of identical size and blends them using spherical linear interpolation to produce a third noise tensor. The mixing proportion is controlled by a floating point `blend_ratio` between 0.0 and 1.0.

This is all that is needed to generate **variations** using the node editor. You use two noise generation nodes. The first has a static seed that you set, and the second has a random seed. Feed them both into `blend_noise` and set the `blend_ratio` to something in the 0.05 to 0.3 range. Each iteration will generate a variation on the image that would have been generated using the fixed seed.

The image variations can be reproduced by providing the original two random seeds and the blend ratio.

I have attached a simple graph with linear workflow to the PR to illustrate.

## Related Tickets & Documents

- Related Issue #3976 #

[generate_variations.json.zip](https://github.com/invoke-ai/InvokeAI/files/12710353/generate_variations.json.zip)
