### PR TITLE
feat(queue): `take one` functionality in session processor

### DIFF
--- a/invokeai/app/api/routers/session_queue.py
+++ b/invokeai/app/api/routers/session_queue.py
@@ -94,6 +94,18 @@ async def Pause(
 
 
 @session_queue_router.put(
+    "/{queue_id}/processor/take_one",
+    operation_id="take_one",
+    responses={200: {"model": SessionProcessorStatus}},
+)
+async def take_one(
+    queue_id: str = Path(description="The queue id to perform this operation on"),
+) -> SessionProcessorStatus:
+    """Executes the next-in-line queue item, pausing the processor afterwards. Has no effect if the queue is resumed."""
+    return ApiDependencies.invoker.services.session_processor.take_one()
+
+
+@session_queue_router.put(
     "/{queue_id}/cancel_by_batch_ids",
     operation_id="cancel_by_batch_ids",
     responses={200: {"model": CancelByBatchIDsResult}},

--- a/invokeai/app/services/session_processor/session_processor_base.py
+++ b/invokeai/app/services/session_processor/session_processor_base.py
@@ -23,6 +23,11 @@ class SessionProcessorBase(ABC):
         pass
 
     @abstractmethod
+    def take_one(self) -> SessionProcessorStatus:
+        """Takes one session from the queue and executes it"""
+        pass
+
+    @abstractmethod
     def get_status(self) -> SessionProcessorStatus:
         """Gets the status of the session processor"""
         pass


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

[feat(queue): take one functionality in session processor](https://github.com/invoke-ai/InvokeAI/commit/2fd0fb819888b9edf4219bd1d46003354e58305f)

Executes the next queue item, then pauses. Does nothing if the queue is already running.

**Note: this PR is based on #4671 **
