### PR TITLE
fix: SDXL Refiner using the incorrect node during inpainting

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildCanvasSDXLInpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildCanvasSDXLInpaintGraph.ts
@@ -663,7 +663,8 @@ export const buildCanvasSDXLInpaintGraph = (
       graph,
       CANVAS_COHERENCE_DENOISE_LATENTS,
       modelLoaderNodeId,
-      canvasInitImage
+      canvasInitImage,
+      canvasMaskImage
     );
     if (seamlessXAxis || seamlessYAxis) {
       modelLoaderNodeId = SDXL_REFINER_SEAMLESS;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [x] Yes
    
## Description

In the Refiner Graph, the inpaint mask was trying to retrieve `mask_combine` node for non-scaled processing. But inpainting does not combine masks causing the graph to crash when using Refiner. This PR should address that.


## Related Tickets & Documents

- Closes #4586 -- Untested (coz I can't test right now) but if anyone else can test this, we can go ahead.
