### PR TITLE
Add DWPose pose estimation preprocessor node for ControlNet depth model

### DIFF
--- a/invokeai/app/invocations/controlnet_image_processors.py
+++ b/invokeai/app/invocations/controlnet_image_processors.py
@@ -6,9 +6,11 @@ from typing import Dict, List, Literal, Optional, Union
 
 import cv2
 import numpy as np
+import torch
 from controlnet_aux import (
     CannyDetector,
     ContentShuffleDetector,
+    DWposeDetector,
     HEDdetector,
     LeresDetector,
     LineartAnimeDetector,
@@ -589,3 +591,27 @@ class ColorMapImageProcessorInvocation(ImageProcessorInvocation):
         color_map = cv2.resize(color_map, (width, height), interpolation=cv2.INTER_NEAREST)
         color_map = Image.fromarray(color_map)
         return color_map
+
+
+@invocation(
+    "dwpose_image_processor",
+    title="DWPose Processor",
+    tags=["controlnet", "dwpose", "pose"],
+    category="controlnet",
+    version="1.0.0",
+)
+class DWPoseImageProcessorInvocation(ImageProcessorInvocation):
+    """Applies DW-Pose processing to image"""
+
+    detect_resolution: int = InputField(default=512, ge=0, description=FieldDescriptions.detect_res)
+    image_resolution: int = InputField(default=512, ge=0, description=FieldDescriptions.image_res)
+
+    def run_processor(self, image):
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        dwpose_processor = DWposeDetector(device=device)
+        processed_image = dwpose_processor(
+            image,
+            detect_resolution=self.detect_resolution,
+            image_resolution=self.image_resolution,
+        )
+        return processed_image

--- a/invokeai/app/invocations/controlnet_image_processors.py
+++ b/invokeai/app/invocations/controlnet_image_processors.py
@@ -127,7 +127,7 @@ class ControlNetInvocation(BaseInvocation):
 
 
 @invocation(
-    "image_processor", title="Base Image Processor", tags=["controlnet"], category="controlnet", version="1.0.0"
+    "image_processor", title="Base Image Processorwp", tags=["controlnet"], category="controlnet", version="1.0.0"
 )
 class ImageProcessorInvocation(BaseInvocation):
     """Base class for invocations that preprocess images for ControlNet"""
@@ -607,7 +607,9 @@ class DWPoseImageProcessorInvocation(ImageProcessorInvocation):
     image_resolution: int = InputField(default=512, ge=0, description=FieldDescriptions.image_res)
 
     def run_processor(self, image):
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        # device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        # for now, executing DWPose processing on CPU only
+        device = "cpu"
         dwpose_processor = DWposeDetector(device=device)
         processed_image = dwpose_processor(
             image,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "click",
   "clip_anytorch",  # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
   "compel~=2.0.2",
-  "controlnet-aux>=0.0.6",
+  "controlnet-aux>=0.0.7",
   "timm==0.6.13",   # needed to override timm latest in controlnet_aux, see  https://github.com/isl-org/ZoeDepth/issues/26
   "datasets",
   "diffusers[torch]~=0.21.0",
@@ -58,6 +58,7 @@ dependencies = [
   "onnx",
   "onnxruntime",
   "opencv-python",
+  "openmim",
   "pydantic==1.*",
   "picklescan",
   "pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,13 +52,16 @@ dependencies = [
   "invisible-watermark~=0.2.0", # needed to install SDXL base and refiner using their repo_ids
   "matplotlib",                 # needed for plotting of Penner easing functions
   "mediapipe",                  # needed for "mediapipeface" controlnet model
+  "mmcv>=2.0.1",
+  "mmdet>=3.1.0",
+  "mmengine",
+  "mmpose>=1.1.0",
   "numpy",
   "npyscreen",
   "omegaconf",
   "onnx",
   "onnxruntime",
   "opencv-python",
-  "openmim",
   "pydantic==1.*",
   "picklescan",
   "pillow",


### PR DESCRIPTION
This is a draft PR because there are still a few issues with deployment:

1) The controlnet_aux package, which this PR relies on, states that using DWPose requires:
```
pip install -U openmim
mim install mmengine
mim install "mmcv>=2.0.1"
mim install "mmdet>=3.1.0"
mim install "mmpose>=1.1.0"
```
I have added openmim as a requirement in pyproject.toml. But I'm not sure how to add the "mim install ..." steps in the InvokeAI installer -- any suggestions? So for this draft the "mim install ..." commands above all need to be performed by the user.

2) I had a (temporary) problem with config files for the models that DWPose needs to do pose estimation
These two config files are included in the controlnet_aux package as *.py files:

          controlnet_aux/dwpose/yolox_config/yolox_l_8xb8-300e_coco.py
          controlnet_aux/dwpose/dwpose_config/dwpose-l_384x288.py

Code further down in the mm* packages requires these two configs be specified by their file paths. And initially I hit problems with this path being wrong which triggered errors. Subsequent attempts at InvokeAI `pip install -e .` seemed to fix this, and I haven't been able to repeat the problem. But I'm worried it will reappear.

Here's an example of usage. Image at right bottom is estimated pose output by DWPose preprocessor and image at right top is generated image when using estimated pose with ControlNet openpose model.
![Screenshot from 2023-09-26 15-24-09](https://github.com/invoke-ai/InvokeAI/assets/303100/5c730499-a79b-4cda-8b0b-d28cd1a15d24)
