### PR TITLE
fix(ui): fit ip adapter image to panel

### DIFF
--- a/invokeai/frontend/web/src/features/controlNet/components/ipAdapter/ParamIPAdapterImage.tsx
+++ b/invokeai/frontend/web/src/features/controlNet/components/ipAdapter/ParamIPAdapterImage.tsx
@@ -63,11 +63,14 @@ const ParamIPAdapterImage = () => {
 
   return (
     <Flex
+      layerStyle="second"
       sx={{
         position: 'relative',
         w: 'full',
         alignItems: 'center',
         justifyContent: 'center',
+        aspectRatio: '1/1',
+        borderRadius: 'base',
       }}
     >
       <IAIDndImage


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

Very tall IP adapter images didn't get fit to the panel. Now they do
