### PR TITLE
Fix absolute path for font file

### DIFF
--- a/invokeai/app/invocations/facetools.py
+++ b/invokeai/app/invocations/facetools.py
@@ -1,5 +1,7 @@
 import math
+import os
 import re
+from pathlib import Path
 from typing import Optional, TypedDict
 
 import cv2
@@ -74,8 +76,6 @@ def create_black_image(w: int, h: int) -> ImageType:
 
 FONT_SIZE = 32
 FONT_STROKE_WIDTH = 4
-
-font = ImageFont.truetype("invokeai/assets/fonts/inter/Inter-Regular.ttf", FONT_SIZE)
 
 
 def prepare_faces_list(
@@ -640,6 +640,10 @@ class FaceIdentifierInvocation(BaseInvocation):
             y_offset=0,
             draw_mesh=False,
         )
+
+        path = Path(__file__).resolve().parent.parent.parent
+        font_path = os.path.abspath(path / "assets/fonts/inter/Inter-Regular.ttf")
+        font = ImageFont.truetype(font_path, FONT_SIZE)
 
         # Paste face IDs on the output image
         draw = ImageDraw.Draw(image)


### PR DESCRIPTION
Make the font file relative to this source file. Not ideal, but it will work no matter where InvokeAI is launched. Also moved font loading to inside of the class where it's used.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No