### PR TITLE
fix(ui): canvas undo staging

### DIFF
--- a/invokeai/frontend/web/src/features/canvas/components/IAICanvasStagingAreaToolbar.tsx
+++ b/invokeai/frontend/web/src/features/canvas/components/IAICanvasStagingAreaToolbar.tsx
@@ -151,15 +151,10 @@ const IAICanvasStagingAreaToolbar = () => {
           isDisabled={!shouldShowStagingImage}
         />
         <IAIButton
-          colorScheme="accent"
+          colorScheme="base"
           pointerEvents="none"
           isDisabled={!shouldShowStagingImage}
-          sx={{
-            background: 'base.600',
-            _dark: {
-              background: 'base.800',
-            },
-          }}
+          minW={20}
         >{`${currentIndex + 1}/${total}`}</IAIButton>
         <IAIIconButton
           tooltip={`${t('unifiedCanvas.next')} (Right)`}

--- a/invokeai/frontend/web/src/features/canvas/store/canvasSelectors.ts
+++ b/invokeai/frontend/web/src/features/canvas/store/canvasSelectors.ts
@@ -6,7 +6,9 @@ export const canvasSelector = (state: RootState): CanvasState => state.canvas;
 
 export const isStagingSelector = createSelector(
   [stateSelector],
-  ({ canvas }) => canvas.batchIds.length > 0
+  ({ canvas }) =>
+    canvas.batchIds.length > 0 ||
+    canvas.layerState.stagingArea.images.length > 0
 );
 
 export const initialCanvasImageSelector = (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

[fix(ui): canvas staging area works after undo](https://github.com/invoke-ai/InvokeAI/commit/3b1981964082e5cb7104e69c061c0d1ba5c7666e)

[feat(ui): staging styling tweak](https://github.com/invoke-ai/InvokeAI/commit/2f8bf7e9721e4bd2c5b0915a602688b597b34c47)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #4760

## QA Instructions, Screenshots, Recordings

Accept a staging area image or discard the staged images, then undo. They should render as expected after undoing.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->
