### PR TITLE
Add font Inter-Regular.ttf to installed assets

### DIFF
--- a/invokeai/app/invocations/facetools.py
+++ b/invokeai/app/invocations/facetools.py
@@ -11,6 +11,7 @@ from PIL import Image, ImageDraw, ImageFilter, ImageFont, ImageOps
 from PIL.Image import Image as ImageType
 from pydantic import validator
 
+import invokeai.assets.fonts as font_assets
 from invokeai.app.invocations.baseinvocation import (
     BaseInvocation,
     InputField,
@@ -641,9 +642,9 @@ class FaceIdentifierInvocation(BaseInvocation):
             draw_mesh=False,
         )
 
-        path = Path(__file__).resolve().parent.parent.parent
-        font_path = os.path.abspath(path / "assets/fonts/inter/Inter-Regular.ttf")
-        font = ImageFont.truetype(font_path, FONT_SIZE)
+        # Note - font may be found either in the repo if running an editable install, or in the venv if running a package install
+        font_path = [x for x in [Path(y, "inter/Inter-Regular.ttf") for y in font_assets.__path__] if x.exists()]
+        font = ImageFont.truetype(font_path[0].as_posix(), FONT_SIZE)
 
         # Paste face IDs on the output image
         draw = ImageDraw.Draw(image)

--- a/invokeai/app/invocations/facetools.py
+++ b/invokeai/app/invocations/facetools.py
@@ -1,5 +1,4 @@
 import math
-import os
 import re
 from pathlib import Path
 from typing import Optional, TypedDict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,16 +161,16 @@ version = { attr = "invokeai.version.__version__" }
 [tool.setuptools.packages.find]
 "where" = ["."]
 "include" = [
-    "invokeai.assets.web*","invokeai.version*",
+    "invokeai.assets.fonts*","invokeai.version*",
     "invokeai.generator*","invokeai.backend*",
     "invokeai.frontend*", "invokeai.frontend.web.dist*",
     "invokeai.frontend.web.static*",
     "invokeai.configs*",
-    "invokeai.app*","ldm*",
+    "invokeai.app*",
 ]
 
 [tool.setuptools.package-data]
-"invokeai.assets.web" = ["**.png","**.js","**.woff2","**.css"]
+"invokeai.assets.fonts" = ["**/*.ttf"]
 "invokeai.backend" = ["**.png"]
 "invokeai.configs" = ["*.example", "**/*.yaml", "*.txt"]
 "invokeai.frontend.web.dist" = ["**"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix


## Have you discussed this change with the InvokeAI team?
- [X] Yes

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No


## Description

This PR causes the font "Inter-Regular.ttf", which is needed by the facetools Face Identifier node, to be installed along with other assets in the virtual environment. It also fixes the font path resolution logic in the invocation to work with both package and editable installs.

## Related Tickets & Documents

Closes #4771 
