### PR TITLE
fix(ui): throw on fetch err when copying image

### DIFF
--- a/invokeai/frontend/web/src/features/ui/hooks/useCopyImageToClipboard.ts
+++ b/invokeai/frontend/web/src/features/ui/hooks/useCopyImageToClipboard.ts
@@ -25,6 +25,9 @@ export const useCopyImageToClipboard = () => {
       try {
         const getImageBlob = async () => {
           const response = await fetch(image_url);
+          if (!response.ok) {
+            throw new Error(`Problem retrieving image data`);
+          }
           return await response.blob();
         };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

fix(ui): throw on fetch err when copying image