### PR TITLE
Remove hardcoded subfolder name from model downloader

### DIFF
--- a/invokeai/backend/install/model_install_backend.py
+++ b/invokeai/backend/install/model_install_backend.py
@@ -335,7 +335,7 @@ class ModelInstall(object):
         # list all the files in the repo
         files = [x.rfilename for x in hinfo.siblings]
         if subfolder:
-            files = [x for x in files if x.startswith("v2/")]
+            files = [x for x in files if x.startswith(f"{subfolder}/")]
         prefix = f"{subfolder}/" if subfolder else ""
 
         location = None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [X] No, because: it is an obvious and easily fixed bug

      
## Have you updated all relevant documentation?
- [X] N/A


## Description

PR #4725 added the ability to download arbitrary models from a repo_id subfolder. Unfortunately the code included a hard-coded subfolder name that was left over from debugging. This PR fixes the issue.

Nobody previously noticed this bug because the subfolder download was only added recently and its main use case is to support downloading the "qrcode monster" controlnet that was added to the startup models list:

```
sd-1/controlnet/qrcode_monster:
   repo_id: monster-labs/control_v1p_sd15_qrcode_monster
   subfolder: v2
```

The hardcoded subfolder happened to be "v2", so the use case works.
