### PR TITLE
fix(ui): fix canvas soft lock

### DIFF
--- a/invokeai/app/services/events.py
+++ b/invokeai/app/services/events.py
@@ -4,7 +4,12 @@ from typing import Any, Optional
 
 from invokeai.app.models.image import ProgressImage
 from invokeai.app.services.model_manager_service import BaseModelType, ModelInfo, ModelType, SubModelType
-from invokeai.app.services.session_queue.session_queue_common import EnqueueBatchResult, SessionQueueItem
+from invokeai.app.services.session_queue.session_queue_common import (
+    BatchStatus,
+    EnqueueBatchResult,
+    SessionQueueItem,
+    SessionQueueStatus,
+)
 from invokeai.app.util.misc import get_timestamp
 
 
@@ -262,21 +267,31 @@ class EventServiceBase:
             ),
         )
 
-    def emit_queue_item_status_changed(self, session_queue_item: SessionQueueItem) -> None:
+    def emit_queue_item_status_changed(
+        self,
+        session_queue_item: SessionQueueItem,
+        batch_status: BatchStatus,
+        queue_status: SessionQueueStatus,
+    ) -> None:
         """Emitted when a queue item's status changes"""
         self.__emit_queue_event(
             event_name="queue_item_status_changed",
             payload=dict(
-                queue_id=session_queue_item.queue_id,
-                queue_item_id=session_queue_item.item_id,
-                status=session_queue_item.status,
-                batch_id=session_queue_item.batch_id,
-                session_id=session_queue_item.session_id,
-                error=session_queue_item.error,
-                created_at=str(session_queue_item.created_at) if session_queue_item.created_at else None,
-                updated_at=str(session_queue_item.updated_at) if session_queue_item.updated_at else None,
-                started_at=str(session_queue_item.started_at) if session_queue_item.started_at else None,
-                completed_at=str(session_queue_item.completed_at) if session_queue_item.completed_at else None,
+                queue_id=queue_status.queue_id,
+                queue_item=dict(
+                    queue_id=session_queue_item.queue_id,
+                    item_id=session_queue_item.item_id,
+                    status=session_queue_item.status,
+                    batch_id=session_queue_item.batch_id,
+                    session_id=session_queue_item.session_id,
+                    error=session_queue_item.error,
+                    created_at=str(session_queue_item.created_at) if session_queue_item.created_at else None,
+                    updated_at=str(session_queue_item.updated_at) if session_queue_item.updated_at else None,
+                    started_at=str(session_queue_item.started_at) if session_queue_item.started_at else None,
+                    completed_at=str(session_queue_item.completed_at) if session_queue_item.completed_at else None,
+                ),
+                batch_status=batch_status.dict(),
+                queue_status=queue_status.dict(),
             ),
         )
 

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -427,7 +427,13 @@ class SqliteSessionQueue(SessionQueueBase):
         finally:
             self.__lock.release()
         queue_item = self.get_queue_item(item_id)
-        self.__invoker.services.events.emit_queue_item_status_changed(queue_item)
+        batch_status = self.get_batch_status(queue_id=queue_item.queue_id, batch_id=queue_item.batch_id)
+        queue_status = self.get_queue_status(queue_id=queue_item.queue_id)
+        self.__invoker.services.events.emit_queue_item_status_changed(
+            session_queue_item=queue_item,
+            batch_status=batch_status,
+            queue_status=queue_status,
+        )
         return queue_item
 
     def is_empty(self, queue_id: str) -> IsEmptyResult:
@@ -609,7 +615,13 @@ class SqliteSessionQueue(SessionQueueBase):
                     queue_batch_id=current_queue_item.batch_id,
                     graph_execution_state_id=current_queue_item.session_id,
                 )
-                self.__invoker.services.events.emit_queue_item_status_changed(current_queue_item)
+                batch_status = self.get_batch_status(queue_id=queue_id, batch_id=current_queue_item.batch_id)
+                queue_status = self.get_queue_status(queue_id=queue_id)
+                self.__invoker.services.events.emit_queue_item_status_changed(
+                    session_queue_item=current_queue_item,
+                    batch_status=batch_status,
+                    queue_status=queue_status,
+                )
         except Exception:
             self.__conn.rollback()
             raise
@@ -655,7 +667,13 @@ class SqliteSessionQueue(SessionQueueBase):
                     queue_batch_id=current_queue_item.batch_id,
                     graph_execution_state_id=current_queue_item.session_id,
                 )
-                self.__invoker.services.events.emit_queue_item_status_changed(current_queue_item)
+                batch_status = self.get_batch_status(queue_id=queue_id, batch_id=current_queue_item.batch_id)
+                queue_status = self.get_queue_status(queue_id=queue_id)
+                self.__invoker.services.events.emit_queue_item_status_changed(
+                    session_queue_item=current_queue_item,
+                    batch_status=batch_status,
+                    queue_status=queue_status,
+                )
         except Exception:
             self.__conn.rollback()
             raise

--- a/invokeai/frontend/web/src/features/canvas/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/canvas/store/canvasSlice.ts
@@ -29,6 +29,7 @@ import {
   isCanvasBaseImage,
   isCanvasMaskLine,
 } from './canvasTypes';
+import { appSocketQueueItemStatusChanged } from 'services/events/actions';
 
 export const initialLayerState: CanvasLayerState = {
   objects: [],
@@ -786,6 +787,18 @@ export const canvasSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
+    builder.addCase(appSocketQueueItemStatusChanged, (state, action) => {
+      const batch_status = action.payload.data.batch_status;
+      if (!state.batchIds.includes(batch_status.batch_id)) {
+        return;
+      }
+
+      if (batch_status.in_progress === 0 && batch_status.pending === 0) {
+        state.batchIds = state.batchIds.filter(
+          (id) => id !== batch_status.batch_id
+        );
+      }
+    });
     builder.addCase(setAspectRatio, (state, action) => {
       const ratio = action.payload;
       if (ratio) {

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -984,7 +984,7 @@ const nodesSlice = createSlice({
       }
     });
     builder.addCase(appSocketQueueItemStatusChanged, (state, action) => {
-      if (['in_progress'].includes(action.payload.data.status)) {
+      if (['in_progress'].includes(action.payload.data.queue_item.status)) {
         forEach(state.nodeExecutionStates, (nes) => {
           nes.status = NodeStatus.PENDING;
           nes.error = null;

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -164,7 +164,9 @@ export const systemSlice = createSlice({
 
     builder.addCase(appSocketQueueItemStatusChanged, (state, action) => {
       if (
-        ['completed', 'canceled', 'failed'].includes(action.payload.data.status)
+        ['completed', 'canceled', 'failed'].includes(
+          action.payload.data.queue_item.status
+        )
       ) {
         state.status = 'CONNECTED';
         state.denoiseProgress = null;

--- a/invokeai/frontend/web/src/services/api/endpoints/queue.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/queue.ts
@@ -135,12 +135,7 @@ export const queueApi = api.injectEndpoints({
         url: `queue/${$queueId.get()}/prune`,
         method: 'PUT',
       }),
-      invalidatesTags: [
-        'SessionQueueStatus',
-        'BatchStatus',
-        'SessionQueueItem',
-        'SessionQueueItemDTO',
-      ],
+      invalidatesTags: ['SessionQueueStatus', 'BatchStatus'],
       onQueryStarted: async (arg, api) => {
         const { dispatch, queryFulfilled } = api;
         try {
@@ -165,8 +160,6 @@ export const queueApi = api.injectEndpoints({
         'BatchStatus',
         'CurrentSessionQueueItem',
         'NextSessionQueueItem',
-        'SessionQueueItem',
-        'SessionQueueItemDTO',
       ],
       onQueryStarted: async (arg, api) => {
         const { dispatch, queryFulfilled } = api;
@@ -218,7 +211,6 @@ export const queueApi = api.injectEndpoints({
         url: `queue/${$queueId.get()}/status`,
         method: 'GET',
       }),
-
       providesTags: ['SessionQueueStatus'],
     }),
     getBatchStatus: build.query<
@@ -269,7 +261,11 @@ export const queueApi = api.injectEndpoints({
               (draft) => {
                 queueItemsAdapter.updateOne(draft, {
                   id: item_id,
-                  changes: { status: data.status },
+                  changes: {
+                    status: data.status,
+                    completed_at: data.completed_at,
+                    updated_at: data.updated_at,
+                  },
                 });
               }
             )
@@ -284,7 +280,6 @@ export const queueApi = api.injectEndpoints({
         }
         return [
           { type: 'SessionQueueItem', id: result.item_id },
-          { type: 'SessionQueueItemDTO', id: result.item_id },
           { type: 'BatchStatus', id: result.batch_id },
         ];
       },
@@ -307,11 +302,7 @@ export const queueApi = api.injectEndpoints({
           // no-op
         }
       },
-      invalidatesTags: [
-        'SessionQueueItem',
-        'SessionQueueItemDTO',
-        'BatchStatus',
-      ],
+      invalidatesTags: ['SessionQueueStatus', 'BatchStatus'],
     }),
     listQueueItems: build.query<
       EntityState<components['schemas']['SessionQueueItemDTO']> & {

--- a/invokeai/frontend/web/src/services/api/index.ts
+++ b/invokeai/frontend/web/src/services/api/index.ts
@@ -21,8 +21,6 @@ export const tagTypes = [
   'ImageMetadataFromFile',
   'IntermediatesCount',
   'SessionQueueItem',
-  'SessionQueueItemDTO',
-  'SessionQueueItemDTOList',
   'SessionQueueStatus',
   'SessionProcessorStatus',
   'CurrentSessionQueueItem',

--- a/invokeai/frontend/web/src/services/api/schema.d.ts
+++ b/invokeai/frontend/web/src/services/api/schema.d.ts
@@ -9701,11 +9701,23 @@ export type components = {
       ui_order?: number;
     };
     /**
-     * StableDiffusionOnnxModelFormat
+     * T2IAdapterModelFormat
      * @description An enumeration.
      * @enum {string}
      */
-    StableDiffusionOnnxModelFormat: "olive" | "onnx";
+    T2IAdapterModelFormat: "diffusers";
+    /**
+     * ControlNetModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    ControlNetModelFormat: "checkpoint" | "diffusers";
+    /**
+     * StableDiffusion2ModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
     /**
      * StableDiffusionXLModelFormat
      * @description An enumeration.
@@ -9713,11 +9725,11 @@ export type components = {
      */
     StableDiffusionXLModelFormat: "checkpoint" | "diffusers";
     /**
-     * StableDiffusion2ModelFormat
+     * StableDiffusionOnnxModelFormat
      * @description An enumeration.
      * @enum {string}
      */
-    StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
+    StableDiffusionOnnxModelFormat: "olive" | "onnx";
     /**
      * CLIPVisionModelFormat
      * @description An enumeration.
@@ -9736,18 +9748,6 @@ export type components = {
      * @enum {string}
      */
     StableDiffusion1ModelFormat: "checkpoint" | "diffusers";
-    /**
-     * T2IAdapterModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    T2IAdapterModelFormat: "diffusers";
-    /**
-     * ControlNetModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    ControlNetModelFormat: "checkpoint" | "diffusers";
   };
   responses: never;
   parameters: never;

--- a/invokeai/frontend/web/src/services/events/types.ts
+++ b/invokeai/frontend/web/src/services/events/types.ts
@@ -170,16 +170,40 @@ export type InvocationRetrievalErrorEvent = {
  */
 export type QueueItemStatusChangedEvent = {
   queue_id: string;
-  queue_item_id: number;
-  queue_batch_id: string;
-  session_id: string;
-  graph_execution_state_id: string;
-  status: components['schemas']['SessionQueueItemDTO']['status'];
-  error: string | undefined;
-  created_at: string;
-  updated_at: string;
-  started_at: string | undefined;
-  completed_at: string | undefined;
+  queue_item: {
+    queue_id: string;
+    item_id: number;
+    batch_id: string;
+    session_id: string;
+    status: components['schemas']['SessionQueueItemDTO']['status'];
+    error: string | undefined;
+    created_at: string;
+    updated_at: string;
+    started_at: string | undefined;
+    completed_at: string | undefined;
+  };
+  batch_status: {
+    queue_id: string;
+    batch_id: string;
+    pending: number;
+    in_progress: number;
+    completed: number;
+    failed: number;
+    canceled: number;
+    total: number;
+  };
+  queue_status: {
+    queue_id: string;
+    item_id?: number;
+    batch_id?: string;
+    session_id?: string;
+    pending: number;
+    in_progress: number;
+    completed: number;
+    failed: number;
+    canceled: number;
+    total: number;
+  };
 };
 
 export type ClientEmitSubscribeQueue = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

[feat(events): add batch status and queue status to queue item status changed events](https://github.com/invoke-ai/InvokeAI/commit/561695d728f0d7567595d75de912ce584013a29c)

The UI will always re-fetch queue and batch status on receiving this event, so we may as well jsut include that data in the event and save the extra network roundtrips.

@maryhipp There are some changes to the session queue service and socket events here.

[fix(ui): fix canvas soft-lock if canceled before first generation](https://github.com/invoke-ai/InvokeAI/commit/6352cfc2abdbff14bb557764ca466039c49184fe)

The canvas needs to be set to staging mode as soon as a canvas-destined batch is enqueued. If the batch is is fully canceled before an image is generated, we need to remove that batch from the canvas `batchIds` watchlist, else canvas gets stuck in staging mode with no way to exit.

The changes here allow the batch status to be tracked, and if a batch has all its items completed, we can remove it from the `batchIds` watchlist. The `batchIds` watchlist now accurately represents *incomplete* canvas batches, fixing this cause of soft lock.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #4764
- Related #4814 (I *think* this closes it, but I'm not 100% sure as I don't think I understand the problem)

## QA Instructions, Screenshots, Recordings

Barring connectivity issues, it should be very difficult to soft-lock the canvas. Try starting a long generation (eg with 500 steps) and then, before it finishes:
- Cancel that generation
- Clear the whole queue
- Cancel the batch (from the queue tab)

In all cases, the canvas should return to its normal state after canceling.

## Added/updated tests?

- [ ] Yes
- [x] No : _please replace this line with details on why tests
      have not been included_
