### PR TITLE
feat(ui): set w/h to multiple of 64 on add t2i

### DIFF
--- a/invokeai/frontend/web/src/features/controlAdapters/store/controlAdaptersSlice.ts
+++ b/invokeai/frontend/web/src/features/controlAdapters/store/controlAdaptersSlice.ts
@@ -3,6 +3,7 @@ import {
   Update,
   createEntityAdapter,
   createSlice,
+  isAnyOf,
 } from '@reduxjs/toolkit';
 import {
   ControlNetModelParam,
@@ -544,3 +545,9 @@ export const {
 } = controlAdaptersSlice.actions;
 
 export default controlAdaptersSlice.reducer;
+
+export const isAnyControlAdapterAdded = isAnyOf(
+  controlAdapterAdded,
+  controlAdapterAddedFromImage,
+  controlAdapterRecalled
+);

--- a/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
+++ b/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
@@ -5,6 +5,7 @@ import { configChanged } from 'features/system/store/configSlice';
 import { clamp } from 'lodash-es';
 import { ImageDTO } from 'services/api/types';
 
+import { isAnyControlAdapterAdded } from 'features/controlAdapters/store/controlAdaptersSlice';
 import { clipSkipMap } from '../types/constants';
 import {
   CanvasCoherenceModeParam,
@@ -300,6 +301,15 @@ export const generationSlice = createSlice({
         if (result.success) {
           state.model = result.data;
         }
+      }
+    });
+
+    // TODO: This is a temp fix to reduce issues with T2I adapter having a different downscaling
+    // factor than the UNet. Hopefully we get an upstream fix in diffusers.
+    builder.addMatcher(isAnyControlAdapterAdded, (state, action) => {
+      if (action.payload.type === 't2i_adapter') {
+        state.width = roundToMultiple(state.width, 64);
+        state.height = roundToMultiple(state.height, 64);
       }
     });
   },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

feat(ui): set w/h to multiple of 64 on add t2i

This is a temp fix to reduce issues with T2I adapter having a different downscaling factor than the UNet. Hopefully we get an upstream fix in diffusers.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

https://discord.com/channels/1020123559063990373/1149513647022948483/1159463867508850819
