### PR TITLE
Fix gratuitous, parasitic, endlessly repeated, pointless menu in version 3.2.0

### DIFF
--- a/invokeai/frontend/install/widgets.py
+++ b/invokeai/frontend/install/widgets.py
@@ -381,12 +381,12 @@ def select_stable_diffusion_config_file(
     wrap: bool = True,
     model_name: str = "Unknown",
 ):
-    message = f"Please select the correct base model for the V2 checkpoint named '{model_name}'. Press <CANCEL> to skip installation."
+    message = f"Please select the correct prediction type for the checkpoint named '{model_name}'. Press <CANCEL> to skip installation."
     title = "CONFIG FILE SELECTION"
     options = [
-        "An SD v2.x base model (512 pixels; no 'parameterization:' line in its yaml file)",
-        "An SD v2.x v-predictive model (768 pixels; 'parameterization: \"v\"' line in its yaml file)",
-        "Skip installation for now and come back later",
+        "'epsilon' - most v1.5 models and v2 models trained on 512 pixel images",
+        "'vprediction' - v2 models trained on 768 pixel images and a few v1.5 models)",
+        "Accept the best guess; you can fix it in the Web UI later",
     ]
 
     F = ConfirmCancelPopup(
@@ -410,7 +410,7 @@ def select_stable_diffusion_config_file(
     choice = F.add(
         npyscreen.SelectOne,
         values=options,
-        value=[0],
+        value=[2],
         max_height=len(options) + 1,
         scroll_exit=True,
     )
@@ -420,5 +420,5 @@ def select_stable_diffusion_config_file(
     if not F.value:
         return None
     assert choice.value[0] in range(0, 3), "invalid choice"
-    choices = ["epsilon", "v", "abort"]
+    choices = ["epsilon", "v", "guess"]
     return choices[choice.value[0]]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

A regression in 3.2.0 causes a seemingly nonsensical multiple choice menu to appear when importing an SD-1 checkpoint model from the autoimport directory. The menu asks the user to identify which type of SD-2 model they are trying to import, which makes no sense.

In fact, the menu is popping up because there are now both "epsilon" and "vprediction" SchedulerPredictionTypes for SD-1 as well as SD-2 models, and the prober can't determine which prediction type to use. This PR does two things:

1) rewords the menu as shown below
2) defaults to the most likely choice -- epsilon for v1 models and vprediction for v2s

Here is the revised multiple-choice menu:
```
Please select the scheduler prediction type of the checkpoint named v1-5-pruned-emaonly.safetensors:
[1] "epsilon" - most v1.5 models and v2 models trained on 512 pixel images
[2] "vprediction" - v2 models trained on 768 pixel images and a few v1.5 models
[3] Accept the best guess;  you can fix it in the Web UI later

select [3]> 
```

Note that one can also put the appropriate config file into the same directory as the checkpoint you wish to import. Give it the same name as the model file, but with the extension `.yaml`. For example `v1-5-pruned-emaonly.yaml`. The system will notice the yaml file and use that, suppressing the quiz entirely.

## Related Tickets & Documents
- Closes #4768
- Closes #4827 
