### PR TITLE
fix(backend): handle systems with `glibc` < 2.33

### DIFF
--- a/invokeai/backend/model_management/memory_snapshot.py
+++ b/invokeai/backend/model_management/memory_snapshot.py
@@ -55,8 +55,10 @@ class MemorySnapshot:
 
         try:
             malloc_info = LibcUtil().mallinfo2()
-        except OSError:
-            # This is expected in environments that do not have the 'libc.so.6' shared library.
+        except (OSError, AttributeError):
+            # OSError: This is expected in environments that do not have the 'libc.so.6' shared library.
+            # AttributeError: This is expected in environments that have `libc.so.6` but do not have the `mallinfo2` (e.g. glibc < 2.33)
+            # TODO: Does `mallinfo` work?
             malloc_info = None
 
         return cls(process_ram, vram, malloc_info)

--- a/tests/backend/model_management/test_libc_util.py
+++ b/tests/backend/model_management/test_libc_util.py
@@ -11,7 +11,10 @@ def test_libc_util_mallinfo2():
         # TODO: Set the expected result preemptively based on the system properties.
         pytest.xfail("libc shared library is not available on this system.")
 
-    info = libc.mallinfo2()
+    try:
+        info = libc.mallinfo2()
+    except AttributeError:
+        pytest.xfail("`mallinfo2` is not available on this system, likely due to glibc < 2.33.")
 
     assert info.arena > 0
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission
    
## Description

[fix(backend): handle systems with glibc < 2.33](https://github.com/invoke-ai/InvokeAI/commit/f0ee3150c504d1e45601455643db1ef1d8ca2fa0)

`mallinfo2` is not available on `glibc` < 2.33.

On these systems, we successfully load the library but get an `AttributeError` on attempting to access `mallinfo2`.

I'm not sure if the old `mallinfo` will work, and not sure how to install it safely to test, so for now we just handle the `AttributeError`.

This means the enhanced memory snapshot logic will be skipped for these systems, which isn't a big deal.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #4878

## QA Instructions, Screenshots, Recordings

@RyanJDick Requesting your review for this.

@RaphaelDreams , ideally you could test this PR on your affected system to confirm it resolves the issue. From my read of the code, it will, but I'm not sure how to test the fix on my system.

## Added/updated tests?

- [x] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_