### PR TITLE
fix(db): use RLock instead of Lock

### DIFF
--- a/invokeai/app/services/board_image_records/board_image_records_sqlite.py
+++ b/invokeai/app/services/board_image_records/board_image_records_sqlite.py
@@ -12,7 +12,7 @@ from .board_image_records_base import BoardImageRecordStorageBase
 class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
-    _lock: threading.Lock
+    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()

--- a/invokeai/app/services/board_records/board_records_sqlite.py
+++ b/invokeai/app/services/board_records/board_records_sqlite.py
@@ -20,7 +20,7 @@ from .board_records_common import (
 class SqliteBoardRecordStorage(BoardRecordStorageBase):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
-    _lock: threading.Lock
+    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()

--- a/invokeai/app/services/image_records/image_records_sqlite.py
+++ b/invokeai/app/services/image_records/image_records_sqlite.py
@@ -24,7 +24,7 @@ from .image_records_common import (
 class SqliteImageRecordStorage(ImageRecordStorageBase):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
-    _lock: threading.Lock
+    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()

--- a/invokeai/app/services/item_storage/item_storage_sqlite.py
+++ b/invokeai/app/services/item_storage/item_storage_sqlite.py
@@ -17,7 +17,7 @@ class SqliteItemStorage(ItemStorageABC, Generic[T]):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
     _id_field: str
-    _lock: threading.Lock
+    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase, table_name: str, id_field: str = "id"):
         super().__init__()

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -37,7 +37,7 @@ class SqliteSessionQueue(SessionQueueBase):
     __invoker: Invoker
     __conn: sqlite3.Connection
     __cursor: sqlite3.Cursor
-    __lock: threading.Lock
+    __lock: threading.RLock
 
     def start(self, invoker: Invoker) -> None:
         self.__invoker = invoker

--- a/invokeai/app/services/shared/sqlite.py
+++ b/invokeai/app/services/shared/sqlite.py
@@ -9,7 +9,7 @@ sqlite_memory = ":memory:"
 
 class SqliteDatabase:
     conn: sqlite3.Connection
-    lock: threading.Lock
+    lock: threading.RLock
     _logger: Logger
     _config: InvokeAIAppConfig
 
@@ -27,7 +27,7 @@ class SqliteDatabase:
             self._logger.info(f"Using database at {location}")
 
         self.conn = sqlite3.connect(location, check_same_thread=False)
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         self.conn.row_factory = sqlite3.Row
 
         if self._config.log_sql:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

When canceling by batch ids or canceling the whole queue, we tried to lock the db mutex within an existing lock, which of course locks the app forever. Use `RLock` instead to allow this pattern.

## Related Tickets & Documents

https://discord.com/channels/1020123559063990373/1149513625321603162/1163229923255791749

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
