### PR TITLE
fix(api): fix socketio breaking change

### DIFF
--- a/invokeai/app/api/sockets.py
+++ b/invokeai/app/api/sockets.py
@@ -30,8 +30,8 @@ class SocketIO:
 
     async def _handle_sub_queue(self, sid, data, *args, **kwargs):
         if "queue_id" in data:
-            self.__sio.enter_room(sid, data["queue_id"])
+            await self.__sio.enter_room(sid, data["queue_id"])
 
     async def _handle_unsub_queue(self, sid, data, *args, **kwargs):
         if "queue_id" in data:
-            self.__sio.enter_room(sid, data["queue_id"])
+            await self.__sio.enter_room(sid, data["queue_id"])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

Fix for breaking change in `python-socketio` 5.10.0 in which `enter_room` and `leave_room` were made coroutines.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->


- Closes #4899
