### PR TITLE
feat: remove `enqueue_graph` routes/methods

### DIFF
--- a/invokeai/app/api/routers/session_queue.py
+++ b/invokeai/app/api/routers/session_queue.py
@@ -12,13 +12,11 @@ from invokeai.app.services.session_queue.session_queue_common import (
     CancelByBatchIDsResult,
     ClearResult,
     EnqueueBatchResult,
-    EnqueueGraphResult,
     PruneResult,
     SessionQueueItem,
     SessionQueueItemDTO,
     SessionQueueStatus,
 )
-from invokeai.app.services.shared.graph import Graph
 from invokeai.app.services.shared.pagination import CursorPaginatedResults
 
 from ..dependencies import ApiDependencies
@@ -31,23 +29,6 @@ class SessionQueueAndProcessorStatus(BaseModel):
 
     queue: SessionQueueStatus
     processor: SessionProcessorStatus
-
-
-@session_queue_router.post(
-    "/{queue_id}/enqueue_graph",
-    operation_id="enqueue_graph",
-    responses={
-        201: {"model": EnqueueGraphResult},
-    },
-)
-async def enqueue_graph(
-    queue_id: str = Path(description="The queue id to perform this operation on"),
-    graph: Graph = Body(description="The graph to enqueue"),
-    prepend: bool = Body(default=False, description="Whether or not to prepend this batch in the queue"),
-) -> EnqueueGraphResult:
-    """Enqueues a graph for single execution."""
-
-    return ApiDependencies.invoker.services.session_queue.enqueue_graph(queue_id=queue_id, graph=graph, prepend=prepend)
 
 
 @session_queue_router.post(

--- a/invokeai/app/services/session_queue/session_queue_base.py
+++ b/invokeai/app/services/session_queue/session_queue_base.py
@@ -9,7 +9,6 @@ from invokeai.app.services.session_queue.session_queue_common import (
     CancelByQueueIDResult,
     ClearResult,
     EnqueueBatchResult,
-    EnqueueGraphResult,
     IsEmptyResult,
     IsFullResult,
     PruneResult,
@@ -17,7 +16,6 @@ from invokeai.app.services.session_queue.session_queue_common import (
     SessionQueueItemDTO,
     SessionQueueStatus,
 )
-from invokeai.app.services.shared.graph import Graph
 from invokeai.app.services.shared.pagination import CursorPaginatedResults
 
 
@@ -27,11 +25,6 @@ class SessionQueueBase(ABC):
     @abstractmethod
     def dequeue(self) -> Optional[SessionQueueItem]:
         """Dequeues the next session queue item."""
-        pass
-
-    @abstractmethod
-    def enqueue_graph(self, queue_id: str, graph: Graph, prepend: bool) -> EnqueueGraphResult:
-        """Enqueues a single graph for execution."""
         pass
 
     @abstractmethod

--- a/invokeai/app/services/session_queue/session_queue_common.py
+++ b/invokeai/app/services/session_queue/session_queue_common.py
@@ -276,14 +276,6 @@ class EnqueueBatchResult(BaseModel):
     priority: int = Field(description="The priority of the enqueued batch")
 
 
-class EnqueueGraphResult(BaseModel):
-    enqueued: int = Field(description="The total number of queue items enqueued")
-    requested: int = Field(description="The total number of queue items requested to be enqueued")
-    batch: Batch = Field(description="The batch that was enqueued")
-    priority: int = Field(description="The priority of the enqueued batch")
-    queue_item: SessionQueueItemDTO = Field(description="The queue item that was enqueued")
-
-
 class ClearResult(BaseModel):
     """Result of clearing the session queue"""
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/anyEnqueued.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/anyEnqueued.ts
@@ -1,15 +1,9 @@
-import { isAnyOf } from '@reduxjs/toolkit';
 import { queueApi } from 'services/api/endpoints/queue';
 import { startAppListening } from '..';
 
-const matcher = isAnyOf(
-  queueApi.endpoints.enqueueBatch.matchFulfilled,
-  queueApi.endpoints.enqueueGraph.matchFulfilled
-);
-
 export const addAnyEnqueuedListener = () => {
   startAppListening({
-    matcher,
+    matcher: queueApi.endpoints.enqueueBatch.matchFulfilled,
     effect: async (_, { dispatch, getState }) => {
       const { data } = queueApi.endpoints.getQueueStatus.select()(getState());
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/controlNetImageProcessed.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/controlNetImageProcessed.ts
@@ -1,22 +1,22 @@
 import { logger } from 'app/logging/logger';
 import { parseify } from 'common/util/serialize';
+import { controlAdapterImageProcessed } from 'features/controlAdapters/store/actions';
 import {
-  pendingControlImagesCleared,
   controlAdapterImageChanged,
-  selectControlAdapterById,
   controlAdapterProcessedImageChanged,
+  pendingControlImagesCleared,
+  selectControlAdapterById,
 } from 'features/controlAdapters/store/controlAdaptersSlice';
+import { isControlNetOrT2IAdapter } from 'features/controlAdapters/store/types';
 import { SAVE_IMAGE } from 'features/nodes/util/graphBuilders/constants';
 import { addToast } from 'features/system/store/systemSlice';
 import { t } from 'i18next';
 import { imagesApi } from 'services/api/endpoints/images';
 import { queueApi } from 'services/api/endpoints/queue';
 import { isImageOutput } from 'services/api/guards';
-import { Graph, ImageDTO } from 'services/api/types';
+import { BatchConfig, ImageDTO } from 'services/api/types';
 import { socketInvocationComplete } from 'services/events/actions';
 import { startAppListening } from '..';
-import { controlAdapterImageProcessed } from 'features/controlAdapters/store/actions';
-import { isControlNetOrT2IAdapter } from 'features/controlAdapters/store/types';
 
 export const addControlNetImageProcessedListener = () => {
   startAppListening({
@@ -37,41 +37,46 @@ export const addControlNetImageProcessedListener = () => {
 
       // ControlNet one-off procressing graph is just the processor node, no edges.
       // Also we need to grab the image.
-      const graph: Graph = {
-        nodes: {
-          [ca.processorNode.id]: {
-            ...ca.processorNode,
-            is_intermediate: true,
-            image: { image_name: ca.controlImage },
+
+      const enqueueBatchArg: BatchConfig = {
+        prepend: true,
+        batch: {
+          graph: {
+            nodes: {
+              [ca.processorNode.id]: {
+                ...ca.processorNode,
+                is_intermediate: true,
+                image: { image_name: ca.controlImage },
+              },
+              [SAVE_IMAGE]: {
+                id: SAVE_IMAGE,
+                type: 'save_image',
+                is_intermediate: true,
+                use_cache: false,
+              },
+            },
+            edges: [
+              {
+                source: {
+                  node_id: ca.processorNode.id,
+                  field: 'image',
+                },
+                destination: {
+                  node_id: SAVE_IMAGE,
+                  field: 'image',
+                },
+              },
+            ],
           },
-          [SAVE_IMAGE]: {
-            id: SAVE_IMAGE,
-            type: 'save_image',
-            is_intermediate: true,
-            use_cache: false,
-          },
+          runs: 1,
         },
-        edges: [
-          {
-            source: {
-              node_id: ca.processorNode.id,
-              field: 'image',
-            },
-            destination: {
-              node_id: SAVE_IMAGE,
-              field: 'image',
-            },
-          },
-        ],
       };
+
       try {
         const req = dispatch(
-          queueApi.endpoints.enqueueGraph.initiate(
-            { graph, prepend: true },
-            {
-              fixedCacheKey: 'enqueueGraph',
-            }
-          )
+          queueApi.endpoints.enqueueBatch.initiate(enqueueBatchArg, {
+            fixedCacheKey: 'enqueueBatch',
+          })
         );
         const enqueueResult = await req.unwrap();
         req.reset();
@@ -83,8 +88,8 @@ export const addControlNetImageProcessedListener = () => {
         const [invocationCompleteAction] = await take(
           (action): action is ReturnType<typeof socketInvocationComplete> =>
             socketInvocationComplete.match(action) &&
-            action.payload.data.graph_execution_state_id ===
-              enqueueResult.queue_item.session_id &&
+            action.payload.data.queue_batch_id ===
+              enqueueResult.batch.batch_id &&
             action.payload.data.source_node_id === SAVE_IMAGE
         );
 
@@ -116,7 +121,10 @@ export const addControlNetImageProcessedListener = () => {
           );
         }
       } catch (error) {
-        log.error({ graph: parseify(graph) }, t('queue.graphFailedToQueue'));
+        log.error(
+          { enqueueBatchArg: parseify(enqueueBatchArg) },
+          t('queue.graphFailedToQueue')
+        );
 
         // handle usage-related errors
         if (error instanceof Object) {

--- a/invokeai/frontend/web/src/features/queue/hooks/useIsQueueMutationInProgress.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useIsQueueMutationInProgress.ts
@@ -3,7 +3,6 @@ import {
   // useCancelByBatchIdsMutation,
   useClearQueueMutation,
   useEnqueueBatchMutation,
-  useEnqueueGraphMutation,
   usePruneQueueMutation,
   useResumeProcessorMutation,
   usePauseProcessorMutation,
@@ -13,10 +12,6 @@ export const useIsQueueMutationInProgress = () => {
   const [_triggerEnqueueBatch, { isLoading: isLoadingEnqueueBatch }] =
     useEnqueueBatchMutation({
       fixedCacheKey: 'enqueueBatch',
-    });
-  const [_triggerEnqueueGraph, { isLoading: isLoadingEnqueueGraph }] =
-    useEnqueueGraphMutation({
-      fixedCacheKey: 'enqueueGraph',
     });
   const [_triggerResumeProcessor, { isLoading: isLoadingResumeProcessor }] =
     useResumeProcessorMutation({
@@ -44,7 +39,6 @@ export const useIsQueueMutationInProgress = () => {
   //   });
   return (
     isLoadingEnqueueBatch ||
-    isLoadingEnqueueGraph ||
     isLoadingResumeProcessor ||
     isLoadingPauseProcessor ||
     isLoadingCancelQueue ||

--- a/invokeai/frontend/web/src/services/api/endpoints/queue.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/queue.ts
@@ -83,30 +83,6 @@ export const queueApi = api.injectEndpoints({
         }
       },
     }),
-    enqueueGraph: build.mutation<
-      paths['/api/v1/queue/{queue_id}/enqueue_graph']['post']['responses']['201']['content']['application/json'],
-      paths['/api/v1/queue/{queue_id}/enqueue_graph']['post']['requestBody']['content']['application/json']
-    >({
-      query: (arg) => ({
-        url: `queue/${$queueId.get()}/enqueue_graph`,
-        body: arg,
-        method: 'POST',
-      }),
-      invalidatesTags: [
-        'SessionQueueStatus',
-        'CurrentSessionQueueItem',
-        'NextSessionQueueItem',
-      ],
-      onQueryStarted: async (arg, api) => {
-        const { dispatch, queryFulfilled } = api;
-        try {
-          await queryFulfilled;
-          resetListQueryData(dispatch);
-        } catch {
-          // no-op
-        }
-      },
-    }),
     resumeProcessor: build.mutation<
       paths['/api/v1/queue/{queue_id}/processor/resume']['put']['responses']['200']['content']['application/json'],
       void
@@ -341,7 +317,6 @@ export const queueApi = api.injectEndpoints({
 
 export const {
   useCancelByBatchIdsMutation,
-  useEnqueueGraphMutation,
   useEnqueueBatchMutation,
   usePauseProcessorMutation,
   useResumeProcessorMutation,

--- a/invokeai/frontend/web/src/services/api/schema.d.ts
+++ b/invokeai/frontend/web/src/services/api/schema.d.ts
@@ -5,6 +5,13 @@
 
 
 export type paths = {
+  "/api/v1/sessions/{session_id}": {
+    /**
+     * Get Session
+     * @description Gets a session
+     */
+    get: operations["get_session"];
+  };
   "/api/v1/utilities/dynamicprompts": {
     /**
      * Parse Dynamicprompts
@@ -274,13 +281,6 @@ export type paths = {
      * @description Clears the invocation cache
      */
     get: operations["get_invocation_cache_status"];
-  };
-  "/api/v1/queue/{queue_id}/enqueue_graph": {
-    /**
-     * Enqueue Graph
-     * @description Enqueues a graph for single execution.
-     */
-    post: operations["enqueue_graph"];
   };
   "/api/v1/queue/{queue_id}/enqueue_batch": {
     /**
@@ -793,17 +793,6 @@ export type components = {
     Body_enqueue_batch: {
       /** @description Batch to process */
       batch: components["schemas"]["Batch"];
-      /**
-       * Prepend
-       * @description Whether or not to prepend this batch in the queue
-       * @default false
-       */
-      prepend?: boolean;
-    };
-    /** Body_enqueue_graph */
-    Body_enqueue_graph: {
-      /** @description The graph to enqueue */
-      graph: components["schemas"]["Graph"];
       /**
        * Prepend
        * @description Whether or not to prepend this batch in the queue
@@ -1897,7 +1886,7 @@ export type components = {
        * Created By
        * @description The name of the creator of the image
        */
-      created_by: string | null;
+      created_by?: string | null;
       /**
        * Positive Prompt
        * @description The positive prompt parameter
@@ -2476,28 +2465,6 @@ export type components = {
        */
       priority: number;
     };
-    /** EnqueueGraphResult */
-    EnqueueGraphResult: {
-      /**
-       * Enqueued
-       * @description The total number of queue items enqueued
-       */
-      enqueued: number;
-      /**
-       * Requested
-       * @description The total number of queue items requested to be enqueued
-       */
-      requested: number;
-      /** @description The batch that was enqueued */
-      batch: components["schemas"]["Batch"];
-      /**
-       * Priority
-       * @description The priority of the enqueued batch
-       */
-      priority: number;
-      /** @description The queue item that was enqueued */
-      queue_item: components["schemas"]["SessionQueueItemDTO"];
-    };
     /**
      * FaceIdentifier
      * @description Outputs an image with detected face IDs printed on each face. For use with other FaceTools.
@@ -3035,7 +3002,7 @@ export type components = {
        * @description The nodes in this graph
        */
       nodes?: {
-        [key: string]: components["schemas"]["ImageConvertInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["FaceIdentifierInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["StringSplitNegInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["ColorMapImageProcessorInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["StringJoinThreeInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["T2IAdapterInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["StringReplaceInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["InfillColorInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["RandomFloatInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["FaceOffInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["IntegerInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["StringJoinInvocation"] | components["schemas"]["StringSplitInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["FaceMaskInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["SaveImageInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["BooleanInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["IPAdapterInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["MainModelLoaderInvocation"];
+        [key: string]: components["schemas"]["IntegerInvocation"] | components["schemas"]["SDXLModelLoaderInvocation"] | components["schemas"]["FloatCollectionInvocation"] | components["schemas"]["ImageBlurInvocation"] | components["schemas"]["StringCollectionInvocation"] | components["schemas"]["ImageWatermarkInvocation"] | components["schemas"]["ImageChannelMultiplyInvocation"] | components["schemas"]["PidiImageProcessorInvocation"] | components["schemas"]["ShowImageInvocation"] | components["schemas"]["ImageCropInvocation"] | components["schemas"]["CvInpaintInvocation"] | components["schemas"]["ContentShuffleImageProcessorInvocation"] | components["schemas"]["OpenposeImageProcessorInvocation"] | components["schemas"]["ImagePasteInvocation"] | components["schemas"]["IntegerCollectionInvocation"] | components["schemas"]["MaskFromAlphaInvocation"] | components["schemas"]["RandomRangeInvocation"] | components["schemas"]["MainModelLoaderInvocation"] | components["schemas"]["ZoeDepthImageProcessorInvocation"] | components["schemas"]["StringSplitNegInvocation"] | components["schemas"]["FaceIdentifierInvocation"] | components["schemas"]["BlendLatentsInvocation"] | components["schemas"]["ImageInvocation"] | components["schemas"]["SDXLRefinerModelLoaderInvocation"] | components["schemas"]["BlankImageInvocation"] | components["schemas"]["SDXLLoraLoaderInvocation"] | components["schemas"]["CannyImageProcessorInvocation"] | components["schemas"]["ColorMapImageProcessorInvocation"] | components["schemas"]["FloatMathInvocation"] | components["schemas"]["MaskEdgeInvocation"] | components["schemas"]["RoundInvocation"] | components["schemas"]["ScaleLatentsInvocation"] | components["schemas"]["CreateDenoiseMaskInvocation"] | components["schemas"]["ImageHueAdjustmentInvocation"] | components["schemas"]["ControlNetInvocation"] | components["schemas"]["OnnxModelLoaderInvocation"] | components["schemas"]["GraphInvocation"] | components["schemas"]["ImageInverseLerpInvocation"] | components["schemas"]["ImageNSFWBlurInvocation"] | components["schemas"]["MultiplyInvocation"] | components["schemas"]["IPAdapterInvocation"] | components["schemas"]["ConditioningCollectionInvocation"] | components["schemas"]["IterateInvocation"] | components["schemas"]["ONNXTextToLatentsInvocation"] | components["schemas"]["CV2InfillInvocation"] | components["schemas"]["StringInvocation"] | components["schemas"]["FaceMaskInvocation"] | components["schemas"]["SchedulerInvocation"] | components["schemas"]["ONNXLatentsToImageInvocation"] | components["schemas"]["DynamicPromptInvocation"] | components["schemas"]["FloatInvocation"] | components["schemas"]["NormalbaeImageProcessorInvocation"] | components["schemas"]["CollectInvocation"] | components["schemas"]["FaceOffInvocation"] | components["schemas"]["LineartImageProcessorInvocation"] | components["schemas"]["SegmentAnythingProcessorInvocation"] | components["schemas"]["NoiseInvocation"] | components["schemas"]["ColorInvocation"] | components["schemas"]["InfillPatchMatchInvocation"] | components["schemas"]["HedImageProcessorInvocation"] | components["schemas"]["FloatLinearRangeInvocation"] | components["schemas"]["SDXLCompelPromptInvocation"] | components["schemas"]["LatentsToImageInvocation"] | components["schemas"]["MetadataAccumulatorInvocation"] | components["schemas"]["CompelInvocation"] | components["schemas"]["StepParamEasingInvocation"] | components["schemas"]["ClipSkipInvocation"] | components["schemas"]["ImageCollectionInvocation"] | components["schemas"]["LatentsInvocation"] | components["schemas"]["ONNXPromptInvocation"] | components["schemas"]["DenoiseLatentsInvocation"] | components["schemas"]["SubtractInvocation"] | components["schemas"]["LeresImageProcessorInvocation"] | components["schemas"]["StringJoinThreeInvocation"] | components["schemas"]["ImageLerpInvocation"] | components["schemas"]["ColorCorrectInvocation"] | components["schemas"]["ESRGANInvocation"] | components["schemas"]["IntegerMathInvocation"] | components["schemas"]["SaveImageInvocation"] | components["schemas"]["LaMaInfillInvocation"] | components["schemas"]["ResizeLatentsInvocation"] | components["schemas"]["ImageResizeInvocation"] | components["schemas"]["StringReplaceInvocation"] | components["schemas"]["BooleanCollectionInvocation"] | components["schemas"]["StringSplitInvocation"] | components["schemas"]["FloatToIntegerInvocation"] | components["schemas"]["StringJoinInvocation"] | components["schemas"]["T2IAdapterInvocation"] | components["schemas"]["ImageChannelInvocation"] | components["schemas"]["MaskCombineInvocation"] | components["schemas"]["AddInvocation"] | components["schemas"]["LatentsCollectionInvocation"] | components["schemas"]["RandomIntInvocation"] | components["schemas"]["ImageChannelOffsetInvocation"] | components["schemas"]["MidasDepthImageProcessorInvocation"] | components["schemas"]["VaeLoaderInvocation"] | components["schemas"]["ImageConvertInvocation"] | components["schemas"]["MlsdImageProcessorInvocation"] | components["schemas"]["DivideInvocation"] | components["schemas"]["LoraLoaderInvocation"] | components["schemas"]["MediapipeFaceProcessorInvocation"] | components["schemas"]["InfillTileInvocation"] | components["schemas"]["PromptsFromFileInvocation"] | components["schemas"]["SeamlessModeInvocation"] | components["schemas"]["ImageScaleInvocation"] | components["schemas"]["LineartAnimeImageProcessorInvocation"] | components["schemas"]["RandomFloatInvocation"] | components["schemas"]["BooleanInvocation"] | components["schemas"]["ConditioningInvocation"] | components["schemas"]["RangeOfSizeInvocation"] | components["schemas"]["ImageToLatentsInvocation"] | components["schemas"]["ImageMultiplyInvocation"] | components["schemas"]["RangeInvocation"] | components["schemas"]["TileResamplerProcessorInvocation"] | components["schemas"]["SDXLRefinerCompelPromptInvocation"] | components["schemas"]["InfillColorInvocation"];
       };
       /**
        * Edges
@@ -3072,7 +3039,7 @@ export type components = {
        * @description The results of node executions
        */
       results: {
-        [key: string]: components["schemas"]["SDXLLoraLoaderOutput"] | components["schemas"]["FloatOutput"] | components["schemas"]["ControlOutput"] | components["schemas"]["ColorOutput"] | components["schemas"]["FaceMaskOutput"] | components["schemas"]["String2Output"] | components["schemas"]["IPAdapterOutput"] | components["schemas"]["DenoiseMaskOutput"] | components["schemas"]["IntegerCollectionOutput"] | components["schemas"]["ImageCollectionOutput"] | components["schemas"]["BooleanCollectionOutput"] | components["schemas"]["ModelLoaderOutput"] | components["schemas"]["MetadataAccumulatorOutput"] | components["schemas"]["ImageOutput"] | components["schemas"]["StringCollectionOutput"] | components["schemas"]["LatentsCollectionOutput"] | components["schemas"]["BooleanOutput"] | components["schemas"]["LoraLoaderOutput"] | components["schemas"]["FloatCollectionOutput"] | components["schemas"]["FaceOffOutput"] | components["schemas"]["GraphInvocationOutput"] | components["schemas"]["IterateInvocationOutput"] | components["schemas"]["LatentsOutput"] | components["schemas"]["StringPosNegOutput"] | components["schemas"]["SeamlessModeOutput"] | components["schemas"]["ClipSkipInvocationOutput"] | components["schemas"]["IntegerOutput"] | components["schemas"]["CollectInvocationOutput"] | components["schemas"]["StringOutput"] | components["schemas"]["ConditioningCollectionOutput"] | components["schemas"]["ONNXModelLoaderOutput"] | components["schemas"]["ConditioningOutput"] | components["schemas"]["NoiseOutput"] | components["schemas"]["ColorCollectionOutput"] | components["schemas"]["T2IAdapterOutput"] | components["schemas"]["SDXLRefinerModelLoaderOutput"] | components["schemas"]["VaeLoaderOutput"] | components["schemas"]["SDXLModelLoaderOutput"] | components["schemas"]["SchedulerOutput"];
+        [key: string]: components["schemas"]["String2Output"] | components["schemas"]["FaceOffOutput"] | components["schemas"]["IntegerCollectionOutput"] | components["schemas"]["SDXLRefinerModelLoaderOutput"] | components["schemas"]["FaceMaskOutput"] | components["schemas"]["SDXLModelLoaderOutput"] | components["schemas"]["StringCollectionOutput"] | components["schemas"]["ConditioningCollectionOutput"] | components["schemas"]["SDXLLoraLoaderOutput"] | components["schemas"]["ONNXModelLoaderOutput"] | components["schemas"]["ControlOutput"] | components["schemas"]["CollectInvocationOutput"] | components["schemas"]["SeamlessModeOutput"] | components["schemas"]["LatentsCollectionOutput"] | components["schemas"]["ImageCollectionOutput"] | components["schemas"]["ClipSkipInvocationOutput"] | components["schemas"]["LatentsOutput"] | components["schemas"]["BooleanOutput"] | components["schemas"]["ModelLoaderOutput"] | components["schemas"]["ConditioningOutput"] | components["schemas"]["IntegerOutput"] | components["schemas"]["StringOutput"] | components["schemas"]["MetadataAccumulatorOutput"] | components["schemas"]["FloatOutput"] | components["schemas"]["FloatCollectionOutput"] | components["schemas"]["SchedulerOutput"] | components["schemas"]["ImageOutput"] | components["schemas"]["ColorOutput"] | components["schemas"]["LoraLoaderOutput"] | components["schemas"]["NoiseOutput"] | components["schemas"]["GraphInvocationOutput"] | components["schemas"]["ColorCollectionOutput"] | components["schemas"]["IPAdapterOutput"] | components["schemas"]["VaeLoaderOutput"] | components["schemas"]["BooleanCollectionOutput"] | components["schemas"]["T2IAdapterOutput"] | components["schemas"]["IterateInvocationOutput"] | components["schemas"]["DenoiseMaskOutput"] | components["schemas"]["StringPosNegOutput"];
       };
       /**
        * Errors
@@ -9139,6 +9106,18 @@ export type components = {
       ui_order: number | null;
     };
     /**
+     * ControlNetModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    ControlNetModelFormat: "checkpoint" | "diffusers";
+    /**
+     * StableDiffusion1ModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    StableDiffusion1ModelFormat: "checkpoint" | "diffusers";
+    /**
      * StableDiffusionOnnxModelFormat
      * @description An enumeration.
      * @enum {string}
@@ -9151,17 +9130,11 @@ export type components = {
      */
     StableDiffusion2ModelFormat: "checkpoint" | "diffusers";
     /**
-     * StableDiffusion1ModelFormat
+     * IPAdapterModelFormat
      * @description An enumeration.
      * @enum {string}
      */
-    StableDiffusion1ModelFormat: "checkpoint" | "diffusers";
-    /**
-     * ControlNetModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    ControlNetModelFormat: "checkpoint" | "diffusers";
+    IPAdapterModelFormat: "invokeai";
     /**
      * CLIPVisionModelFormat
      * @description An enumeration.
@@ -9169,23 +9142,17 @@ export type components = {
      */
     CLIPVisionModelFormat: "diffusers";
     /**
-     * StableDiffusionXLModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    StableDiffusionXLModelFormat: "checkpoint" | "diffusers";
-    /**
-     * IPAdapterModelFormat
-     * @description An enumeration.
-     * @enum {string}
-     */
-    IPAdapterModelFormat: "invokeai";
-    /**
      * T2IAdapterModelFormat
      * @description An enumeration.
      * @enum {string}
      */
     T2IAdapterModelFormat: "diffusers";
+    /**
+     * StableDiffusionXLModelFormat
+     * @description An enumeration.
+     * @enum {string}
+     */
+    StableDiffusionXLModelFormat: "checkpoint" | "diffusers";
   };
   responses: never;
   parameters: never;
@@ -9200,6 +9167,36 @@ export type external = Record<string, never>;
 
 export type operations = {
 
+  /**
+   * Get Session
+   * @description Gets a session
+   */
+  get_session: {
+    parameters: {
+      path: {
+        /** @description The id of the session to get */
+        session_id: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GraphExecutionState"];
+        };
+      };
+      /** @description Session not found */
+      404: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   /**
    * Parse Dynamicprompts
    * @description Creates a batch process
@@ -10305,43 +10302,6 @@ export type operations = {
       200: {
         content: {
           "application/json": components["schemas"]["InvocationCacheStatus"];
-        };
-      };
-    };
-  };
-  /**
-   * Enqueue Graph
-   * @description Enqueues a graph for single execution.
-   */
-  enqueue_graph: {
-    parameters: {
-      path: {
-        /** @description The queue id to perform this operation on */
-        queue_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Body_enqueue_graph"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["EnqueueGraphResult"];
-        };
-      };
-      /** @description Created */
-      201: {
-        content: {
-          "application/json": components["schemas"]["EnqueueGraphResult"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -26,7 +26,6 @@ export type BatchConfig =
   paths['/api/v1/queue/{queue_id}/enqueue_batch']['post']['requestBody']['content']['application/json'];
 
 export type EnqueueBatchResult = components['schemas']['EnqueueBatchResult'];
-export type EnqueueGraphResult = components['schemas']['EnqueueGraphResult'];
 
 /**
  * This is an unsafe type; the object inside is not guaranteed to be valid.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description

[feat: remove enqueue_graph routes/methods](https://github.com/invoke-ai/InvokeAI/commit/2201b4a0553f9361d18682dd4fe86b78b6cc08e6)

This is totally extraneous - it's almost identical to `enqueue_batch`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue: split out from #4686, where it has no business being

## QA Instructions, Screenshots, Recordings

This route was used for controlnet image processing and ad-hoc upscaling:
- Upscale an image using the ad-hoc upscaling button, ensuring it upscales
- Set a control image, ensuring it auto-processes

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->
