### PR TITLE
fix(ui): use pidi processor for sketch

### DIFF
--- a/invokeai/frontend/web/src/features/controlAdapters/store/constants.ts
+++ b/invokeai/frontend/web/src/features/controlAdapters/store/constants.ts
@@ -246,7 +246,7 @@ export const CONTROLNET_MODEL_DEFAULT_PROCESSORS: {
   mlsd: 'mlsd_image_processor',
   depth: 'midas_depth_image_processor',
   bae: 'normalbae_image_processor',
-  sketch: 'lineart_image_processor',
+  sketch: 'pidi_image_processor',
   scribble: 'lineart_image_processor',
   lineart: 'lineart_image_processor',
   lineart_anime: 'lineart_anime_image_processor',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

fix(ui): use pidi processor for sketch control adapters
