### PR TITLE
fix(ui): fix multiple control adapters on canvas

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addControlNetToLinearGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addControlNetToLinearGraph.ts
@@ -43,6 +43,16 @@ export const addControlNetToLinearGraph = (
       },
     });
 
+    if (CANVAS_COHERENCE_DENOISE_LATENTS in graph.nodes) {
+      graph.edges.push({
+        source: { node_id: CONTROL_NET_COLLECT, field: 'collection' },
+        destination: {
+          node_id: CANVAS_COHERENCE_DENOISE_LATENTS,
+          field: 'control',
+        },
+      });
+    }
+
     validControlNets.forEach((controlNet) => {
       if (!controlNet.model) {
         return;
@@ -106,16 +116,6 @@ export const addControlNetToLinearGraph = (
           field: 'item',
         },
       });
-
-      if (CANVAS_COHERENCE_DENOISE_LATENTS in graph.nodes) {
-        graph.edges.push({
-          source: { node_id: controlNetNode.id, field: 'control' },
-          destination: {
-            node_id: CANVAS_COHERENCE_DENOISE_LATENTS,
-            field: 'control',
-          },
-        });
-      }
     });
   }
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addIPAdapterToLinearGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addIPAdapterToLinearGraph.ts
@@ -32,14 +32,24 @@ export const addIPAdapterToLinearGraph = (
       type: 'collect',
       is_intermediate: true,
     };
-    graph.nodes[ipAdapterCollectNode.id] = ipAdapterCollectNode;
+    graph.nodes[IP_ADAPTER_COLLECT] = ipAdapterCollectNode;
     graph.edges.push({
-      source: { node_id: ipAdapterCollectNode.id, field: 'collection' },
+      source: { node_id: IP_ADAPTER_COLLECT, field: 'collection' },
       destination: {
         node_id: baseNodeId,
         field: 'ip_adapter',
       },
     });
+
+    if (CANVAS_COHERENCE_DENOISE_LATENTS in graph.nodes) {
+      graph.edges.push({
+        source: { node_id: IP_ADAPTER_COLLECT, field: 'collection' },
+        destination: {
+          node_id: CANVAS_COHERENCE_DENOISE_LATENTS,
+          field: 'ip_adapter',
+        },
+      });
+    }
 
     validIPAdapters.forEach((ipAdapter) => {
       if (!ipAdapter.model) {
@@ -87,16 +97,6 @@ export const addIPAdapterToLinearGraph = (
           field: 'item',
         },
       });
-
-      if (CANVAS_COHERENCE_DENOISE_LATENTS in graph.nodes) {
-        graph.edges.push({
-          source: { node_id: ipAdapterNode.id, field: 'ip_adapter' },
-          destination: {
-            node_id: CANVAS_COHERENCE_DENOISE_LATENTS,
-            field: 'ip_adapter',
-          },
-        });
-      }
     });
   }
 };

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addT2IAdapterToLinearGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/addT2IAdapterToLinearGraph.ts
@@ -42,6 +42,16 @@ export const addT2IAdaptersToLinearGraph = (
       },
     });
 
+    if (CANVAS_COHERENCE_DENOISE_LATENTS in graph.nodes) {
+      graph.edges.push({
+        source: { node_id: T2I_ADAPTER_COLLECT, field: 'collection' },
+        destination: {
+          node_id: CANVAS_COHERENCE_DENOISE_LATENTS,
+          field: 't2i_adapter',
+        },
+      });
+    }
+
     validT2IAdapters.forEach((t2iAdapter) => {
       if (!t2iAdapter.model) {
         return;
@@ -103,16 +113,6 @@ export const addT2IAdaptersToLinearGraph = (
           field: 'item',
         },
       });
-
-      if (CANVAS_COHERENCE_DENOISE_LATENTS in graph.nodes) {
-        graph.edges.push({
-          source: { node_id: t2iAdapterNode.id, field: 't2i_adapter' },
-          destination: {
-            node_id: CANVAS_COHERENCE_DENOISE_LATENTS,
-            field: 't2i_adapter',
-          },
-        });
-      }
     });
   }
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

[fix(ui): fix multiple control adapters on canvas](https://github.com/invoke-ai/InvokeAI/commit/2e160c8c101a34a8d0b052a9f965fd1853158ea9)

We were making an edges for each adapter where we should isntead have one from the adapter's collect node into the denoising node

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #4939

## QA Instructions, Screenshots, Recordings

Try multiple t2i, controlnet or ip adapters on canvas outpainting.
