### PR TITLE
fix(ui): fix canvas color picker when value is zero

### DIFF
--- a/invokeai/frontend/web/src/features/canvas/hooks/useColorUnderCursor.ts
+++ b/invokeai/frontend/web/src/features/canvas/hooks/useColorUnderCursor.ts
@@ -37,7 +37,12 @@ const useColorPicker = () => {
           1
         ).data;
 
-      if (!(a && r && g && b)) {
+      if (
+        r === undefined ||
+        g === undefined ||
+        b === undefined ||
+        a === undefined
+      ) {
         return;
       }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

[fix(ui): fix canvas color picker when value is zero](https://github.com/invoke-ai/InvokeAI/commit/678333c9b871af67675f410fadbbed47de440f72)

good ol' zero is false-y

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #4955
