### PR TITLE
fix(nodes): explicitly include custom nodes files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ version = { attr = "invokeai.version.__version__" }
 "invokeai.configs" = ["*.example", "**/*.yaml", "*.txt"]
 "invokeai.frontend.web.dist" = ["**"]
 "invokeai.frontend.web.static" = ["**"]
+"invokeai.app.invocations" = ["**"]
 
 #=== Begin: PyTest and Coverage
 [tool.pytest.ini_options]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

fix(nodes): explicitly include custom nodes files

setuptools ignores markdown files - explicitly include all files in `"invokeai.app.invocations"` to ensure all custom node files are included
