### PR TITLE
Add negative IP Adapter support

### DIFF
--- a/invokeai/app/invocations/ip_adapter.py
+++ b/invokeai/app/invocations/ip_adapter.py
@@ -67,7 +67,7 @@ class IPAdapterInvocation(BaseInvocation):
 
     # weight: float = InputField(default=1.0, description="The weight of the IP-Adapter.", ui_type=UIType.Float)
     weight: Union[float, List[float]] = InputField(
-        default=1, ge=0, description="The weight given to the IP-Adapter", ui_type=UIType.Float, title="Weight"
+        default=1, ge=-1, description="The weight given to the IP-Adapter", ui_type=UIType.Float, title="Weight"
     )
 
     begin_step_percent: float = InputField(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ x ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ x ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ x ] No


## Description

This enables support for negative IP adapters but allowing for a value of -1 or more. This limit may not be needed at all, but for the time being (unless proven otherwise) I think -1 will likely solve for most use-cases (if any).