### PR TITLE
Make the merge script work again

### DIFF
--- a/invokeai/frontend/merge/merge_diffusers.py
+++ b/invokeai/frontend/merge/merge_diffusers.py
@@ -131,6 +131,7 @@ class mergeModelsForm(npyscreen.FormMultiPageAction):
             values=[
                 "Models Built on SD-1.x",
                 "Models Built on SD-2.x",
+                "Models Built on SDXL",
             ],
             value=[self.current_base],
             columns=4,
@@ -309,7 +310,7 @@ class mergeModelsForm(npyscreen.FormMultiPageAction):
         else:
             return True
 
-    def get_model_names(self, base_model: Optional[BaseModelType] = None) -> List[str]:
+    def get_model_names(self, base_model: BaseModelType = BaseModelType.StableDiffusion1) -> List[str]:
         model_names = [
             info["model_name"]
             for info in self.model_manager.list_models(model_type=ModelType.Main, base_model=base_model)
@@ -318,7 +319,8 @@ class mergeModelsForm(npyscreen.FormMultiPageAction):
         return sorted(model_names)
 
     def _populate_models(self, value=None):
-        base_model = tuple(BaseModelType)[value[0]]
+        bases = ["sd-1", "sd-2", "sdxl"]
+        base_model = BaseModelType(bases[value[0]])
         self.model_names = self.get_model_names(base_model)
 
         models_plus_none = self.model_names.copy()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because n/a

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

The introduction of `BaseModelType.Any` broke the code in the merge script which relied on sd-1 coming first in the BaseModelType enum. This assumption has been removed and the code should be less brittle now.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
