### PR TITLE
fix(ui): show collapse labels only if not default value

### DIFF
--- a/invokeai/frontend/web/src/features/dynamicPrompts/components/ParamDynamicPromptsCollapse.tsx
+++ b/invokeai/frontend/web/src/features/dynamicPrompts/components/ParamDynamicPromptsCollapse.tsx
@@ -16,15 +16,13 @@ const ParamDynamicPromptsCollapse = () => {
     () =>
       createSelector(stateSelector, ({ dynamicPrompts }) => {
         const count = dynamicPrompts.prompts.length;
-        if (count === 1) {
-          return t('dynamicPrompts.promptsWithCount_one', {
-            count,
-          });
-        } else {
+        if (count > 1) {
           return t('dynamicPrompts.promptsWithCount_other', {
             count,
           });
         }
+
+        return;
       }),
     [t]
   );

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/Advanced/ParamAdvancedCollapse.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/Advanced/ParamAdvancedCollapse.tsx
@@ -28,9 +28,7 @@ export default function ParamAdvancedCollapse() {
   const activeLabel = useMemo(() => {
     const activeLabel: string[] = [];
 
-    if (shouldUseCpuNoise) {
-      activeLabel.push(t('parameters.cpuNoise'));
-    } else {
+    if (!shouldUseCpuNoise) {
       activeLabel.push(t('parameters.gpuNoise'));
     }
 

--- a/invokeai/frontend/web/src/features/parameters/components/Parameters/HighResFix/ParamHrfCollapse.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Parameters/HighResFix/ParamHrfCollapse.tsx
@@ -4,12 +4,13 @@ import { RootState, stateSelector } from 'app/store/store';
 import { useAppSelector } from 'app/store/storeHooks';
 import { defaultSelectorOptions } from 'app/store/util/defaultMemoizeOptions';
 import IAICollapse from 'common/components/IAICollapse';
+import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import ParamHrfHeight from './ParamHrfHeight';
 import ParamHrfStrength from './ParamHrfStrength';
 import ParamHrfToggle from './ParamHrfToggle';
 import ParamHrfWidth from './ParamHrfWidth';
-import ParamHrfHeight from './ParamHrfHeight';
-import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
 
 const selector = createSelector(
   stateSelector,
@@ -22,15 +23,14 @@ const selector = createSelector(
 );
 
 export default function ParamHrfCollapse() {
+  const { t } = useTranslation();
   const isHRFFeatureEnabled = useFeatureStatus('hrf').isFeatureEnabled;
   const { hrfEnabled } = useAppSelector(selector);
   const activeLabel = useMemo(() => {
     if (hrfEnabled) {
-      return 'On';
-    } else {
-      return 'Off';
+      return t('common.on');
     }
-  }, [hrfEnabled]);
+  }, [t, hrfEnabled]);
 
   if (!isHRFFeatureEnabled) {
     return null;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

fix(ui): show collapse labels only if not default value

- Dynamic Prompts only displays if more than one prompt is parsed
- HRF only displays if enabled
- Noise device only shows if set to GPU

Closes #4974 