### PR TITLE
fix(ui): hide refiner collapse if refiner not installed

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -722,7 +722,9 @@
         "noMatchingModels": "No matching Models",
         "noModelsAvailable": "No models available",
         "selectLoRA": "Select a LoRA",
-        "selectModel": "Select a Model"
+        "selectModel": "Select a Model",
+        "noLoRAsInstalled": "No LoRAs installed",
+        "noRefinerModelsInstalled": "No SDXL Refiner models installed"
     },
     "nodes": {
         "addNode": "Add Node",

--- a/invokeai/frontend/web/src/features/lora/components/ParamLoraSelect.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/ParamLoraSelect.tsx
@@ -10,6 +10,7 @@ import { loraAdded } from 'features/lora/store/loraSlice';
 import { MODEL_TYPE_MAP } from 'features/parameters/types/constants';
 import { forEach } from 'lodash-es';
 import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useGetLoRAModelsQuery } from 'services/api/endpoints/models';
 
 const selector = createSelector(
@@ -24,7 +25,7 @@ const ParamLoRASelect = () => {
   const dispatch = useAppDispatch();
   const { loras } = useAppSelector(selector);
   const { data: loraModels } = useGetLoRAModelsQuery();
-
+  const { t } = useTranslation();
   const currentMainModel = useAppSelector(
     (state: RootState) => state.generation.model
   );
@@ -79,7 +80,7 @@ const ParamLoRASelect = () => {
     return (
       <Flex sx={{ justifyContent: 'center', p: 2 }}>
         <Text sx={{ fontSize: 'sm', color: 'base.500', _dark: 'base.700' }}>
-          No LoRAs Loaded
+          {t('models.noLoRAsInstalled')}
         </Text>
       </Flex>
     );

--- a/invokeai/frontend/web/src/features/sdxl/components/ParamSDXLRefinerCollapse.tsx
+++ b/invokeai/frontend/web/src/features/sdxl/components/ParamSDXLRefinerCollapse.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { stateSelector } from 'app/store/store';
 import { useAppSelector } from 'app/store/storeHooks';
@@ -35,7 +35,15 @@ const ParamSDXLRefinerCollapse = () => {
   const isRefinerAvailable = useIsRefinerAvailable();
 
   if (!isRefinerAvailable) {
-    return null;
+    return (
+      <IAICollapse label={t('sdxl.refiner')} activeLabel={activeLabel}>
+        <Flex sx={{ justifyContent: 'center', p: 2 }}>
+          <Text sx={{ fontSize: 'sm', color: 'base.500', _dark: 'base.700' }}>
+            {t('models.noRefinerModelsInstalled')}
+          </Text>
+        </Flex>
+      </IAICollapse>
+    );
   }
 
   return (

--- a/invokeai/frontend/web/src/features/sdxl/components/ParamSDXLRefinerCollapse.tsx
+++ b/invokeai/frontend/web/src/features/sdxl/components/ParamSDXLRefinerCollapse.tsx
@@ -14,6 +14,7 @@ import ParamSDXLRefinerStart from './SDXLRefiner/ParamSDXLRefinerStart';
 import ParamSDXLRefinerSteps from './SDXLRefiner/ParamSDXLRefinerSteps';
 import ParamUseSDXLRefiner from './SDXLRefiner/ParamUseSDXLRefiner';
 import { useTranslation } from 'react-i18next';
+import { useIsRefinerAvailable } from 'services/api/hooks/useIsRefinerAvailable';
 
 const selector = createSelector(
   stateSelector,
@@ -31,6 +32,11 @@ const selector = createSelector(
 const ParamSDXLRefinerCollapse = () => {
   const { activeLabel, shouldUseSliders } = useAppSelector(selector);
   const { t } = useTranslation();
+  const isRefinerAvailable = useIsRefinerAvailable();
+
+  if (!isRefinerAvailable) {
+    return null;
+  }
 
   return (
     <IAICollapse label={t('sdxl.refiner')} activeLabel={activeLabel}>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

fix(ui): hide refiner collapse if refiner not installed
