### PR TITLE
Add resize modes to image resize node

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -346,7 +346,16 @@ PIL_RESAMPLING_MAP = {
 }
 
 
-@invocation("img_resize", title="Resize Image", tags=["image", "resize"], category="image", version="1.0.0")
+RESIZE_MODES = Literal[
+    "fill",
+    "stretch",
+    "fit",
+    "center",
+    "crop",
+]
+
+
+@invocation("img_resize", title="Resize Image", tags=["image", "resize"], category="image", version="1.1.0")
 class ImageResizeInvocation(BaseInvocation, WithMetadata, WithWorkflow):
     """Resizes an image to specific dimensions"""
 
@@ -354,16 +363,23 @@ class ImageResizeInvocation(BaseInvocation, WithMetadata, WithWorkflow):
     width: int = InputField(default=512, gt=0, description="The width to resize to (px)")
     height: int = InputField(default=512, gt=0, description="The height to resize to (px)")
     resample_mode: PIL_RESAMPLING_MODES = InputField(default="bicubic", description="The resampling mode")
+    resize_mode: RESIZE_MODES = InputField(default="fit", description="The resize mode")
 
     def invoke(self, context: InvocationContext) -> ImageOutput:
+        RESIZE_MODES_MAP = {
+            "fill": self.fill,
+            "stretch": self.stretch,
+            "fit": self.fit,
+            "center": self.center,
+            "crop": self.crop,
+        }
+
         image = context.services.images.get_pil_image(self.image.image_name)
 
         resample_mode = PIL_RESAMPLING_MAP[self.resample_mode]
 
-        resize_image = image.resize(
-            (self.width, self.height),
-            resample=resample_mode,
-        )
+        resize_image_mode_def = RESIZE_MODES_MAP[self.resize_mode]
+        resize_image = resize_image_mode_def(resample_mode, image)
 
         image_dto = context.services.images.create(
             image=resize_image,
@@ -381,7 +397,83 @@ class ImageResizeInvocation(BaseInvocation, WithMetadata, WithWorkflow):
             width=image_dto.width,
             height=image_dto.height,
         )
+    
+    
+    def fill(self, resample_mode, image):
+        original_width, original_height = image.size
+        
+        width_ratio = self.width / original_width
+        height_ratio = self.height / original_height
+        
+        resize_ratio = max(width_ratio, height_ratio)
+        
+        new_width = int(original_width * resize_ratio)
+        new_height = int(original_height * resize_ratio)
+        resized_image = image.resize((new_width, new_height), resample_mode)
+        
+        final_image = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+        final_image.paste(resized_image, ((self.width - new_width) // 2, (self.height - new_height) // 2))
+        
+        return final_image
+    
 
+    def stretch(self, resample_mode, image):
+        final_image = image.resize((self.width, self.height), resample_mode)
+        
+        return final_image
+    
+
+    def fit(self, resample_mode, image):
+        original_width, original_height = image.size
+
+        resize_ratio = original_width / original_height
+        width = self.width
+        height = self.height
+
+        if (width / height) < resize_ratio:
+            height = int(width / resize_ratio)
+        else:
+            width = int(height * resize_ratio)
+
+        final_image = image.resize((width, height), resample_mode)
+        
+        return final_image
+
+
+    def center(self, resample_mode, image):
+        original_width, original_height = image.size
+
+        width_ratio = self.width / original_width
+        height_ratio = self.height / original_height
+        scale_ratio = min(width_ratio, height_ratio)
+
+        new_width = int(scale_ratio * original_width)
+        new_height = int(scale_ratio * original_height)
+
+        resized_image = image.resize((new_width, new_height), resample_mode)
+
+        final_image = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+
+        x = (self.width - new_width) // 2
+        y = (self.height - new_height) // 2
+
+        final_image.paste(resized_image, (x, y))
+
+        return final_image
+    
+
+    def crop(self, resample_mode, image):
+        original_width, original_height = image.size
+        
+        final_image = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+
+        x = (self.width - original_width) // 2
+        y = (self.height - original_height) // 2
+
+        final_image.paste(image, (x, y))
+
+        return final_image
+    
 
 @invocation("img_scale", title="Scale Image", tags=["image", "scale"], category="image", version="1.0.0")
 class ImageScaleInvocation(BaseInvocation, WithMetadata, WithWorkflow):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x ] Yes #5014
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x ] No: I'm not sure if there is documentation for this to update it.


## Description
Add resize mode property to image resize node:

1. Fill: In this mode, the image is adjusted to completely fill the available space while maintaining its aspect ratio. This means the image may be cropped to fit the desired dimensions. The entire available space is covered, but some parts of the image may be cut off.

2. Stretch: In this mode, the image is forcibly stretched or squished to fit the specified dimensions, disregarding its original aspect ratio. This can lead to distortion of image as the aspect ratio is not maintained.

3. Fit: This mode ensures that the entire image fits within the specified dimensions, while maintaining its aspect ratio. The image is resized proportionally to fit entirely within the specified dimensions.

4. Center: In this mode, the image is centered within the specified dimensions without any scaling or cropping. If the original image is smaller than the specified dimensions, it will be displayed as is, with empty space around it.

5. Crop: This mode the image is not scaled to fit the specified dimensions. Instead, the original image is inserted into the available space while maintaining its original size. If the specified dimensions are smaller than the original image, part of the image will be cropped.

## Related Tickets & Documents
- Related Issue #5014
- Closes #5014

## QA Instructions, Screenshots, Recordings
When selecting the resizing mode the image should look as indicated in the description

## Added/updated tests?

- [ ] Yes
- [ x] No : I do not know how to do this
