### PR TITLE
Improve text encoder model loading speed by skipping parameter init

### DIFF
--- a/invokeai/backend/model_management/model_load_optimizations.py
+++ b/invokeai/backend/model_management/model_load_optimizations.py
@@ -17,7 +17,7 @@ def skip_torch_weight_init():
     completely unnecessary if the intent is to load checkpoint weights from disk for the layer. This context manager
     monkey-patches common torch layers to skip the weight initialization step.
     """
-    torch_modules = [torch.nn.Linear, torch.nn.modules.conv._ConvNd]
+    torch_modules = [torch.nn.Linear, torch.nn.modules.conv._ConvNd, torch.nn.Embedding]
     saved_functions = [m.reset_parameters for m in torch_modules]
 
     try:

--- a/tests/backend/model_management/test_model_load_optimization.py
+++ b/tests/backend/model_management/test_model_load_optimization.py
@@ -11,6 +11,7 @@ from invokeai.backend.model_management.model_load_optimizations import _no_op, s
         (torch.nn.Conv1d, {"in_channels": 10, "out_channels": 20, "kernel_size": 3}),
         (torch.nn.Conv2d, {"in_channels": 10, "out_channels": 20, "kernel_size": 3}),
         (torch.nn.Conv3d, {"in_channels": 10, "out_channels": 20, "kernel_size": 3}),
+        (torch.nn.Embedding, {"num_embeddings": 10, "embedding_dim": 10}),
     ],
 )
 def test_skip_torch_weight_init_linear(torch_module, layer_args):
@@ -36,12 +37,14 @@ def test_skip_torch_weight_init_linear(torch_module, layer_args):
     # Check that reset_parameters is skipped while `skip_torch_weight_init()` is active.
     assert reset_params_fn_during == _no_op
     assert not torch.allclose(layer_before.weight, layer_during.weight)
-    assert not torch.allclose(layer_before.bias, layer_during.bias)
+    if hasattr(layer_before, "bias"):
+        assert not torch.allclose(layer_before.bias, layer_during.bias)
 
     # Check that the original behavior is restored after `skip_torch_weight_init()` ends.
     assert reset_params_fn_before is reset_params_fn_after
     assert torch.allclose(layer_before.weight, layer_after.weight)
-    assert torch.allclose(layer_before.bias, layer_after.bias)
+    if hasattr(layer_before, "bias"):
+        assert torch.allclose(layer_before.bias, layer_after.bias)
 
 
 def test_skip_torch_weight_init_restores_base_class_behavior():


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission
      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No

## Description

This PR monkey patches `torch.nn.Embedding.reset_parameters(...)` to skip this operations when we are loading a text encoder (and are going to overwrite all of the weights anyways).

In my local testing, I saw the following speed improvements:
```txt
SD1 text_encoder:    before=2.0s, after=0.3s, change=-1.7s
SDXL text_encoder_1: before=2.1s, after=0.4s, change=-1.7s
SDXL text_encoder_2: before=3.8s, after=1.1s, change=-2.7s
```

## QA Instructions, Screenshots, Recordings

Did some profiling to measure the speed improvement (see Description).

I also manually confirmed that there was no diff in the generated images.

## Added/updated tests?

- [x] Yes
- [ ] No

