### PR TITLE
Add `log_memory_usage` flag to `ModelCache`

### DIFF
--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -262,8 +262,7 @@ class InvokeAIAppConfig(InvokeAISettings):
     ram                 : float = Field(default=7.5, gt=0, description="Maximum memory amount used by model cache for rapid switching (floating point number, GB)", json_schema_extra=Categories.ModelCache, )
     vram                : float = Field(default=0.25, ge=0, description="Amount of VRAM reserved for model storage (floating point number, GB)", json_schema_extra=Categories.ModelCache, )
     lazy_offload        : bool = Field(default=True, description="Keep models in VRAM until their space is needed", json_schema_extra=Categories.ModelCache, )
-    log_memory_usage    : bool = Field(default=False, description="If True, a memory snapshot will be captured before and after every model cache operation, and the result will be logged (at debug level). There is a time cost to capturing the memory snapshots, so it is recommended to only enable this feature unless you are actively inspecting the model cache's behaviour.", json_schema_extra=Categories.ModelCache)
-
+    log_memory_usage    : bool = Field(default=False, description="If True, a memory snapshot will be captured before and after every model cache operation, and the result will be logged (at debug level). There is a time cost to capturing the memory snapshots, so it is recommended to only enable this feature if you are actively inspecting the model cache's behaviour.", json_schema_extra=Categories.ModelCache)
 
     # DEVICE
     device              : Literal["auto", "cpu", "cuda", "cuda:1", "mps"] = Field(default="auto", description="Generation device", json_schema_extra=Categories.Device)

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -45,6 +45,7 @@ InvokeAI:
     ram: 13.5
     vram: 0.25
     lazy_offload: true
+    log_memory_usage: false
   Device:
     device: auto
     precision: auto
@@ -261,6 +262,8 @@ class InvokeAIAppConfig(InvokeAISettings):
     ram                 : float = Field(default=7.5, gt=0, description="Maximum memory amount used by model cache for rapid switching (floating point number, GB)", json_schema_extra=Categories.ModelCache, )
     vram                : float = Field(default=0.25, ge=0, description="Amount of VRAM reserved for model storage (floating point number, GB)", json_schema_extra=Categories.ModelCache, )
     lazy_offload        : bool = Field(default=True, description="Keep models in VRAM until their space is needed", json_schema_extra=Categories.ModelCache, )
+    log_memory_usage    : bool = Field(default=False, description="If True, a memory snapshot will be captured before and after every model cache operation, and the result will be logged (at debug level). There is a time cost to capturing the memory snapshots, so it is recommended to only enable this feature unless you are actively inspecting the model cache's behaviour.", json_schema_extra=Categories.ModelCache)
+
 
     # DEVICE
     device              : Literal["auto", "cpu", "cuda", "cuda:1", "mps"] = Field(default="auto", description="Generation device", json_schema_extra=Categories.Device)

--- a/invokeai/backend/model_management/memory_snapshot.py
+++ b/invokeai/backend/model_management/memory_snapshot.py
@@ -64,7 +64,7 @@ class MemorySnapshot:
         return cls(process_ram, vram, malloc_info)
 
 
-def get_pretty_snapshot_diff(snapshot_1: MemorySnapshot, snapshot_2: MemorySnapshot) -> str:
+def get_pretty_snapshot_diff(snapshot_1: Optional[MemorySnapshot], snapshot_2: Optional[MemorySnapshot]) -> str:
     """Get a pretty string describing the difference between two `MemorySnapshot`s."""
 
     def get_msg_line(prefix: str, val1: int, val2: int):
@@ -72,6 +72,9 @@ def get_pretty_snapshot_diff(snapshot_1: MemorySnapshot, snapshot_2: MemorySnaps
         return f"{prefix: <30} ({(diff/GB):+5.3f}): {(val1/GB):5.3f}GB -> {(val2/GB):5.3f}GB\n"
 
     msg = ""
+
+    if snapshot_1 is None or snapshot_2 is None:
+        return msg
 
     msg += get_msg_line("Process RAM", snapshot_1.process_ram, snapshot_2.process_ram)
 

--- a/invokeai/backend/model_management/model_manager.py
+++ b/invokeai/backend/model_management/model_manager.py
@@ -934,7 +934,8 @@ class ModelManager(object):
         """
         Returns the preamble for the config file.
         """
-        return textwrap.dedent("""
+        return textwrap.dedent(
+            """
             # This file describes the alternative machine learning models
             # available to InvokeAI script.
             #
@@ -942,7 +943,8 @@ class ModelManager(object):
             # model requires a model config file, a weights file,
             # and the width and height of the images it
             # was trained on.
-        """)
+        """
+        )
 
     def scan_models_directory(
         self,

--- a/invokeai/backend/model_management/model_manager.py
+++ b/invokeai/backend/model_management/model_manager.py
@@ -351,6 +351,7 @@ class ModelManager(object):
             precision=precision,
             sequential_offload=sequential_offload,
             logger=logger,
+            log_memory_usage=self.app_config.log_memory_usage,
         )
 
         self._read_models(config)
@@ -933,8 +934,7 @@ class ModelManager(object):
         """
         Returns the preamble for the config file.
         """
-        return textwrap.dedent(
-            """
+        return textwrap.dedent("""
             # This file describes the alternative machine learning models
             # available to InvokeAI script.
             #
@@ -942,8 +942,7 @@ class ModelManager(object):
             # model requires a model config file, a weights file,
             # and the width and height of the images it
             # was trained on.
-        """
-        )
+        """)
 
     def scan_models_directory(
         self,

--- a/tests/backend/model_management/test_memory_snapshot.py
+++ b/tests/backend/model_management/test_memory_snapshot.py
@@ -17,6 +17,7 @@ snapshots = [
     MemorySnapshot(process_ram=1.0, vram=2.0, malloc_info=None),
     MemorySnapshot(process_ram=1.0, vram=None, malloc_info=Struct_mallinfo2()),
     MemorySnapshot(process_ram=1.0, vram=None, malloc_info=None),
+    None,
 ]
 
 
@@ -26,10 +27,12 @@ def test_get_pretty_snapshot_diff(snapshot_1, snapshot_2):
     """Test that get_pretty_snapshot_diff() works with various combinations of missing MemorySnapshot fields."""
     msg = get_pretty_snapshot_diff(snapshot_1, snapshot_2)
 
-    expected_lines = 1
-    if snapshot_1.vram is not None and snapshot_2.vram is not None:
+    expected_lines = 0
+    if snapshot_1 is not None and snapshot_2 is not None:
         expected_lines += 1
-    if snapshot_1.malloc_info is not None and snapshot_2.malloc_info is not None:
-        expected_lines += 5
+        if snapshot_1.vram is not None and snapshot_2.vram is not None:
+            expected_lines += 1
+        if snapshot_1.malloc_info is not None and snapshot_2.malloc_info is not None:
+            expected_lines += 5
 
     assert len(msg.splitlines()) == expected_lines

--- a/tests/backend/model_management/test_memory_snapshot.py
+++ b/tests/backend/model_management/test_memory_snapshot.py
@@ -13,10 +13,10 @@ def test_memory_snapshot_capture():
 
 
 snapshots = [
-    MemorySnapshot(process_ram=1.0, vram=2.0, malloc_info=Struct_mallinfo2()),
-    MemorySnapshot(process_ram=1.0, vram=2.0, malloc_info=None),
-    MemorySnapshot(process_ram=1.0, vram=None, malloc_info=Struct_mallinfo2()),
-    MemorySnapshot(process_ram=1.0, vram=None, malloc_info=None),
+    MemorySnapshot(process_ram=1, vram=2, malloc_info=Struct_mallinfo2()),
+    MemorySnapshot(process_ram=1, vram=2, malloc_info=None),
+    MemorySnapshot(process_ram=1, vram=None, malloc_info=Struct_mallinfo2()),
+    MemorySnapshot(process_ram=1, vram=None, malloc_info=None),
     None,
 ]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission
      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

Memory usage logging is helpful for diagnosing model cache / memory issues, but comes at a speed cost. This PR adds a `log_memory_usage` flag to the app config that controls this feature (off by default).

### Results from local speed testing:
First-run text-to-image speed with (`log_memory_usage=True`):
- SD-1: 14.2s
- SDXL: 32.7s

First-run text-to-image speed with (`log_memory_usage=False`):
- SD-1: 10.2s
- SDXL: 25.7s

## QA Instructions, Screenshots, Recordings

Tested locally with `log_memory_usage` enabled/disabled.

## Added/updated tests?

- [x] Yes
- [ ] No
