### PR TITLE
Remove the LoWRA LORA from recommended starter models

### DIFF
--- a/invokeai/configs/INITIAL_MODELS.yaml
+++ b/invokeai/configs/INITIAL_MODELS.yaml
@@ -117,9 +117,6 @@ sd-1/embedding/EasyNegative:
    recommended: True
 sd-1/embedding/ahx-beta-453407d:
    repo_id: sd-concepts-library/ahx-beta-453407d
-sd-1/lora/LowRA:
-   path: https://civitai.com/api/download/models/63006
-   recommended: True
 sd-1/lora/Ink scenery:
    path: https://civitai.com/api/download/models/83390
 sd-1/ip_adapter/ip_adapter_sd15:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

This PR removes the low lighting LORA, LowRA, from the list of recommended models in INITIAL_MODELS.yaml. This LoWRA has been deleted from Civitai and is no longer accessible.