### PR TITLE
Speed optimization: reduce frequency of `gc.collect(...)` calls in model cache

### DIFF
--- a/invokeai/backend/model_management/model_cache.py
+++ b/invokeai/backend/model_management/model_cache.py
@@ -474,11 +474,11 @@ class ModelCache(object):
                 f" refs: {refs}"
             )
 
-            # 2 refs:
+            # Expected refs:
             # 1 from cache_entry
             # 1 from getrefcount function
             # 1 from onnx runtime object
-            if not cache_entry.locked and refs <= 3 if "onnx" in model_key else 2:
+            if not cache_entry.locked and refs <= (3 if "onnx" in model_key else 2):
                 self.logger.debug(
                     f"Unloading model {model_key} to free {(model_size/GIG):.2f} GB (-{(cache_entry.size/GIG):.2f} GB)"
                 )

--- a/invokeai/backend/model_management/model_cache.py
+++ b/invokeai/backend/model_management/model_cache.py
@@ -444,6 +444,10 @@ class ModelCache(object):
 
             refs = sys.getrefcount(cache_entry.model)
 
+            # HACK: This is a workaround for a memory-management issue that we haven't tracked down yet. We are directly
+            # going against the advice in the Python docs by using `gc.get_referrers(...)` in this way:
+            # https://docs.python.org/3/library/gc.html#gc.get_referrers
+
             # manualy clear local variable references of just finished function calls
             # for some reason python don't want to collect it even by gc.collect() immidiately
             if refs > 2:

--- a/invokeai/backend/model_management/model_cache.py
+++ b/invokeai/backend/model_management/model_cache.py
@@ -507,7 +507,6 @@ class ModelCache(object):
                 vram_in_use = torch.cuda.memory_allocated()
                 self.logger.debug(f"{(vram_in_use/GIG):.2f}GB VRAM used for models; max allowed={(reserved/GIG):.2f}GB")
 
-        gc.collect()
         torch.cuda.empty_cache()
         if choose_torch_device() == torch.device("mps"):
             mps.empty_cache()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission
      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No

## Description

This PR improves model loading speed by reducing the number of extraneous calls to `gc.collect(...)` in model_cache.py.

For context, here is some important background about garbage collection in python:
- In python, most objects are deleted by the interpreter as soon as their reference count hits 0. Contrary to what some people assume, the `gc` module is _only_ responsible for handling reference cycles (i.e. unreachable objects with reference cycles that prevent their reference count from reaching 0).
- Calling `gc.collect()` is expensive _even if there is no garbage to collect_. The time taken increases with the number of objects. In my rough local tests, every call in Invoke takes ~ 0.2-0.4 secs.

Prior to this change, we were making many costly calls to gc.collect, most of which weren't collecting any garbage.

In my local tests, I saw the following speedup:
```
SD1 t2i first-run:   6.6  -> 4.4  (-2.2 s)
SD1 t2i second-run:  2.9  -> 1.8  (-1.1 s)
SDXL t2i first-run:  17.0 -> 15.5 (-1.5 s)
SDXL t2i second-run: 10.5 -> 8.9  (-1.6 s)
```

## QA Instructions

My main concern with this change is that peak memory utilization could be _slightly_ higher. On most machines this is well worth the benefit, but under strict memory constraints it could increase the risk of OOM errors.

It is very difficult to estimate how much higher peak memory usage will be. From the experimentation that I've done I'd guess that it would be in the range of ~100-500 MB.

## Added/updated tests?

- [ ] Yes
- [x] No _Test coverage of the ModelCache is currently non-existent._
