### PR TITLE
Fix updater option list numbering

### DIFF
--- a/invokeai/frontend/install/invokeai_update.py
+++ b/invokeai/frontend/install/invokeai_update.py
@@ -63,8 +63,8 @@ def welcome(latest_release: str, latest_prerelease: str):
         yield "[bold yellow]Options:"
         yield f"""[1] Update to the latest [bold]official release[/bold] ([italic]{latest_release}[/italic])
 [2] Update to the latest [bold]pre-release[/bold] (may be buggy; caveat emptor!) ([italic]{latest_prerelease}[/italic])
-[2] Manually enter the [bold]tag name[/bold] for the version you wish to update to
-[3] Manually enter the [bold]branch name[/bold] for the version you wish to update to"""
+[3] Manually enter the [bold]tag name[/bold] for the version you wish to update to
+[4] Manually enter the [bold]branch name[/bold] for the version you wish to update to"""
 
     console.rule()
     print(


### PR DESCRIPTION
Fix updater option list numbering in invokeai_update.py so that they don't go 1, 2, 2, 3.  The options themselves work fine.

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Have you discussed this change with the InvokeAI team?
- [x] No, because:  No point

## Have you updated all relevant documentation?
- [x] n/a