### PR TITLE
Feat (ui): Add VAE Model to Recall Parameters

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -583,6 +583,7 @@
         "strength": "Image to image strength",
         "Threshold": "Noise Threshold",
         "variations": "Seed-weight pairs",
+        "vae": "VAE", 
         "width": "Width",
         "workflow": "Workflow"
     },

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
@@ -31,6 +31,7 @@ const ImageMetadataActions = (props: Props) => {
     recallCfgScale,
     recallModel,
     recallScheduler,
+    recallVaeModel,
     recallSteps,
     recallWidth,
     recallHeight,
@@ -71,6 +72,10 @@ const ImageMetadataActions = (props: Props) => {
   const handleRecallScheduler = useCallback(() => {
     recallScheduler(metadata?.scheduler);
   }, [metadata?.scheduler, recallScheduler]);
+
+  const handleRecallVaeModel = useCallback(() => {
+    recallVaeModel(metadata?.vae);
+  }, [metadata?.vae, recallVaeModel]);
 
   const handleRecallSteps = useCallback(() => {
     recallSteps(metadata?.steps);
@@ -217,6 +222,13 @@ const ImageMetadataActions = (props: Props) => {
           label={t('metadata.scheduler')}
           value={metadata.scheduler}
           onClick={handleRecallScheduler}
+        />
+      )}
+      {metadata.vae && (
+        <ImageMetadataItem
+          label={t('metadata.vae')}
+          value={metadata.vae.model_name}
+          onClick={handleRecallVaeModel}
         />
       )}
       {metadata.steps && (

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
@@ -224,13 +224,11 @@ const ImageMetadataActions = (props: Props) => {
           onClick={handleRecallScheduler}
         />
       )}
-      {metadata.vae && (
-        <ImageMetadataItem
-          label={t('metadata.vae')}
-          value={metadata.vae.model_name}
-          onClick={handleRecallVaeModel}
-        />
-      )}
+      <ImageMetadataItem
+        label={t('metadata.vae')}
+        value={metadata.vae?.model_name ?? 'Default'}
+        onClick={handleRecallVaeModel}
+      />
       {metadata.steps && (
         <ImageMetadataItem
           label={t('metadata.steps')}

--- a/invokeai/frontend/web/src/features/parameters/hooks/useRecallParameters.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useRecallParameters.ts
@@ -36,6 +36,7 @@ import {
   setRefinerStart,
   setRefinerSteps,
 } from 'features/sdxl/store/sdxlSlice';
+import { isNil } from 'lodash-es';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ImageDTO } from 'services/api/types';
@@ -68,6 +69,7 @@ import {
   vaeSelected,
 } from '../store/generationSlice';
 import {
+  isValidBoolean,
   isValidCfgScale,
   isValidControlNetModel,
   isValidHeight,
@@ -87,11 +89,9 @@ import {
   isValidSeed,
   isValidSteps,
   isValidStrength,
-  isValidWidth,
   isValidVaeModel,
-  isValidBoolean,
+  isValidWidth,
 } from '../types/parameterSchemas';
-import _ from 'lodash';
 
 const selector = createSelector(
   stateSelector,
@@ -314,11 +314,11 @@ export const useRecallParameters = () => {
    */
   const recallVaeModel = useCallback(
     (vae: unknown) => {
-      if (!isValidVaeModel(vae) && !_.isNil(vae)) {
+      if (!isValidVaeModel(vae) && !isNil(vae)) {
         parameterNotSetToast();
         return;
       }
-      if (_.isNil(vae)) {
+      if (isNil(vae)) {
         dispatch(vaeSelected(null));
       } else {
         dispatch(vaeSelected(vae));
@@ -821,8 +821,8 @@ export const useRecallParameters = () => {
       if (isValidScheduler(scheduler)) {
         dispatch(setScheduler(scheduler));
       }
-      if (isValidVaeModel(vae) || _.isNil(vae)) {
-        if (_.isNil(vae)) {
+      if (isValidVaeModel(vae) || isNil(vae)) {
+        if (isNil(vae)) {
           dispatch(vaeSelected(null));
         } else {
           dispatch(vaeSelected(vae));

--- a/invokeai/frontend/web/src/features/parameters/hooks/useRecallParameters.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useRecallParameters.ts
@@ -91,6 +91,7 @@ import {
   isValidVaeModel,
   isValidBoolean,
 } from '../types/parameterSchemas';
+import _ from 'lodash';
 
 const selector = createSelector(
   stateSelector,
@@ -312,12 +313,16 @@ export const useRecallParameters = () => {
    * Recall vae model
    */
   const recallVaeModel = useCallback(
-    (vaeModel: unknown) => {
-      if (!isValidVaeModel(vaeModel)) {
+    (vae: unknown) => {
+      if (!isValidVaeModel(vae) && !_.isNil(vae)) {
         parameterNotSetToast();
         return;
       }
-      dispatch(vaeSelected(vaeModel));
+      if (_.isNil(vae)) {
+        dispatch(vaeSelected(null));
+      } else {
+        dispatch(vaeSelected(vae));
+      }
       parameterSetToast();
     },
     [dispatch, parameterSetToast, parameterNotSetToast]
@@ -816,8 +821,12 @@ export const useRecallParameters = () => {
       if (isValidScheduler(scheduler)) {
         dispatch(setScheduler(scheduler));
       }
-      if (isValidVaeModel(vae)) {
-        dispatch(vaeSelected(vae));
+      if (isValidVaeModel(vae) || _.isNil(vae)) {
+        if (_.isNil(vae)) {
+          dispatch(vaeSelected(null));
+        } else {
+          dispatch(vaeSelected(vae));
+        }
       }
 
       if (isValidSeed(seed)) {

--- a/invokeai/frontend/web/src/features/parameters/hooks/useRecallParameters.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useRecallParameters.ts
@@ -65,6 +65,7 @@ import {
   setSeed,
   setSteps,
   setWidth,
+  vaeSelected,
 } from '../store/generationSlice';
 import {
   isValidCfgScale,
@@ -87,6 +88,7 @@ import {
   isValidSteps,
   isValidStrength,
   isValidWidth,
+  isValidVaeModel,
   isValidBoolean,
 } from '../types/parameterSchemas';
 
@@ -301,6 +303,21 @@ export const useRecallParameters = () => {
         return;
       }
       dispatch(setScheduler(scheduler));
+      parameterSetToast();
+    },
+    [dispatch, parameterSetToast, parameterNotSetToast]
+  );
+
+  /**
+   * Recall vae model
+   */
+  const recallVaeModel = useCallback(
+    (vaeModel: unknown) => {
+      if (!isValidVaeModel(vaeModel)) {
+        parameterNotSetToast();
+        return;
+      }
+      dispatch(vaeSelected(vaeModel));
       parameterSetToast();
     },
     [dispatch, parameterSetToast, parameterNotSetToast]
@@ -757,6 +774,7 @@ export const useRecallParameters = () => {
         positive_prompt,
         negative_prompt,
         scheduler,
+        vae,
         seed,
         steps,
         width,
@@ -797,6 +815,9 @@ export const useRecallParameters = () => {
 
       if (isValidScheduler(scheduler)) {
         dispatch(setScheduler(scheduler));
+      }
+      if (isValidVaeModel(vae)) {
+        dispatch(vaeSelected(vae));
       }
 
       if (isValidSeed(seed)) {
@@ -932,6 +953,7 @@ export const useRecallParameters = () => {
     recallCfgScale,
     recallModel,
     recallScheduler,
+    recallVaeModel,
     recallSteps,
     recallWidth,
     recallHeight,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: it is 2 am est

#4796      

## Have you updated all relevant documentation?
- [ ] Yes
- [X] No

I don't believe there is any documentation explicitly referencing the recall parameters.

## Description

This code changes allows users to recall the VAE model as a Recall Parameter. The VAE model is now part of the "recall all parameters" setting. There is room to add the VAE Precision to the metadata and also making that a recall parameter..

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #4796 
- Closes #4796 

## QA Instructions, Screenshots, Recordings

1. Generate an image using a VAE other than default.
2. Select that generated image, change the VAE model, and select "Use All"
3. VAE model should change in the UI.
4. VAE model is available in "recall parameters" of the metadata section.


https://github.com/invoke-ai/InvokeAI/assets/22108632/04a52722-6faf-4ab4-b414-81806fe4aa54


<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [X] No : no frontend test suite

## [optional] Are there any post deployment tasks we need to perform?
