### PR TITLE
fix(backend): fix controlnet zip len

### DIFF
--- a/invokeai/backend/util/hotfixes.py
+++ b/invokeai/backend/util/hotfixes.py
@@ -748,7 +748,7 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlnetMixin):
 
             scales = scales * conditioning_scale
             down_block_res_samples = [
-                sample * scale for sample, scale in zip(down_block_res_samples, scales, strict=True)
+                sample * scale for sample, scale in zip(down_block_res_samples, scales, strict=False)
             ]
             mid_block_res_sample = mid_block_res_sample * scales[-1]  # last one
         else:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

[fix(backend): fix controlnet zip len](https://github.com/invoke-ai/InvokeAI/commit/080608c05e8ec2ad78935fb0ae9d580efa4409a4)

Do not use `strict=True` when scaling controlnet conditioning.

When using `guess_mode` (e.g. `more_control` or `more_prompt`), `down_block_res_samples` and `scales` are zipped.

These two objects are of different lengths, so using zip's strict mode raises an error.

In testing, `len(scales) === len(down_block_res_samples) + 1`.

It appears this behaviour is intentional, as the final "extra" item in `scales` is used immediately afterwards.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related https://discord.com/channels/1020123559063990373/1049495067846524939/1173464143123197993
- Introduced by #5070 

## QA Instructions, Screenshots, Recordings

Use controlnet with the control mode set to `more_control` or `more_prompt`. Should work.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->
