### PR TITLE
feat(ui): use IndexedDB for persistence

### DIFF
--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -76,6 +76,7 @@
     "framer-motion": "^10.16.4",
     "i18next": "^23.6.0",
     "i18next-http-backend": "^2.3.1",
+    "idb-keyval": "^6.2.1",
     "konva": "^9.2.3",
     "lodash-es": "^4.17.21",
     "nanostores": "^0.9.4",

--- a/invokeai/frontend/web/src/app/components/App.tsx
+++ b/invokeai/frontend/web/src/app/components/App.tsx
@@ -20,6 +20,7 @@ import AppErrorBoundaryFallback from './AppErrorBoundaryFallback';
 import GlobalHotkeys from './GlobalHotkeys';
 import PreselectedImage from './PreselectedImage';
 import Toaster from './Toaster';
+import { useClearStorage } from 'common/hooks/useClearStorage';
 
 const DEFAULT_CONFIG = {};
 
@@ -36,12 +37,13 @@ const App = ({ config = DEFAULT_CONFIG, selectedImage }: Props) => {
 
   const logger = useLogger('system');
   const dispatch = useAppDispatch();
+  const clearStorage = useClearStorage();
 
   const handleReset = useCallback(() => {
-    localStorage.clear();
+    clearStorage();
     location.reload();
     return false;
-  }, []);
+  }, [clearStorage]);
 
   useEffect(() => {
     i18n.changeLanguage(language);

--- a/invokeai/frontend/web/src/app/components/InvokeAIUI.tsx
+++ b/invokeai/frontend/web/src/app/components/InvokeAIUI.tsx
@@ -1,11 +1,17 @@
 import { Middleware } from '@reduxjs/toolkit';
+import { $customStarUI, CustomStarUi } from 'app/store/nanostores/customStarUI';
+import { $headerComponent } from 'app/store/nanostores/headerComponent';
 import { store } from 'app/store/store';
 import { PartialAppConfig } from 'app/types/invokeai';
+import {
+  $queueId,
+  DEFAULT_QUEUE_ID,
+} from 'features/queue/store/queueNanoStore';
 import React, {
-  lazy,
-  memo,
   PropsWithChildren,
   ReactNode,
+  lazy,
+  memo,
   useEffect,
 } from 'react';
 import { Provider } from 'react-redux';
@@ -13,14 +19,8 @@ import { addMiddleware, resetMiddlewares } from 'redux-dynamic-middlewares';
 import { $authToken, $baseUrl, $projectId } from 'services/api/client';
 import { socketMiddleware } from 'services/events/middleware';
 import Loading from '../../common/components/Loading/Loading';
-import '../../i18n';
 import AppDndContext from '../../features/dnd/components/AppDndContext';
-import { $customStarUI, CustomStarUi } from 'app/store/nanostores/customStarUI';
-import { $headerComponent } from 'app/store/nanostores/headerComponent';
-import {
-  $queueId,
-  DEFAULT_QUEUE_ID,
-} from 'features/queue/store/queueNanoStore';
+import '../../i18n';
 
 const App = lazy(() => import('./App'));
 const ThemeLocaleProvider = lazy(() => import('./ThemeLocaleProvider'));

--- a/invokeai/frontend/web/src/app/components/ThemeLocaleProvider.tsx
+++ b/invokeai/frontend/web/src/app/components/ThemeLocaleProvider.tsx
@@ -9,9 +9,9 @@ import { TOAST_OPTIONS, theme as invokeAITheme } from 'theme/theme';
 
 import '@fontsource-variable/inter';
 import { MantineProvider } from '@mantine/core';
+import { useMantineTheme } from 'mantine-theme/theme';
 import 'overlayscrollbars/overlayscrollbars.css';
 import 'theme/css/overlayscrollbars.css';
-import { useMantineTheme } from 'mantine-theme/theme';
 
 type ThemeLocaleProviderProps = {
   children: ReactNode;

--- a/invokeai/frontend/web/src/app/store/constants.ts
+++ b/invokeai/frontend/web/src/app/store/constants.ts
@@ -1,8 +1,1 @@
-export const LOCALSTORAGE_KEYS = [
-  'chakra-ui-color-mode',
-  'i18nextLng',
-  'ROARR_FILTER',
-  'ROARR_LOG',
-];
-
-export const LOCALSTORAGE_PREFIX = '@@invokeai-';
+export const STORAGE_PREFIX = '@@invokeai-';

--- a/invokeai/frontend/web/src/common/hooks/useClearStorage.ts
+++ b/invokeai/frontend/web/src/common/hooks/useClearStorage.ts
@@ -1,0 +1,12 @@
+import { idbKeyValStore } from 'app/store/store';
+import { clear } from 'idb-keyval';
+import { useCallback } from 'react';
+
+export const useClearStorage = () => {
+  const clearStorage = useCallback(() => {
+    clear(idbKeyValStore);
+    localStorage.clear();
+  }, []);
+
+  return clearStorage;
+};

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -14,11 +14,11 @@ import {
 } from '@chakra-ui/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { VALID_LOG_LEVELS } from 'app/logging/logger';
-import { LOCALSTORAGE_KEYS, LOCALSTORAGE_PREFIX } from 'app/store/constants';
 import { stateSelector } from 'app/store/store';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import IAIButton from 'common/components/IAIButton';
 import IAIMantineSelect from 'common/components/IAIMantineSelect';
+import { useClearStorage } from 'common/hooks/useClearStorage';
 import {
   consoleLogLevelChanged,
   setEnableImageDebugging,
@@ -164,20 +164,14 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
     shouldEnableInformationalPopovers,
   } = useAppSelector(selector);
 
+  const clearStorage = useClearStorage();
+
   const handleClickResetWebUI = useCallback(() => {
-    // Only remove our keys
-    Object.keys(window.localStorage).forEach((key) => {
-      if (
-        LOCALSTORAGE_KEYS.includes(key) ||
-        key.startsWith(LOCALSTORAGE_PREFIX)
-      ) {
-        localStorage.removeItem(key);
-      }
-    });
+    clearStorage();
     onSettingsModalClose();
     onRefreshModalOpen();
     setInterval(() => setCountdown((prev) => prev - 1), 1000);
-  }, [onSettingsModalClose, onRefreshModalOpen]);
+  }, [clearStorage, onSettingsModalClose, onRefreshModalOpen]);
 
   useEffect(() => {
     if (countdown <= 0) {

--- a/invokeai/frontend/web/yarn.lock
+++ b/invokeai/frontend/web/yarn.lock
@@ -4143,6 +4143,11 @@ i18next@^23.6.0:
   dependencies:
     "@babel/runtime" "^7.22.5"
 
+idb-keyval@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
+  integrity sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

[feat(ui): use IndexedDB for persistence](https://github.com/invoke-ai/InvokeAI/commit/49cf7928abcf861b8f3e9484b99eecf6496f1bd0)

IndexedDB has a much larger storage limit than LocalStorage, and is widely supported.

Implemented as a custom storage driver for `redux-remember` via `idb-keyval`. `idb-keyval` is a simple wrapper for IndexedDB that allows it to be used easily as a key-value store.

The logic to clear persisted storage has been updated throughout the app.

---

This change is a prerequisite for planned "workflow tab" enhancements where multiple workflows may be opened at once.

**This change does not migrate UI settings (like prompt, steps, etc) from the previous `localStorage` persistence implementation. It is thus roughly equivalent to clicking `Reset Web UI`. If this is a problem, I can work out some migration logic, but I'm not particularly excited by that prospect.**

## QA Instructions, Screenshots, Recordings

- Settings should still persist reloads per usual
- `Reset Web UI` should still reset the app per usual

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->
