### PR TITLE
Update Pytorch to ~2.1.0 in the installer script

### DIFF
--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -244,7 +244,7 @@ class InvokeAiInstance:
                 "numpy~=1.24.0",  # choose versions that won't be uninstalled during phase 2
                 "urllib3~=1.26.0",
                 "requests~=2.28.0",
-                "torch~=2.0.0",
+                "torch~=2.1.0",
                 "torchmetrics==0.11.4",
                 "torchvision>=0.14.1",
                 "--force-reinstall",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [X] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because it's required

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No, not necessary


## Description

We use Pytorch ~2.1.0 as a dependency for InvokeAI, but the installer still installs 2.0.1 first until Invoke AIs dependencies kick in which causes it to get deleted anyway and replaced with 2.1.0. This is unnecessary and probably not wanted.

Fixed the dependencies for the installation script to install Pytorch ~2.1.0 to begin with.

P.s. Is there any reason why "torchmetrics==0.11.4" is pinned? What is the reason for that? Does that change with Pytorch 2.1? It seems to work since we use it already. It would be nice to know the reason.

Greetings

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
