### PR TITLE
Change stylecheck name from "black" to "ruff"

### DIFF
--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -6,7 +6,7 @@ on:
     branches: main
 
 jobs:
-  black:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: it is trivial

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No


## Description

After the switch to the "ruff" linter, I noticed that the stylecheck workflow is still described as "black" in the action logs. This small PR should fix the issue.