### PR TITLE
fix(ui): metadata error on img2img

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearImageToImageGraph.ts
@@ -329,7 +329,7 @@ export const buildLinearImageToImageGraph = (
       strength,
       init_image: initialImage.imageName,
     },
-    IMAGE_TO_LATENTS
+    LATENTS_TO_IMAGE
   );
 
   // Add Seamless To Graph

--- a/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearSDXLImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graphBuilders/buildLinearSDXLImageToImageGraph.ts
@@ -350,7 +350,7 @@ export const buildLinearSDXLImageToImageGraph = (
       positive_style_prompt: positiveStylePrompt,
       negative_style_prompt: negativeStylePrompt,
     },
-    IMAGE_TO_LATENTS
+    LATENTS_TO_IMAGE
   );
 
   // Add Seamless To Graph


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

Caused by a typo. Whoops!

Fixes 
![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/ffa9e060-aee4-4391-aeee-2d19e1e86100)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://discord.com/channels/1020123559063990373/1049495067846524939/1174867331478982656

## QA Instructions, Screenshots, Recordings

img2img should work
