### PR TITLE
Fix double LoRA patching of the UNet

### DIFF
--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -706,7 +706,6 @@ class DenoiseLatentsInvocation(BaseInvocation):
             )
             with (
                 ExitStack() as exit_stack,
-                ModelPatcher.apply_lora_unet(unet_info.context.model, _lora_loader()),
                 ModelPatcher.apply_freeu(unet_info.context.model, self.unet.freeu_config),
                 set_seamless(unet_info.context.model, self.unet.seamless_axes),
                 unet_info as unet,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

This PR fixes a bug where LoRAs are applied twice to the UNet. This bug was introduced here: https://github.com/invoke-ai/InvokeAI/pull/4846/files#diff-7eda251c434414576edbb85e9f6ca2a803838a24d1601a322f812e33485556f9R713. Presumably this was done accidentally while resolving a merge conflict.

## QA Instructions, Screenshots, Recordings

Before the fix, generating with a Voxel LoRA at 0.75:
![image](https://github.com/invoke-ai/InvokeAI/assets/14897797/00b34bfe-7a6a-425b-88e7-e32d1c1c9ebb)

After the fix, same parameters:
![image](https://github.com/invoke-ai/InvokeAI/assets/14897797/42c42c3a-ab78-42d2-8d64-33899010b3d7)

## Added/updated tests?

- [ ] Yes
- [x] No : No new tests added now, but this is a prime example of something that would have easily been caught by automated regression tests.

