### PR TITLE
Add image tiling nodes to enable Tiled Upscaling

### DIFF
--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -1194,16 +1194,6 @@ class CropLatentsCoreInvocation(BaseInvocation):
         description=FieldDescriptions.latents,
         input=Input.Connection,
     )
-    width: int = InputField(
-        ge=1,
-        multiple_of=LATENT_SCALE_FACTOR,
-        description="The width (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
-    )
-    height: int = InputField(
-        ge=1,
-        multiple_of=LATENT_SCALE_FACTOR,
-        description="The height (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
-    )
     x_offset: int = InputField(
         ge=0,
         multiple_of=LATENT_SCALE_FACTOR,
@@ -1213,6 +1203,16 @@ class CropLatentsCoreInvocation(BaseInvocation):
         ge=0,
         multiple_of=LATENT_SCALE_FACTOR,
         description="The top y coordinate (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
+    )
+    width: int = InputField(
+        ge=1,
+        multiple_of=LATENT_SCALE_FACTOR,
+        description="The width (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
+    )
+    height: int = InputField(
+        ge=1,
+        multiple_of=LATENT_SCALE_FACTOR,
+        description="The height (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
     )
 
     def invoke(self, context: InvocationContext) -> LatentsOutput:

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -1182,31 +1182,33 @@ class BlendLatentsInvocation(BaseInvocation):
     version="1.0.0",
 )
 class CropLatentsInvocation(BaseInvocation):
-    """Crops latents"""
+    """Crops a latent-space tensor to a box specified in image-space. The box dimensions and coordinates must be
+    divisible by the latent scale factor of 8.
+    """
 
     latents: LatentsField = InputField(
         description=FieldDescriptions.latents,
         input=Input.Connection,
     )
     width: int = InputField(
-        ge=64,
+        ge=1,
         multiple_of=LATENT_SCALE_FACTOR,
-        description=FieldDescriptions.width,
+        description="The width (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
     )
     height: int = InputField(
-        ge=64,
+        ge=1,
         multiple_of=LATENT_SCALE_FACTOR,
-        description=FieldDescriptions.width,
+        description="The height (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
     )
     x_offset: int = InputField(
         ge=0,
         multiple_of=LATENT_SCALE_FACTOR,
-        description="x-coordinate",
+        description="The left x coordinate (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
     )
     y_offset: int = InputField(
         ge=0,
         multiple_of=LATENT_SCALE_FACTOR,
-        description="y-coordinate",
+        description="The top y coordinate (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
     )
 
     def invoke(self, context: InvocationContext) -> LatentsOutput:

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -1174,14 +1174,18 @@ class BlendLatentsInvocation(BaseInvocation):
         return build_latents_output(latents_name=name, latents=blended_latents)
 
 
+# The Crop Latents node was copied from @skunkworxdark's implementation here:
+# https://github.com/skunkworxdark/XYGrid_nodes/blob/74647fa9c1fa57d317a94bd43ca689af7f0aae5e/images_to_grids.py#L1117C1-L1167C80
 @invocation(
-    "lcrop",
+    "crop_latents",
     title="Crop Latents",
     tags=["latents", "crop"],
     category="latents",
     version="1.0.0",
 )
-class CropLatentsInvocation(BaseInvocation):
+# TODO(ryand): Named `CropLatentsCoreInvocation` to prevent a conflict with custom node `CropLatentsInvocation`.
+# Currently, if the class names conflict then 'GET /openapi.json' fails.
+class CropLatentsCoreInvocation(BaseInvocation):
     """Crops a latent-space tensor to a box specified in image-space. The box dimensions and coordinates must be
     divisible by the latent scale factor of 8.
     """
@@ -1219,9 +1223,7 @@ class CropLatentsInvocation(BaseInvocation):
         x2 = x1 + (self.width // LATENT_SCALE_FACTOR)
         y2 = y1 + (self.height // LATENT_SCALE_FACTOR)
 
-        cropped_latents = latents[:, :, y1:y2, x1:x2]
-
-        # resized_latents = resized_latents.to("cpu")
+        cropped_latents = latents[..., y1:y2, x1:x2]
 
         name = f"{context.graph_execution_state_id}__{self.id}"
         context.services.latents.save(name, cropped_latents)

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -79,6 +79,12 @@ DEFAULT_PRECISION = choose_precision(choose_torch_device())
 
 SAMPLER_NAME_VALUES = Literal[tuple(SCHEDULER_MAP.keys())]
 
+# HACK: Many nodes are currently hard-coded to use a fixed latent scale factor of 8. This is fragile, and will need to
+# be addressed if future models use a different latent scale factor. Also, note that there may be places where the scale
+# factor is hard-coded to a literal '8' rather than using this constant.
+# The ratio of image:latent dimensions is LATENT_SCALE_FACTOR:1, or 8:1.
+LATENT_SCALE_FACTOR = 8
+
 
 @invocation_output("scheduler_output")
 class SchedulerOutput(BaseInvocationOutput):
@@ -394,9 +400,9 @@ class DenoiseLatentsInvocation(BaseInvocation):
         exit_stack: ExitStack,
         do_classifier_free_guidance: bool = True,
     ) -> List[ControlNetData]:
-        # assuming fixed dimensional scaling of 8:1 for image:latents
-        control_height_resize = latents_shape[2] * 8
-        control_width_resize = latents_shape[3] * 8
+        # Assuming fixed dimensional scaling of LATENT_SCALE_FACTOR.
+        control_height_resize = latents_shape[2] * LATENT_SCALE_FACTOR
+        control_width_resize = latents_shape[3] * LATENT_SCALE_FACTOR
         if control_input is None:
             control_list = None
         elif isinstance(control_input, list) and len(control_input) == 0:
@@ -909,12 +915,12 @@ class ResizeLatentsInvocation(BaseInvocation):
     )
     width: int = InputField(
         ge=64,
-        multiple_of=8,
+        multiple_of=LATENT_SCALE_FACTOR,
         description=FieldDescriptions.width,
     )
     height: int = InputField(
         ge=64,
-        multiple_of=8,
+        multiple_of=LATENT_SCALE_FACTOR,
         description=FieldDescriptions.width,
     )
     mode: LATENTS_INTERPOLATION_MODE = InputField(default="bilinear", description=FieldDescriptions.interp_mode)
@@ -928,7 +934,7 @@ class ResizeLatentsInvocation(BaseInvocation):
 
         resized_latents = torch.nn.functional.interpolate(
             latents.to(device),
-            size=(self.height // 8, self.width // 8),
+            size=(self.height // LATENT_SCALE_FACTOR, self.width // LATENT_SCALE_FACTOR),
             mode=self.mode,
             antialias=self.antialias if self.mode in ["bilinear", "bicubic"] else False,
         )
@@ -1184,32 +1190,32 @@ class CropLatentsInvocation(BaseInvocation):
     )
     width: int = InputField(
         ge=64,
-        multiple_of=_downsampling_factor,
+        multiple_of=LATENT_SCALE_FACTOR,
         description=FieldDescriptions.width,
     )
     height: int = InputField(
         ge=64,
-        multiple_of=_downsampling_factor,
+        multiple_of=LATENT_SCALE_FACTOR,
         description=FieldDescriptions.width,
     )
     x_offset: int = InputField(
         ge=0,
-        multiple_of=_downsampling_factor,
+        multiple_of=LATENT_SCALE_FACTOR,
         description="x-coordinate",
     )
     y_offset: int = InputField(
         ge=0,
-        multiple_of=_downsampling_factor,
+        multiple_of=LATENT_SCALE_FACTOR,
         description="y-coordinate",
     )
 
     def invoke(self, context: InvocationContext) -> LatentsOutput:
         latents = context.services.latents.get(self.latents.latents_name)
 
-        x1 = self.x_offset // _downsampling_factor
-        y1 = self.y_offset // _downsampling_factor
-        x2 = x1 + (self.width // _downsampling_factor)
-        y2 = y1 + (self.height // _downsampling_factor)
+        x1 = self.x_offset // LATENT_SCALE_FACTOR
+        y1 = self.y_offset // LATENT_SCALE_FACTOR
+        x2 = x1 + (self.width // LATENT_SCALE_FACTOR)
+        y2 = y1 + (self.height // LATENT_SCALE_FACTOR)
 
         cropped_latents = latents[:, :, y1:y2, x1:x2]
 

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -1194,12 +1194,12 @@ class CropLatentsCoreInvocation(BaseInvocation):
         description=FieldDescriptions.latents,
         input=Input.Connection,
     )
-    x_offset: int = InputField(
+    x: int = InputField(
         ge=0,
         multiple_of=LATENT_SCALE_FACTOR,
         description="The left x coordinate (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
     )
-    y_offset: int = InputField(
+    y: int = InputField(
         ge=0,
         multiple_of=LATENT_SCALE_FACTOR,
         description="The top y coordinate (in px) of the crop rectangle in image space. This value will be converted to a dimension in latent space.",
@@ -1218,8 +1218,8 @@ class CropLatentsCoreInvocation(BaseInvocation):
     def invoke(self, context: InvocationContext) -> LatentsOutput:
         latents = context.services.latents.get(self.latents.latents_name)
 
-        x1 = self.x_offset // LATENT_SCALE_FACTOR
-        y1 = self.y_offset // LATENT_SCALE_FACTOR
+        x1 = self.x // LATENT_SCALE_FACTOR
+        y1 = self.y // LATENT_SCALE_FACTOR
         x2 = x1 + (self.width // LATENT_SCALE_FACTOR)
         y2 = y1 + (self.height // LATENT_SCALE_FACTOR)
 

--- a/invokeai/app/invocations/tiles.py
+++ b/invokeai/app/invocations/tiles.py
@@ -30,7 +30,7 @@ class CalculateImageTilesOutput(BaseInvocationOutput):
 
 
 @invocation("calculate_image_tiles", title="Calculate Image Tiles", tags=["tiles"], category="tiles", version="1.0.0")
-class CalculateImageTiles(BaseInvocation):
+class CalculateImageTilesInvocation(BaseInvocation):
     """Calculate the coordinates and overlaps of tiles that cover a target image shape."""
 
     image_height: int = InputField(
@@ -70,7 +70,7 @@ class TileToPropertiesOutput(BaseInvocationOutput):
 
 
 @invocation("tile_to_properties", title="Tile to Properties", tags=["tiles"], category="tiles", version="1.0.0")
-class TileToProperties(BaseInvocation):
+class TileToPropertiesInvocation(BaseInvocation):
     """Split a Tile into its individual properties."""
 
     tile: Tile = InputField(description="The tile to split into properties.")
@@ -94,7 +94,7 @@ class PairTileImageOutput(BaseInvocationOutput):
 
 
 @invocation("pair_tile_image", title="Pair Tile with Image", tags=["tiles"], category="tiles", version="1.0.0")
-class PairTileImage(BaseInvocation):
+class PairTileImageInvocation(BaseInvocation):
     """Pair an image with its tile properties."""
 
     # TODO(ryand): The only reason that PairTileImage is needed is because the iterate/collect nodes don't preserve
@@ -113,7 +113,7 @@ class PairTileImage(BaseInvocation):
 
 
 @invocation("merge_tiles_to_image", title="Merge Tiles to Image", tags=["tiles"], category="tiles", version="1.0.0")
-class MergeTilesToImage(BaseInvocation, WithMetadata, WithWorkflow):
+class MergeTilesToImageInvocation(BaseInvocation, WithMetadata, WithWorkflow):
     """Merge multiple tile images into a single image."""
 
     # Inputs

--- a/invokeai/app/invocations/tiles.py
+++ b/invokeai/app/invocations/tiles.py
@@ -15,11 +15,8 @@ from invokeai.app.invocations.baseinvocation import (
 )
 from invokeai.app.invocations.primitives import ImageField, ImageOutput
 from invokeai.app.services.image_records.image_records_common import ImageCategory, ResourceOrigin
-from invokeai.backend.tiles.tiles import calc_tiles, merge_tiles_with_linear_blending
+from invokeai.backend.tiles.tiles import calc_tiles_with_overlap, merge_tiles_with_linear_blending
 from invokeai.backend.tiles.utils import Tile
-
-# TODO(ryand): Is this important?
-_DIMENSION_MULTIPLE_OF = 8
 
 
 class TileWithImage(BaseModel):
@@ -27,53 +24,56 @@ class TileWithImage(BaseModel):
     image: ImageField
 
 
-@invocation_output("calc_tiles_output")
-class CalcTilesOutput(BaseInvocationOutput):
-    # TODO(ryand): Add description from FieldDescriptions.
-    tiles: list[Tile] = OutputField(description="")
+@invocation_output("calculate_image_tiles_output")
+class CalculateImageTilesOutput(BaseInvocationOutput):
+    tiles: list[Tile] = OutputField(description="The tiles coordinates that cover a particular image shape.")
 
 
-@invocation("calculate_tiles", title="Calculate Tiles", tags=["tiles"], category="tiles", version="1.0.0")
-class CalcTiles(BaseInvocation):
-    """TODO(ryand)"""
+@invocation("calculate_image_tiles", title="Calculate Image Tiles", tags=["tiles"], category="tiles", version="1.0.0")
+class CalculateImageTiles(BaseInvocation):
+    """Calculate the coordinates and overlaps of tiles that cover a target image shape."""
 
-    # Inputs
-    image_height: int = InputField(ge=1)
-    image_width: int = InputField(ge=1)
-    tile_height: int = InputField(ge=1, multiple_of=_DIMENSION_MULTIPLE_OF, default=576)
-    tile_width: int = InputField(ge=1, multiple_of=_DIMENSION_MULTIPLE_OF, default=576)
-    overlap: int = InputField(ge=0, multiple_of=_DIMENSION_MULTIPLE_OF, default=64)
+    image_height: int = InputField(
+        ge=1, default=1024, description="The image height, in pixels, to calculate tiles for."
+    )
+    image_width: int = InputField(ge=1, default=1024, description="The image width, in pixels, to calculate tiles for.")
+    tile_height: int = InputField(ge=1, default=576, description="The tile height, in pixels.")
+    tile_width: int = InputField(ge=1, default=576, description="The tile width, in pixels.")
+    overlap: int = InputField(
+        ge=0,
+        default=128,
+        description="The target overlap, in pixels, between adjacent tiles. Adjacent tiles will overlap by at least this amount",
+    )
 
-    def invoke(self, context: InvocationContext) -> CalcTilesOutput:
-        tiles = calc_tiles(
+    def invoke(self, context: InvocationContext) -> CalculateImageTilesOutput:
+        tiles = calc_tiles_with_overlap(
             image_height=self.image_height,
             image_width=self.image_width,
             tile_height=self.tile_height,
             tile_width=self.tile_width,
             overlap=self.overlap,
         )
-        return CalcTilesOutput(tiles=tiles)
+        return CalculateImageTilesOutput(tiles=tiles)
 
 
 @invocation_output("tile_to_properties_output")
 class TileToPropertiesOutput(BaseInvocationOutput):
-    # TODO(ryand): Add descriptions.
-    coords_top: int = OutputField(description="")
-    coords_bottom: int = OutputField(description="")
-    coords_left: int = OutputField(description="")
-    coords_right: int = OutputField(description="")
+    coords_top: int = OutputField(description="Top coordinate of the tile relative to its parent image.")
+    coords_bottom: int = OutputField(description="Bottom coordinate of the tile relative to its parent image.")
+    coords_left: int = OutputField(description="Left coordinate of the tile relative to its parent image.")
+    coords_right: int = OutputField(description="Right coordinate of the tile relative to its parent image.")
 
-    overlap_top: int = OutputField(description="")
-    overlap_bottom: int = OutputField(description="")
-    overlap_left: int = OutputField(description="")
-    overlap_right: int = OutputField(description="")
+    overlap_top: int = OutputField(description="Overlap between this tile and its top neighbor.")
+    overlap_bottom: int = OutputField(description="Overlap between this tile and its bottom neighbor.")
+    overlap_left: int = OutputField(description="Overlap between this tile and its left neighbor.")
+    overlap_right: int = OutputField(description="Overlap between this tile and its right neighbor.")
 
 
-@invocation("tile_to_properties")
+@invocation("tile_to_properties", title="Tile to Properties", tags=["tiles"], category="tiles", version="1.0.0")
 class TileToProperties(BaseInvocation):
     """Split a Tile into its individual properties."""
 
-    tile: Tile = InputField()
+    tile: Tile = InputField(description="The tile to split into properties.")
 
     def invoke(self, context: InvocationContext) -> TileToPropertiesOutput:
         return TileToPropertiesOutput(
@@ -88,19 +88,20 @@ class TileToProperties(BaseInvocation):
         )
 
 
-# HACK(ryand): The only reason that PairTileImage is needed is because the iterate/collect nodes don't preserve order.
-# Can this be fixed?
-
-
 @invocation_output("pair_tile_image_output")
 class PairTileImageOutput(BaseInvocationOutput):
-    tile_with_image: TileWithImage = OutputField(description="")
+    tile_with_image: TileWithImage = OutputField(description="A tile description with its corresponding image.")
 
 
 @invocation("pair_tile_image", title="Pair Tile with Image", tags=["tiles"], category="tiles", version="1.0.0")
 class PairTileImage(BaseInvocation):
-    image: ImageField = InputField()
-    tile: Tile = InputField()
+    """Pair an image with its tile properties."""
+
+    # TODO(ryand): The only reason that PairTileImage is needed is because the iterate/collect nodes don't preserve
+    # order. Can this be fixed?
+
+    image: ImageField = InputField(description="The tile image.")
+    tile: Tile = InputField(description="The tile properties.")
 
     def invoke(self, context: InvocationContext) -> PairTileImageOutput:
         return PairTileImageOutput(
@@ -111,15 +112,18 @@ class PairTileImage(BaseInvocation):
         )
 
 
-@invocation("merge_tiles_to_image", title="Merge Tiles To Image", tags=["tiles"], category="tiles", version="1.0.0")
+@invocation("merge_tiles_to_image", title="Merge Tiles to Image", tags=["tiles"], category="tiles", version="1.0.0")
 class MergeTilesToImage(BaseInvocation, WithMetadata, WithWorkflow):
-    """TODO(ryand)"""
+    """Merge multiple tile images into a single image."""
 
     # Inputs
-    image_height: int = InputField(ge=1)
-    image_width: int = InputField(ge=1)
-    tiles_with_images: list[TileWithImage] = InputField()
-    blend_amount: int = InputField(ge=0)
+    image_height: int = InputField(ge=1, description="The height of the output image, in pixels.")
+    image_width: int = InputField(ge=1, description="The width of the output image, in pixels.")
+    tiles_with_images: list[TileWithImage] = InputField(description="A list of tile images with tile properties.")
+    blend_amount: int = InputField(
+        ge=0,
+        description="The amount to blend adjacent tiles in pixels. Must be <= the amount of overlap between adjacent tiles.",
+    )
 
     def invoke(self, context: InvocationContext) -> ImageOutput:
         images = [twi.image for twi in self.tiles_with_images]

--- a/invokeai/app/invocations/tiles.py
+++ b/invokeai/app/invocations/tiles.py
@@ -33,12 +33,12 @@ class CalculateImageTilesOutput(BaseInvocationOutput):
 class CalculateImageTilesInvocation(BaseInvocation):
     """Calculate the coordinates and overlaps of tiles that cover a target image shape."""
 
+    image_width: int = InputField(ge=1, default=1024, description="The image width, in pixels, to calculate tiles for.")
     image_height: int = InputField(
         ge=1, default=1024, description="The image height, in pixels, to calculate tiles for."
     )
-    image_width: int = InputField(ge=1, default=1024, description="The image width, in pixels, to calculate tiles for.")
-    tile_height: int = InputField(ge=1, default=576, description="The tile height, in pixels.")
     tile_width: int = InputField(ge=1, default=576, description="The tile width, in pixels.")
+    tile_height: int = InputField(ge=1, default=576, description="The tile height, in pixels.")
     overlap: int = InputField(
         ge=0,
         default=128,
@@ -117,8 +117,8 @@ class MergeTilesToImageInvocation(BaseInvocation, WithMetadata, WithWorkflow):
     """Merge multiple tile images into a single image."""
 
     # Inputs
-    image_height: int = InputField(ge=1, description="The height of the output image, in pixels.")
     image_width: int = InputField(ge=1, description="The width of the output image, in pixels.")
+    image_height: int = InputField(ge=1, description="The height of the output image, in pixels.")
     tiles_with_images: list[TileWithImage] = InputField(description="A list of tile images with tile properties.")
     blend_amount: int = InputField(
         ge=0,

--- a/invokeai/app/invocations/tiles.py
+++ b/invokeai/app/invocations/tiles.py
@@ -1,0 +1,162 @@
+import numpy as np
+from PIL import Image
+from pydantic import BaseModel
+
+from invokeai.app.invocations.baseinvocation import (
+    BaseInvocation,
+    BaseInvocationOutput,
+    InputField,
+    InvocationContext,
+    OutputField,
+    WithMetadata,
+    WithWorkflow,
+    invocation,
+    invocation_output,
+)
+from invokeai.app.invocations.primitives import ImageField, ImageOutput
+from invokeai.app.services.image_records.image_records_common import ImageCategory, ResourceOrigin
+from invokeai.backend.tiles.tiles import calc_tiles, merge_tiles_with_linear_blending
+from invokeai.backend.tiles.utils import Tile
+
+# TODO(ryand): Is this important?
+_DIMENSION_MULTIPLE_OF = 8
+
+
+class TileWithImage(BaseModel):
+    tile: Tile
+    image: ImageField
+
+
+@invocation_output("calc_tiles_output")
+class CalcTilesOutput(BaseInvocationOutput):
+    # TODO(ryand): Add description from FieldDescriptions.
+    tiles: list[Tile] = OutputField(description="")
+
+
+@invocation("calculate_tiles", title="Calculate Tiles", tags=["tiles"], category="tiles", version="1.0.0")
+class CalcTiles(BaseInvocation):
+    """TODO(ryand)"""
+
+    # Inputs
+    image_height: int = InputField(ge=1)
+    image_width: int = InputField(ge=1)
+    tile_height: int = InputField(ge=1, multiple_of=_DIMENSION_MULTIPLE_OF, default=576)
+    tile_width: int = InputField(ge=1, multiple_of=_DIMENSION_MULTIPLE_OF, default=576)
+    overlap: int = InputField(ge=0, multiple_of=_DIMENSION_MULTIPLE_OF, default=64)
+
+    def invoke(self, context: InvocationContext) -> CalcTilesOutput:
+        tiles = calc_tiles(
+            image_height=self.image_height,
+            image_width=self.image_width,
+            tile_height=self.tile_height,
+            tile_width=self.tile_width,
+            overlap=self.overlap,
+        )
+        return CalcTilesOutput(tiles=tiles)
+
+
+@invocation_output("tile_to_properties_output")
+class TileToPropertiesOutput(BaseInvocationOutput):
+    # TODO(ryand): Add descriptions.
+    coords_top: int = OutputField(description="")
+    coords_bottom: int = OutputField(description="")
+    coords_left: int = OutputField(description="")
+    coords_right: int = OutputField(description="")
+
+    overlap_top: int = OutputField(description="")
+    overlap_bottom: int = OutputField(description="")
+    overlap_left: int = OutputField(description="")
+    overlap_right: int = OutputField(description="")
+
+
+@invocation("tile_to_properties")
+class TileToProperties(BaseInvocation):
+    """Split a Tile into its individual properties."""
+
+    tile: Tile = InputField()
+
+    def invoke(self, context: InvocationContext) -> TileToPropertiesOutput:
+        return TileToPropertiesOutput(
+            coords_top=self.tile.coords.top,
+            coords_bottom=self.tile.coords.bottom,
+            coords_left=self.tile.coords.left,
+            coords_right=self.tile.coords.right,
+            overlap_top=self.tile.overlap.top,
+            overlap_bottom=self.tile.overlap.bottom,
+            overlap_left=self.tile.overlap.left,
+            overlap_right=self.tile.overlap.right,
+        )
+
+
+# HACK(ryand): The only reason that PairTileImage is needed is because the iterate/collect nodes don't preserve order.
+# Can this be fixed?
+
+
+@invocation_output("pair_tile_image_output")
+class PairTileImageOutput(BaseInvocationOutput):
+    tile_with_image: TileWithImage = OutputField(description="")
+
+
+@invocation("pair_tile_image", title="Pair Tile with Image", tags=["tiles"], category="tiles", version="1.0.0")
+class PairTileImage(BaseInvocation):
+    image: ImageField = InputField()
+    tile: Tile = InputField()
+
+    def invoke(self, context: InvocationContext) -> PairTileImageOutput:
+        return PairTileImageOutput(
+            tile_with_image=TileWithImage(
+                tile=self.tile,
+                image=self.image,
+            )
+        )
+
+
+@invocation("merge_tiles_to_image", title="Merge Tiles To Image", tags=["tiles"], category="tiles", version="1.0.0")
+class MergeTilesToImage(BaseInvocation, WithMetadata, WithWorkflow):
+    """TODO(ryand)"""
+
+    # Inputs
+    image_height: int = InputField(ge=1)
+    image_width: int = InputField(ge=1)
+    tiles_with_images: list[TileWithImage] = InputField()
+    blend_amount: int = InputField(ge=0)
+
+    def invoke(self, context: InvocationContext) -> ImageOutput:
+        images = [twi.image for twi in self.tiles_with_images]
+        tiles = [twi.tile for twi in self.tiles_with_images]
+
+        # Get all tile images for processing.
+        # TODO(ryand): It pains me that we spend time PNG decoding each tile from disk when they almost certainly
+        # existed in memory at an earlier point in the graph.
+        tile_np_images: list[np.ndarray] = []
+        for image in images:
+            pil_image = context.services.images.get_pil_image(image.image_name)
+            pil_image = pil_image.convert("RGB")
+            tile_np_images.append(np.array(pil_image))
+
+        # Prepare the output image buffer.
+        # Check the first tile to determine how many image channels are expected in the output.
+        channels = tile_np_images[0].shape[-1]
+        dtype = tile_np_images[0].dtype
+        np_image = np.zeros(shape=(self.image_height, self.image_width, channels), dtype=dtype)
+
+        merge_tiles_with_linear_blending(
+            dst_image=np_image, tiles=tiles, tile_images=tile_np_images, blend_amount=self.blend_amount
+        )
+        pil_image = Image.fromarray(np_image)
+
+        image_dto = context.services.images.create(
+            image=pil_image,
+            image_origin=ResourceOrigin.INTERNAL,
+            image_category=ImageCategory.GENERAL,
+            node_id=self.id,
+            session_id=context.graph_execution_state_id,
+            is_intermediate=self.is_intermediate,
+            metadata=self.metadata,
+            workflow=self.workflow,
+        )
+        return ImageOutput(
+            image=ImageField(image_name=image_dto.image_name),
+            width=image_dto.width,
+            height=image_dto.height,
+        )

--- a/invokeai/app/invocations/tiles.py
+++ b/invokeai/app/invocations/tiles.py
@@ -63,6 +63,14 @@ class TileToPropertiesOutput(BaseInvocationOutput):
     coords_left: int = OutputField(description="Left coordinate of the tile relative to its parent image.")
     coords_right: int = OutputField(description="Right coordinate of the tile relative to its parent image.")
 
+    # HACK: The width and height fields are 'meta' fields that can easily be calculated from the other fields on this
+    # object. Including redundant fields that can cheaply/easily be re-calculated goes against conventional API design
+    # principles. These fields are included, because 1) they are often useful in tiled workflows, and 2) they are
+    # difficult to calculate in a workflow (even though it's just a couple of subtraction nodes the graph gets
+    # surprisingly complicated).
+    width: int = OutputField(description="The width of the tile. Equal to coords_right - coords_left.")
+    height: int = OutputField(description="The height of the tile. Equal to coords_bottom - coords_top.")
+
     overlap_top: int = OutputField(description="Overlap between this tile and its top neighbor.")
     overlap_bottom: int = OutputField(description="Overlap between this tile and its bottom neighbor.")
     overlap_left: int = OutputField(description="Overlap between this tile and its left neighbor.")
@@ -81,6 +89,8 @@ class TileToPropertiesInvocation(BaseInvocation):
             coords_bottom=self.tile.coords.bottom,
             coords_left=self.tile.coords.left,
             coords_right=self.tile.coords.right,
+            width=self.tile.coords.right - self.tile.coords.left,
+            height=self.tile.coords.bottom - self.tile.coords.top,
             overlap_top=self.tile.overlap.top,
             overlap_bottom=self.tile.overlap.bottom,
             overlap_left=self.tile.overlap.left,

--- a/invokeai/app/invocations/tiles.py
+++ b/invokeai/app/invocations/tiles.py
@@ -58,10 +58,10 @@ class CalculateImageTilesInvocation(BaseInvocation):
 
 @invocation_output("tile_to_properties_output")
 class TileToPropertiesOutput(BaseInvocationOutput):
-    coords_top: int = OutputField(description="Top coordinate of the tile relative to its parent image.")
-    coords_bottom: int = OutputField(description="Bottom coordinate of the tile relative to its parent image.")
     coords_left: int = OutputField(description="Left coordinate of the tile relative to its parent image.")
     coords_right: int = OutputField(description="Right coordinate of the tile relative to its parent image.")
+    coords_top: int = OutputField(description="Top coordinate of the tile relative to its parent image.")
+    coords_bottom: int = OutputField(description="Bottom coordinate of the tile relative to its parent image.")
 
     # HACK: The width and height fields are 'meta' fields that can easily be calculated from the other fields on this
     # object. Including redundant fields that can cheaply/easily be re-calculated goes against conventional API design
@@ -85,10 +85,10 @@ class TileToPropertiesInvocation(BaseInvocation):
 
     def invoke(self, context: InvocationContext) -> TileToPropertiesOutput:
         return TileToPropertiesOutput(
-            coords_top=self.tile.coords.top,
-            coords_bottom=self.tile.coords.bottom,
             coords_left=self.tile.coords.left,
             coords_right=self.tile.coords.right,
+            coords_top=self.tile.coords.top,
+            coords_bottom=self.tile.coords.bottom,
             width=self.tile.coords.right - self.tile.coords.left,
             height=self.tile.coords.bottom - self.tile.coords.top,
             overlap_top=self.tile.overlap.top,

--- a/invokeai/backend/tiles/tiles.py
+++ b/invokeai/backend/tiles/tiles.py
@@ -1,0 +1,155 @@
+import math
+
+import numpy as np
+
+from invokeai.backend.tiles.utils import TBLR, Tile, paste
+
+# TODO(ryand)
+# Test the following:
+# - Tile too big in x, y
+# - Overlap too big in x, y
+# - Single tile fits
+# - Multiple tiles fit perfectly
+# - Not evenly divisible by tile size(with overlap)
+
+
+def calc_tiles_with_overlap(
+    image_height: int, image_width: int, tile_height: int, tile_width: int, overlap: int = 0
+) -> list[Tile]:
+    """Calculate the tile coordinates for a given image shape under a simple tiling scheme with overlaps.
+
+    Args:
+        image_height (int): The image height in px.
+        image_width (int): The image width in px.
+        tile_height (int): The tile height in px. All tiles will have this height.
+        tile_width (int): The tile width in px. All tiles will have this width.
+        overlap (int, optional): The target overlap between adjacent tiles. If the tiles do not evenly cover the image
+            shape, then the last row/column of tiles will overlap more than this. Defaults to 0.
+
+    Returns:
+        list[Tile]: A list of tiles that cover the image shape. Ordered from left-to-right, top-to-bottom.
+    """
+    assert image_height >= tile_height
+    assert image_width >= tile_width
+    assert overlap < tile_height
+    assert overlap < tile_width
+
+    non_overlap_per_tile_height = tile_height - overlap
+    non_overlap_per_tile_width = tile_width - overlap
+
+    num_tiles_y = math.ceil((image_height - overlap) / non_overlap_per_tile_height)
+    num_tiles_x = math.ceil((image_width - overlap) / non_overlap_per_tile_width)
+
+    # Calculate tile coordinates and overlaps.
+    tiles: list[Tile] = []
+    for tile_idx_y in range(num_tiles_y):
+        for tile_idx_x in range(num_tiles_x):
+            tile = Tile(
+                coords=TBLR(
+                    top=tile_idx_y * non_overlap_per_tile_height,
+                    bottom=tile_idx_y * non_overlap_per_tile_height + tile_height,
+                    left=tile_idx_x * non_overlap_per_tile_width,
+                    right=tile_idx_x * non_overlap_per_tile_width + tile_width,
+                ),
+                overlap=TBLR(
+                    top=0 if tile_idx_y == 0 else overlap,
+                    bottom=overlap,
+                    left=0 if tile_idx_x == 0 else overlap,
+                    right=overlap,
+                ),
+            )
+
+            if tile.coords.bottom > image_height:
+                # If this tile would go off the bottom of the image, shift it so that it is aligned with the bottom
+                # of the image.
+                tile.coords.bottom = image_height
+                tile.coords.top = image_height - tile_height
+                tile.overlap.bottom = 0
+                # Note that this could result in a large overlap between this tile and the one above it.
+                top_neighbor_bottom = (tile_idx_y - 1) * non_overlap_per_tile_height + tile_height
+                tile.overlap.top = top_neighbor_bottom - tile.coords.top
+
+            if tile.coords.right > image_width:
+                # If this tile would go off the right edge of the image, shift it so that it is aligned with the
+                # right edge of the image.
+                tile.coords.right = image_width
+                tile.coords.left = image_width - tile_width
+                tile.overlap.right = 0
+                # Note that this could result in a large overlap between this tile and the one to its left.
+                left_neighbor_right = (tile_idx_x - 1) * non_overlap_per_tile_width + tile_width
+                tile.overlap.left = left_neighbor_right - tile.coords.left
+
+            tiles.append(tile)
+
+    return tiles
+
+
+# TODO(ryand):
+# - Test with blend_amount=0
+# - Test tiles that go off of the dst_image.
+# - Test mismatched tiles and tile_images lengths.
+# - Test mismatched
+
+
+def merge_tiles_with_linear_blending(
+    dst_image: np.ndarray, tiles: list[Tile], tile_images: list[np.ndarray], blend_amount: int
+):
+    """Merge a set of image tiles into `dst_image` with linear blending between the tiles.
+
+    We expect every tile edge to either:
+    1) have an overlap of 0, because it is aligned with the image edge, or
+    2) have an overlap >= blend_amount.
+    If neither of these conditions are satisfied, we raise an exception.
+
+    The linear blending is centered at the halfway point of the overlap between adjacent tiles.
+
+    Args:
+        dst_image (np.ndarray): The destination image. Shape: (H, W, C).
+        tiles (list[Tile]): The list of tiles describing the locations of the respective `tile_images`.
+        tile_images (list[np.ndarray]): The tile images to merge into `dst_image`.
+        blend_amount (int): The amount of blending (in px) between adjacent overlapping tiles.
+    """
+    # Sort tiles and images first by left x coordinate, then by top y coordinate. During tile processing, we want to
+    # iterate over tiles left-to-right, top-to-bottom.
+    tiles_and_images = list(zip(tiles, tile_images, strict=True))
+    tiles_and_images = sorted(tiles_and_images, key=lambda x: x[0].coords.left)
+    tiles_and_images = sorted(tiles_and_images, key=lambda x: x[0].coords.top)
+
+    # Prepare 1D linear gradients for blending.
+    gradient_left_x = np.linspace(start=0.0, stop=1.0, num=blend_amount)
+    gradient_top_y = np.linspace(start=0.0, stop=1.0, num=blend_amount)
+    # Convert shape: (blend_amount, ) -> (blend_amount, 1). The extra dimension enables the gradient to be applied
+    # to a 2D image via broadcasting. Note that no additional dimension is needed on gradient_left_x for
+    # broadcasting to work correctly.
+    gradient_top_y = np.expand_dims(gradient_top_y, axis=1)
+
+    for tile, tile_image in tiles_and_images:
+        # We expect tiles to be written left-to-right, top-to-bottom. We construct a mask that applies linear blending
+        # to the top and to the left of the current tile. The inverse linear blending is automatically applied to the
+        # bottom/right of the tiles that have already been pasted by the paste(...) operation.
+        tile_height, tile_width, _ = tile_image.shape
+        mask = np.ones(shape=(tile_height, tile_width), dtype=np.float64)
+        # Top blending:
+        if tile.overlap.top > 0:
+            assert tile.overlap.top >= blend_amount
+            # Center the blending gradient in the middle of the overlap.
+            blend_start_top = tile.overlap.top // 2 - blend_amount // 2
+            # The region above the blending region is masked completely.
+            mask[:blend_start_top, :] = 0.0
+            # Apply the blend gradient to the mask. Note that we use `*=` rather than `=` to achieve more natural
+            # behavior on the corners where vertical and horizontal blending gradients overlap.
+            mask[blend_start_top : blend_start_top + blend_amount, :] *= gradient_top_y
+            # HACK(ryand): For debugging
+            # tile_image[blend_start_top : blend_start_top + blend_amount, :] = 0
+
+        # Left blending:
+        # (See comments under 'top blending' for an explanation of the logic.)
+        if tile.overlap.left > 0:
+            assert tile.overlap.left >= blend_amount
+            blend_start_left = tile.overlap.left // 2 - blend_amount // 2
+            mask[:, :blend_start_left] = 0.0
+            mask[:, blend_start_left : blend_start_left + blend_amount] *= gradient_left_x
+            # HACK(ryand): For debugging
+            # tile_image[:, blend_start_left : blend_start_left + blend_amount] = 0
+
+        paste(dst_image=dst_image, src_image=tile_image, box=tile.coords, mask=mask)

--- a/invokeai/backend/tiles/tiles.py
+++ b/invokeai/backend/tiles/tiles.py
@@ -90,13 +90,6 @@ def calc_tiles_with_overlap(
     return tiles
 
 
-# TODO(ryand):
-# - Test with blend_amount=0
-# - Test tiles that go off of the dst_image.
-# - Test mismatched tiles and tile_images lengths.
-# - Test mismatched
-
-
 def merge_tiles_with_linear_blending(
     dst_image: np.ndarray, tiles: list[Tile], tile_images: list[np.ndarray], blend_amount: int
 ):
@@ -145,7 +138,7 @@ def merge_tiles_with_linear_blending(
             # Apply the blend gradient to the mask. Note that we use `*=` rather than `=` to achieve more natural
             # behavior on the corners where vertical and horizontal blending gradients overlap.
             mask[blend_start_top : blend_start_top + blend_amount, :] *= gradient_top_y
-            # HACK(ryand): For debugging
+            # For visual debugging:
             # tile_image[blend_start_top : blend_start_top + blend_amount, :] = 0
 
         # Left blending:
@@ -155,7 +148,7 @@ def merge_tiles_with_linear_blending(
             blend_start_left = tile.overlap.left // 2 - blend_amount // 2
             mask[:, :blend_start_left] = 0.0
             mask[:, blend_start_left : blend_start_left + blend_amount] *= gradient_left_x
-            # HACK(ryand): For debugging
+            # For visual debugging:
             # tile_image[:, blend_start_left : blend_start_left + blend_amount] = 0
 
         paste(dst_image=dst_image, src_image=tile_image, box=tile.coords, mask=mask)

--- a/invokeai/backend/tiles/utils.py
+++ b/invokeai/backend/tiles/utils.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+
+class TBLR(BaseModel):
+    top: int
+    bottom: int
+    left: int
+    right: int
+
+
+class Tile(BaseModel):
+    coords: TBLR = Field(description="The coordinates of this tile relative to its parent image.")
+    overlap: TBLR = Field(description="The amount of overlap with adjacent tiles on each side of this tile.")
+
+
+def paste(dst_image: np.ndarray, src_image: np.ndarray, box: TBLR, mask: Optional[np.ndarray] = None):
+    """Paste a source image into a destination image.
+
+    Args:
+        dst_image (torch.Tensor): The destination image to paste into. Shape: (H, W, C).
+        src_image (torch.Tensor): The source image to paste. Shape: (H, W, C). H and W must be compatible with 'box'.
+        box (TBLR): Box defining the region in the 'dst_image' where 'src_image' will be pasted.
+        mask (Optional[torch.Tensor]): A mask that defines the blending between 'src_image' and 'dst_image'.
+            Range: [0.0, 1.0], Shape: (H, W). The output is calculate per-pixel according to
+            `src * mask + dst * (1 - mask)`.
+    """
+
+    if mask is None:
+        dst_image[box.top : box.bottom, box.left : box.right] = src_image
+    else:
+        mask = np.expand_dims(mask, -1)
+        dst_image_box = dst_image[box.top : box.bottom, box.left : box.right]
+        dst_image[box.top : box.bottom, box.left : box.right] = src_image * mask + dst_image_box * (1.0 - mask)

--- a/invokeai/backend/tiles/utils.py
+++ b/invokeai/backend/tiles/utils.py
@@ -10,10 +10,21 @@ class TBLR(BaseModel):
     left: int
     right: int
 
+    def __eq__(self, other):
+        return (
+            self.top == other.top
+            and self.bottom == other.bottom
+            and self.left == other.left
+            and self.right == other.right
+        )
+
 
 class Tile(BaseModel):
     coords: TBLR = Field(description="The coordinates of this tile relative to its parent image.")
     overlap: TBLR = Field(description="The amount of overlap with adjacent tiles on each side of this tile.")
+
+    def __eq__(self, other):
+        return self.coords == other.coords and self.overlap == other.overlap
 
 
 def paste(dst_image: np.ndarray, src_image: np.ndarray, box: TBLR, mask: Optional[np.ndarray] = None):

--- a/tests/backend/tiles/test_tiles.py
+++ b/tests/backend/tiles/test_tiles.py
@@ -1,0 +1,84 @@
+import pytest
+
+from invokeai.backend.tiles.tiles import calc_tiles_with_overlap
+from invokeai.backend.tiles.utils import TBLR, Tile
+
+####################################
+# Test calc_tiles_with_overlap(...)
+####################################
+
+
+def test_calc_tiles_with_overlap_single_tile():
+    """Test calc_tiles_with_overlap() behavior when a single tile covers the image."""
+    tiles = calc_tiles_with_overlap(image_height=512, image_width=1024, tile_height=512, tile_width=1024, overlap=64)
+
+    expected_tiles = [
+        Tile(coords=TBLR(top=0, bottom=512, left=0, right=1024), overlap=TBLR(top=0, bottom=0, left=0, right=0))
+    ]
+
+    assert tiles == expected_tiles
+
+
+def test_calc_tiles_with_overlap_evenly_divisible():
+    """Test calc_tiles_with_overlap() behavior when the image is evenly covered by multiple tiles."""
+    # Parameters chosen so that image is evenly covered by 2 rows, 3 columns of tiles.
+    tiles = calc_tiles_with_overlap(image_height=576, image_width=1600, tile_height=320, tile_width=576, overlap=64)
+
+    expected_tiles = [
+        # Row 0
+        Tile(coords=TBLR(top=0, bottom=320, left=0, right=576), overlap=TBLR(top=0, bottom=64, left=0, right=64)),
+        Tile(coords=TBLR(top=0, bottom=320, left=512, right=1088), overlap=TBLR(top=0, bottom=64, left=64, right=64)),
+        Tile(coords=TBLR(top=0, bottom=320, left=1024, right=1600), overlap=TBLR(top=0, bottom=64, left=64, right=0)),
+        # Row 1
+        Tile(coords=TBLR(top=256, bottom=576, left=0, right=576), overlap=TBLR(top=64, bottom=0, left=0, right=64)),
+        Tile(coords=TBLR(top=256, bottom=576, left=512, right=1088), overlap=TBLR(top=64, bottom=0, left=64, right=64)),
+        Tile(coords=TBLR(top=256, bottom=576, left=1024, right=1600), overlap=TBLR(top=64, bottom=0, left=64, right=0)),
+    ]
+
+    assert tiles == expected_tiles
+
+
+def test_calc_tiles_with_overlap_not_evenly_divisible():
+    """Test calc_tiles_with_overlap() behavior when the image requires 'uneven' overlaps to achieve proper coverage."""
+    # Parameters chosen so that image is covered by 2 rows and 3 columns of tiles, with uneven overlaps.
+    tiles = calc_tiles_with_overlap(image_height=400, image_width=1200, tile_height=256, tile_width=512, overlap=64)
+
+    expected_tiles = [
+        # Row 0
+        Tile(coords=TBLR(top=0, bottom=256, left=0, right=512), overlap=TBLR(top=0, bottom=112, left=0, right=64)),
+        Tile(coords=TBLR(top=0, bottom=256, left=448, right=960), overlap=TBLR(top=0, bottom=112, left=64, right=272)),
+        Tile(coords=TBLR(top=0, bottom=256, left=688, right=1200), overlap=TBLR(top=0, bottom=112, left=272, right=0)),
+        # Row 1
+        Tile(coords=TBLR(top=144, bottom=400, left=0, right=512), overlap=TBLR(top=112, bottom=0, left=0, right=64)),
+        Tile(
+            coords=TBLR(top=144, bottom=400, left=448, right=960), overlap=TBLR(top=112, bottom=0, left=64, right=272)
+        ),
+        Tile(
+            coords=TBLR(top=144, bottom=400, left=688, right=1200), overlap=TBLR(top=112, bottom=0, left=272, right=0)
+        ),
+    ]
+
+    assert tiles == expected_tiles
+
+
+@pytest.mark.parametrize(
+    ["image_height", "image_width", "tile_height", "tile_width", "overlap", "raises"],
+    [
+        (128, 128, 128, 128, 127, False),  # OK
+        (128, 128, 128, 128, 0, False),  # OK
+        (128, 128, 64, 64, 0, False),  # OK
+        (128, 128, 129, 128, 0, True),  # tile_height exceeds image_height.
+        (128, 128, 128, 129, 0, True),  # tile_width exceeds image_width.
+        (128, 128, 64, 128, 64, True),  # overlap equals tile_height.
+        (128, 128, 128, 64, 64, True),  # overlap equals tile_width.
+    ],
+)
+def test_calc_tiles_with_overlap_input_validation(
+    image_height: int, image_width: int, tile_height: int, tile_width: int, overlap: int, raises: bool
+):
+    """Test that calc_tiles_with_overlap() raises an exception if the inputs are invalid."""
+    if raises:
+        with pytest.raises(AssertionError):
+            calc_tiles_with_overlap(image_height, image_width, tile_height, tile_width, overlap)
+    else:
+        calc_tiles_with_overlap(image_height, image_width, tile_height, tile_width, overlap)

--- a/tests/backend/tiles/test_utils.py
+++ b/tests/backend/tiles/test_utils.py
@@ -1,0 +1,101 @@
+import numpy as np
+import pytest
+
+from invokeai.backend.tiles.utils import TBLR, paste
+
+
+def test_paste_no_mask_success():
+    """Test successful paste with mask=None."""
+    dst_image = np.zeros((5, 5, 3), dtype=np.uint8)
+
+    # Create src_image with a pattern that can be used to validate that it was pasted correctly.
+    src_image = np.zeros((3, 3, 3), dtype=np.uint8)
+    src_image[0, :, 0] = 1  # Row of 1s in channel 0.
+    src_image[:, 0, 1] = 2  # Column of 2s in channel 1.
+
+    # Paste in bottom-center of dst_image.
+    box = TBLR(top=2, bottom=5, left=1, right=4)
+
+    # Construct expected output image.
+    expected_output = np.zeros((5, 5, 3), dtype=np.uint8)
+    expected_output[2, 1:4, 0] = 1
+    expected_output[2:5, 1, 1] = 2
+
+    paste(dst_image=dst_image, src_image=src_image, box=box)
+
+    np.testing.assert_array_equal(dst_image, expected_output, strict=True)
+
+
+def test_paste_with_mask_success():
+    """Test successful paste with a mask."""
+    dst_image = np.zeros((5, 5, 3), dtype=np.uint8)
+
+    # Create src_image with a pattern that can be used to validate that it was pasted correctly.
+    src_image = np.zeros((3, 3, 3), dtype=np.uint8)
+    src_image[0, :, 0] = 64  # Row of 64s in channel 0.
+    src_image[:, 0, 1] = 128  # Column of 128s in channel 1.
+
+    # Paste in bottom-center of dst_image.
+    box = TBLR(top=2, bottom=5, left=1, right=4)
+
+    # Create a mask that blends the top-left corner of 'src_image' at 50%, and ignores the rest of src_image.
+    mask = np.zeros((3, 3))
+    mask[0, 0] = 0.5
+
+    # Construct expected output image.
+    expected_output = np.zeros((5, 5, 3), dtype=np.uint8)
+    expected_output[2, 1, 0] = 32
+    expected_output[2, 1, 1] = 64
+
+    paste(dst_image=dst_image, src_image=src_image, box=box, mask=mask)
+
+    np.testing.assert_array_equal(dst_image, expected_output, strict=True)
+
+
+@pytest.mark.parametrize("use_mask", [True, False])
+def test_paste_box_overflows_dst_image(use_mask: bool):
+    """Test that an exception is raised if 'box' overflows the 'dst_image'."""
+    dst_image = np.zeros((5, 5, 3), dtype=np.uint8)
+    src_image = np.zeros((3, 3, 3), dtype=np.uint8)
+    mask = None
+    if use_mask:
+        mask = np.zeros((3, 3))
+
+    # Construct box that overflows bottom of dst_image.
+    top = 3
+    left = 0
+    box = TBLR(top=top, bottom=top + src_image.shape[0], left=left, right=left + src_image.shape[1])
+
+    with pytest.raises(ValueError):
+        paste(dst_image=dst_image, src_image=src_image, box=box, mask=mask)
+
+
+@pytest.mark.parametrize("use_mask", [True, False])
+def test_paste_src_image_does_not_match_box(use_mask: bool):
+    """Test that an exception is raised if the 'src_image' shape does not match the 'box' dimensions."""
+    dst_image = np.zeros((5, 5, 3), dtype=np.uint8)
+    src_image = np.zeros((3, 3, 3), dtype=np.uint8)
+    mask = None
+    if use_mask:
+        mask = np.zeros((3, 3))
+
+    # Construct box that is smaller than src_image.
+    box = TBLR(top=0, bottom=src_image.shape[0] - 1, left=0, right=src_image.shape[1])
+
+    with pytest.raises(ValueError):
+        paste(dst_image=dst_image, src_image=src_image, box=box, mask=mask)
+
+
+def test_paste_mask_does_not_match_src_image():
+    """Test that an exception is raised if the 'mask' shape is different than the 'src_image' shape."""
+    dst_image = np.zeros((5, 5, 3), dtype=np.uint8)
+    src_image = np.zeros((3, 3, 3), dtype=np.uint8)
+
+    # Construct mask that is smaller than the src_image.
+    mask = np.zeros((src_image.shape[0] - 1, src_image.shape[1]))
+
+    # Construct box that matches src_image shape.
+    box = TBLR(top=0, bottom=src_image.shape[0], left=0, right=src_image.shape[1])
+
+    with pytest.raises(ValueError):
+        paste(dst_image=dst_image, src_image=src_image, box=box, mask=mask)


### PR DESCRIPTION
## Contributors

Big thanks to @JPPhoto, @dwringer, @skunkworxdark and @dunkeroni for their contributions in this discord discussion: https://discord.com/channels/1020123559063990373/1161727357309165608.

The implementation in this PR is based closely on their work.

Check out that discussion for a more-advanced, continually-evolving implementation of tiled upscaling.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description

This PR adds several new invocations to enable image tiling workflows:
- `CalculateImageTilesInvocation`
- `TileToPropertiesInvocation`
- `PairTileImageInvocation`
- `MergeTilesToImageInvocation`

Here is a sample Tiled Upscaling workflow to illustrate how these tiling invocations are intended to be used: [tiled_upscaling.json](https://github.com/invoke-ai/InvokeAI/files/13420162/tiled_upscaling.json)

## Known Limitations / Weirdness

During development of this feature there was lots of deliberation around how best to implement it within the 'nodes' ecosystem (a single tiled upscaling node vs. multiple nodes to enable tile splitting/merging). Below is a list of the known shortcomings of the selected implementation. Many of these point to improvements that could be made to node workflows in general.

- CustomTypes
  - Solved! This PR depends on https://github.com/invoke-ai/InvokeAI/pull/5113.
- Performance:
  - The current implementation does lots of unnecessary image encode/decode roundtrips to pass images between nodes when we really just want to pass tensors in memory. This wastes time.
  - The current implementation results in much more model switching than is necessary. Specifically, we alternate between 'Denoise Latents' and 'VAE Decode' rather than performing 'Denoise Latents' on all images followed by 'VAE Decode'. On systems with limited RAM/VRAM model cache space this model switching could be very costly. It is possible to work around this issue, but it requires adding a bunch more complexity to the workflow graph in the form of more iterate/collect nodes. The takeaway here is that complex node-based workflows can encourage inefficient model switching behavior.
- Algorithm constraints:
  - The selected node architecture prevents us from using information from previously-refined tiles while processing the current tile, because we do not support cyclic graphs. This has been proposed as a possible improvement to the algorithm, but would require a very different implementation and node interface.
- Usability:
  - Unfortunately, users needs a pretty complex graph to do anything useful with these new tiling nodes.
  - I fear that the API is likely to change. Should we make these 'experimental' nodes and hide from the UI somehow?

## Related Tickets & Documents

I previously posted this RFC with an alternative single-node implementation: https://github.com/invoke-ai/InvokeAI/pull/5109

After exploring it further, I decided to proceed with the approach in this PR. The biggest challenge with the single-node approach is that it is cumbersome to call into all of the necessary logic that is spread across the Stable Diffusion nodes (e.g. to support ControlNet, IP-Adapter, etc.).

## QA Instructions, Screenshots, Recordings

Here is a sample Tiled Upscaling workflow: [tiled_upscaling.json](https://github.com/invoke-ai/InvokeAI/files/13420162/tiled_upscaling.json). Try it out and let me know what you think.

Please reflect on whether this is the right API for tiling. Now is the easiest time to change it.

## Added/updated tests?

- [x] Yes
- [ ] No

The core tiling logic has strong unit test coverage. Invocations are not currently covered.

## TODO

- [ ] Change the target branch to main after https://github.com/invoke-ai/InvokeAI/pull/5113 is merged!