### PR TITLE
Fix attempt to deserialize on CUDA on Mac

### DIFF
--- a/invokeai/backend/model_management/model_probe.py
+++ b/invokeai/backend/model_management/model_probe.py
@@ -225,7 +225,7 @@ class ModelProbe(object):
         with SilenceWarnings():
             if model_path.suffix.endswith((".ckpt", ".pt", ".bin")):
                 cls._scan_model(model_path, model_path)
-                return torch.load(model_path)
+                return torch.load(model_path, map_location="cpu")
             else:
                 return safetensors.torch.load_file(model_path)
 


### PR DESCRIPTION
Without specifying map_location="cpu" in ModelProbe, Invoke attempts to use non-existent CUDA to deserialize embeddings on macOS, resulting in a warning / failure to load.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: Minor bug fix, only for macOS platform

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No


## Description

Noticed in a fresh install of 3.4.0post2 on macOS that InvokeAI logs a warning about attempting to deserialize embeddings on CUDA, which is not available.  This change eliminates that warning.

It is not clear to me if this needs to be conditional on the availability of CUDA hardware.  I noticed that other places in the code are hardcoded to use map_location="cpu", so I followed that lead.

I believe this is the same issue as #4265 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #4265
- Closes #4265

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [X] No : Tested locally on my Macs

## [optional] Are there any post deployment tasks we need to perform?
