### PR TITLE
Fix type mismatches in invokeai.app.services.config

### DIFF
--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -232,7 +232,6 @@ app.mount("/locales", StaticFiles(directory=Path(web_root_path, "dist/locales/")
 
 
 def invoke_api() -> None:
-
     def find_port(port: int) -> int:
         """Find a port not in use starting at given port"""
         # Taken from https://waylonwalker.com/python-find-available-port/, thanks Waylon!

--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -1,4 +1,5 @@
 from typing import Any
+import sys
 
 from fastapi.responses import HTMLResponse
 
@@ -7,8 +8,12 @@ from .services.config import InvokeAIAppConfig
 # parse_args() must be called before any other imports. if it is not called first, consumers of the config
 # which are imported/used before parse_args() is called will get the default config values instead of the
 # values from the command line or config file.
+from invokeai.version.invokeai_version import __version__
 app_config = InvokeAIAppConfig.get_config()
 app_config.parse_args()
+if app_config.version:
+    print(f"InvokeAI version {__version__}")
+    sys.exit(0)
 
 if True:  # hack to make flake8 happy with imports coming after setting up the config
     import asyncio
@@ -34,7 +39,6 @@ if True:  # hack to make flake8 happy with imports coming after setting up the c
     # noinspection PyUnresolvedReferences
     import invokeai.backend.util.hotfixes  # noqa: F401 (monkeypatching on import)
     import invokeai.frontend.web as web_dir
-    from invokeai.version.invokeai_version import __version__
 
     from ..backend.util.logging import InvokeAILogger
     from .api.dependencies import ApiDependencies
@@ -222,6 +226,7 @@ app.mount("/locales", StaticFiles(directory=Path(web_root_path, "dist/locales/")
 
 
 def invoke_api() -> None:
+
     def find_port(port: int) -> int:
         """Find a port not in use starting at given port"""
         # Taken from https://waylonwalker.com/python-find-available-port/, thanks Waylon!
@@ -273,7 +278,4 @@ def invoke_api() -> None:
 
 
 if __name__ == "__main__":
-    if app_config.version:
-        print(f"InvokeAI version {__version__}")
-    else:
-        invoke_api()
+    invoke_api()

--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -1,14 +1,15 @@
-from typing import Any
 import sys
+from typing import Any
 
 from fastapi.responses import HTMLResponse
-
-from .services.config import InvokeAIAppConfig
 
 # parse_args() must be called before any other imports. if it is not called first, consumers of the config
 # which are imported/used before parse_args() is called will get the default config values instead of the
 # values from the command line or config file.
 from invokeai.version.invokeai_version import __version__
+
+from .services.config import InvokeAIAppConfig
+
 app_config = InvokeAIAppConfig.get_config()
 app_config.parse_args()
 if app_config.version:
@@ -55,7 +56,12 @@ if True:  # hack to make flake8 happy with imports coming after setting up the c
         workflows,
     )
     from .api.sockets import SocketIO
-    from .invocations.baseinvocation import BaseInvocation, UIConfigBase, _InputField, _OutputField
+    from .invocations.baseinvocation import (
+        BaseInvocation,
+        UIConfigBase,
+        _InputField,
+        _OutputField,
+    )
 
     if is_mps_available():
         import invokeai.backend.util.mps_fixes  # noqa: F401 (monkeypatching on import)

--- a/invokeai/app/invocations/__init__.py
+++ b/invokeai/app/invocations/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from invokeai.app.services.config.config_default import InvokeAIAppConfig
 
-custom_nodes_path = Path(InvokeAIAppConfig.get_config().custom_nodes_path.absolute())
+custom_nodes_path = Path(InvokeAIAppConfig.get_config().custom_nodes_path.resolve())
 custom_nodes_path.mkdir(parents=True, exist_ok=True)
 
 custom_nodes_init_path = str(custom_nodes_path / "__init__.py")

--- a/invokeai/app/services/config/config_base.py
+++ b/invokeai/app/services/config/config_base.py
@@ -152,6 +152,9 @@ class InvokeAISettings(BaseSettings):
             "free_gpu_mem",
             "xformers_enabled",
             "tiled_decode",
+            "lora_dir",
+            "embedding_dir",
+            "controlnet_dir",
         ]
 
     @classmethod

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -231,15 +231,12 @@ class InvokeAIAppConfig(InvokeAISettings):
 
     # PATHS
     root                : Optional[Path] = Field(default=None, description='InvokeAI runtime root directory', json_schema_extra=Categories.Paths)
-    autoimport_dir      : Optional[Path] = Field(default=Path('autoimport'), description='Path to a directory of models files to be imported on startup.', json_schema_extra=Categories.Paths)
-    lora_dir            : Optional[Path] = Field(default=None, description='Path to a directory of LoRA/LyCORIS models to be imported on startup.', json_schema_extra=Categories.Paths)
-    embedding_dir       : Optional[Path] = Field(default=None, description='Path to a directory of Textual Inversion embeddings to be imported on startup.', json_schema_extra=Categories.Paths)
-    controlnet_dir      : Optional[Path] = Field(default=None, description='Path to a directory of ControlNet embeddings to be imported on startup.', json_schema_extra=Categories.Paths)
-    conf_path           : Optional[Path] = Field(default=Path('configs/models.yaml'), description='Path to models definition file', json_schema_extra=Categories.Paths)
-    models_dir          : Optional[Path] = Field(default=Path('models'), description='Path to the models directory', json_schema_extra=Categories.Paths)
-    legacy_conf_dir     : Optional[Path] = Field(default=Path('configs/stable-diffusion'), description='Path to directory of legacy checkpoint config files', json_schema_extra=Categories.Paths)
-    db_dir              : Optional[Path] = Field(default=Path('databases'), description='Path to InvokeAI databases directory', json_schema_extra=Categories.Paths)
-    outdir              : Optional[Path] = Field(default=Path('outputs'), description='Default folder for output images', json_schema_extra=Categories.Paths)
+    autoimport_dir      : Path = Field(default=Path('autoimport'), description='Path to a directory of models files to be imported on startup.', json_schema_extra=Categories.Paths)
+    conf_path           : Path = Field(default=Path('configs/models.yaml'), description='Path to models definition file', json_schema_extra=Categories.Paths)
+    models_dir          : Path = Field(default=Path('models'), description='Path to the models directory', json_schema_extra=Categories.Paths)
+    legacy_conf_dir     : Path = Field(default=Path('configs/stable-diffusion'), description='Path to directory of legacy checkpoint config files', json_schema_extra=Categories.Paths)
+    db_dir              : Path = Field(default=Path('databases'), description='Path to InvokeAI databases directory', json_schema_extra=Categories.Paths)
+    outdir              : Path = Field(default=Path('outputs'), description='Default folder for output images', json_schema_extra=Categories.Paths)
     use_memory_db       : bool = Field(default=False, description='Use in-memory database for storing image metadata', json_schema_extra=Categories.Paths)
     custom_nodes_dir    : Path = Field(default=Path('nodes'), description='Path to directory for custom nodes', json_schema_extra=Categories.Paths)
     from_file           : Optional[Path] = Field(default=None, description='Take command input from the indicated file (command-line client only)', json_schema_extra=Categories.Paths)
@@ -282,11 +279,15 @@ class InvokeAIAppConfig(InvokeAISettings):
 
     # DEPRECATED FIELDS - STILL HERE IN ORDER TO OBTAN VALUES FROM PRE-3.1 CONFIG FILES
     always_use_cpu      : bool = Field(default=False, description="If true, use the CPU for rendering even if a GPU is available.", json_schema_extra=Categories.MemoryPerformance)
-    free_gpu_mem        : Optional[bool] = Field(default=None, description="If true, purge model from GPU after each generation.", json_schema_extra=Categories.MemoryPerformance)
     max_cache_size      : Optional[float] = Field(default=None, gt=0, description="Maximum memory amount used by model cache for rapid switching", json_schema_extra=Categories.MemoryPerformance)
     max_vram_cache_size : Optional[float] = Field(default=None, ge=0, description="Amount of VRAM reserved for model storage", json_schema_extra=Categories.MemoryPerformance)
     xformers_enabled    : bool = Field(default=True, description="Enable/disable memory-efficient attention", json_schema_extra=Categories.MemoryPerformance)
     tiled_decode        : bool = Field(default=False, description="Whether to enable tiled VAE decode (reduces memory consumption with some performance penalty)", json_schema_extra=Categories.MemoryPerformance)
+    lora_dir            : Optional[Path] = Field(default=None, description='Path to a directory of LoRA/LyCORIS models to be imported on startup.', json_schema_extra=Categories.Paths)
+    embedding_dir       : Optional[Path] = Field(default=None, description='Path to a directory of Textual Inversion embeddings to be imported on startup.', json_schema_extra=Categories.Paths)
+    controlnet_dir      : Optional[Path] = Field(default=None, description='Path to a directory of ControlNet embeddings to be imported on startup.', json_schema_extra=Categories.Paths)
+    # this is not referred to in the source code and can be removed entirely
+    #free_gpu_mem        : Optional[bool] = Field(default=None, description="If true, purge model from GPU after each generation.", json_schema_extra=Categories.MemoryPerformance)
 
     # See InvokeAIAppConfig subclass below for CACHE and DEVICE categories
     # fmt: on
@@ -336,7 +337,9 @@ class InvokeAIAppConfig(InvokeAISettings):
     def get_config(cls, **kwargs) -> InvokeAIAppConfig:
         """Return a singleton InvokeAIAppConfig configuration object."""
         if (
-            cls.singleton_config is None or type(cls.singleton_config) is not cls or (kwargs and cls.singleton_init != kwargs)
+            cls.singleton_config is None
+            or type(cls.singleton_config) is not cls
+            or (kwargs and cls.singleton_init != kwargs)
         ):
             cls.singleton_config = cls(**kwargs)
             cls.singleton_init = kwargs
@@ -363,42 +366,43 @@ class InvokeAIAppConfig(InvokeAISettings):
     @property
     def init_file_path(self) -> Path:
         """Path to invokeai.yaml."""
-        return self._resolve(INIT_FILE)
+        resolved_path = self._resolve(INIT_FILE)
+        assert resolved_path is not None
+        return resolved_path
 
     @property
-    def output_path(self) -> Path:
+    def output_path(self) -> Optional[Path]:
         """Path to defaults outputs directory."""
-        assert self.outdir
         return self._resolve(self.outdir)
 
     @property
     def db_path(self) -> Path:
         """Path to the invokeai.db file."""
-        assert self.db_dir
-        return self._resolve(self.db_dir) / DB_FILE
+        db_dir = self._resolve(self.db_dir)
+        assert db_dir is not None
+        return db_dir / DB_FILE
 
     @property
-    def model_conf_path(self) -> Path:
+    def model_conf_path(self) -> Optional[Path]:
         """Path to models configuration file."""
-        assert self.conf_path
         return self._resolve(self.conf_path)
 
     @property
-    def legacy_conf_path(self) -> Path:
+    def legacy_conf_path(self) -> Optional[Path]:
         """Path to directory of legacy configuration files (e.g. v1-inference.yaml)."""
-        assert self.legacy_conf_dir
         return self._resolve(self.legacy_conf_dir)
 
     @property
-    def models_path(self) -> Path:
+    def models_path(self) -> Optional[Path]:
         """Path to the models directory."""
-        assert self.models_dir
         return self._resolve(self.models_dir)
 
     @property
     def custom_nodes_path(self) -> Path:
         """Path to the custom nodes directory."""
-        return self._resolve(self.custom_nodes_dir)
+        custom_nodes_path = self._resolve(self.custom_nodes_dir)
+        assert custom_nodes_path is not None
+        return custom_nodes_path
 
     # the following methods support legacy calls leftover from the Globals era
     @property

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -177,7 +177,7 @@ from typing import ClassVar, Dict, List, Literal, Optional, Union, get_type_hint
 
 from omegaconf import DictConfig, OmegaConf
 from pydantic import Field, TypeAdapter
-from pydantic.fields import JsonDict
+from pydantic.config import JsonDict
 from pydantic_settings import SettingsConfigDict
 
 from .config_base import InvokeAISettings

--- a/invokeai/app/services/model_records/model_records_sql.py
+++ b/invokeai/app/services/model_records/model_records_sql.py
@@ -48,7 +48,6 @@ from typing import List, Optional, Union
 from invokeai.backend.model_manager.config import (
     AnyModelConfig,
     BaseModelType,
-    ModelConfigBase,
     ModelConfigFactory,
     ModelType,
 )
@@ -158,7 +157,7 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
             ("version", CONFIG_FILE_VERSION),
         )
 
-    def add_model(self, key: str, config: Union[dict, ModelConfigBase]) -> AnyModelConfig:
+    def add_model(self, key: str, config: Union[dict, AnyModelConfig]) -> AnyModelConfig:
         """
         Add a model to the database.
 
@@ -255,7 +254,7 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
                 self._db.conn.rollback()
                 raise e
 
-    def update_model(self, key: str, config: ModelConfigBase) -> AnyModelConfig:
+    def update_model(self, key: str, config: Union[dict, AnyModelConfig]) -> AnyModelConfig:
         """
         Update the model, returning the updated version.
 
@@ -368,7 +367,7 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
             results = [ModelConfigFactory.make_config(json.loads(x[0])) for x in self._cursor.fetchall()]
         return results
 
-    def search_by_path(self, path: Union[str, Path]) -> List[ModelConfigBase]:
+    def search_by_path(self, path: Union[str, Path]) -> List[AnyModelConfig]:
         """Return models with the indicated path."""
         results = []
         with self._db.lock:
@@ -382,7 +381,7 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
             results = [ModelConfigFactory.make_config(json.loads(x[0])) for x in self._cursor.fetchall()]
         return results
 
-    def search_by_hash(self, hash: str) -> List[ModelConfigBase]:
+    def search_by_hash(self, hash: str) -> List[AnyModelConfig]:
         """Return models with the indicated original_hash."""
         results = []
         with self._db.lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,8 +227,6 @@ module = [
   "invokeai.app.api.routers.models",
   "invokeai.app.invocations.compel",
   "invokeai.app.invocations.latent",
-  "invokeai.app.services.config.config_base",
-  "invokeai.app.services.config.config_default",
   "invokeai.app.services.invocation_stats.invocation_stats_default",
   "invokeai.app.services.model_manager.model_manager_base",
   "invokeai.app.services.model_manager.model_manager_default",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: trivial

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

This PR does two things:

1) Fixes various type-checking errors in invokeai/app/services/config/config_base.py and config_default.py.
2) Adds back the ability to get `invokeai-web` to print out the current version number with `--version` on the command line.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Just check that the frontend runs and that changing configuration variables in the `invokeai.yaml` file and/or command line are having the expected effect.

## Added/updated tests?

- [X] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
