### PR TITLE
pin opencv-python to get required cv2.typing module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "omegaconf",
   "onnx",
   "onnxruntime",
-  "opencv-python",
+  "opencv-python~=4.8.1.1",
   "pydantic~=2.5.0",
   "pydantic-settings~=2.0.3",
   "picklescan",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

A recent merge introduced a new dependency on the `cv2.typing` module. This is not present in older versions of the `opencv-python` package. This pins `opencv-python` to a recent version that contains the module in question.

## QA Instructions, Screenshots, Recordings

After pulling, run `pip install -e .` to update to a compatible version of `cv2`.
