### PR TITLE
UI: Current Image Display - Smooth Preview

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImagePreview.tsx
@@ -9,17 +9,17 @@ import {
   TypesafeDraggableData,
   TypesafeDroppableData,
 } from 'features/dnd/types';
+import ImageMetadataViewer from 'features/gallery/components/ImageMetadataViewer/ImageMetadataViewer';
+import NextPrevImageButtons from 'features/gallery/components/NextPrevImageButtons';
 import { useNextPrevImage } from 'features/gallery/hooks/useNextPrevImage';
 import { selectLastSelectedImage } from 'features/gallery/store/gallerySelectors';
 import { AnimatePresence, motion } from 'framer-motion';
 import { isEqual } from 'lodash-es';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { useTranslation } from 'react-i18next';
 import { FaImage } from 'react-icons/fa';
 import { useGetImageDTOQuery } from 'services/api/endpoints/images';
-import ImageMetadataViewer from 'features/gallery/components/ImageMetadataViewer/ImageMetadataViewer';
-import NextPrevImageButtons from 'features/gallery/components/NextPrevImageButtons';
-import { useTranslation } from 'react-i18next';
 
 export const imagesSelector = createSelector(
   [stateSelector, selectLastSelectedImage],
@@ -144,39 +144,85 @@ const CurrentImagePreview = () => {
       }}
     >
       {denoiseProgress?.progress_image && shouldShowProgressInViewer ? (
-        <Image
-          src={denoiseProgress.progress_image.dataURL}
-          width={denoiseProgress.progress_image.width}
-          height={denoiseProgress.progress_image.height}
-          draggable={false}
-          data-testid="progress-image"
-          sx={{
-            objectFit: 'contain',
-            maxWidth: 'full',
-            maxHeight: 'full',
-            height: 'auto',
-            position: 'absolute',
-            borderRadius: 'base',
-            imageRendering: shouldAntialiasProgressImage ? 'auto' : 'pixelated',
-          }}
-        />
-      ) : (
-        <IAIDndImage
-          imageDTO={imageDTO}
-          droppableData={droppableData}
-          draggableData={draggableData}
-          isUploadDisabled={true}
-          fitContainer
-          useThumbailFallback
-          dropLabel={t('gallery.setCurrentImage')}
-          noContentFallback={
-            <IAINoContentFallback
-              icon={FaImage}
-              label={t('gallery.noImageSelected')}
+        <AnimatePresence>
+          <motion.div
+            key="progressDisplayImage"
+            initial={{
+              opacity: 0,
+            }}
+            animate={{
+              opacity: 1,
+              transition: { duration: 1 },
+            }}
+            exit={{
+              opacity: 0,
+              transition: { duration: 2 },
+            }}
+            style={{
+              position: 'absolute',
+              width: '100%',
+              height: '100%',
+            }}
+          >
+            <Image
+              src={denoiseProgress.progress_image.dataURL}
+              width={denoiseProgress.progress_image.width}
+              height={denoiseProgress.progress_image.height}
+              draggable={false}
+              data-testid="progress-image"
+              sx={{
+                objectFit: 'contain',
+                maxWidth: 'full',
+                maxHeight: 'full',
+                height: 'auto',
+                position: 'relative',
+                margin: 'auto',
+                borderRadius: 'base',
+                imageRendering: shouldAntialiasProgressImage
+                  ? 'auto'
+                  : 'pixelated',
+              }}
             />
-          }
-          dataTestId="image-preview"
-        />
+          </motion.div>
+        </AnimatePresence>
+      ) : (
+        <AnimatePresence>
+          <motion.div
+            key="currentDisplayImage"
+            initial={{
+              opacity: 0,
+            }}
+            animate={{
+              opacity: [0, 1],
+              transition: { duration: 1.25 },
+            }}
+            exit={{
+              opacity: 0,
+              transition: { duration: 2 },
+            }}
+            style={{
+              width: '100%',
+              height: '100%',
+            }}
+          >
+            <IAIDndImage
+              imageDTO={imageDTO}
+              droppableData={droppableData}
+              draggableData={draggableData}
+              isUploadDisabled={true}
+              fitContainer
+              useThumbailFallback
+              dropLabel={t('gallery.setCurrentImage')}
+              noContentFallback={
+                <IAINoContentFallback
+                  icon={FaImage}
+                  label={t('gallery.noImageSelected')}
+                />
+              }
+              dataTestId="image-preview"
+            />
+          </motion.div>
+        </AnimatePresence>
       )}
       {shouldShowImageDetails && imageDTO && (
         <Box

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -108,7 +108,7 @@ export const systemSlice = createSlice({
      * Invocation Started
      */
     builder.addCase(appSocketInvocationStarted, (state) => {
-      state.denoiseProgress = null;
+      // state.denoiseProgress = null;
       state.status = 'PROCESSING';
     });
 
@@ -142,7 +142,7 @@ export const systemSlice = createSlice({
      * Invocation Complete
      */
     builder.addCase(appSocketInvocationComplete, (state) => {
-      state.denoiseProgress = null;
+      // state.denoiseProgress = null;
       state.status = 'CONNECTED';
     });
 
@@ -169,7 +169,7 @@ export const systemSlice = createSlice({
         )
       ) {
         state.status = 'CONNECTED';
-        state.denoiseProgress = null;
+        // state.denoiseProgress = null;
       }
     });
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Have you discussed this change with the InvokeAI team?
- [x] No

      
## Description

- Changes image saving to CV2 instead of PIL. Shows better performance for me. Can be reverted if this is not the general case.
- Hacky effort to make the Current Image Display smoother with transitions and animation. Looks neat imo.

https://github.com/invoke-ai/InvokeAI/assets/54517381/4b9191ef-5696-4ee8-ab9f-215ff1d037f1


