### PR TITLE
Add support for `IPAdapterFull` models

### DIFF
--- a/tests/backend/ip_adapter/test_ip_adapter.py
+++ b/tests/backend/ip_adapter/test_ip_adapter.py
@@ -37,6 +37,14 @@ def build_dummy_sd15_unet_input(torch_device):
             "unet_model_id": "runwayml/stable-diffusion-v1-5",
             "unet_model_name": "stable-diffusion-v1-5",
         },
+        # SD1.5, IPAdapterFull
+        {
+            "ip_adapter_model_id": "InvokeAI/ip-adapter-full-face_sd15",
+            "ip_adapter_model_name": "ip-adapter-full-face_sd15",
+            "base_model": BaseModelType.StableDiffusion1,
+            "unet_model_id": "runwayml/stable-diffusion-v1-5",
+            "unet_model_name": "stable-diffusion-v1-5",
+        },
     ],
 )
 @pytest.mark.slow


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

The recently-released [ip-adapter-full-face_sd15](https://huggingface.co/InvokeAI/ip-adapter-full-face_sd15) model uses a new IP-Adapter architecture (`IPAdapterFull`). This new architecture was added upstream in the official IP-Adapter repo here: https://github.com/tencent-ailab/IP-Adapter/pull/139

This PR adds support for `IPAdapterFull` models.

## QA Instructions, Screenshots, Recordings

I tested the following:
- Installed the model via the UI.
- Generated with the following IP-Adapters:
  - IPAdapter (SD1.5)
  - IPAdapterPlus (SD1.5)
  - IPAdapterPlusXL (SDXL)
  - IPAdapterFul (SD1.5)

## Added/updated tests?

- [x] Yes
- [ ] No

I added a unit test for IPAdapterFull model loading. Run with `pytest tests/ -m slow`.
