### PR TITLE
feat(nodes): add index and total to iterate output

### DIFF
--- a/invokeai/app/services/shared/graph.py
+++ b/invokeai/app/services/shared/graph.py
@@ -207,10 +207,12 @@ class IterateInvocationOutput(BaseInvocationOutput):
     item: Any = OutputField(
         description="The item being iterated over", title="Collection Item", ui_type=UIType._CollectionItem
     )
+    index: int = OutputField(description="The index of the item", title="Index")
+    total: int = OutputField(description="The total number of items", title="Total")
 
 
 # TODO: Fill this out and move to invocations
-@invocation("iterate", version="1.0.0")
+@invocation("iterate", version="1.1.0")
 class IterateInvocation(BaseInvocation):
     """Iterates over a list of items"""
 
@@ -221,7 +223,7 @@ class IterateInvocation(BaseInvocation):
 
     def invoke(self, context: InvocationContext) -> IterateInvocationOutput:
         """Produces the outputs as values"""
-        return IterateInvocationOutput(item=self.collection[self.index])
+        return IterateInvocationOutput(item=self.collection[self.index], index=self.index, total=len(self.collection))
 
 
 @invocation_output("collect_output")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

- Adds the total number of items the iterate node received, and the current it's index, to its output.
- `IterateInvocation` bumped to 1.1.0

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## QA Instructions, Screenshots, Recordings

<img width="905" alt="image" src="https://github.com/invoke-ai/InvokeAI/assets/4822129/1dd9c56e-6b24-4bdb-8180-7b208992b129">


<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->
