### PR TITLE
Set minimum numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
   "invisible-watermark~=0.2.0",            # needed to install SDXL base and refiner using their repo_ids
   "matplotlib",                            # needed for plotting of Penner easing functions
   "mediapipe",                             # needed for "mediapipeface" controlnet model
-  "numpy",
+  # Minimum numpy version of 1.24.0 is needed to use the 'strict' argument to np.testing.assert_array_equal().
+  "numpy>=1.24.0",
   "npyscreen",
   "omegaconf",
   "onnx",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

Set minimum `numpy` version in response to this bug: https://discord.com/channels/1020123559063990373/1049495067846524939/1180152828027748402


## Added/updated tests?

- [x] Yes
- [ ] No