### PR TITLE
Fix link to xpuct/deliberate in starter models

### DIFF
--- a/invokeai/configs/INITIAL_MODELS.yaml
+++ b/invokeai/configs/INITIAL_MODELS.yaml
@@ -32,9 +32,9 @@ sd-1/main/Analog-Diffusion:
    description: An SD-1.5 model trained on diverse analog photographs (2.13 GB)
    repo_id: wavymulder/Analog-Diffusion
    recommended: False
-sd-1/main/Deliberate:
+sd-1/main/Deliberate_v5:
    description: Versatile model that produces detailed images up to 768px (4.27 GB)
-   repo_id: XpucT/Deliberate
+   path: https://huggingface.co/XpucT/Deliberate/resolve/main/Deliberate_v5.safetensors
    recommended: False
 sd-1/main/Dungeons-and-Diffusion:
    description: Dungeons & Dragons characters (2.13 GB)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] N/A


## Description

The HuggingFace `XpucT/deliberate` model page has been reorganized and is no longer available as a diffusers model. This fix will download the current .safetensors version. Tested and works.


## Related Tickets & Documents

First mentioned on discord at: https://discord.com/channels/1020123559063990373/1181369595974647828/1181650223471267870

## QA Instructions, Screenshots, Recordings

If you wish to test installation, please use `invokeai-model-install` and select the `Deliberate_v5` checkbox.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [ ] Yes
- [X] N/A

## [optional] Are there any post deployment tasks we need to perform?
