### PR TITLE
feat: serve HTTPS when configured with `ssl_certfile`

### DIFF
--- a/docs/features/CONFIGURATION.md
+++ b/docs/features/CONFIGURATION.md
@@ -154,14 +154,16 @@ groups in `invokeia.yaml`:
 
 ### Web Server
 
-| Setting  | Default Value  |  Description |
-|----------|----------------|--------------|
-| `host`     | `localhost`      | Name or IP address of the network interface that the web server will listen on  |
-| `port`     | `9090`           | Network port number that the web server will listen on  |
-| `allow_origins`  | `[]`       | A list of host names or IP addresses that are allowed to connect to the InvokeAI API in the format `['host1','host2',...]` |
-| `allow_credentials` | `true`   | Require credentials for a foreign host to access the InvokeAI API (don't change this) |
-| `allow_methods` | `*`         | List of HTTP methods ("GET", "POST") that the web server is allowed to use when accessing the API  |
-| `allow_headers` | `*`         | List of HTTP headers that the web server will accept when accessing the API  |
+| Setting             | Default Value | Description                                                                                                                |
+|---------------------|---------------|----------------------------------------------------------------------------------------------------------------------------|
+| `host`              | `localhost`   | Name or IP address of the network interface that the web server will listen on                                             |
+| `port`              | `9090`        | Network port number that the web server will listen on                                                                     |
+| `allow_origins`     | `[]`          | A list of host names or IP addresses that are allowed to connect to the InvokeAI API in the format `['host1','host2',...]` |
+| `allow_credentials` | `true`        | Require credentials for a foreign host to access the InvokeAI API (don't change this)                                      |
+| `allow_methods`     | `*`           | List of HTTP methods ("GET", "POST") that the web server is allowed to use when accessing the API                          |
+| `allow_headers`     | `*`           | List of HTTP headers that the web server will accept when accessing the API                                                |
+| `ssl_certfile`      | null          | Path to an SSL certificate file, used to enable HTTPS.                                                                     |
+| `ssl_keyfile`       | null          | Path to an SSL keyfile, if the key is not included in the certificate file.                                                |
 
 The documentation for InvokeAI's API can be accessed by browsing to the following URL: [http://localhost:9090/docs].
 

--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -272,6 +272,8 @@ def invoke_api() -> None:
         port=port,
         loop="asyncio",
         log_level=app_config.log_level,
+        ssl_certfile=app_config.ssl_certfile,
+        ssl_keyfile=app_config.ssl_keyfile,
     )
     server = uvicorn.Server(config)
 

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -221,6 +221,9 @@ class InvokeAIAppConfig(InvokeAISettings):
     allow_credentials   : bool = Field(default=True, description="Allow CORS credentials", json_schema_extra=Categories.WebServer)
     allow_methods       : List[str] = Field(default=["*"], description="Methods allowed for CORS", json_schema_extra=Categories.WebServer)
     allow_headers       : List[str] = Field(default=["*"], description="Headers allowed for CORS", json_schema_extra=Categories.WebServer)
+    # SSL options correspond to https://www.uvicorn.org/settings/#https
+    ssl_certfile        : Optional[Path] = Field(default=None, description="SSL certificate file (for HTTPS)", json_schema_extra=Categories.WebServer)
+    ssl_keyfile         : Optional[Path] = Field(default=None, description="SSL key file", json_schema_extra=Categories.WebServer)
 
     # FEATURES
     esrgan              : bool = Field(default=True, description="Enable/disable upscaling code", json_schema_extra=Categories.Features)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Feature

## Have you discussed this change with the InvokeAI team?
- not yet

      
## Have you updated all relevant documentation?
- Yes

## Description

The web server will use HTTPS when given a SSL certificate file, added to the Web section of the configuration file.

## Related Tickets & Documents

- Closes #3970
