### PR TITLE
[Feature] Allow the model record migrate script to update existing model records

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -85,7 +85,7 @@ class ModelInstallService(ModelInstallServiceBase):
     def event_bus(self) -> Optional[EventServiceBase]:  # noqa D102
         return self._event_bus
 
-    def stop(self) -> None:
+    def stop(self, *args, **kwargs) -> None:
         """Stop the install thread; after this the object can be deleted and garbage collected."""
         self._install_queue.put(STOP_JOB)
 

--- a/invokeai/backend/model_manager/migrate_to_db.py
+++ b/invokeai/backend/model_manager/migrate_to_db.py
@@ -56,7 +56,7 @@ class MigrateModelYamlToDb:
         """Fetch the models.yaml DictConfig for this installation."""
         yaml_path = self.config.model_conf_path
         omegaconf = OmegaConf.load(yaml_path)
-        assert isinstance(omegaconf,DictConfig)
+        assert isinstance(omegaconf, DictConfig)
         return omegaconf
 
     def migrate(self) -> None:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No


## Description

1. The new model manager sqlite3-based configuration record storage system is automatically populated with probed values from existing models found in the models path when `invokeai-web` starts up for the first time. However, the user's customization of these models in `invokeai.yaml`, including such things as the prediction type and model description, are not automatically copied over. This PR enhances the `invokeai-migrate-models-to-db` script so that any customized configuration data from `invokeai.yaml` replaces the original probed values. This script only needs to be run once, but it does not hurt to run it additional times. In the near future, I'm going to register this module with psychedelicious's sqlite migration system so that the update happens automatically during database migration.

2. The SQL-based model config record system stores a JSON version of the config, as well as several fields that are broken out into individual columns for search/indexing purposes. This PR keeps the JSON and the broken-out fields in sync using the `json_extract()` sqlite3 function to populate the broken out `base`, `type`, `name`, `path` and `format` fields in the `model_config` table.

3. Finally, this PR fixes the annoying `invokeai-web` shutdown message: `TypeError: ModelInstallService.stop() takes 1 positional argument but 2 were given`

## Related Tickets & Documents


- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

If you've run `invokeai-web` at any time since PR #5039, your `invokeai.db` will have a `model_config` table containing probe information from all models in the invokeai models directory as well as those in `autoimport` (if applicable). However, any models present in `models.yaml` whose paths are outside these directories will not be present. To add them, and to  update the description and other values from `models.yaml`, run the command `invokeai-migrate-models-to-db`. You should see the missing models added to the database table with the correct information.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [X] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
