### PR TITLE
chore/fix: bump fastapi to 0.105.0

### DIFF
--- a/invokeai/app/services/model_install/model_install_base.py
+++ b/invokeai/app/services/model_install/model_install_base.py
@@ -5,7 +5,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from fastapi import Body
 from pydantic import BaseModel, Field, field_validator
 from pydantic.networks import AnyHttpUrl
 from typing_extensions import Annotated
@@ -112,17 +111,7 @@ class URLModelSource(StringLikeSource):
         return str(self.url)
 
 
-# Body() is being applied here rather than Field() because otherwise FastAPI will
-# refuse to generate a schema. Relevant links:
-#
-# "Model Manager Refactor Phase 1 - SQL-based config storage
-#        https://github.com/invoke-ai/InvokeAI/pull/5039#discussion_r1389752119 (comment)
-# Param: xyz can only be a request body, using Body() when using discriminated unions
-#        https://github.com/tiangolo/fastapi/discussions/9761
-# Body parameter cannot be a pydantic union anymore sinve v0.95
-#       https://github.com/tiangolo/fastapi/discussions/9287
-
-ModelSource = Annotated[Union[LocalModelSource, HFModelSource, URLModelSource], Body(discriminator="type")]
+ModelSource = Annotated[Union[LocalModelSource, HFModelSource, URLModelSource], Field(discriminator="type")]
 
 
 class ModelInstallJob(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "easing-functions",
   "einops",
   "facexlib",
-  "fastapi~=0.104.1",
+  "fastapi~=0.105.0",
   "fastapi-events~=0.9.1",
   "huggingface-hub~=0.16.4",
   "imohash",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

This fixes a problem with `Annotated` which prevented us from using pydantic's `Field` to specify a discriminator for a union. We had to use FastAPI's `Body` as a workaround.