### PR TITLE
[BUG]: Tiled upscaling graph - fix for calc_tiles_min_overlap when tile size is bigger than image size

### DIFF
--- a/invokeai/backend/tiles/tiles.py
+++ b/invokeai/backend/tiles/tiles.py
@@ -199,10 +199,8 @@ def calc_tiles_min_overlap(
     if image_height < tile_height:
         tile_height = image_height
 
-    num_tiles_x = math.ceil((image_width - min_overlap) / (tile_width - min_overlap)) if tile_width < image_width else 1
-    num_tiles_y = (
-        math.ceil((image_height - min_overlap) / (tile_height - min_overlap)) if tile_height < image_height else 1
-    )
+    num_tiles_x = math.ceil((image_width - min_overlap) / (tile_width - min_overlap))
+    num_tiles_y = math.ceil((image_height - min_overlap) / (tile_height - min_overlap))
 
     # tiles[y * num_tiles_x + x] is the tile for the y'th row, x'th column.
     tiles: list[Tile] = []

--- a/invokeai/backend/tiles/tiles.py
+++ b/invokeai/backend/tiles/tiles.py
@@ -191,7 +191,14 @@ def calc_tiles_min_overlap(
     assert min_overlap < tile_height
     assert min_overlap < tile_width
 
-    # The If Else catches the case when the tile size is larger than the images size and just clips the number of tiles to 1
+    # catches the cases when the tile size is larger than the images size and just clips the number of tiles to 1
+
+    if image_width < tile_width:
+        tile_width = image_width
+
+    if image_height < tile_height:
+        tile_height = image_height
+
     num_tiles_x = math.ceil((image_width - min_overlap) / (tile_width - min_overlap)) if tile_width < image_width else 1
     num_tiles_y = (
         math.ceil((image_height - min_overlap) / (tile_height - min_overlap)) if tile_height < image_height else 1

--- a/invokeai/backend/tiles/tiles.py
+++ b/invokeai/backend/tiles/tiles.py
@@ -191,8 +191,7 @@ def calc_tiles_min_overlap(
     assert min_overlap < tile_height
     assert min_overlap < tile_width
 
-    # catches the cases when the tile size is larger than the images size and just clips the number of tiles to 1
-
+    # catches the cases when the tile size is larger than the images size and adjusts the tile size
     if image_width < tile_width:
         tile_width = image_width
 

--- a/tests/backend/tiles/test_tiles.py
+++ b/tests/backend/tiles/test_tiles.py
@@ -241,6 +241,28 @@ def test_calc_tiles_min_overlap_not_evenly_divisible():
     assert tiles == expected_tiles
 
 
+def test_calc_tiles_min_overlap_tile_bigger_than_image():
+    """Test calc_tiles_min_overlap() behavior when the tile is nigger than the image"""
+    # Parameters mimic roughly the same output as the original tile generations of the same test name
+    tiles = calc_tiles_min_overlap(
+        image_height=1024,
+        image_width=1024,
+        tile_height=1408,
+        tile_width=1408,
+        min_overlap=128,
+    )
+
+    expected_tiles = [
+        # single tile
+        Tile(
+            coords=TBLR(top=0, bottom=1024, left=0, right=1024),
+            overlap=TBLR(top=0, bottom=0, left=0, right=0),
+        ),
+    ]
+
+    assert tiles == expected_tiles
+
+
 @pytest.mark.parametrize(
     [
         "image_height",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: N/A

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description

In the tiled upscaling graph - In `calc_tiles_min_overlap` when the tile size is bigger than the image size it now correctly adjusts the tile size to fit. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Added/updated tests?

- [x] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
