### PR TITLE
fix(ui): do not cache VAE decode on linear

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasImageToImageGraph.ts
@@ -144,6 +144,7 @@ export const buildCanvasImageToImageGraph = (
         type: 'l2i',
         id: CANVAS_OUTPUT,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [
@@ -255,6 +256,7 @@ export const buildCanvasImageToImageGraph = (
       is_intermediate,
       width: width,
       height: height,
+      use_cache: false,
     };
 
     graph.edges.push(
@@ -295,6 +297,7 @@ export const buildCanvasImageToImageGraph = (
       id: CANVAS_OUTPUT,
       is_intermediate,
       fp32,
+      use_cache: false,
     };
 
     (graph.nodes[IMAGE_TO_LATENTS] as ImageToLatentsInvocation).image =

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasInpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasInpaintGraph.ts
@@ -191,6 +191,7 @@ export const buildCanvasInpaintGraph = (
         id: CANVAS_OUTPUT,
         is_intermediate,
         reference: canvasInitImage,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasOutpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasOutpaintGraph.ts
@@ -199,6 +199,7 @@ export const buildCanvasOutpaintGraph = (
         type: 'color_correct',
         id: CANVAS_OUTPUT,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLImageToImageGraph.ts
@@ -266,6 +266,7 @@ export const buildCanvasSDXLImageToImageGraph = (
       is_intermediate,
       width: width,
       height: height,
+      use_cache: false,
     };
 
     graph.edges.push(
@@ -306,6 +307,7 @@ export const buildCanvasSDXLImageToImageGraph = (
       id: CANVAS_OUTPUT,
       is_intermediate,
       fp32,
+      use_cache: false,
     };
 
     (graph.nodes[IMAGE_TO_LATENTS] as ImageToLatentsInvocation).image =

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLInpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLInpaintGraph.ts
@@ -196,6 +196,7 @@ export const buildCanvasSDXLInpaintGraph = (
         id: CANVAS_OUTPUT,
         is_intermediate,
         reference: canvasInitImage,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLOutpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLOutpaintGraph.ts
@@ -204,6 +204,7 @@ export const buildCanvasSDXLOutpaintGraph = (
         type: 'color_correct',
         id: CANVAS_OUTPUT,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLTextToImageGraph.ts
@@ -258,6 +258,7 @@ export const buildCanvasSDXLTextToImageGraph = (
       is_intermediate,
       width: width,
       height: height,
+      use_cache: false,
     };
 
     graph.edges.push(
@@ -288,6 +289,7 @@ export const buildCanvasSDXLTextToImageGraph = (
       id: CANVAS_OUTPUT,
       is_intermediate,
       fp32,
+      use_cache: false,
     };
 
     graph.edges.push({

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasTextToImageGraph.ts
@@ -246,6 +246,7 @@ export const buildCanvasTextToImageGraph = (
       is_intermediate,
       width: width,
       height: height,
+      use_cache: false,
     };
 
     graph.edges.push(
@@ -276,6 +277,7 @@ export const buildCanvasTextToImageGraph = (
       id: CANVAS_OUTPUT,
       is_intermediate,
       fp32,
+      use_cache: false,
     };
 
     graph.edges.push({

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearImageToImageGraph.ts
@@ -143,6 +143,7 @@ export const buildLinearImageToImageGraph = (
         // },
         fp32,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearSDXLImageToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearSDXLImageToImageGraph.ts
@@ -154,6 +154,7 @@ export const buildLinearSDXLImageToImageGraph = (
         // },
         fp32,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearSDXLTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearSDXLTextToImageGraph.ts
@@ -127,6 +127,7 @@ export const buildLinearSDXLTextToImageGraph = (
         id: LATENTS_TO_IMAGE,
         fp32,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearTextToImageGraph.ts
@@ -146,6 +146,7 @@ export const buildLinearTextToImageGraph = (
         id: LATENTS_TO_IMAGE,
         fp32,
         is_intermediate,
+        use_cache: false,
       },
     },
     edges: [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

The VAE decode on linear graphs was getting cached. This caused some unexpected behaviour around image outputs.

For example, say you ran the exact same graph twice. The first time, you get an image written to disk and added to gallery. The second time, the VAE decode is cached and no image file is created. But, the UI still gets the graph complete event and selects the first image in the gallery. The second run does not add an image to the gallery.

There are probbably edge cases related to this - the UI does not expect this to happen. I'm not sure how to handle it any better in the UI.

The solution is to not cache VAE decode on the linear graphs, ever. If you run a graph twice in linear, you expect two images.

This simple change disables the node cache for terminal VAE decode nodes in all linear graphs, ensuring you always get images. If they graph was fully cached, all images after the first will be created very quickly of course.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Discord convo https://discord.com/channels/1020123559063990373/1049495067846524939/1185345697948639252

## QA Instructions, Screenshots, Recordings

You can recreate this issue by setting a manual seed on any linear tab, then queuing multiple times. The first queued batch will add new images to the gallery as expected, but subsequent batches will just kinda flash the selection box around the gallery on the previously-generated images.

After checking this PR out, and queuing a batch multiple times, you should get an image for each iteration. After the first batch, the images should appear really quickly without any progress (because the graph is cached).

It's possible there was something else going on but this is def a problem to be fixed.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This can be merged after @hipsterusername reproduces the issue as described in this PR and confirms the PR fixes it.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
