### PR TITLE
Tag model manager v2 api as unstable

### DIFF
--- a/invokeai/app/api/routers/model_records.py
+++ b/invokeai/app/api/routers/model_records.py
@@ -26,7 +26,7 @@ from invokeai.backend.model_manager.config import (
 
 from ..dependencies import ApiDependencies
 
-model_records_router = APIRouter(prefix="/v1/model/record", tags=["model_manager_v2"])
+model_records_router = APIRouter(prefix="/v1/model/record", tags=["model_manager_v2_unstable"])
 
 
 class ModelsList(BaseModel):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

As discussed with @psychedelicious , this PR changes the swagger label on the model manager V2 routes to `model_manager_v2_unstable` in order to warn community members that the API is liable to change.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
