### PR TITLE
remove MacOS Sonoma check in devices.py

### DIFF
--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -5,7 +5,6 @@ from contextlib import nullcontext
 from typing import Union
 
 import torch
-from packaging import version
 from torch import autocast
 
 from invokeai.app.services.config import InvokeAIAppConfig
@@ -37,7 +36,7 @@ def choose_precision(device: torch.device) -> str:
         device_name = torch.cuda.get_device_name(device)
         if not ("GeForce GTX 1660" in device_name or "GeForce GTX 1650" in device_name):
             return "float16"
-    elif device.type == "mps" and version.parse(platform.mac_ver()[0]) < version.parse("14.0.0"):
+    elif device.type == "mps":
         return "float16"
     return "float32"
 

--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 from contextlib import nullcontext
 from typing import Union
 


### PR DESCRIPTION
As of pytorch 2.1.0, float16 works with our MPS fixes on Sonoma, so the check is no longer needed.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: small change

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No - no documentation change needed


## Description
The original MacOS Sonoma check was implemented when we had reports of our float16 patches not working on beta versions of Sonoma. We implemented this so that it would fall back to float32 for those affected, rather than crashing, with the goal of eventually figuring out why things weren't working and fixing what was required, once Sonoma was fully released. 

Instead, pytorch 2.1.0 fixed the issues, so now that InvokeAI uses that version, we can remove the check.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->
To test the behavior, I printed the output of `choose_precision(choose_torch_device())`.

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
This PR can be merged when approved - as we're now using pytorch 2.1.0 in release/main, we're good to go.

## Added/updated tests?

- [ ] Yes
- [x] No : No tests, but if/when we do have device check tests I can add the above.

## [optional] Are there any post deployment tasks we need to perform?
