### PR TITLE
feat(backend): disable graph library

### DIFF
--- a/invokeai/app/api/dependencies.py
+++ b/invokeai/app/api/dependencies.py
@@ -29,8 +29,7 @@ from ..services.model_records import ModelRecordServiceSQL
 from ..services.names.names_default import SimpleNameService
 from ..services.session_processor.session_processor_default import DefaultSessionProcessor
 from ..services.session_queue.session_queue_sqlite import SqliteSessionQueue
-from ..services.shared.default_graphs import create_system_graphs
-from ..services.shared.graph import GraphExecutionState, LibraryGraph
+from ..services.shared.graph import GraphExecutionState
 from ..services.urls.urls_default import LocalUrlService
 from ..services.workflow_records.workflow_records_sqlite import SqliteWorkflowRecordsStorage
 from .events import FastAPIEventService
@@ -80,7 +79,6 @@ class ApiDependencies:
         boards = BoardService()
         events = FastAPIEventService(event_handler_id)
         graph_execution_manager = SqliteItemStorage[GraphExecutionState](db=db, table_name="graph_executions")
-        graph_library = SqliteItemStorage[LibraryGraph](db=db, table_name="graphs")
         image_records = SqliteImageRecordStorage(db=db)
         images = ImageService()
         invocation_cache = MemoryInvocationCache(max_cache_size=config.node_cache_size)
@@ -107,7 +105,6 @@ class ApiDependencies:
             configuration=configuration,
             events=events,
             graph_execution_manager=graph_execution_manager,
-            graph_library=graph_library,
             image_files=image_files,
             image_records=image_records,
             images=images,
@@ -126,8 +123,6 @@ class ApiDependencies:
             urls=urls,
             workflow_records=workflow_records,
         )
-
-        create_system_graphs(services.graph_library)
 
         ApiDependencies.invoker = Invoker(services)
         db.clean()

--- a/invokeai/app/services/invocation_services.py
+++ b/invokeai/app/services/invocation_services.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from .names.names_base import NameServiceBase
     from .session_processor.session_processor_base import SessionProcessorBase
     from .session_queue.session_queue_base import SessionQueueBase
-    from .shared.graph import GraphExecutionState, LibraryGraph
+    from .shared.graph import GraphExecutionState
     from .urls.urls_base import UrlServiceBase
     from .workflow_records.workflow_records_base import WorkflowRecordsStorageBase
 
@@ -43,7 +43,6 @@ class InvocationServices:
     configuration: "InvokeAIAppConfig"
     events: "EventServiceBase"
     graph_execution_manager: "ItemStorageABC[GraphExecutionState]"
-    graph_library: "ItemStorageABC[LibraryGraph]"
     images: "ImageServiceABC"
     image_records: "ImageRecordStorageBase"
     image_files: "ImageFileStorageBase"
@@ -71,7 +70,6 @@ class InvocationServices:
         configuration: "InvokeAIAppConfig",
         events: "EventServiceBase",
         graph_execution_manager: "ItemStorageABC[GraphExecutionState]",
-        graph_library: "ItemStorageABC[LibraryGraph]",
         images: "ImageServiceABC",
         image_files: "ImageFileStorageBase",
         image_records: "ImageRecordStorageBase",
@@ -97,7 +95,6 @@ class InvocationServices:
         self.configuration = configuration
         self.events = events
         self.graph_execution_manager = graph_execution_manager
-        self.graph_library = graph_library
         self.images = images
         self.image_files = image_files
         self.image_records = image_records

--- a/tests/aa_nodes/test_graph_execution_state.py
+++ b/tests/aa_nodes/test_graph_execution_state.py
@@ -26,7 +26,6 @@ from invokeai.app.services.shared.graph import (
     Graph,
     GraphExecutionState,
     IterateInvocation,
-    LibraryGraph,
 )
 from invokeai.backend.util.logging import InvokeAILogger
 from tests.fixtures.sqlite_database import create_mock_sqlite_database
@@ -61,7 +60,6 @@ def mock_services() -> InvocationServices:
         configuration=configuration,
         events=TestEventService(),
         graph_execution_manager=graph_execution_manager,
-        graph_library=SqliteItemStorage[LibraryGraph](db=db, table_name="graphs"),
         image_files=None,  # type: ignore
         image_records=None,  # type: ignore
         images=None,  # type: ignore

--- a/tests/aa_nodes/test_invoker.py
+++ b/tests/aa_nodes/test_invoker.py
@@ -24,7 +24,7 @@ from invokeai.app.services.invocation_stats.invocation_stats_default import Invo
 from invokeai.app.services.invoker import Invoker
 from invokeai.app.services.item_storage.item_storage_sqlite import SqliteItemStorage
 from invokeai.app.services.session_queue.session_queue_common import DEFAULT_QUEUE_ID
-from invokeai.app.services.shared.graph import Graph, GraphExecutionState, GraphInvocation, LibraryGraph
+from invokeai.app.services.shared.graph import Graph, GraphExecutionState, GraphInvocation
 
 
 @pytest.fixture
@@ -66,7 +66,6 @@ def mock_services() -> InvocationServices:
         configuration=configuration,
         events=TestEventService(),
         graph_execution_manager=graph_execution_manager,
-        graph_library=SqliteItemStorage[LibraryGraph](db=db, table_name="graphs"),
         image_files=None,  # type: ignore
         image_records=None,  # type: ignore
         images=None,  # type: ignore


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

The graph library occasionally causes issues when the default graph changes substantially between versions and pydantic validation fails. See #5289 for an example.

We are not currently using the graph library, so we can disable it until we are ready to use it. It's possible that the workflow library will supersede it anyways.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #5289

## QA Instructions, Screenshots, Recordings

This should be a totally transparent change. Starting the app successfully is enough to test.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This can be merged when approved.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [x] No: n/a

## [optional] Are there any post deployment tasks we need to perform?

nope