### PR TITLE
easy docker quickstart on nvidia + fix variable value

### DIFF
--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -11,5 +11,5 @@ INVOKEAI_ROOT=
 # HUGGING_FACE_HUB_TOKEN=
 
 ## optional variables specific to the docker setup.
-# GPU_DRIVER=cuda # or rocm
+# GPU_DRIVER=nvidia #| rocm
 # CONTAINER_UID=1000

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,14 @@
 # InvokeAI Containerized
 
-All commands are to be run from the `docker` directory: `cd docker`
+All commands should be run within the `docker` directory: `cd docker`
+
+## Quickstart :rocket:
+
+On a known working Linux+Docker+CUDA (Nvidia) system, execute `./run.sh` in this directory. It will take a few minutes - depending on your internet speed - to install the core models. Once the application starts up, open `http://localhost:9090` in your browser to Invoke!
+
+For more configuration options (using an AMD GPU, custom root directory location, etc): read on.
+
+## Detailed setup
 
 #### Linux
 
@@ -18,7 +26,7 @@ All commands are to be run from the `docker` directory: `cd docker`
 
 This is done via Docker Desktop preferences
 
-## Quickstart
+### Configure Invoke environment
 
 1. Make a copy of `env.sample` and name it `.env` (`cp env.sample .env` (Mac/Linux) or `copy example.env .env` (Windows)). Make changes as necessary. Set `INVOKEAI_ROOT` to an absolute path to:
     a. the desired location of the InvokeAI runtime directory, or
@@ -37,19 +45,21 @@ The runtime directory (holding models and outputs) will be created in the locati
 
 The Docker daemon on the system must be already set up to use the GPU. In case of Linux, this involves installing `nvidia-docker-runtime` and configuring the `nvidia` runtime as default. Steps will be different for AMD. Please see Docker documentation for the most up-to-date instructions for using your GPU with Docker.
 
+To use an AMD GPU, set `GPU_DRIVER=rocm` in your `.env` file.
+
 ## Customize
 
 Check the `.env.sample` file. It contains some environment variables for running in Docker. Copy it, name it `.env`, and fill it in with your own values. Next time you run `run.sh`, your custom values will be used.
 
 You can also set these values in `docker-compose.yml` directly, but `.env` will help avoid conflicts when code is updated.
 
-Example (values are optional, but setting `INVOKEAI_ROOT` is highly recommended):
+Values are optional, but setting `INVOKEAI_ROOT` is highly recommended. The default is `~/invokeai`. Example:
 
 ```bash
 INVOKEAI_ROOT=/Volumes/WorkDrive/invokeai
 HUGGINGFACE_TOKEN=the_actual_token
 CONTAINER_UID=1000
-GPU_DRIVER=cuda
+GPU_DRIVER=nvidia
 ```
 
 Any environment variables supported by InvokeAI can be set here - please see the [Configuration docs](https://invoke-ai.github.io/InvokeAI/features/CONFIGURATION/) for further detail.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [x] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

- corrects usage of `GPU_DRIVER` - `nvidia` replaced `cuda` in a prior PR - fixes #5336 
- sets up a default  "happy path" for docker on linux + nvidia and document
- simplifies docker quickstart / README

