### PR TITLE
Sisco/docker allow relative paths for invokeai data

### DIFF
--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -2,10 +2,13 @@
 ## Any environment variables supported by InvokeAI can be specified here,
 ## in addition to the examples below.
 
-# LOCAL_DATA_PATH is the path to a path on the local filesystem where InvokeAI will store data.
+# INVOKEAI_LOCAL_ROOT is the path to a path on the local filesystem where InvokeAI will store data.
 # Outputs will also be stored here by default.
 # If relative, it will be relative to the docker directory in which the docker-compose.yml file is located
-LOCAL_DATA_PATH=../../invokeai-data
+INVOKEAI_LOCAL_ROOT=../../invokeai-data
+
+# INVOKEAI_ROOT is the path to the root of the InvokeAI repository within the container.
+# INVOKEAI_ROOT=~/invokeai
 
 # Get this value from your HuggingFace account settings page.
 # HUGGING_FACE_HUB_TOKEN=

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -2,10 +2,10 @@
 ## Any environment variables supported by InvokeAI can be specified here,
 ## in addition to the examples below.
 
-# HOST_INVOKEAI_ROOT is the path on the docker hosts filesystem where InvokeAI will store data.
+# HOST_INVOKEAI_ROOT is the path on the docker host's filesystem where InvokeAI will store data.
 # Outputs will also be stored here by default.
 # If relative, it will be relative to the docker directory in which the docker-compose.yml file is located
-HOST_INVOKEAI_ROOT=../../invokeai-data
+#HOST_INVOKEAI_ROOT=../../invokeai-data
 
 # INVOKEAI_ROOT is the path to the root of the InvokeAI repository within the container.
 # INVOKEAI_ROOT=~/invokeai

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -2,10 +2,10 @@
 ## Any environment variables supported by InvokeAI can be specified here,
 ## in addition to the examples below.
 
-# INVOKEAI_LOCAL_ROOT is the path to a path on the local filesystem where InvokeAI will store data.
+# HOST_INVOKEAI_ROOT is the path on the docker hosts filesystem where InvokeAI will store data.
 # Outputs will also be stored here by default.
 # If relative, it will be relative to the docker directory in which the docker-compose.yml file is located
-INVOKEAI_LOCAL_ROOT=../../invokeai-data
+HOST_INVOKEAI_ROOT=../../invokeai-data
 
 # INVOKEAI_ROOT is the path to the root of the InvokeAI repository within the container.
 # INVOKEAI_ROOT=~/invokeai

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -2,10 +2,10 @@
 ## Any environment variables supported by InvokeAI can be specified here,
 ## in addition to the examples below.
 
-# INVOKEAI_ROOT is the path to a path on the local filesystem where InvokeAI will store data.
+# LOCAL_DATA_PATH is the path to a path on the local filesystem where InvokeAI will store data.
 # Outputs will also be stored here by default.
-# This **must** be an absolute path.
-INVOKEAI_ROOT=
+# If relative, it will be relative to the docker directory in which the docker-compose.yml file is located
+LOCAL_DATA_PATH=../../invokeai-data
 
 # Get this value from your HuggingFace account settings page.
 # HUGGING_FACE_HUB_TOKEN=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ x-invokeai: &invokeai
       - "${INVOKEAI_PORT:-9090}:9090"
     volumes:
       - type: bind
-        source: ${INVOKEAI_LOCAL_ROOT:-${INVOKEAI_ROOT:-~/invokeai}}
+        source: ${HOST_INVOKEAI_ROOT:-${INVOKEAI_ROOT:-~/invokeai}}
         target: ${INVOKEAI_ROOT:-/invokeai}
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
       # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ x-invokeai: &invokeai
       - "${INVOKEAI_PORT:-9090}:9090"
     volumes:
       - type: bind
-        source: ${INVOKEAI_LOCAL_ROOT:${INVOKEAI_ROOT:~/invokeai}}
+        source: ${INVOKEAI_LOCAL_ROOT:-${INVOKEAI_ROOT:-~/invokeai}}
         target: ${INVOKEAI_ROOT:-/invokeai}
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
       # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,9 @@ x-invokeai: &invokeai
     ports:
       - "${INVOKEAI_PORT:-9090}:9090"
     volumes:
-      - ${INVOKEAI_ROOT:-~/invokeai}:${INVOKEAI_ROOT:-/invokeai}
+      - type: bind
+        source: ${LOCAL_DATA_PATH:-~/invokeai}
+        target: ${INVOKEAI_ROOT:-/invokeai}
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
       # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}
       # - ${INVOKEAI_MODELS_CONFIG_PATH:-${INVOKEAI_ROOT:-/invokeai/configs/models.yaml}}
@@ -45,7 +47,7 @@ services:
           devices:
             - driver: nvidia
               count: 1
-              capabilities: [gpu]
+              capabilities: [compute, utility]
 
   invokeai-cpu:
     <<: *invokeai

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ x-invokeai: &invokeai
       - "${INVOKEAI_PORT:-9090}:9090"
     volumes:
       - type: bind
-        source: ${LOCAL_DATA_PATH:-~/invokeai}
+        source: ${LOCAL_DATA_PATH:${INVOKEAI_ROOT:~/invokeai}}
         target: ${INVOKEAI_ROOT:-/invokeai}
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
       # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
           devices:
             - driver: nvidia
               count: 1
-              capabilities: [compute, utility]
+              capabilities: [gpu]
 
   invokeai-cpu:
     <<: *invokeai

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ x-invokeai: &invokeai
       - "${INVOKEAI_PORT:-9090}:9090"
     volumes:
       - type: bind
-        source: ${LOCAL_DATA_PATH:${INVOKEAI_ROOT:~/invokeai}}
+        source: ${INVOKEAI_LOCAL_ROOT:${INVOKEAI_ROOT:~/invokeai}}
         target: ${INVOKEAI_ROOT:-/invokeai}
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
       # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: it's small, discuss it in the comments

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No
- [X] Maybe?


## Description
This PR removes the docker-compose absolute path restriction for the data path of InvokeAI. 
The compose file will now bind the external Invoke data directory using the following envar values (in order of priority): 
1) `INVOKEAI_LOCAL_ROOT`
2) `INVOKEAI_ROOT`
3) `~/invokeai`

Since this change provides a fallback to the original `INVOKEAI_ROOT` variable, it should not impact existing users.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [X] No

## [optional] Are there any post deployment tasks we need to perform?
