### PR TITLE
fix(ui): fix panel resize bug

### DIFF
--- a/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
+++ b/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
@@ -125,14 +125,25 @@ export const usePanel = (arg: UsePanelOptions): UsePanelReturn => {
 
       _setMinSize(minSizePct);
 
-      // Resize if the current size is smaller than the new min size - happens when the window is resized smaller
-      if (panelHandleRef.current.getSize() < minSizePct) {
+      const currentSize = panelHandleRef.current.getSize();
+
+      // If currentSize is 0, the panel is collapsed, so we don't want to resize it
+      // If it's not 0, but less than the minSize, resize it
+      if (currentSize && currentSize < minSizePct) {
         panelHandleRef.current.resize(minSizePct);
       }
     });
 
     resizeObserver.observe(panelGroupElement);
     panelGroupHandleElements.forEach((el) => resizeObserver.observe(el));
+
+    // Resize the panel to the min size once on startup
+    const minSizePct = getSizeAsPercentage(
+      arg.minSize,
+      arg.panelGroupRef,
+      arg.panelGroupDirection
+    );
+    panelHandleRef.current?.resize(minSizePct);
 
     return () => {
       resizeObserver.disconnect();

--- a/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
+++ b/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
@@ -129,7 +129,7 @@ export const usePanel = (arg: UsePanelOptions): UsePanelReturn => {
 
       // If currentSize is 0, the panel is collapsed, so we don't want to resize it
       // If it's not 0, but less than the minSize, resize it
-      if (currentSize && currentSize < minSizePct) {
+      if (currentSize > 0 && currentSize < minSizePct) {
         panelHandleRef.current.resize(minSizePct);
       }
     });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

A bug that caused panels to be collapsed on a fresh indexedDb in was fixed in dd32c632cdf5006796614386f1f6094bdfb9328a, but this re-introduced a different bug that caused the panels to expand on window resize, if they were already collapsed.

Revert the previous change and instead add one imperative resize outside the observer, so that on startup, we set both panels to their minimum sizes.

## QA Instructions, Screenshots, Recordings

- Collapse both panels
- Resize the window - they should not expand
- Reset web UI - panels should be expanded after refresh

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
