### PR TITLE
ui: slightly reposition floating bars.

### DIFF
--- a/invokeai/frontend/web/src/features/ui/components/FloatingGalleryButton.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/FloatingGalleryButton.tsx
@@ -25,7 +25,7 @@ const FloatingGalleryButton = (props: Props) => {
         transform="translate(0, -50%)"
         minW={8}
         top="50%"
-        insetInlineEnd={0}
+        insetInlineEnd="21px"
       >
         <InvTooltip
           label={t('accessibility.showGalleryPanel')}

--- a/invokeai/frontend/web/src/features/ui/components/FloatingParametersPanelButtons.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/FloatingParametersPanelButtons.tsx
@@ -50,7 +50,7 @@ const FloatingSidePanelButtons = (props: Props) => {
         transform="translate(0, -50%)"
         minW={8}
         top="50%"
-        insetInlineStart="54px"
+        insetInlineStart="63px"
         direction="column"
         gap={2}
         h={48}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

Slightly adjusted the position of the floating bars so begin right after the drag lines start/end and the drag line also becomes accessible on the gallery side now in the same areas as the button.

![opera_cyty0XzXnL](https://github.com/invoke-ai/InvokeAI/assets/54517381/3ea66db7-b7b8-4fc5-9ceb-1c2e95e244a9)
![opera_k0gLGXHFho](https://github.com/invoke-ai/InvokeAI/assets/54517381/b05ad59e-9856-474d-b813-9ce93b0ac118)

