### PR TITLE
dont reload UI when socket reconnects

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -1,7 +1,5 @@
 import { logger } from 'app/logging/logger';
-import { isInitializedChanged } from 'features/system/store/systemSlice';
 import { size } from 'lodash-es';
-import { api } from 'services/api';
 import { receivedOpenAPISchema } from 'services/api/thunks/schema';
 import { appSocketConnected, socketConnected } from 'services/events/actions';
 
@@ -15,19 +13,12 @@ export const addSocketConnectedEventListener = () => {
 
       log.debug('Connected');
 
-      const { nodeTemplates, config, system } = getState();
+      const { nodeTemplates, config } = getState();
 
       const { disabledTabs } = config;
 
       if (!size(nodeTemplates.templates) && !disabledTabs.includes('nodes')) {
         dispatch(receivedOpenAPISchema());
-      }
-
-      if (system.isInitialized) {
-        // only reset the query caches if this connect event is a *reconnect* event
-        dispatch(api.util.resetApiState());
-      } else {
-        dispatch(isInitializedChanged(true));
       }
 
       // pass along the socket event as an application action

--- a/invokeai/frontend/web/src/features/system/store/systemPersistDenylist.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemPersistDenylist.ts
@@ -1,7 +1,6 @@
 import type { SystemState } from './types';
 
 export const systemPersistDenylist: (keyof SystemState)[] = [
-  'isInitialized',
   'isConnected',
   'denoiseProgress',
   'status',

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -82,7 +82,7 @@ export const systemSlice = createSlice({
       action: PayloadAction<boolean>
     ) {
       state.shouldEnableInformationalPopovers = action.payload;
-    }
+    },
   },
   extraReducers(builder) {
     /**

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -25,7 +25,6 @@ import {
 import type { Language, SystemState } from './types';
 
 export const initialSystemState: SystemState = {
-  isInitialized: false,
   isConnected: false,
   shouldConfirmOnDelete: true,
   enableImageDebugging: false,
@@ -83,10 +82,7 @@ export const systemSlice = createSlice({
       action: PayloadAction<boolean>
     ) {
       state.shouldEnableInformationalPopovers = action.payload;
-    },
-    isInitializedChanged(state, action: PayloadAction<boolean>) {
-      state.isInitialized = action.payload;
-    },
+    }
   },
   extraReducers(builder) {
     /**
@@ -205,7 +201,6 @@ export const {
   shouldUseNSFWCheckerChanged,
   shouldUseWatermarkerChanged,
   setShouldEnableInformationalPopovers,
-  isInitializedChanged,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/invokeai/frontend/web/src/features/system/store/types.ts
+++ b/invokeai/frontend/web/src/features/system/store/types.ts
@@ -43,7 +43,6 @@ export const isLanguage = (v: unknown): v is Language =>
   zLanguage.safeParse(v).success;
 
 export interface SystemState {
-  isInitialized: boolean;
   isConnected: boolean;
   shouldConfirmOnDelete: boolean;
   enableImageDebugging: boolean;

--- a/invokeai/frontend/web/src/services/events/actions.ts
+++ b/invokeai/frontend/web/src/services/events/actions.ts
@@ -32,7 +32,9 @@ export const appSocketConnected = createAction('socket/appSocketConnected');
  *
  * Do not use. Only for use in middleware.
  */
-export const socketConnectionError = createAction<{ error: Error }>('socket/socketConnectionError');/**
+export const socketConnectionError = createAction<{ error: Error }>(
+  'socket/socketConnectionError'
+); /**
 
 * Socket.IO Disconnect
 *

--- a/invokeai/frontend/web/src/services/events/actions.ts
+++ b/invokeai/frontend/web/src/services/events/actions.ts
@@ -28,10 +28,16 @@ export const socketConnected = createAction('socket/socketConnected');
 export const appSocketConnected = createAction('socket/appSocketConnected');
 
 /**
- * Socket.IO Disconnect
+ * Socket.IO Connection Error
  *
  * Do not use. Only for use in middleware.
  */
+export const socketConnectionError = createAction<{ error: Error }>('socket/socketConnectionError');/**
+
+* Socket.IO Disconnect
+*
+* Do not use. Only for use in middleware.
+*/
 export const socketDisconnected = createAction('socket/socketDisconnected');
 
 /**

--- a/invokeai/frontend/web/src/services/events/util/setEventListeners.ts
+++ b/invokeai/frontend/web/src/services/events/util/setEventListeners.ts
@@ -4,6 +4,7 @@ import { addToast } from 'features/system/store/systemSlice';
 import { makeToast } from 'features/system/util/makeToast';
 import {
   socketConnected,
+  socketConnectionError,
   socketDisconnected,
   socketGeneratorProgress,
   socketGraphExecutionStateComplete,
@@ -56,6 +57,7 @@ export const setEventListeners = (arg: SetEventListenersArg) => {
         );
       }
     }
+    dispatch(socketConnectionError({ error }))
   });
 
   /**

--- a/invokeai/frontend/web/src/services/events/util/setEventListeners.ts
+++ b/invokeai/frontend/web/src/services/events/util/setEventListeners.ts
@@ -57,7 +57,7 @@ export const setEventListeners = (arg: SetEventListenersArg) => {
         );
       }
     }
-    dispatch(socketConnectionError({ error }))
+    dispatch(socketConnectionError({ error }));
   });
 
   /**


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
* do not reload UI when socket connects, in the event of back-end instability this makes for a very jarring UX
* added an action for socket connection error for commercial analytics

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
