### PR TITLE
fix(ui): fix gallery nav math

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/ImageGridItemContainer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/ImageGridItemContainer.tsx
@@ -3,17 +3,15 @@ import { Box, forwardRef } from '@chakra-ui/react';
 import type { PropsWithChildren } from 'react';
 import { memo } from 'react';
 
-// This is exported so that we can use it to calculate the number of images per row
-// for the directional gallery navigation.
-export const GALLERY_IMAGE_PADDING_PX = 6;
+export const imageItemContainerTestId = 'image-item-container';
 
 type ItemContainerProps = PropsWithChildren & FlexProps;
 const ItemContainer = forwardRef((props: ItemContainerProps, ref) => (
   <Box
     className="item-container"
     ref={ref}
-    p={`${GALLERY_IMAGE_PADDING_PX}px`}
-    data-testid="image-item-container"
+    p={1.5}
+    data-testid={imageItemContainerTestId}
   >
     {props.children}
   </Box>

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/ImageGridListContainer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/ImageGridListContainer.tsx
@@ -4,6 +4,8 @@ import { useAppSelector } from 'app/store/storeHooks';
 import type { PropsWithChildren } from 'react';
 import { memo } from 'react';
 
+export const imageListContainerTestId = 'image-list-container';
+
 type ListContainerProps = PropsWithChildren & FlexProps;
 const ListContainer = forwardRef((props: ListContainerProps, ref) => {
   const galleryImageMinimumWidth = useAppSelector(
@@ -16,7 +18,7 @@ const ListContainer = forwardRef((props: ListContainerProps, ref) => {
       className="list-container"
       ref={ref}
       gridTemplateColumns={`repeat(auto-fill, minmax(${galleryImageMinimumWidth}px, 1fr))`}
-      data-testid="image-list-container"
+      data-testid={imageListContainerTestId}
     >
       {props.children}
     </Grid>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: trivial bugfix

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No, n/a


## Description

- Use the virtuoso grid item container and list containers to calculate imagesPerRow, skipping manual compensation for padding of images
- Round the imagesPerRow instead of flooring - we often will end up with values like 4.99999 due to floating point precision
- Update `getDownImage` comments & logic to be clearer
- Use variables for the ids in query selectors, preventing future typos
- Only scroll if the new selected image is different from the prev one

## QA Instructions, Screenshots, Recordings

Arrow nav of gallery should work correctly at all gallery sizes and scales

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [x] No, n/a

## [optional] Are there any post deployment tasks we need to perform?

n/a