### PR TITLE
fix(ui): reduce reconnect requests

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/anyEnqueued.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/anyEnqueued.ts
@@ -1,4 +1,4 @@
-import { queueApi } from 'services/api/endpoints/queue';
+import { queueApi, selectQueueStatus } from 'services/api/endpoints/queue';
 
 import { startAppListening } from '..';
 
@@ -6,7 +6,7 @@ export const addAnyEnqueuedListener = () => {
   startAppListening({
     matcher: queueApi.endpoints.enqueueBatch.matchFulfilled,
     effect: async (_, { dispatch, getState }) => {
-      const { data } = queueApi.endpoints.getQueueStatus.select()(getState());
+      const { data } = selectQueueStatus(getState());
 
       if (!data || data.processor.is_started) {
         return;

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -1,7 +1,9 @@
 import { logger } from 'app/logging/logger';
-import { isInitializedChanged } from 'features/system/store/systemSlice';
+import { $baseUrl } from 'app/store/nanostores/baseUrl';
 import { size } from 'lodash-es';
+import { atom } from 'nanostores';
 import { api } from 'services/api';
+import { queueApi, selectQueueStatus } from 'services/api/endpoints/queue';
 import { receivedOpenAPISchema } from 'services/api/thunks/schema';
 import { socketConnected } from 'services/events/actions';
 
@@ -9,25 +11,95 @@ import { startAppListening } from '../..';
 
 const log = logger('socketio');
 
+const $isFirstConnection = atom(true);
+
 export const addSocketConnectedEventListener = () => {
   startAppListening({
     actionCreator: socketConnected,
-    effect: (action, { dispatch, getState }) => {
+    effect: async (
+      action,
+      { dispatch, getState, cancelActiveListeners, delay }
+    ) => {
       log.debug('Connected');
 
-      const { nodeTemplates, config, system } = getState();
+      /**
+       * The rest of this listener has recovery logic for when the socket disconnects and reconnects.
+       * If we had generations in progress, we need to reset the API state to re-fetch everything.
+       */
 
-      const { disabledTabs } = config;
-
-      if (!size(nodeTemplates.templates) && !disabledTabs.includes('nodes')) {
-        dispatch(receivedOpenAPISchema());
+      if ($isFirstConnection.get()) {
+        // Bail on the recovery logic if this is the first connection
+        $isFirstConnection.set(false);
+        return;
       }
 
-      if (system.isInitialized) {
-        // only reset the query caches if this connect event is a *reconnect* event
+      const { data: prevQueueStatusData } = selectQueueStatus(getState());
+
+      // Bail if queue was empty before - we have nothing to recover
+      if (
+        !prevQueueStatusData?.queue.in_progress &&
+        !prevQueueStatusData?.queue.pending
+      ) {
+        return;
+      }
+
+      // Else, we need to re-fetch the queue status to see if it has changed
+
+      if ($baseUrl.get()) {
+        // If we have a baseUrl (e.g. not localhost), we need to debounce the re-fetch to not hammer server
+        cancelActiveListeners();
+        // Add artificial jitter to the debounce
+        await delay(1000 + Math.random() * 1000);
+      }
+
+      try {
+        // Fetch the queue status again
+        const queueStatusRequest = dispatch(
+          await queueApi.endpoints.getQueueStatus.initiate(undefined, {
+            forceRefetch: true,
+          })
+        );
+
+        const nextQueueStatusData = await queueStatusRequest.unwrap();
+        queueStatusRequest.unsubscribe();
+
+        // If we haven't completed more items since the last check, bail
+        if (
+          prevQueueStatusData.queue.completed ===
+          nextQueueStatusData.queue.completed
+        ) {
+          return;
+        }
+
+        /**
+         * Else, we need to reset the API state to update everything.
+         * 
+         * TODO: This is rather inefficient. We don't actually need to re-fetch *all* network requests,
+         * but determining which ones to re-fetch is non-trivial. It's at least the queue related ones
+         * and gallery, but likely others. We'd also need to keep track of which requests need to be
+         * re-fetch in this situation, which opens the door for bugs.
+         * 
+         * Optimize this later.
+         */
         dispatch(api.util.resetApiState());
-      } else {
-        dispatch(isInitializedChanged(true));
+      } catch {
+        // no-op
+        log.debug('Unable to get current queue status on reconnect');
+      }
+    },
+  });
+
+  startAppListening({
+    actionCreator: socketConnected,
+    effect: async (action, { dispatch, getState }) => {
+      const { nodeTemplates, config } = getState();
+      if (
+        !size(nodeTemplates.templates) &&
+        !config.disabledTabs.includes('nodes')
+      ) {
+        // This request is a createAsyncThunk - resetting API state as in the above listener
+        // will not trigger this request, so we need to manually do it.
+        dispatch(receivedOpenAPISchema());
       }
     },
   });

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -38,6 +38,12 @@ export const addSocketConnectedEventListener = () => {
         return;
       }
 
+      // If we are in development mode, reset the whole API state. In this scenario, reconnects will
+      // typically be caused by reloading the server, in which case we do want to reset the whole API.
+      if (import.meta.env.MODE === 'development') {
+        dispatch(api.util.resetApiState());
+      }
+
       // Else, we need to compare the last-known queue status with the current queue status, re-fetching
       // everything if it has changed.
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -73,12 +73,12 @@ export const addSocketConnectedEventListener = () => {
 
         /**
          * Else, we need to reset the API state to update everything.
-         * 
+         *
          * TODO: This is rather inefficient. We don't actually need to re-fetch *all* network requests,
          * but determining which ones to re-fetch is non-trivial. It's at least the queue related ones
          * and gallery, but likely others. We'd also need to keep track of which requests need to be
          * re-fetch in this situation, which opens the door for bugs.
-         * 
+         *
          * Optimize this later.
          */
         dispatch(api.util.resetApiState());

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -24,11 +24,13 @@ export const addSocketConnectedEventListener = () => {
 
       /**
        * The rest of this listener has recovery logic for when the socket disconnects and reconnects.
-       * If we had generations in progress, we need to reset the API state to re-fetch everything.
+       *
+       * If a queue item completed during while disconnected, we need to reset the API state to re-
+       * fetch everything, updating the gallery and queue.
        */
 
       if ($isFirstConnection.get()) {
-        // Bail on the recovery logic if this is the first connection
+        // Bail on the recovery logic if this is the first connection - we don't need to recover anything
         $isFirstConnection.set(false);
         return;
       }
@@ -93,6 +95,7 @@ export const addSocketConnectedEventListener = () => {
     actionCreator: socketConnected,
     effect: async (action, { dispatch, getState }) => {
       const { nodeTemplates, config } = getState();
+      // We only want to re-fetch the schema if we don't have any node templates
       if (
         !size(nodeTemplates.templates) &&
         !config.disabledTabs.includes('nodes')

--- a/invokeai/frontend/web/src/features/system/store/systemPersistDenylist.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemPersistDenylist.ts
@@ -1,7 +1,6 @@
 import type { SystemState } from './types';
 
 export const systemPersistDenylist: (keyof SystemState)[] = [
-  'isInitialized',
   'isConnected',
   'denoiseProgress',
   'status',

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -26,7 +26,6 @@ import type { Language, SystemState } from './types';
 
 export const initialSystemState: SystemState = {
   _version: 1,
-  isInitialized: false,
   isConnected: false,
   shouldConfirmOnDelete: true,
   enableImageDebugging: false,
@@ -84,9 +83,6 @@ export const systemSlice = createSlice({
       action: PayloadAction<boolean>
     ) {
       state.shouldEnableInformationalPopovers = action.payload;
-    },
-    isInitializedChanged(state, action: PayloadAction<boolean>) {
-      state.isInitialized = action.payload;
     },
   },
   extraReducers(builder) {
@@ -206,7 +202,6 @@ export const {
   shouldUseNSFWCheckerChanged,
   shouldUseWatermarkerChanged,
   setShouldEnableInformationalPopovers,
-  isInitializedChanged,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/invokeai/frontend/web/src/features/system/store/types.ts
+++ b/invokeai/frontend/web/src/features/system/store/types.ts
@@ -44,7 +44,6 @@ export const isLanguage = (v: unknown): v is Language =>
 
 export interface SystemState {
   _version: 1;
-  isInitialized: boolean;
   isConnected: boolean;
   shouldConfirmOnDelete: boolean;
   enableImageDebugging: boolean;

--- a/invokeai/frontend/web/src/services/api/endpoints/appInfo.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/appInfo.ts
@@ -29,7 +29,7 @@ export const appInfoApi = api.injectEndpoints({
         url: `app/invocation_cache/status`,
         method: 'GET',
       }),
-      providesTags: ['InvocationCacheStatus'],
+      providesTags: ['InvocationCacheStatus', 'FetchOnReconnect'],
     }),
     clearInvocationCache: build.mutation<void, void>({
       query: () => ({

--- a/invokeai/frontend/web/src/services/api/endpoints/boards.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/boards.ts
@@ -23,7 +23,10 @@ export const boardsApi = api.injectEndpoints({
       query: (arg) => ({ url: 'boards/', params: arg }),
       providesTags: (result) => {
         // any list of boards
-        const tags: ApiTagDescription[] = [{ type: 'Board', id: LIST_TAG }];
+        const tags: ApiTagDescription[] = [
+          { type: 'Board', id: LIST_TAG },
+          'FetchOnReconnect',
+        ];
 
         if (result) {
           // and individual tags for each board
@@ -46,7 +49,10 @@ export const boardsApi = api.injectEndpoints({
       }),
       providesTags: (result) => {
         // any list of boards
-        const tags: ApiTagDescription[] = [{ type: 'Board', id: LIST_TAG }];
+        const tags: ApiTagDescription[] = [
+          { type: 'Board', id: LIST_TAG },
+          'FetchOnReconnect',
+        ];
 
         if (result) {
           // and individual tags for each board
@@ -68,6 +74,7 @@ export const boardsApi = api.injectEndpoints({
       }),
       providesTags: (result, error, arg) => [
         { type: 'ImageNameList', id: arg },
+        'FetchOnReconnect',
       ],
       keepUnusedDataFor: 0,
     }),
@@ -85,6 +92,7 @@ export const boardsApi = api.injectEndpoints({
       }),
       providesTags: (result, error, arg) => [
         { type: 'BoardImagesTotal', id: arg ?? 'none' },
+        'FetchOnReconnect',
       ],
       transformResponse: (response: OffsetPaginatedResults_ImageDTO_) => {
         return { total: response.total };
@@ -104,6 +112,7 @@ export const boardsApi = api.injectEndpoints({
       }),
       providesTags: (result, error, arg) => [
         { type: 'BoardAssetsTotal', id: arg ?? 'none' },
+        'FetchOnReconnect',
       ],
       transformResponse: (response: OffsetPaginatedResults_ImageDTO_) => {
         return { total: response.total };

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -47,6 +47,7 @@ export const imagesApi = api.injectEndpoints({
       providesTags: (result, error, { board_id, categories }) => [
         // Make the tags the same as the cache key
         { type: 'ImageList', id: getListImagesUrl({ board_id, categories }) },
+        'FetchOnReconnect',
       ],
       serializeQueryArgs: ({ queryArgs }) => {
         // Create cache & key based on board_id and categories - skip the other args.
@@ -100,7 +101,7 @@ export const imagesApi = api.injectEndpoints({
     }),
     getIntermediatesCount: build.query<number, void>({
       query: () => ({ url: 'images/intermediates' }),
-      providesTags: ['IntermediatesCount'],
+      providesTags: ['IntermediatesCount', 'FetchOnReconnect'],
     }),
     clearIntermediates: build.mutation<number, void>({
       query: () => ({ url: `images/intermediates`, method: 'DELETE' }),

--- a/invokeai/frontend/web/src/services/api/endpoints/queue.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/queue.ts
@@ -164,7 +164,10 @@ export const queueApi = api.injectEndpoints({
         method: 'GET',
       }),
       providesTags: (result) => {
-        const tags: ApiTagDescription[] = ['CurrentSessionQueueItem'];
+        const tags: ApiTagDescription[] = [
+          'CurrentSessionQueueItem',
+          'FetchOnReconnect',
+        ];
         if (result) {
           tags.push({ type: 'SessionQueueItem', id: result.item_id });
         }
@@ -180,7 +183,10 @@ export const queueApi = api.injectEndpoints({
         method: 'GET',
       }),
       providesTags: (result) => {
-        const tags: ApiTagDescription[] = ['NextSessionQueueItem'];
+        const tags: ApiTagDescription[] = [
+          'NextSessionQueueItem',
+          'FetchOnReconnect',
+        ];
         if (result) {
           tags.push({ type: 'SessionQueueItem', id: result.item_id });
         }
@@ -195,7 +201,7 @@ export const queueApi = api.injectEndpoints({
         url: `queue/${$queueId.get()}/status`,
         method: 'GET',
       }),
-      providesTags: ['SessionQueueStatus'],
+      providesTags: ['SessionQueueStatus', 'FetchOnReconnect'],
     }),
     getBatchStatus: build.query<
       paths['/api/v1/queue/{queue_id}/b/{batch_id}/status']['get']['responses']['200']['content']['application/json'],
@@ -206,10 +212,11 @@ export const queueApi = api.injectEndpoints({
         method: 'GET',
       }),
       providesTags: (result) => {
-        if (!result) {
-          return [];
+        const tags: ApiTagDescription[] = ['FetchOnReconnect'];
+        if (result) {
+          tags.push({ type: 'BatchStatus', id: result.batch_id });
         }
-        return [{ type: 'BatchStatus', id: result.batch_id }];
+        return tags;
       },
     }),
     getQueueItem: build.query<
@@ -221,10 +228,11 @@ export const queueApi = api.injectEndpoints({
         method: 'GET',
       }),
       providesTags: (result) => {
-        if (!result) {
-          return [];
+        const tags: ApiTagDescription[] = ['FetchOnReconnect'];
+        if (result) {
+          tags.push({ type: 'SessionQueueItem', id: result.item_id });
         }
-        return [{ type: 'SessionQueueItem', id: result.item_id }];
+        return tags;
       },
     }),
     cancelQueueItem: build.mutation<
@@ -319,6 +327,7 @@ export const queueApi = api.injectEndpoints({
       },
       forceRefetch: ({ currentArg, previousArg }) => currentArg !== previousArg,
       keepUnusedDataFor: 60 * 5, // 5 minutes
+      providesTags: ['FetchOnReconnect'],
     }),
   }),
 });

--- a/invokeai/frontend/web/src/services/api/endpoints/queue.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/queue.ts
@@ -339,6 +339,8 @@ export const {
   useGetBatchStatusQuery,
 } = queueApi;
 
+export const selectQueueStatus = queueApi.endpoints.getQueueStatus.select();
+
 const resetListQueryData = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dispatch: ThunkDispatch<any, any, UnknownAction>

--- a/invokeai/frontend/web/src/services/api/endpoints/utilities.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/utilities.ts
@@ -14,6 +14,9 @@ export const utilitiesApi = api.injectEndpoints({
         method: 'POST',
       }),
       keepUnusedDataFor: 86400, // 24 hours
+      // We need to fetch this on reconnect bc the user may have changed the text field while
+      // disconnected.
+      providesTags: ['FetchOnReconnect'],
     }),
   }),
 });

--- a/invokeai/frontend/web/src/services/api/endpoints/workflows.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/workflows.ts
@@ -11,6 +11,7 @@ export const workflowsApi = api.injectEndpoints({
       query: (workflow_id) => `workflows/i/${workflow_id}`,
       providesTags: (result, error, workflow_id) => [
         { type: 'Workflow', id: workflow_id },
+        'FetchOnReconnect',
       ],
       onQueryStarted: async (arg, api) => {
         const { dispatch, queryFulfilled } = api;
@@ -74,7 +75,7 @@ export const workflowsApi = api.injectEndpoints({
         url: 'workflows/',
         params,
       }),
-      providesTags: [{ type: 'Workflow', id: LIST_TAG }],
+      providesTags: ['FetchOnReconnect', { type: 'Workflow', id: LIST_TAG }],
     }),
   }),
 });

--- a/invokeai/frontend/web/src/services/api/index.ts
+++ b/invokeai/frontend/web/src/services/api/index.ts
@@ -40,6 +40,9 @@ export const tagTypes = [
   'SDXLRefinerModel',
   'Workflow',
   'WorkflowsRecent',
+  // This is invalidated on reconnect. It should be used for queries that have changing data,
+  // especially related to the queue and generation.
+  'FetchOnReconnect',
 ] as const;
 export type ApiTagDescription = TagDescription<(typeof tagTypes)[number]>;
 export const LIST_TAG = 'LIST';


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

See the changes in `invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts` for well-commented recovery logic.

- Add checks to the "recovery" logic for socket connect events to reduce the number of network requests.
- Remove the `isInitialized` state from `systemSlice` and make it a nanostore local to the socketConnected listener. It didn't need to be global state. It's also now more clearly named `isFirstConnection`.
- Export the queue status selector (minor improvement, memoizes it correctly).

Note: Currently re-fetch _everything_ during a socket connect event. We don't need to re-fetch everything - we only need to re-fetch things related to the queue and gallery. At least, I think that's all we need to re-fetch. However, those are exactly the things that are resource-intensive. The other requests are much lighter.

Instead of attempting to figure out exactly the minimal number of requests to re-fetch, and possibly miss something or do it wrong (I'd need to include the default args for all the requests, took, which is not trivial), _and_ need to maintain that list as the app changes, I have left it as a full API reset.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Vite's dev server forcibly reloads the page if its own internal socket connection is closed, making working on reconnect behaviour impossible. I had to patch vite directly to get past this. There's an issue upstream, and I've included my patch there for posterity: https://github.com/vitejs/vite/issues/5675 

## QA Instructions, Screenshots, Recordings

This is kinda tricky to fully test. You'll need simulate a network blip and either 1) patch vite per the above linked issue or 2) test this with a production build. Suggest just building and testing the build.

To simulate a network blip you an create a local SSH tunnel and kill it.

Keep the network tab open as you run these tests so you can see what requests are being made.

### Test Case 1

First, test the case we have a queue running, we disconnect, a generation finishes, and then we reconnect.

In this scenario, there will be at least one image that is missing from the gallery, so we need to re-fetch to sync the UI w/ server.

- Create a local SSH tunnel from a free port to 9090: `ssh -L 1337:localhost:9090 localhost`
- Run the server
- Access the app via `localhost:1337`
- Add to the queue - say 5 iterations - and then kill the SSH tunnel
- Wait until a generation finishes
- Recreate the SSH tunnel

Once it automatically reconnects, you should see a handful of network requests as everything is re-fetched, then the image(s) that completed while disconnected should be added to the gallery per usual.

### Test Case 2

Next, test the scenario where the reconnect happens but we are not generating anything.

In this scenario, we shouldn't re-fetch anything because the server state hasn't changed.

Picking up from where you left off a moment ago in the previous test case:
- Cancel all generations (or let them finish)
- Kill the SSH tunnel
- Recreate the SSH tunnel
- Check network tab

You should have no additional requests when it reconnects

### Test Case 3

Finally, test the scenario where the reconnect happens during generation, but it all happens between the start and finish of a single generation.

In this scenario, the only thing that has changed between the disconnect and reconnect is denoising progress, which is a socket event - not HTTP request. So, we do not want to re-fetch everything.

You should see one extra request to get the queue status. This extra request is used to check if a last known queue items completed count is different from the new completed count. In this scenario, these counts are the same, so there are no further network requests.

Picking up from where we left off above:
- Set steps pretty high if you are on a fast machine - you'll need time to reset your SSH tunnel
- Queue some generations
- Immediately kill the SSH tunnel
- Immediately recreate it
- If you managed to do this before that first generation completed, you should see a single network request to get the queue status, then the normal network activity that occurs during generation.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR needs actual review and testing. It is not eligible for rubber-stamping. Once it is carefully reviewed and tested, it can be merged.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [x] No : n/a
