### PR TITLE
feat: pin deps

### DIFF
--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -241,12 +241,12 @@ class InvokeAiInstance:
             pip[
                 "install",
                 "--require-virtualenv",
-                "numpy~=1.24.0",  # choose versions that won't be uninstalled during phase 2
+                "numpy==1.26.3",  # choose versions that won't be uninstalled during phase 2
                 "urllib3~=1.26.0",
                 "requests~=2.28.0",
                 "torch==2.1.2",
                 "torchmetrics==0.11.4",
-                "torchvision>=0.16.2",
+                "torchvision==0.16.2",
                 "--force-reinstall",
                 "--find-links" if find_links is not None else None,
                 find_links,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,37 +32,50 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Image Processing',
 ]
 dependencies = [
-  "accelerate~=0.25.0",
-  "albumentations",
-  "basicsr",
-  "click",
-  "clip_anytorch",              # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
-  "compel~=2.0.2",
-  "controlnet-aux>=0.0.6",
+  # Core generation dependencies, pinned for reproducible builds.
+  "accelerate==0.25.0",
+  "basicsr==1.4.2",
+  "clip_anytorch==2.5.2",       # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
+  "compel==2.0.2",
+  "controlnet-aux==0.0.7",
+  "diffusers[torch]==0.25.0",
+  "invisible-watermark==0.2.0", # needed to install SDXL base and refiner using their repo_ids
+  "mediapipe==0.10.7",          # needed for "mediapipeface" controlnet model
+  "numpy==1.26.3",              # >1.24.0 is needed to use the 'strict' argument to np.testing.assert_array_equal()
+  "onnx==1.15.0",
+  "onnxruntime==1.16.3",
+  "opencv-python==4.9.0.80",
+  "pytorch-lightning==2.1.3",
+  "safetensors==0.4.1",
   "timm==0.6.13",               # needed to override timm latest in controlnet_aux, see  https://github.com/isl-org/ZoeDepth/issues/26
+  "torch==2.1.2",
+  "torchmetrics==0.11.4",
+  "torchsde==0.2.6",
+  "torchvision==0.16.2",
+  "transformers==4.36.2",
+
+  # Core application dependencies, pinned for reproducible builds.
+  "fastapi-events==0.10.0",
+  "fastapi==0.108.0",
+  "huggingface-hub==0.20.2",
+  "pydantic-settings==2.1.0",
+  "pydantic==2.5.3",
+  "python-socketio==5.11.0",
+  "uvicorn[standard]==0.25.0",
+
+  # Auxiliary dependencies, pinned only if necessary.
+  "albumentations",
+  "click",
   "datasets",
-  "diffusers[torch]~=0.25.0",
   "dnspython~=2.4.0",
   "dynamicprompts",
   "easing-functions",
   "einops",
   "facexlib",
-  "fastapi~=0.105.0",
-  "fastapi-events~=0.9.1",
-  "huggingface-hub~=0.19.4",
   "imohash",
-  "invisible-watermark~=0.2.0", # needed to install SDXL base and refiner using their repo_ids
-  "matplotlib",                 # needed for plotting of Penner easing functions
-  "mediapipe",                  # needed for "mediapipeface" controlnet model
-  # Minimum numpy version of 1.24.0 is needed to use the 'strict' argument to np.testing.assert_array_equal().
-  "numpy>=1.24.0",
+  "matplotlib",                            # needed for plotting of Penner easing functions
   "npyscreen",
   "omegaconf",
-  "onnx",
-  "onnxruntime",
-  "opencv-python~=4.8.1.1",
-  "pydantic~=2.5.2",
-  "pydantic-settings~=2.0.3",
   "picklescan",
   "pillow",
   "prompt-toolkit",
@@ -71,25 +84,25 @@ dependencies = [
   'pyperclip',
   "pyreadline3",
   "python-multipart",
-  "python-socketio~=5.10.0",
-  "pytorch-lightning",
   "requests~=2.28.2",
   "rich~=13.3",
-  "safetensors~=0.4.0",
   "scikit-image~=0.21.0",
   "semver~=3.0.1",
   "send2trash",
   "test-tube~=0.7.5",
-  "torch==2.1.2",
-  "torchvision==0.16.2",
-  "torchmetrics~=0.11.0",
-  "torchsde~=0.2.5",
-  "transformers~=4.36.0",
-  "uvicorn[standard]~=0.21.1",
   "windows-curses; sys_platform=='win32'",
 ]
 
 [project.optional-dependencies]
+"xformers" = [
+  # Core generation dependencies, pinned for reproducible builds.
+  "xformers==0.0.23.post1; sys_platform!='darwin'",
+  # Auxiliary dependencies, pinned only if necessary.
+  "triton; sys_platform=='linux'",
+]
+"onnx" = ["onnxruntime"]
+"onnx-cuda" = ["onnxruntime-gpu"]
+"onnx-directml" = ["onnxruntime-directml"]
 "dist" = ["pip-tools", "pipdeptree", "twine"]
 "docs" = [
   "mkdocs-material<9.0",
@@ -98,7 +111,7 @@ dependencies = [
 ]
 "dev" = ["jurigged", "pudb"]
 "test" = [
-  "ruff==0.1.7",
+  "ruff==0.1.11",
   "ruff-lsp",
   "mypy",
   "pre-commit",
@@ -107,13 +120,6 @@ dependencies = [
   "pytest-datadir",
   "requests_testadapter",
 ]
-"xformers" = [
-  "xformers==0.0.23.post1; sys_platform!='darwin'",
-  "triton; sys_platform=='linux'",
-]
-"onnx" = ["onnxruntime"]
-"onnx-cuda" = ["onnxruntime-gpu"]
-"onnx-directml" = ["onnxruntime-directml"]
 
 [project.scripts]
 


### PR DESCRIPTION
## Description

Organise deps into ~3 categories:
- Core generation dependencies, pinned for reproducible builds.
- Core application dependencies, pinned for reproducible builds.
- Auxiliary dependencies, pinned only if necessary.

I pinned / bumped these to latest:
- `controlnet_aux`
- `fastapi`
- `fastapi-events`
- `huggingface-hub`
- `numpy`
- `python-socketio`
- `torchmetrics`
- `transformers`
- `uvicorn`

I checked the release notes for these and didn't see any breaking changes that would affect us. There is a `fastapi` breaking change in v108 related to background tasks but it doesn't affect us.

I tested on a fresh venv. The app still works and I can generate on macOS.

Hopefully, enforcing explicit pinned versions will reduce the issues where people get CPU torch.

It also means we should periodically bump versions up to ensure we don't get too far behind on our dependencies and have to do painful upgrades.

## QA Instructions, Screenshots, Recordings

I don't expect any issues with the minor version bumps involved. I've tested on macOS so far. I'll test on linux shortly, and it would be great to test on window too.

But, if we cut an RC, is much more effective a way to test.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->