### PR TITLE
Allow bfloat16 to be configurable in invoke.yaml

### DIFF
--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -263,7 +263,7 @@ class InvokeAIAppConfig(InvokeAISettings):
 
     # DEVICE
     device              : Literal["auto", "cpu", "cuda", "cuda:1", "mps"] = Field(default="auto", description="Generation device", json_schema_extra=Categories.Device)
-    precision           : Literal["auto", "float16", "float32", "autocast"] = Field(default="auto", description="Floating point precision", json_schema_extra=Categories.Device)
+    precision           : Literal["auto", "float16", "bfloat16", "float32", "autocast"] = Field(default="auto", description="Floating point precision", json_schema_extra=Categories.Device)
 
     # GENERATION
     sequential_guidance : bool = Field(default=False, description="Whether to calculate guidance in serial instead of in parallel, lowering memory requirements", json_schema_extra=Categories.Generation)

--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -34,7 +34,10 @@ def choose_precision(device: torch.device) -> str:
     if device.type == "cuda":
         device_name = torch.cuda.get_device_name(device)
         if not ("GeForce GTX 1660" in device_name or "GeForce GTX 1650" in device_name):
-            return "float16"
+            if config.precision == "bfloat16":
+                return "bfloat16"
+            else:
+                return "float16"
     elif device.type == "mps":
         return "float16"
     return "float32"
@@ -43,8 +46,10 @@ def choose_precision(device: torch.device) -> str:
 def torch_dtype(device: torch.device) -> torch.dtype:
     if config.full_precision:
         return torch.float32
-    if choose_precision(device) == "float16":
-        return torch.bfloat16 if device.type == "cuda" else torch.float16
+    if config(device) == "float16":
+        return torch.float16
+    if config(device) == "bfloat16":
+        return torch.bfloat16
     else:
         return torch.float32
 

--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -44,13 +44,13 @@ def choose_precision(device: torch.device) -> str:
 
 
 def torch_dtype(device: torch.device) -> torch.dtype:
-    if config.full_precision:
-        return torch.float32
-    if config(device) == "float16":
+    precision = choose_precision(device)
+    if precision == "float16":
         return torch.float16
-    if config(device) == "bfloat16":
+    if precision == "bfloat16":
         return torch.bfloat16
     else:
+        # "auto", "autocast", "float32"
         return torch.float32
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: simple change

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No


## Description
Allow bfloat16 to be configured in invoke.yaml

Need help testing as I cannot on my machine. 


## QA Instructions, Screenshots, Recordings
Set `precision: bfloat16` and test generations. Then set `precision: auto` and test generations. 

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan
Can be merged once tested.
<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [X] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
N/A