### PR TITLE
feat(ui): resize options/gallery panels to min on window resize

### DIFF
--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -96,7 +96,7 @@
     "react-icons": "^4.12.0",
     "react-konva": "^18.2.10",
     "react-redux": "9.0.4",
-    "react-resizable-panels": "^1.0.8",
+    "react-resizable-panels": "^1.0.9",
     "react-select": "5.8.0",
     "react-textarea-autosize": "^8.5.3",
     "react-use": "^17.4.2",

--- a/invokeai/frontend/web/pnpm-lock.yaml
+++ b/invokeai/frontend/web/pnpm-lock.yaml
@@ -143,8 +143,8 @@ dependencies:
     specifier: 9.0.4
     version: 9.0.4(@types/react@18.2.47)(react@18.2.0)(redux@5.0.1)
   react-resizable-panels:
-    specifier: ^1.0.8
-    version: 1.0.8(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^1.0.9
+    version: 1.0.9(react-dom@18.2.0)(react@18.2.0)
   react-select:
     specifier: 5.8.0
     version: 5.8.0(@types/react@18.2.47)(react-dom@18.2.0)(react@18.2.0)
@@ -11638,8 +11638,8 @@ packages:
       use-sidecar: 1.1.2(@types/react@18.2.47)(react@18.2.0)
     dev: false
 
-  /react-resizable-panels@1.0.8(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-IuivK06FWN115VSN8TDGYuIoAzplC4oPUCDZ5d+VWJj0p6N3SMfwjggpjMUGSpQJLvMi0FXPSLLn4rGVmESjmA==}
+  /react-resizable-panels@1.0.9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-QPfW3L7yetEC6z04G9AYYFz5kBklh8rTWcOsVFImYMNUVhr1Y1r9Qc/20Yks2tA+lXMBWCUz4fkGEvbS7tpBSg==}
     peerDependencies:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0

--- a/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
+++ b/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
@@ -107,11 +107,8 @@ export const usePanel = (arg: UsePanelOptions): UsePanelReturn => {
       return;
     }
     const id = arg.panelGroupRef.current.getId();
-    const panelGroupElement = getPanelGroupElement(id, document);
-    const panelGroupHandleElements = getResizeHandleElementsForGroup(
-      id,
-      document
-    );
+    const panelGroupElement = getPanelGroupElement(id);
+    const panelGroupHandleElements = getResizeHandleElementsForGroup(id);
     if (!panelGroupElement) {
       return;
     }
@@ -128,13 +125,15 @@ export const usePanel = (arg: UsePanelOptions): UsePanelReturn => {
 
       _setMinSize(minSizePct);
 
-      const currentSize = panelHandleRef.current.getSize();
-
-      // If currentSize is 0, the panel is collapsed, so we don't want to resize it
-      // If it's not 0, but less than the minSize, resize it
-      if (currentSize > 0 && currentSize < minSizePct) {
-        panelHandleRef.current.resize(minSizePct);
-      }
+      /**
+       * TODO(psyche): Ideally, we only resize the panel if there is not enough room for it in the
+       * panel group. This is a bit tricky, though. We'd need to track the last known panel size
+       * and compare it to the new size before resizing. This introduces some complexity that I'd
+       * rather not need to maintain.
+       *
+       * For now, we'll just resize the panel to the min size every time the panel group is resized.
+       */
+      panelHandleRef.current.resize(minSizePct);
     });
 
     resizeObserver.observe(panelGroupElement);
@@ -247,7 +246,7 @@ const getSizeAsPercentage = (
     return 0;
   }
   const id = panelGroupHandleRef.current.getId();
-  const panelGroupElement = getPanelGroupElement(id, document);
+  const panelGroupElement = getPanelGroupElement(id);
   if (!panelGroupElement) {
     // No panel group element, size is 0
     return 0;
@@ -260,7 +259,7 @@ const getSizeAsPercentage = (
       : panelGroupElement.offsetHeight;
 
   // ...minus the width/height of the resize handles
-  getResizeHandleElementsForGroup(id, document).forEach((el) => {
+  getResizeHandleElementsForGroup(id).forEach((el) => {
     availableSpace -=
       panelGroupDirection === 'horizontal' ? el.offsetWidth : el.offsetHeight;
   });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

Per user feedback, this is preferrable to letting them expand when the window grows.

Also bumps `react-resizable-panels` now that one of my PRs is merged to fix an issue.

---



## Related Tickets & Documents

https://discord.com/channels/1020123559063990373/1195752052136087582/1195752052136087582

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## QA Instructions, Screenshots, Recordings

Panel should resize to minimum when the window resizes.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
