### PR TITLE
fix(api): add `NoCacheStaticFiles` to prevent *all* caching

### DIFF
--- a/invokeai/app/api/no_cache_staticfiles.py
+++ b/invokeai/app/api/no_cache_staticfiles.py
@@ -11,7 +11,7 @@ class NoCacheStaticFiles(StaticFiles):
     never cache the files.
 
     Static files include the javascript bundles, fonts, locales, and some images. Generated
-    images are not included, as they are service by a router.
+    images are not included, as they are served by a router.
     """
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/invokeai/app/api/no_cache_staticfiles.py
+++ b/invokeai/app/api/no_cache_staticfiles.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from starlette.responses import Response
+from starlette.staticfiles import StaticFiles
+
+
+class NoCacheStaticFiles(StaticFiles):
+    """
+    This class is used to override the default caching behavior of starlette for static files,
+    ensuring we *never* cache static files. It modifies the file response headers to strictly
+    never cache the files.
+
+    Ttatic files include the javascript bundles, fonts, locales, and some images. Generated
+    images are not included, as they are service by a router.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        self.cachecontrol = "max-age=0, no-cache, no-store, , must-revalidate"
+        self.pragma = "no-cache"
+        self.expires = "0"
+        super().__init__(*args, **kwargs)
+
+    def file_response(self, *args: Any, **kwargs: Any) -> Response:
+        resp = super().file_response(*args, **kwargs)
+        resp.headers.setdefault("Cache-Control", self.cachecontrol)
+        resp.headers.setdefault("Pragma", self.pragma)
+        resp.headers.setdefault("Expires", self.expires)
+        return resp

--- a/invokeai/app/api/no_cache_staticfiles.py
+++ b/invokeai/app/api/no_cache_staticfiles.py
@@ -10,7 +10,7 @@ class NoCacheStaticFiles(StaticFiles):
     ensuring we *never* cache static files. It modifies the file response headers to strictly
     never cache the files.
 
-    Ttatic files include the javascript bundles, fonts, locales, and some images. Generated
+    Static files include the javascript bundles, fonts, locales, and some images. Generated
     images are not included, as they are service by a router.
     """
 

--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -225,7 +225,9 @@ try:
     app.mount("/", NoCacheStaticFiles(directory=Path(web_root_path, "dist"), html=True), name="ui")
 except RuntimeError:
     logger.warn(f"No UI found at {web_root_path}/dist, skipping UI mount")
-app.mount("/static", NoCacheStaticFiles(directory=Path(web_root_path, "static/")), name="static")  # docs favicon is in here
+app.mount(
+    "/static", NoCacheStaticFiles(directory=Path(web_root_path, "static/")), name="static"
+)  # docs favicon is in here
 
 
 def invoke_api() -> None:

--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -3,6 +3,7 @@
 # values from the command line or config file.
 import sys
 
+from invokeai.app.api.no_cache_staticfiles import NoCacheStaticFiles
 from invokeai.version.invokeai_version import __version__
 
 from .services.config import InvokeAIAppConfig
@@ -27,8 +28,7 @@ if True:  # hack to make flake8 happy with imports coming after setting up the c
     from fastapi.middleware.gzip import GZipMiddleware
     from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
     from fastapi.openapi.utils import get_openapi
-    from fastapi.responses import FileResponse, HTMLResponse
-    from fastapi.staticfiles import StaticFiles
+    from fastapi.responses import HTMLResponse
     from fastapi_events.handlers.local import local_handler
     from fastapi_events.middleware import EventHandlerASGIMiddleware
     from pydantic.json_schema import models_json_schema
@@ -221,19 +221,11 @@ def overridden_redoc() -> HTMLResponse:
 
 web_root_path = Path(list(web_dir.__path__)[0])
 
-# Only serve the UI if we it has a build
-if (web_root_path / "dist").exists():
-    # Cannot add headers to StaticFiles, so we must serve index.html with a custom route
-    # Add cache-control: no-store header to prevent caching of index.html, which leads to broken UIs at release
-    @app.get("/", include_in_schema=False, name="ui_root")
-    def get_index() -> FileResponse:
-        return FileResponse(Path(web_root_path, "dist/index.html"), headers={"Cache-Control": "no-store"})
-
-    # Must mount *after* the other routes else it borks em
-    app.mount("/assets", StaticFiles(directory=Path(web_root_path, "dist/assets/")), name="assets")
-    app.mount("/locales", StaticFiles(directory=Path(web_root_path, "dist/locales/")), name="locales")
-
-app.mount("/static", StaticFiles(directory=Path(web_root_path, "static/")), name="static")  # docs favicon is in here
+try:
+    app.mount("/", NoCacheStaticFiles(directory=Path(web_root_path, "dist"), html=True), name="ui")
+except RuntimeError:
+    logger.warn(f"No UI found at {web_root_path}/dist, skipping UI mount")
+app.mount("/static", NoCacheStaticFiles(directory=Path(web_root_path, "static/")), name="static")  # docs favicon is in here
 
 
 def invoke_api() -> None:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

The previous method wasn't totally foolproof, and locales/assets were cached.

To solve this once and for all (famous last words, I know), we can subclass `StaticFiles` and use maximally strict no-caching headers to disable caching on all static files.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #5507

## QA Instructions, Screenshots, Recordings

First, reproduce the issue:
- Build the frontend on `main`
- Navigate to the UI, open the network panel of your browser devtools and reload the page
- Change the language to something else and back to your preference
- Reload again
- Change the language to the one you selected before and back again
- Reload again, change lang again
- Note that instead of transferred, you see `cached` for JS assets and language files

Next, check out this PR, open an incognito window (or clear your cache) and do the same steps. You should see that only the favicon is cached between reloads.

Unfortunately, if the browser is caching a file, a normal reload cannot break that. You must wait for the browser to decide to clear the cache itself or explicitly clear it. After getting that fresh start, there should be no caching.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved
<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
