### PR TITLE
fix: :bug: truncates loRa name lengths and adds tooltips where necessary

### DIFF
--- a/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
@@ -38,9 +38,16 @@ export const LoRACard = memo((props: LoRACardProps) => {
   return (
     <InvCard variant="lora">
       <InvCardHeader>
-        <InvTooltip label={lora.model_name} placement="top" isDisabled={lora.model_name.length < loRaNameMaxLength}>
+        <InvTooltip
+          label={lora.model_name}
+          placement="top"
+          isDisabled={lora.model_name.length < loRaNameMaxLength}
+        >
           <InvLabel noOfLines={1}>
-            {truncate(String(lora.model_name), { length: loRaNameMaxLength, omission: '...' })}
+            {truncate(String(lora.model_name), {
+              length: loRaNameMaxLength,
+              omission: '...',
+            })}
           </InvLabel>
         </InvTooltip>
         <InvIconButton

--- a/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
@@ -8,8 +8,10 @@ import { InvLabel } from 'common/components/InvControl/InvLabel';
 import { InvIconButton } from 'common/components/InvIconButton/InvIconButton';
 import { InvNumberInput } from 'common/components/InvNumberInput/InvNumberInput';
 import { InvSlider } from 'common/components/InvSlider/InvSlider';
+import { InvTooltip } from 'common/components/InvTooltip/InvTooltip';
 import type { LoRA } from 'features/lora/store/loraSlice';
 import { loraRemoved, loraWeightChanged } from 'features/lora/store/loraSlice';
+import { truncate } from 'lodash-es';
 import { memo, useCallback } from 'react';
 import { FaTrashCan } from 'react-icons/fa6';
 
@@ -20,6 +22,7 @@ type LoRACardProps = {
 export const LoRACard = memo((props: LoRACardProps) => {
   const dispatch = useAppDispatch();
   const { lora } = props;
+  const loRaNameMaxLength = 24;
 
   const handleChange = useCallback(
     (v: number) => {
@@ -35,9 +38,11 @@ export const LoRACard = memo((props: LoRACardProps) => {
   return (
     <InvCard variant="lora">
       <InvCardHeader>
-        <InvLabel noOfLines={1} wordBreak="break-all">
-          {lora.model_name}
-        </InvLabel>
+        <InvTooltip label={lora.model_name} placement="top" isDisabled={lora.model_name.length < loRaNameMaxLength}>
+          <InvLabel noOfLines={1}>
+            {truncate(String(lora.model_name), { length: loRaNameMaxLength, omission: '...' })}
+          </InvLabel>
+        </InvTooltip>
         <InvIconButton
           aria-label="Remove LoRA"
           variant="ghost"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: I'm merely addressing a GitHub Issue

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
This PR fixes LoRa model name lengths that may be too long and negatively affect the layout.
I did this by truncating loRa model names to 24 characters and adding a tooltip if it exceeds that length.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #5496

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [x] No : I don't wanna

## [optional] Are there any post deployment tasks we need to perform?
