### PR TITLE
feat: :sparkles: setting to collapse advanced by default

### DIFF
--- a/invokeai/frontend/web/.eslintrc.js
+++ b/invokeai/frontend/web/.eslintrc.js
@@ -126,7 +126,7 @@ module.exports = {
       files: ['**/*.ts', '**/*.tsx'],
       rules: {
         'react/prop-types': 'off',
-      }
+      },
     },
   ],
   settings: {

--- a/invokeai/frontend/web/.eslintrc.js
+++ b/invokeai/frontend/web/.eslintrc.js
@@ -122,6 +122,12 @@ module.exports = {
         'i18next/no-literal-string': 'off',
       },
     },
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        'react/prop-types': 'off',
+      }
+    },
   ],
   settings: {
     react: {

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1307,6 +1307,7 @@
         "showProgressInViewer": "Show Progress Images in Viewer",
         "ui": "User Interface",
         "useSlidersForAll": "Use Sliders For All Options",
+        "collapseAdvancedOptions": "Collapse Advanced Options",
         "clearIntermediatesDisabled": "Queue must be empty to clear intermediates",
         "clearIntermediatesDesc1": "Clearing intermediates will reset your Canvas and ControlNet state.",
         "clearIntermediatesDesc2": "Intermediate images are byproducts of generation, different from the result images in the gallery. Clearing intermediates will free disk space.",
@@ -1451,6 +1452,12 @@
             "heading": "Scheduler",
             "paragraphs": [
                 "Scheduler defines how to iteratively add noise to an image or how to update a sample based on a model's output."
+            ]
+        },
+        "collapseAdvancedOptions": {
+            "heading": "Collapse Advanced Options",
+            "paragraphs": [
+                "Collapses options containing advanced generation settings within the UI by default. These options can always be expanded by clicking on them."
             ]
         },
         "compositingBlur": {

--- a/invokeai/frontend/web/src/common/components/InformationalPopover/constants.ts
+++ b/invokeai/frontend/web/src/common/components/InformationalPopover/constants.ts
@@ -6,6 +6,7 @@ export type Feature =
   | 'paramNegativeConditioning'
   | 'paramPositiveConditioning'
   | 'paramScheduler'
+  | 'collapseAdvancedOptions'
   | 'compositingBlur'
   | 'compositingBlurMethod'
   | 'compositingCoherencePass'

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
@@ -46,18 +46,22 @@ const badgesSelector = createMemoizedSelector(
   }
 );
 
-export const GenerationSettingsAccordion = memo(() => {
+interface GenerationSettingsAccordionProps {
+  collapseAdvanced: boolean;
+}
+
+export const GenerationSettingsAccordion = memo<GenerationSettingsAccordionProps>(({ collapseAdvanced = false }) => {
   const { t } = useTranslation();
   const { loraTabBadges, accordionBadges } = useAppSelector(badgesSelector);
-  const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
-    useExpanderToggle({
-      id: 'generation-settings-advanced',
-      defaultIsOpen: false,
-    });
   const { isOpen: isOpenAccordion, onToggle: onToggleAccordion } =
     useStandaloneAccordionToggle({
       id: 'generation-settings',
       defaultIsOpen: true,
+    });
+  const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
+    useExpanderToggle({
+      id: 'generation-settings-advanced',
+      defaultIsOpen: !collapseAdvanced,
     });
 
   return (

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
@@ -50,60 +50,61 @@ interface GenerationSettingsAccordionProps {
   collapseAdvanced: boolean;
 }
 
-export const GenerationSettingsAccordion = memo<GenerationSettingsAccordionProps>(({ collapseAdvanced = false }) => {
-  const { t } = useTranslation();
-  const { loraTabBadges, accordionBadges } = useAppSelector(badgesSelector);
-  const { isOpen: isOpenAccordion, onToggle: onToggleAccordion } =
-    useStandaloneAccordionToggle({
-      id: 'generation-settings',
-      defaultIsOpen: true,
-    });
-  const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
-    useExpanderToggle({
-      id: 'generation-settings-advanced',
-      defaultIsOpen: !collapseAdvanced,
-    });
+export const GenerationSettingsAccordion =
+  memo<GenerationSettingsAccordionProps>(({ collapseAdvanced = false }) => {
+    const { t } = useTranslation();
+    const { loraTabBadges, accordionBadges } = useAppSelector(badgesSelector);
+    const { isOpen: isOpenAccordion, onToggle: onToggleAccordion } =
+      useStandaloneAccordionToggle({
+        id: 'generation-settings',
+        defaultIsOpen: true,
+      });
+    const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
+      useExpanderToggle({
+        id: 'generation-settings-advanced',
+        defaultIsOpen: !collapseAdvanced,
+      });
 
-  return (
-    <StandaloneAccordion
-      label={t('accordions.generation.title')}
-      badges={accordionBadges}
-      isOpen={isOpenAccordion}
-      onToggle={onToggleAccordion}
-    >
-      <Tabs variant="collapse">
-        <TabList>
-          <Tab>{t('accordions.generation.modelTab')}</Tab>
-          <Tab badges={loraTabBadges}>
-            {t('accordions.generation.conceptsTab')}
-          </Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel overflow="visible" px={4} pt={4}>
-            <Flex gap={4} alignItems="center">
-              <ParamMainModelSelect />
-              <SyncModelsIconButton />
-            </Flex>
-            <Expander isOpen={isOpenExpander} onToggle={onToggleExpander}>
-              <Flex gap={4} flexDir="column" pb={4}>
-                <FormControlGroup formLabelProps={formLabelProps}>
-                  <ParamScheduler />
-                  <ParamSteps />
-                  <ParamCFGScale />
-                </FormControlGroup>
+    return (
+      <StandaloneAccordion
+        label={t('accordions.generation.title')}
+        badges={accordionBadges}
+        isOpen={isOpenAccordion}
+        onToggle={onToggleAccordion}
+      >
+        <Tabs variant="collapse">
+          <TabList>
+            <Tab>{t('accordions.generation.modelTab')}</Tab>
+            <Tab badges={loraTabBadges}>
+              {t('accordions.generation.conceptsTab')}
+            </Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel overflow="visible" px={4} pt={4}>
+              <Flex gap={4} alignItems="center">
+                <ParamMainModelSelect />
+                <SyncModelsIconButton />
               </Flex>
-            </Expander>
-          </TabPanel>
-          <TabPanel>
-            <Flex gap={4} p={4} flexDir="column">
-              <LoRASelect />
-              <LoRAList />
-            </Flex>
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-    </StandaloneAccordion>
-  );
-});
+              <Expander isOpen={isOpenExpander} onToggle={onToggleExpander}>
+                <Flex gap={4} flexDir="column" pb={4}>
+                  <FormControlGroup formLabelProps={formLabelProps}>
+                    <ParamScheduler />
+                    <ParamSteps />
+                    <ParamCFGScale />
+                  </FormControlGroup>
+                </Flex>
+              </Expander>
+            </TabPanel>
+            <TabPanel>
+              <Flex gap={4} p={4} flexDir="column">
+                <LoRASelect />
+                <LoRAList />
+              </Flex>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </StandaloneAccordion>
+    );
+  });
 
 GenerationSettingsAccordion.displayName = 'GenerationSettingsAccordion';

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
@@ -47,7 +47,7 @@ const badgesSelector = createMemoizedSelector(
 );
 
 interface GenerationSettingsAccordionProps {
-  collapseAdvanced: boolean;
+  collapseAdvanced?: boolean;
 }
 
 export const GenerationSettingsAccordion =

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSettingsAccordion.tsx
@@ -78,52 +78,60 @@ interface ImageSettingsAccordionProps {
   collapseAdvanced?: boolean;
 }
 
-export const ImageSettingsAccordion = memo<ImageSettingsAccordionProps>(({ collapseAdvanced = false }) => {
-  const { t } = useTranslation();
-  const { badges, activeTabName } = useAppSelector(selector);
-  const { isOpen: isOpenAccordion, onToggle: onToggleAccordion } =
-    useStandaloneAccordionToggle({ id: 'image-settings', defaultIsOpen: true });
-  const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
-    useExpanderToggle({ id: 'image-settings-advanced', defaultIsOpen: !collapseAdvanced });
+export const ImageSettingsAccordion = memo<ImageSettingsAccordionProps>(
+  ({ collapseAdvanced = false }) => {
+    const { t } = useTranslation();
+    const { badges, activeTabName } = useAppSelector(selector);
+    const { isOpen: isOpenAccordion, onToggle: onToggleAccordion } =
+      useStandaloneAccordionToggle({
+        id: 'image-settings',
+        defaultIsOpen: true,
+      });
+    const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
+      useExpanderToggle({
+        id: 'image-settings-advanced',
+        defaultIsOpen: !collapseAdvanced,
+      });
 
-  return (
-    <StandaloneAccordion
-      label={t('accordions.image.title')}
-      badges={badges}
-      isOpen={isOpenAccordion}
-      onToggle={onToggleAccordion}
-    >
-      <Flex px={4} pt={4} w="full" h="full" flexDir="column">
-        {activeTabName === 'unifiedCanvas' ? (
-          <ImageSizeCanvas />
-        ) : (
-          <ImageSizeLinear />
-        )}
-        <Expander isOpen={isOpenExpander} onToggle={onToggleExpander}>
-          <Flex gap={4} pb={4} flexDir="column">
-            <Flex gap={4} alignItems="center">
-              <ParamSeedNumberInput />
-              <ParamSeedShuffle />
-              <ParamSeedRandomize />
+    return (
+      <StandaloneAccordion
+        label={t('accordions.image.title')}
+        badges={badges}
+        isOpen={isOpenAccordion}
+        onToggle={onToggleAccordion}
+      >
+        <Flex px={4} pt={4} w="full" h="full" flexDir="column">
+          {activeTabName === 'unifiedCanvas' ? (
+            <ImageSizeCanvas />
+          ) : (
+            <ImageSizeLinear />
+          )}
+          <Expander isOpen={isOpenExpander} onToggle={onToggleExpander}>
+            <Flex gap={4} pb={4} flexDir="column">
+              <Flex gap={4} alignItems="center">
+                <ParamSeedNumberInput />
+                <ParamSeedShuffle />
+                <ParamSeedRandomize />
+              </Flex>
+              {(activeTabName === 'img2img' ||
+                activeTabName === 'unifiedCanvas') && <ImageToImageStrength />}
+              {activeTabName === 'img2img' && <ImageToImageFit />}
+              {activeTabName === 'txt2img' && <HrfSettings />}
+              {activeTabName === 'unifiedCanvas' && (
+                <>
+                  <ParamScaleBeforeProcessing />
+                  <FormControlGroup formLabelProps={scalingLabelProps}>
+                    <ParamScaledWidth />
+                    <ParamScaledHeight />
+                  </FormControlGroup>
+                </>
+              )}
             </Flex>
-            {(activeTabName === 'img2img' ||
-              activeTabName === 'unifiedCanvas') && <ImageToImageStrength />}
-            {activeTabName === 'img2img' && <ImageToImageFit />}
-            {activeTabName === 'txt2img' && <HrfSettings />}
-            {activeTabName === 'unifiedCanvas' && (
-              <>
-                <ParamScaleBeforeProcessing />
-                <FormControlGroup formLabelProps={scalingLabelProps}>
-                  <ParamScaledWidth />
-                  <ParamScaledHeight />
-                </FormControlGroup>
-              </>
-            )}
-          </Flex>
-        </Expander>
-      </Flex>
-    </StandaloneAccordion>
-  );
-});
+          </Expander>
+        </Flex>
+      </StandaloneAccordion>
+    );
+  }
+);
 
 ImageSettingsAccordion.displayName = 'ImageSettingsAccordion';

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSettingsAccordion.tsx
@@ -74,13 +74,17 @@ const scalingLabelProps: FormLabelProps = {
   minW: '4.5rem',
 };
 
-export const ImageSettingsAccordion = memo(() => {
+interface ImageSettingsAccordionProps {
+  collapseAdvanced?: boolean;
+}
+
+export const ImageSettingsAccordion = memo<ImageSettingsAccordionProps>(({ collapseAdvanced = false }) => {
   const { t } = useTranslation();
   const { badges, activeTabName } = useAppSelector(selector);
   const { isOpen: isOpenAccordion, onToggle: onToggleAccordion } =
     useStandaloneAccordionToggle({ id: 'image-settings', defaultIsOpen: true });
   const { isOpen: isOpenExpander, onToggle: onToggleExpander } =
-    useExpanderToggle({ id: 'image-settings-advanced', defaultIsOpen: false });
+    useExpanderToggle({ id: 'image-settings-advanced', defaultIsOpen: !collapseAdvanced });
 
   return (
     <StandaloneAccordion

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -293,7 +293,9 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
                         feature="collapseAdvancedOptions"
                         inPortal={false}
                       >
-                        <FormLabel>{t('settings.collapseAdvancedOptions')}</FormLabel>
+                        <FormLabel>
+                          {t('settings.collapseAdvancedOptions')}
+                        </FormLabel>
                       </InformationalPopover>
                       <Switch
                         isChecked={shouldCollapseAdvancedOptions}

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -24,6 +24,7 @@ import { useClearIntermediates } from 'features/system/components/SettingsModal/
 import { StickyScrollable } from 'features/system/components/StickyScrollable';
 import {
   setEnableImageDebugging,
+  setShouldCollapseAdvancedOptions,
   setShouldConfirmOnDelete,
   setShouldEnableInformationalPopovers,
   shouldAntialiasProgressImageChanged,
@@ -126,6 +127,9 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
   const shouldEnableInformationalPopovers = useAppSelector(
     (s) => s.system.shouldEnableInformationalPopovers
   );
+  const shouldCollapseAdvancedOptions = useAppSelector(
+    (s) => s.system.shouldCollapseAdvancedOptions
+  );
 
   const clearStorage = useClearStorage();
 
@@ -194,6 +198,12 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
   const handleChangeShouldUseCpuNoise = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       dispatch(shouldUseCpuNoiseChanged(e.target.checked));
+    },
+    [dispatch]
+  );
+  const handleShouldCollapseAdvancedOptions = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      dispatch(setShouldCollapseAdvancedOptions(e.target.checked));
     },
     [dispatch]
   );
@@ -276,6 +286,18 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
                       <Switch
                         isChecked={shouldUseCpuNoise}
                         onChange={handleChangeShouldUseCpuNoise}
+                      />
+                    </FormControl>
+                    <FormControl>
+                      <InformationalPopover
+                        feature="collapseAdvancedOptions"
+                        inPortal={false}
+                      >
+                        <FormLabel>{t('settings.collapseAdvancedOptions')}</FormLabel>
+                      </InformationalPopover>
+                      <Switch
+                        isChecked={shouldCollapseAdvancedOptions}
+                        onChange={handleShouldCollapseAdvancedOptions}
                       />
                     </FormControl>
                     {shouldShowLocalizationToggle && <SettingsLanguageSelect />}

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -38,6 +38,7 @@ export const initialSystemState: SystemState = {
   shouldUseNSFWChecker: false,
   shouldUseWatermarker: false,
   shouldEnableInformationalPopovers: false,
+  shouldCollapseAdvancedOptions: true,
   status: 'DISCONNECTED',
 };
 
@@ -84,6 +85,12 @@ export const systemSlice = createSlice({
     ) {
       state.shouldEnableInformationalPopovers = action.payload;
     },
+    setShouldCollapseAdvancedOptions(
+      state,
+      action: PayloadAction<boolean>
+    ) {
+      state.shouldCollapseAdvancedOptions = action.payload;
+    }
   },
   extraReducers(builder) {
     /**
@@ -202,6 +209,7 @@ export const {
   shouldUseNSFWCheckerChanged,
   shouldUseWatermarkerChanged,
   setShouldEnableInformationalPopovers,
+  setShouldCollapseAdvancedOptions,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -85,12 +85,9 @@ export const systemSlice = createSlice({
     ) {
       state.shouldEnableInformationalPopovers = action.payload;
     },
-    setShouldCollapseAdvancedOptions(
-      state,
-      action: PayloadAction<boolean>
-    ) {
+    setShouldCollapseAdvancedOptions(state, action: PayloadAction<boolean>) {
       state.shouldCollapseAdvancedOptions = action.payload;
-    }
+    },
   },
   extraReducers(builder) {
     /**

--- a/invokeai/frontend/web/src/features/system/store/types.ts
+++ b/invokeai/frontend/web/src/features/system/store/types.ts
@@ -57,6 +57,7 @@ export interface SystemState {
   shouldUseWatermarker: boolean;
   status: SystemStatus;
   shouldEnableInformationalPopovers: boolean;
+  shouldCollapseAdvancedOptions: boolean;
 }
 
 export const STATUS_TRANSLATION_KEYS: Record<SystemStatus, string> = {

--- a/invokeai/frontend/web/src/features/ui/components/ParametersPanel.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/ParametersPanel.tsx
@@ -41,8 +41,12 @@ const ParametersPanel = () => {
           >
             <Flex gap={2} flexDirection="column" h="full" w="full">
               {isSDXL ? <SDXLPrompts /> : <Prompts />}
-              <ImageSettingsAccordion collapseAdvanced={shouldCollapseAdvancedOptions} />
-              <GenerationSettingsAccordion collapseAdvanced={shouldCollapseAdvancedOptions} />
+              <ImageSettingsAccordion
+                collapseAdvanced={shouldCollapseAdvancedOptions}
+              />
+              <GenerationSettingsAccordion
+                collapseAdvanced={shouldCollapseAdvancedOptions}
+              />
               <ControlSettingsAccordion />
               {activeTabName === 'unifiedCanvas' && (
                 <CompositingSettingsAccordion />

--- a/invokeai/frontend/web/src/features/ui/components/ParametersPanel.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/ParametersPanel.tsx
@@ -25,6 +25,9 @@ const ParametersPanel = () => {
   const isSDXL = useAppSelector(
     (s) => s.generation.model?.base_model === 'sdxl'
   );
+  const shouldCollapseAdvancedOptions = useAppSelector(
+    (s) => s.system.shouldCollapseAdvancedOptions
+  );
 
   return (
     <Flex w="full" h="full" flexDir="column" gap={2}>
@@ -38,8 +41,8 @@ const ParametersPanel = () => {
           >
             <Flex gap={2} flexDirection="column" h="full" w="full">
               {isSDXL ? <SDXLPrompts /> : <Prompts />}
-              <ImageSettingsAccordion />
-              <GenerationSettingsAccordion />
+              <ImageSettingsAccordion collapseAdvanced={shouldCollapseAdvancedOptions} />
+              <GenerationSettingsAccordion collapseAdvanced={shouldCollapseAdvancedOptions} />
               <ControlSettingsAccordion />
               {activeTabName === 'unifiedCanvas' && (
                 <CompositingSettingsAccordion />


### PR DESCRIPTION
Adds a setting to keep advanced options open/closed by default within UI accordions

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [x] No, because: I thought this would be neat

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
Adds a neat setting for whether the "advanced options" accordions within parameter panel accordions should be expanded by default. This would be beneficial to InvokeAI power users who dislike opening more panels and such to find the settings they're looking for.

## QA Instructions, Screenshots, Recordings
![image](https://github.com/invoke-ai/InvokeAI/assets/23065423/f9921d81-8113-4c0d-8f69-5cef43c19b9f)

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [x] No : I'm not in love with setting up tests nor am I familiar with the existing testing methods.

## [optional] Are there any post deployment tasks we need to perform?
