### PR TITLE
fix(ui): the bottom button on floating side panel clears all queue items

### DIFF
--- a/invokeai/frontend/web/src/features/queue/components/ClearQueueIconButton.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/ClearQueueIconButton.tsx
@@ -12,7 +12,7 @@ type ClearQueueIconButtonProps = ClearQueueButtonProps & {
   onOpen: () => void;
 };
 
-const ClearAllQueueIconButton = ({ onOpen, ...props }: ClearQueueIconButtonProps) => {
+export const ClearAllQueueIconButton = ({ onOpen, ...props }: ClearQueueIconButtonProps) => {
   const { t } = useTranslation();
   const { isLoading, isDisabled } = useClearQueue();
 

--- a/invokeai/frontend/web/src/features/ui/components/FloatingParametersPanelButtons.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/FloatingParametersPanelButtons.tsx
@@ -1,7 +1,8 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
-import { ButtonGroup, Flex, Icon, IconButton, Portal, spinAnimation } from '@invoke-ai/ui-library';
+import { ButtonGroup, Flex, Icon, IconButton, Portal, spinAnimation, useDisclosure } from '@invoke-ai/ui-library';
 import CancelCurrentQueueItemIconButton from 'features/queue/components/CancelCurrentQueueItemIconButton';
-import ClearQueueIconButton from 'features/queue/components/ClearQueueIconButton';
+import ClearQueueConfirmationAlertDialog from 'features/queue/components/ClearQueueConfirmationAlertDialog';
+import { ClearAllQueueIconButton } from 'features/queue/components/ClearQueueIconButton';
 import { QueueButtonTooltip } from 'features/queue/components/QueueButtonTooltip';
 import { useQueueBack } from 'features/queue/hooks/useQueueBack';
 import type { UsePanelReturn } from 'features/ui/hooks/usePanel';
@@ -34,6 +35,8 @@ const FloatingSidePanelButtons = (props: Props) => {
       ),
     [isDisabled, queueStatus?.processor.is_processing]
   );
+
+  const disclosure = useDisclosure();
 
   if (!props.panelApi.isCollapsed) {
     return null;
@@ -71,7 +74,8 @@ const FloatingSidePanelButtons = (props: Props) => {
           />
           <CancelCurrentQueueItemIconButton sx={floatingButtonStyles} />
         </ButtonGroup>
-        <ClearQueueIconButton sx={floatingButtonStyles} />
+        <ClearAllQueueIconButton sx={floatingButtonStyles} onOpen={disclosure.onOpen} />
+        <ClearQueueConfirmationAlertDialog disclosure={disclosure} />
       </Flex>
     </Portal>
   );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
Buttons that handle the queue on the floating panel used to perform the same thing which is confusing. This pr makes the bottom one only clear the entire queue while the upper one clears the current item (behavior unchanged).
![image](https://github.com/invoke-ai/InvokeAI/assets/4258136/61c9060a-0847-498f-9ff3-833d9751d721)

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

1. Toggle the side panel to the folded state so that the floating panel appears
2. Queue up multiple items
3. The bottom button should cancel the entire queue (via confirmation dialog)

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
This PR can be merged when approved
