### PR TITLE
fix(ui): cursor obstructing brush

### DIFF
--- a/invokeai/frontend/web/src/features/canvas/store/canvasNanostore.ts
+++ b/invokeai/frontend/web/src/features/canvas/store/canvasNanostore.ts
@@ -22,7 +22,6 @@ export const $isModifyingBoundingBox = computed(
 export const resetCanvasInteractionState = () => {
   $cursorPosition.set(null);
   $isDrawing.set(false);
-  $isMouseOverBoundingBox.set(false);
   $isMoveBoundingBoxKeyHeld.set(false);
   $isMoveStageKeyHeld.set(false);
   $isMovingBoundingBox.set(false);
@@ -31,7 +30,6 @@ export const resetCanvasInteractionState = () => {
 
 export const resetToolInteractionState = () => {
   $isTransformingBoundingBox.set(false);
-  $isMouseOverBoundingBox.set(false);
   $isMovingBoundingBox.set(false);
   $isMovingStage.set(false);
 };


### PR DESCRIPTION
Remove resetting cursor when resetting state letting event handlers to take care of presentation

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
This PR addresses a bug on unified canvas tab when switching between tools using shortcuts. It only happens if the "Limit strokes to box" setting is on. While inside the bounding box switching tools resets the cursor to default thus obstructing the brush (especially if the brush size is small).


https://github.com/invoke-ai/InvokeAI/assets/4258136/922697fe-7eb6-45dc-9ce2-941620a63b59



## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
This PR can be merged when approved

