### PR TITLE
fix(ui): refetch intermediates count when settings modal open

### DIFF
--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -81,9 +81,10 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
     hasPendingItems,
     intermediatesCount,
     isLoading: isLoadingClearIntermediates,
+    refetchIntermediatesCount,
   } = useClearIntermediates(shouldShowClearIntermediates);
 
-  const { isOpen: isSettingsModalOpen, onOpen: onSettingsModalOpen, onClose: onSettingsModalClose } = useDisclosure();
+  const { isOpen: isSettingsModalOpen, onOpen: _onSettingsModalOpen, onClose: onSettingsModalClose } = useDisclosure();
 
   const { isOpen: isRefreshModalOpen, onOpen: onRefreshModalOpen, onClose: onRefreshModalClose } = useDisclosure();
 
@@ -98,6 +99,11 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
   const shouldEnableInformationalPopovers = useAppSelector((s) => s.system.shouldEnableInformationalPopovers);
 
   const clearStorage = useClearStorage();
+
+  const handleOpenSettingsModel = useCallback(() => {
+    refetchIntermediatesCount();
+    _onSettingsModalOpen();
+  }, [_onSettingsModalOpen, refetchIntermediatesCount]);
 
   const handleClickResetWebUI = useCallback(() => {
     clearStorage();
@@ -171,7 +177,7 @@ const SettingsModal = ({ children, config }: SettingsModalProps) => {
   return (
     <>
       {cloneElement(children, {
-        onClick: onSettingsModalOpen,
+        onClick: handleOpenSettingsModel,
       })}
 
       <Modal isOpen={isSettingsModalOpen} onClose={onSettingsModalClose} size="2xl" isCentered>

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/useClearIntermediates.ts
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/useClearIntermediates.ts
@@ -12,13 +12,14 @@ export type UseClearIntermediatesReturn = {
   clearIntermediates: () => void;
   isLoading: boolean;
   hasPendingItems: boolean;
+  refetchIntermediatesCount: () => void;
 };
 
 export const useClearIntermediates = (shouldShowClearIntermediates: boolean): UseClearIntermediatesReturn => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
-  const { data: intermediatesCount } = useGetIntermediatesCountQuery(undefined, {
+  const { data: intermediatesCount, refetch: refetchIntermediatesCount } = useGetIntermediatesCountQuery(undefined, {
     refetchOnMountOrArgChange: true,
     skip: !shouldShowClearIntermediates,
   });
@@ -58,5 +59,5 @@ export const useClearIntermediates = (shouldShowClearIntermediates: boolean): Us
       });
   }, [t, _clearIntermediates, dispatch, hasPendingItems]);
 
-  return { intermediatesCount, clearIntermediates, isLoading, hasPendingItems };
+  return { intermediatesCount, clearIntermediates, isLoading, hasPendingItems, refetchIntermediatesCount };
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Description

The `getIntermediatesCount` query is set to `refetchOnMountOrArgsChange`. The intention was for when the settings modal opens (i.e. mounts), the `getIntermediatesCount` query is refetched. But it doesn't work - modals only mount once, there is no lazy rendering for them. 

So we have to imperatively refetch, by refetching as we open the modal.

--- 

Another way to handle this would be to invalidate the `IntermediatesCount` tag when the settings modal is opened, but this is a bit more complex. Internally, the `clearIntermediates` mutation invalidates this tag, so when you click the button, it automatically refreshes.

We will not be making the intermediates count refresh "live", we'd have to refetch constantly. With this change, you can close and open the settings modal again to update it.

## Related Tickets & Documents

- Closes #5639

## QA Instructions, Screenshots, Recordings

- Clear intermediates, so its says 0
- Generate stuff that would create intermediates
- Open settings modal
- It should show >0 intermediates

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->