### PR TITLE
fix(ui): handle fields with single option literal

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputTemplate.ts
@@ -373,6 +373,8 @@ const buildEnumFieldInputTemplate: FieldInputTemplateBuilder<EnumFieldInputTempl
     } else {
       options = firstAnyOf.enum ?? [];
     }
+  } else if (schemaObject.const) {
+    options = [schemaObject.const];
   } else {
     options = schemaObject.enum ?? [];
   }

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseFieldType.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseFieldType.ts
@@ -55,6 +55,14 @@ export const parseFieldType = (schemaObject: OpenAPIV3_1SchemaOrRef): FieldType 
     }
   }
   if (isSchemaObject(schemaObject)) {
+    if (schemaObject.const) {
+      // Fields with a single const value are defined as `Literal["value"]` in the pydantic schema - it's actually an enum
+      return {
+        name: 'EnumField',
+        isCollection: false,
+        isCollectionOrScalar: false,
+      };
+    }
     if (!schemaObject.type) {
       // if schemaObject has no type, then it should have one of allOf, anyOf, oneOf
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

Turns out the OpenAPI schema definition for a pydantic field with a `Literal` type annotation is different depending on the number of options.

When there is a single value (e.g. `Literal["foo"]`, this results in a `const` schema object. The schema parser didn't know how to handle this, and displayed a warning in the JS console.

 This situation is now handled. When a `const` schema object is encountered, we interpret that as an `EnumField` with a single option.

 I think this makes sense - if you had a truly constant value, you wouldn't make it a field, so a `const` must mean a dynamically generated enum that ended up with only a single option.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #5616

## QA Instructions, Screenshots, Recordings

Example node:
```py
@invocation(
    "literal_test", title="Literal Test", tags=["primitives", "boolean"], category="primitives", version="1.0.0"
)
class LiteralTestInvocation(BaseInvocation):
    """Literal test value"""

    foo: Literal["bar"] = InputField(default="bar", description="The literal value")

    def invoke(self, context: InvocationContext) -> BooleanOutput:
        return BooleanOutput(value=True)
```

On `main`, this node will not display `foo` as an input field.

On this PR, the node should display a drop-down input field with one option.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->