### PR TITLE
fix(ui): do not swallow errors during schema parsing 

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -124,6 +124,20 @@ export const parseSchema = (
                 message: e.message,
               })
             );
+          } else {
+            logger('nodes').warn(
+              {
+                node: type,
+                field: propertyName,
+                schema: parseify(property),
+                error: serializeError(e),
+              },
+              t('nodes.inputFieldTypeParseError', {
+                node: type,
+                field: propertyName,
+                message: 'unknown error',
+              })
+            );
           }
         }
 
@@ -201,6 +215,20 @@ export const parseSchema = (
                 node: type,
                 field: propertyName,
                 message: e.message,
+              })
+            );
+          } else {
+            logger('nodes').warn(
+              {
+                node: type,
+                field: propertyName,
+                schema: parseify(property),
+                error: serializeError(e),
+              },
+              t('nodes.outputFieldTypeParseError', {
+                node: type,
+                field: propertyName,
+                message: 'unknown error',
               })
             );
           }

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -12,6 +12,7 @@ import {
 import { t } from 'i18next';
 import { reduce } from 'lodash-es';
 import type { OpenAPIV3_1 } from 'openapi-types';
+import { serializeError } from 'serialize-error';
 
 import { buildFieldInputTemplate } from './buildFieldInputTemplate';
 import { buildFieldOutputTemplate } from './buildFieldOutputTemplate';
@@ -103,7 +104,10 @@ export const parseSchema = (
           const fieldType = parseFieldType(property);
 
           if (isReservedFieldType(fieldType.name)) {
-            // Skip processing this reserved field
+            logger('nodes').trace(
+              { node: type, field: propertyName, schema: parseify(property) },
+              'Skipped reserved input field'
+            );
             return inputsAccumulator;
           }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

- Unknown errors were swallowed during schema parsing. Now they log a warning.
- Added trace log for when skipping reserved input field type

## QA Instructions, Screenshots, Recordings

I don't know how to create a situation where this is relevant, but I'm sure it exists.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->