### PR TITLE
feat(nodes): improved stats reporting, error handling

### DIFF
--- a/invokeai/app/services/invocation_processor/invocation_processor_default.py
+++ b/invokeai/app/services/invocation_processor/invocation_processor_default.py
@@ -182,8 +182,6 @@ class DefaultInvocationProcessor(InvocationProcessorABC):
                         error_type=e.__class__.__name__,
                         error=error,
                     )
-                    with suppress(GESStatsNotFoundError):
-                        self.__invoker.services.performance_statistics.reset_stats(graph_execution_state.id)
                     pass
 
                 # Check queue to see if this is canceled, and skip if so

--- a/invokeai/app/services/invocation_processor/invocation_processor_default.py
+++ b/invokeai/app/services/invocation_processor/invocation_processor_default.py
@@ -54,6 +54,17 @@ class DefaultInvocationProcessor(InvocationProcessorABC):
                 else None
             )
 
+            def stats_cleanup(graph_execution_state_id: str) -> None:
+                if profiler:
+                    profile_path = profiler.stop()
+                    stats_path = profile_path.with_suffix(".json")
+                    self.__invoker.services.performance_statistics.dump_stats(
+                        graph_execution_state_id=graph_execution_state_id, output_path=stats_path
+                    )
+                with suppress(GESStatsNotFoundError):
+                    self.__invoker.services.performance_statistics.log_stats(graph_execution_state_id)
+                    self.__invoker.services.performance_statistics.reset_stats(graph_execution_state_id)
+
             while not stop_event.is_set():
                 try:
                     queue_item = self.__invoker.services.queue.get()
@@ -156,15 +167,7 @@ class DefaultInvocationProcessor(InvocationProcessorABC):
                     pass
 
                 except CanceledException:
-                    with suppress(GESStatsNotFoundError):
-                        if profiler:
-                            profile_path = profiler.stop()
-                            stats_path = profile_path.with_suffix(".json")
-                            self.__invoker.services.performance_statistics.dump_stats(
-                                graph_execution_state_id=graph_execution_state.id, output_path=stats_path
-                            )
-                        self.__invoker.services.performance_statistics.log_stats(graph_execution_state.id)
-                        self.__invoker.services.performance_statistics.reset_stats(graph_execution_state.id)
+                    stats_cleanup(graph_execution_state.id)
                     pass
 
                 except Exception as e:
@@ -226,15 +229,7 @@ class DefaultInvocationProcessor(InvocationProcessorABC):
                         queue_id=queue_item.session_queue_id,
                         graph_execution_state_id=graph_execution_state.id,
                     )
-                    if profiler:
-                        profile_path = profiler.stop()
-                        stats_path = profile_path.with_suffix(".json")
-                        self.__invoker.services.performance_statistics.dump_stats(
-                            graph_execution_state_id=graph_execution_state.id, output_path=stats_path
-                        )
-                    with suppress(GESStatsNotFoundError):
-                        self.__invoker.services.performance_statistics.log_stats(graph_execution_state.id)
-                        self.__invoker.services.performance_statistics.reset_stats(graph_execution_state.id)
+                    stats_cleanup(graph_execution_state.id)
 
         except KeyboardInterrupt:
             pass  # Log something? KeyboardInterrupt is probably not going to be seen by the processor

--- a/invokeai/app/services/invocation_stats/invocation_stats_default.py
+++ b/invokeai/app/services/invocation_stats/invocation_stats_default.py
@@ -106,9 +106,9 @@ class InvocationStatsService(InvocationStatsServiceBase):
             del self._stats[graph_execution_state_id]
             del self._cache_stats[graph_execution_state_id]
         except KeyError as e:
-            msg = f"Attempted to clear statistics for unknown graph {graph_execution_state_id}: {e}."
-            logger.error(msg)
-            raise GESStatsNotFoundError(msg) from e
+            raise GESStatsNotFoundError(
+                f"Attempted to clear statistics for unknown graph {graph_execution_state_id}: {e}."
+            ) from e
 
     def get_stats(self, graph_execution_state_id: str) -> InvocationStatsSummary:
         graph_stats_summary = self._get_graph_summary(graph_execution_state_id)
@@ -136,9 +136,9 @@ class InvocationStatsService(InvocationStatsServiceBase):
         try:
             cache_stats = self._cache_stats[graph_execution_state_id]
         except KeyError as e:
-            msg = f"Attempted to get model cache statistics for unknown graph {graph_execution_state_id}: {e}."
-            logger.error(msg)
-            raise GESStatsNotFoundError(msg) from e
+            raise GESStatsNotFoundError(
+                f"Attempted to get model cache statistics for unknown graph {graph_execution_state_id}: {e}."
+            ) from e
 
         return ModelCacheStatsSummary(
             cache_hits=cache_stats.hits,
@@ -154,9 +154,9 @@ class InvocationStatsService(InvocationStatsServiceBase):
         try:
             graph_stats = self._stats[graph_execution_state_id]
         except KeyError as e:
-            msg = f"Attempted to get graph statistics for unknown graph {graph_execution_state_id}: {e}."
-            logger.error(msg)
-            raise GESStatsNotFoundError(msg) from e
+            raise GESStatsNotFoundError(
+                f"Attempted to get graph statistics for unknown graph {graph_execution_state_id}: {e}."
+            ) from e
 
         return graph_stats.get_graph_stats_summary(graph_execution_state_id)
 
@@ -164,8 +164,8 @@ class InvocationStatsService(InvocationStatsServiceBase):
         try:
             graph_stats = self._stats[graph_execution_state_id]
         except KeyError as e:
-            msg = f"Attempted to get node statistics for unknown graph {graph_execution_state_id}: {e}."
-            logger.error(msg)
-            raise GESStatsNotFoundError(msg) from e
+            raise GESStatsNotFoundError(
+                f"Attempted to get node statistics for unknown graph {graph_execution_state_id}: {e}."
+            ) from e
 
         return graph_stats.get_node_stats_summaries()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

Improved stats reporting and error handling. See commits.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related https://discord.com/channels/1020123559063990373/1149513625321603162/1204279425231749181

## QA Instructions, Screenshots, Recordings

- Cancel a running graph (just a normal t2i on linear tab is fine). You should get stats for it.
- Create a graph that will fail (for example, a single resize image node with no image - disable validation in the workflow editor settings to be able to submit this). You should get only the invocation error, and then stats. You should _not_ get an error message saying "Attempted to get graph statistics for unknown graph..."

Note: If you cancel during the very first model load, you get no output. I cannot figure out where the processor loop exits for the life of me. I thought it might be here:

```py
# Check queue to see if this is canceled, and skip if so
if self.__invoker.services.queue.is_canceled(graph_execution_state.id):
    continue
```

But putting a breakpoint there or print statement doesn't catch it. So, I guess, let the first model load happen before you cancel...

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
