### PR TITLE
Print correct version when a non-default version is selected for install

### DIFF
--- a/installer/lib/messages.py
+++ b/installer/lib/messages.py
@@ -92,7 +92,8 @@ def choose_version(available_releases: tuple | None = None) -> str:
         completer=FuzzyWordCompleter(choices),
     )
 
-    console.print(f"   Version {choices[0]} will be installed.")
+    console.print(f"   Version {choices[0] if response == "" else response} will be installed.")
+
     console.line()
 
     return "stable" if response == "" else response


### PR DESCRIPTION
…elected

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description

Small bugfix: the installer would always print the latest stable version as the one to be installed, even if a different one was selected. The selected version would still be installed correctly. This PR fixes the message. 

## QA Instructions, Screenshots, Recordings

Select a pre-release version on install and observe the correct version being printed. Compare to current behaviour to ascertain the fix.

## Merge Plan

- "This PR can be merged when approved"

## Added/updated tests?

- [ ] Yes
- [x] No 
