### PR TITLE
fix(ui): when using control image dimensions, round to 8

### DIFF
--- a/invokeai/frontend/web/src/features/controlAdapters/components/ControlAdapterImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlAdapters/components/ControlAdapterImagePreview.tsx
@@ -5,6 +5,7 @@ import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import IAIDndImage from 'common/components/IAIDndImage';
 import IAIDndImageIcon from 'common/components/IAIDndImageIcon';
+import { roundToMultiple } from 'common/util/roundDownToMultiple';
 import { setBoundingBoxDimensions } from 'features/canvas/store/canvasSlice';
 import { useControlAdapterControlImage } from 'features/controlAdapters/hooks/useControlAdapterControlImage';
 import { useControlAdapterProcessedControlImage } from 'features/controlAdapters/hooks/useControlAdapterProcessedControlImage';
@@ -91,19 +92,14 @@ const ControlAdapterImagePreview = ({ isSmall, id }: Props) => {
       return;
     }
 
+    const width = roundToMultiple(controlImage.width, 8);
+    const height = roundToMultiple(controlImage.height, 8);
+
     if (activeTabName === 'unifiedCanvas') {
-      dispatch(
-        setBoundingBoxDimensions(
-          {
-            width: controlImage.width,
-            height: controlImage.height,
-          },
-          optimalDimension
-        )
-      );
+      dispatch(setBoundingBoxDimensions({ width, height }, optimalDimension));
     } else {
-      dispatch(widthChanged(controlImage.width));
-      dispatch(heightChanged(controlImage.height));
+      dispatch(widthChanged(width));
+      dispatch(heightChanged(height));
     }
   }, [controlImage, activeTabName, dispatch, optimalDimension]);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

The control image dimensions were set directly without rounding them to 8, causing an error during generation if they weren't a multiple of 8.

## QA Instructions, Screenshots, Recordings

- Upload an image with dimensions that are not a multiple of 8
- Use it as a control image
- Click the button to use the control image dimensions
- They should round to 8 before being set

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->