### PR TITLE
fix(ui): omit disabled loras from sdxl graphs

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/addSDXLLoRAstoGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/addSDXLLoRAstoGraph.ts
@@ -1,7 +1,7 @@
 import type { RootState } from 'app/store/store';
 import type { LoRAMetadataItem } from 'features/nodes/types/metadata';
 import { zLoRAMetadataItem } from 'features/nodes/types/metadata';
-import { forEach, size } from 'lodash-es';
+import { filter, size } from 'lodash-es';
 import type { NonNullableGraph, SDXLLoraLoaderInvocation } from 'services/api/types';
 
 import {
@@ -31,8 +31,8 @@ export const addSDXLLoRAsToGraph = (
    * So we need to inject a LoRA chain into the graph.
    */
 
-  const { loras } = state.lora;
-  const loraCount = size(loras);
+  const enabledLoRAs = filter(state.lora.loras, (l) => l.isEnabled ?? false);
+  const loraCount = size(enabledLoRAs);
 
   if (loraCount === 0) {
     return;
@@ -59,7 +59,7 @@ export const addSDXLLoRAsToGraph = (
   let lastLoraNodeId = '';
   let currentLoraIndex = 0;
 
-  forEach(loras, (lora) => {
+  enabledLoRAs.forEach((lora) => {
     const { model_name, base_model, weight } = lora;
     const currentLoraNodeId = `${LORA_LOADER}_${model_name.replace('.', '_')}`;
 

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
@@ -23,7 +23,7 @@ import ParamMainModelSelect from 'features/parameters/components/MainModel/Param
 import { selectGenerationSlice } from 'features/parameters/store/generationSlice';
 import { useExpanderToggle } from 'features/settingsAccordions/hooks/useExpanderToggle';
 import { useStandaloneAccordionToggle } from 'features/settingsAccordions/hooks/useStandaloneAccordionToggle';
-import { filter, size } from 'lodash-es';
+import { filter } from 'lodash-es';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,7 +33,7 @@ const formLabelProps: FormLabelProps = {
 
 const badgesSelector = createMemoizedSelector(selectLoraSlice, selectGenerationSlice, (lora, generation) => {
   const enabledLoRAsCount = filter(lora.loras, (l) => !!l.isEnabled).length;
-  const loraTabBadges = size(lora.loras) ? [enabledLoRAsCount] : [];
+  const loraTabBadges = enabledLoRAsCount ? [enabledLoRAsCount] : [];
   const accordionBadges: (string | number)[] = [];
   if (generation.model) {
     accordionBadges.push(generation.model.model_name);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

We weren't omitting disabled LoRAs from the SDXL graphs. Fixed that.

Also fixed the LoRA count badge - it was showing `0` when there were were LoRAs added but all disabled.

## QA Instructions, Screenshots, Recordings

Use a LoRA on SDXL with manual seed. Disable the LoRA; the image should be different.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->