### PR TITLE
wip: Showcase

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1621,7 +1621,9 @@
         "seamlessChecker": "Seamless Checker",
         "zoomIn": "Zoom In",
         "zoomOut": "Zoom Out",
-        "resetZoom": "Reset Zoom"
+        "resetPosition": "Reset Position",
+        "resetZoom": "Reset Zoom",
+        "resetView": "Reset View"
     },
     "ui": {
         "hideProgressImages": "Hide Progress Images",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -644,6 +644,10 @@
             "desc": "Toggles Snap to Grid",
             "title": "Toggle Snap"
         },
+        "toggleShowcase": {
+            "desc": "Open and close the Showcase",
+            "title": "Toggle Showcase"
+        },
         "undoStroke": {
             "desc": "Undo a brush stroke",
             "title": "Undo Stroke"

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1617,7 +1617,10 @@
         }
     },
     "showcase": {
-        "seamlessChecker": "Seamless Checker"
+        "seamlessChecker": "Seamless Checker",
+        "zoomIn": "Zoom In",
+        "zoomOut": "Zoom Out",
+        "resetZoom": "Reset Zoom"
     },
     "ui": {
         "hideProgressImages": "Hide Progress Images",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -131,6 +131,8 @@
         "nodesDesc": "A node based system for the generation of images is under development currently. Stay tuned for updates about this amazing feature.",
         "notInstalled": "Not $t(common.installed)",
         "openInNewTab": "Open in New Tab",
+        "openShowcase": "Open Showcase",
+        "closeShowcase": "Close Showcase",
         "orderBy": "Order By",
         "outpaint": "outpaint",
         "outputs": "Outputs",
@@ -1609,6 +1611,9 @@
                 "Scales the selected area to the size best suited for the model before the image generation process."
             ]
         }
+    },
+    "showcase": {
+        "seamlessChecker": "Seamless Checker"
     },
     "ui": {
         "hideProgressImages": "Hide Progress Images",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -131,7 +131,7 @@
         "nodesDesc": "A node based system for the generation of images is under development currently. Stay tuned for updates about this amazing feature.",
         "notInstalled": "Not $t(common.installed)",
         "openInNewTab": "Open in New Tab",
-        "openShowcase": "Open Showcase",
+        "openShowcase": "Open in Showcase",
         "closeShowcase": "Close Showcase",
         "orderBy": "Order By",
         "outpaint": "outpaint",

--- a/invokeai/frontend/web/src/app/store/store.ts
+++ b/invokeai/frontend/web/src/app/store/store.ts
@@ -22,6 +22,7 @@ import { generationPersistConfig, generationSlice } from 'features/parameters/st
 import { postprocessingPersistConfig, postprocessingSlice } from 'features/parameters/store/postprocessingSlice';
 import { queueSlice } from 'features/queue/store/queueSlice';
 import { sdxlPersistConfig, sdxlSlice } from 'features/sdxl/store/sdxlSlice';
+import { showcaseSlice } from 'features/showcase/store/showcaseSlice';
 import { configSlice } from 'features/system/store/configSlice';
 import { systemPersistConfig, systemSlice } from 'features/system/store/systemSlice';
 import { uiPersistConfig, uiSlice } from 'features/ui/store/uiSlice';
@@ -51,6 +52,7 @@ const allReducers = {
   [systemSlice.name]: systemSlice.reducer,
   [configSlice.name]: configSlice.reducer,
   [uiSlice.name]: uiSlice.reducer,
+  [showcaseSlice.name]: showcaseSlice.reducer,
   [controlAdaptersSlice.name]: controlAdaptersSlice.reducer,
   [dynamicPromptsSlice.name]: dynamicPromptsSlice.reducer,
   [deleteImageModalSlice.name]: deleteImageModalSlice.reducer,

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImageButtons.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImageButtons.tsx
@@ -16,7 +16,11 @@ import { initialImageSelected } from 'features/parameters/store/actions';
 import { useIsQueueMutationInProgress } from 'features/queue/hooks/useIsQueueMutationInProgress';
 import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
 import { selectSystemSlice } from 'features/system/store/systemSlice';
-import { setShouldShowImageDetails, setShouldShowProgressInViewer } from 'features/ui/store/uiSlice';
+import {
+  setShouldShowImageDetails,
+  setShouldShowProgressInViewer,
+  setShouldShowShowcase,
+} from 'features/ui/store/uiSlice';
 import { useGetAndLoadEmbeddedWorkflow } from 'features/workflowLibrary/hooks/useGetAndLoadEmbeddedWorkflow';
 import { memo, useCallback } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -29,6 +33,7 @@ import {
   PiHourglassHighBold,
   PiInfoBold,
   PiPlantBold,
+  PiProjectorScreen,
   PiQuotesBold,
   PiRulerBold,
 } from 'react-icons/pi';
@@ -50,6 +55,7 @@ const CurrentImageButtons = () => {
   const isConnected = useAppSelector((s) => s.system.isConnected);
   const shouldShowImageDetails = useAppSelector((s) => s.ui.shouldShowImageDetails);
   const shouldShowProgressInViewer = useAppSelector((s) => s.ui.shouldShowProgressInViewer);
+  const showShowcase = useAppSelector((s) => s.ui.showShowcase);
   const lastSelectedImage = useAppSelector(selectLastSelectedImage);
   const shouldDisableToolbarButtons = useAppSelector(selectShouldDisableToolbarButtons);
 
@@ -65,6 +71,16 @@ const CurrentImageButtons = () => {
   const { metadata, isLoading: isLoadingMetadata } = useDebouncedMetadata(lastSelectedImage?.image_name);
 
   const { getAndLoadEmbeddedWorkflow, getAndLoadEmbeddedWorkflowResult } = useGetAndLoadEmbeddedWorkflow({});
+
+  const toggleShowcase = useCallback(() => {
+    if (imageDTO && !showShowcase) {
+      dispatch(setShouldShowShowcase(imageDTO));
+    } else {
+      dispatch(setShouldShowShowcase(null));
+    }
+  }, [dispatch, showShowcase, imageDTO]);
+
+  useHotkeys('shift+s', toggleShowcase);
 
   const handleLoadWorkflow = useCallback(() => {
     if (!lastSelectedImage || !lastSelectedImage.has_workflow) {
@@ -201,6 +217,15 @@ const CurrentImageButtons = () => {
             <MenuList>{imageDTO && <SingleSelectionMenuItems imageDTO={imageDTO} />}</MenuList>
           </Menu>
         </ButtonGroup>
+
+        <IconButton
+          icon={<PiProjectorScreen />}
+          tooltip={`${!showShowcase ? t('common.openShowcase') : t('common.closeShowcase')} (Shift+S)`}
+          aria-label={`${!showShowcase ? t('common.openShowcase') : t('common.closeShowcase')} (Shift+S)`}
+          isDisabled={!imageDTO}
+          onClick={toggleShowcase}
+          isChecked={showShowcase !== null}
+        />
 
         <ButtonGroup isDisabled={shouldDisableToolbarButtons}>
           <IconButton

--- a/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/CurrentImage/CurrentImagePreview.tsx
@@ -9,6 +9,7 @@ import ProgressImage from 'features/gallery/components/CurrentImage/ProgressImag
 import ImageMetadataViewer from 'features/gallery/components/ImageMetadataViewer/ImageMetadataViewer';
 import NextPrevImageButtons from 'features/gallery/components/NextPrevImageButtons';
 import { selectLastSelectedImage } from 'features/gallery/store/gallerySelectors';
+import Showcase from 'features/showcase/components/Showcase';
 import type { AnimationProps } from 'framer-motion';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { CSSProperties } from 'react';
@@ -27,6 +28,7 @@ const CurrentImagePreview = () => {
   const imageName = useAppSelector(selectLastSelectedImageName);
   const hasDenoiseProgress = useAppSelector((s) => Boolean(s.system.denoiseProgress));
   const shouldShowProgressInViewer = useAppSelector((s) => s.ui.shouldShowProgressInViewer);
+  const showShowcase = useAppSelector((s) => s.ui.showShowcase);
 
   const { currentData: imageDTO } = useGetImageDTOQuery(imageName ?? skipToken);
 
@@ -67,42 +69,51 @@ const CurrentImagePreview = () => {
   }, []);
 
   return (
-    <Flex
-      onMouseOver={handleMouseOver}
-      onMouseOut={handleMouseOut}
-      width="full"
-      height="full"
-      alignItems="center"
-      justifyContent="center"
-      position="relative"
-    >
-      {hasDenoiseProgress && shouldShowProgressInViewer ? (
-        <ProgressImage />
-      ) : (
-        <IAIDndImage
-          imageDTO={imageDTO}
-          droppableData={droppableData}
-          draggableData={draggableData}
-          isUploadDisabled={true}
-          fitContainer
-          useThumbailFallback
-          dropLabel={t('gallery.setCurrentImage')}
-          noContentFallback={<IAINoContentFallback icon={PiImageBold} label={t('gallery.noImageSelected')} />}
-          dataTestId="image-preview"
-        />
-      )}
-      {shouldShowImageDetails && imageDTO && (
-        <Box position="absolute" top="0" width="full" height="full" borderRadius="base">
-          <ImageMetadataViewer image={imageDTO} />
-        </Box>
-      )}
-      <AnimatePresence>
-        {!shouldShowImageDetails && imageDTO && shouldShowNextPrevButtons && (
-          <motion.div key="nextPrevButtons" initial={initial} animate={animate} exit={exit} style={motionStyles}>
-            <NextPrevImageButtons />
-          </motion.div>
+    <Flex sx={{ width: 'full', height: 'full', position: 'relative' }}>
+      <Flex
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
+        width="full"
+        height="full"
+        alignItems="center"
+        justifyContent="center"
+        position="relative"
+      >
+        {hasDenoiseProgress && shouldShowProgressInViewer ? (
+          <ProgressImage />
+        ) : (
+          <>
+            <IAIDndImage
+              imageDTO={imageDTO}
+              droppableData={droppableData}
+              draggableData={draggableData}
+              isUploadDisabled={true}
+              fitContainer
+              useThumbailFallback
+              dropLabel={t('gallery.setCurrentImage')}
+              noContentFallback={<IAINoContentFallback icon={PiImageBold} label={t('gallery.noImageSelected')} />}
+              dataTestId="image-preview"
+            />
+          </>
         )}
-      </AnimatePresence>
+        {showShowcase && imageDTO && (
+          <Box position="absolute" top="0" width="full" height="full" borderRadius="base">
+            <Showcase imageDTO={imageDTO} />
+          </Box>
+        )}
+        {shouldShowImageDetails && imageDTO && (
+          <Box position="absolute" top="0" width="full" height="full" borderRadius="base">
+            <ImageMetadataViewer image={imageDTO} />
+          </Box>
+        )}
+        <AnimatePresence>
+          {!shouldShowImageDetails && imageDTO && shouldShowNextPrevButtons && (
+            <motion.div key="nextPrevButtons" initial={initial} animate={animate} exit={exit} style={motionStyles}>
+              <NextPrevImageButtons />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </Flex>
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
@@ -1,6 +1,7 @@
 import { Flex, MenuDivider, MenuItem, Spinner } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { useAppToaster } from 'app/components/Toaster';
+import { galleryImageClicked } from 'app/store/middleware/listenerMiddleware/listeners/galleryImageClicked';
 import { $customStarUI } from 'app/store/nanostores/customStarUI';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useCopyImageToClipboard } from 'common/hooks/useCopyImageToClipboard';
@@ -50,7 +51,6 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
   const customStarUi = useStore($customStarUI);
   const { downloadImage } = useDownloadImage();
   const { metadata, isLoading: isLoadingMetadata } = useDebouncedMetadata(imageDTO?.image_name);
-  const showShowcase = useAppSelector((s) => s.ui.showShowcase);
 
   const { getAndLoadEmbeddedWorkflow, getAndLoadEmbeddedWorkflowResult } = useGetAndLoadEmbeddedWorkflow({});
 
@@ -150,12 +150,16 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
   }, [downloadImage, imageDTO.image_name, imageDTO.image_url]);
 
   const handleOpenInShowcase = useCallback(() => {
+    dispatch(
+      galleryImageClicked({
+        imageDTO,
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+      })
+    );
     dispatch(setShouldShowShowcase(imageDTO));
   }, [dispatch, imageDTO]);
-
-  const handleCloseShowcase = useCallback(() => {
-    dispatch(setShouldShowShowcase(null));
-  }, [dispatch]);
 
   return (
     <>
@@ -171,15 +175,9 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
         {t('parameters.downloadImage')}
       </MenuItem>
 
-      {!showShowcase ? (
-        <MenuItem icon={<PiShareFatBold />} onClickCapture={handleOpenInShowcase}>
-          {t('common.openShowcase')}
-        </MenuItem>
-      ) : (
-        <MenuItem color="warning.300" icon={<PiShareFatBold />} onClickCapture={handleCloseShowcase}>
-          {t('common.closeShowcase')}
-        </MenuItem>
-      )}
+      <MenuItem icon={<PiShareFatBold />} onClickCapture={handleOpenInShowcase}>
+        {t('common.openShowcase')}
+      </MenuItem>
 
       <MenuDivider />
       <MenuItem

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
@@ -13,7 +13,7 @@ import { useRecallParameters } from 'features/parameters/hooks/useRecallParamete
 import { initialImageSelected } from 'features/parameters/store/actions';
 import { selectOptimalDimension } from 'features/parameters/store/generationSlice';
 import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
-import { setActiveTab } from 'features/ui/store/uiSlice';
+import { setActiveTab, setShouldShowShowcase } from 'features/ui/store/uiSlice';
 import { useGetAndLoadEmbeddedWorkflow } from 'features/workflowLibrary/hooks/useGetAndLoadEmbeddedWorkflow';
 import { memo, useCallback } from 'react';
 import { flushSync } from 'react-dom';
@@ -50,6 +50,7 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
   const customStarUi = useStore($customStarUI);
   const { downloadImage } = useDownloadImage();
   const { metadata, isLoading: isLoadingMetadata } = useDebouncedMetadata(imageDTO?.image_name);
+  const showShowcase = useAppSelector((s) => s.ui.showShowcase);
 
   const { getAndLoadEmbeddedWorkflow, getAndLoadEmbeddedWorkflowResult } = useGetAndLoadEmbeddedWorkflow({});
 
@@ -148,6 +149,14 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
     downloadImage(imageDTO.image_url, imageDTO.image_name);
   }, [downloadImage, imageDTO.image_name, imageDTO.image_url]);
 
+  const handleOpenInShowcase = useCallback(() => {
+    dispatch(setShouldShowShowcase(imageDTO));
+  }, [dispatch, imageDTO]);
+
+  const handleCloseShowcase = useCallback(() => {
+    dispatch(setShouldShowShowcase(null));
+  }, [dispatch]);
+
   return (
     <>
       <MenuItem as="a" href={imageDTO.image_url} target="_blank" icon={<PiShareFatBold />}>
@@ -161,6 +170,17 @@ const SingleSelectionMenuItems = (props: SingleSelectionMenuItemsProps) => {
       <MenuItem icon={<PiDownloadSimpleBold />} onClickCapture={handleDownloadImage}>
         {t('parameters.downloadImage')}
       </MenuItem>
+
+      {!showShowcase ? (
+        <MenuItem icon={<PiShareFatBold />} onClickCapture={handleOpenInShowcase}>
+          {t('common.openShowcase')}
+        </MenuItem>
+      ) : (
+        <MenuItem color="warning.300" icon={<PiShareFatBold />} onClickCapture={handleCloseShowcase}>
+          {t('common.closeShowcase')}
+        </MenuItem>
+      )}
+
       <MenuDivider />
       <MenuItem
         icon={getAndLoadEmbeddedWorkflowResult.isLoading ? <SpinnerIcon /> : <PiFlowArrowBold />}

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -59,11 +59,11 @@ const LightBox = (props: LightBoxProps) => {
   }, [resetPan, resetZoom]);
 
   return (
-    <Flex sx={{ width: '100%', height: '100%', position: 'relative' }}>
+    <Flex sx={{ width: '100%', height: '100%', position: 'relative' }} onMouseLeave={handleMousePanUp}>
       <Image
         ref={imageRef}
         src={imageDTO.image_url}
-        w="auto"
+        w="100%"
         h="auto"
         objectFit="contain"
         style={{
@@ -75,6 +75,7 @@ const LightBox = (props: LightBoxProps) => {
         onMouseDown={handleMousePanDown}
         onMouseUp={handleMousePanUp}
         onMouseMove={handleMousePanMove}
+        onMouseLeave={handleMousePanUp}
       />
       <Flex sx={{ position: 'absolute', top: 2, w: 'full', h: 'max-content', gap: 2, justifyContent: 'center' }}>
         <ButtonGroup>

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -76,6 +76,7 @@ const LightBox = (props: LightBoxProps) => {
         onMouseUp={handleMousePanUp}
         onMouseMove={handleMousePanMove}
         onMouseLeave={handleMousePanUp}
+        onDoubleClick={resetView}
       />
       <Flex sx={{ position: 'absolute', top: 2, w: 'full', h: 'max-content', gap: 2, justifyContent: 'center' }}>
         <ButtonGroup>

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -69,7 +69,7 @@ const LightBox = (props: LightBoxProps) => {
         style={{
           scale: `${zoomLevel}`,
           translate: `${panPosition.x}px ${panPosition.y}px`,
-          transition: 'all 0.1s ease-out',
+          transition: 'scale 0.1s ease-out',
           cursor: 'move',
         }}
         onMouseDown={handleMousePanDown}

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -31,7 +31,7 @@ const LightBox = (props: LightBoxProps) => {
   const handleZoomScroll = useCallback(
     (e: WheelEvent) => {
       e.preventDefault();
-      const zoomFactor = e.deltaY > 0 ? zoomPercent : 1 / zoomPercent;
+      const zoomFactor = e.deltaY > 0 ? 1 / zoomPercent : zoomPercent;
       setZoomLevel(zoomLevel * zoomFactor);
     },
     [zoomLevel, zoomPercent]

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -1,8 +1,15 @@
 import { ButtonGroup, Flex, IconButton, Image } from '@invoke-ai/ui-library';
 import { useFocusedMouseWheel } from 'features/showcase/hooks/useFocusedMouseWheel';
+import { useMousePan } from 'features/showcase/hooks/useMousePan';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiMagnifyingGlassFill, PiMagnifyingGlassMinusBold, PiMagnifyingGlassPlusBold } from 'react-icons/pi';
+import {
+  PiArrowsIn,
+  PiMagnifyingGlassFill,
+  PiMagnifyingGlassMinusBold,
+  PiMagnifyingGlassPlusBold,
+  PiScan,
+} from 'react-icons/pi';
 import type { ImageDTO } from 'services/api/types';
 
 interface LightBoxProps {
@@ -11,10 +18,17 @@ interface LightBoxProps {
 
 const LightBox = (props: LightBoxProps) => {
   const { imageDTO } = props;
+  const { t } = useTranslation();
+
+  // Refs
+  const imageRef = useRef<HTMLImageElement | null>(null);
+
+  // Zoom
   const [zoomLevel, setZoomLevel] = useState(1);
   const zoomPercent = 1 + 20 / 100; // 20% -> Feels okay. Don't need to expose I think
-  const { t } = useTranslation();
-  const lightBoxRef = useRef<HTMLDivElement | null>(null);
+
+  // Pan
+  const { panPosition, handleMousePanDown, handleMousePanUp, handleMousePanMove, resetPan } = useMousePan(imageRef);
 
   const handleZoomIn = useCallback(() => {
     setZoomLevel(zoomLevel * zoomPercent);
@@ -37,18 +51,40 @@ const LightBox = (props: LightBoxProps) => {
     [zoomLevel, zoomPercent]
   );
 
-  useFocusedMouseWheel(lightBoxRef, handleZoomScroll);
+  useFocusedMouseWheel(imageRef, handleZoomScroll);
+
+  const resetView = useCallback(() => {
+    resetZoom();
+    resetPan();
+  }, [resetPan, resetZoom]);
 
   return (
-    <Flex sx={{ width: '100%', height: '100%', position: 'relative' }} ref={lightBoxRef}>
+    <Flex sx={{ width: '100%', height: '100%', position: 'relative' }}>
       <Image
+        ref={imageRef}
         src={imageDTO.image_url}
         w="auto"
         h="auto"
         objectFit="contain"
-        style={{ transform: `scale(${zoomLevel})`, transition: 'transform 0.3s ease' }}
+        style={{
+          scale: `${zoomLevel}`,
+          translate: `${panPosition.x}px ${panPosition.y}px`,
+          transition: 'all 0.1s ease-out',
+          cursor: 'move',
+        }}
+        onMouseDown={handleMousePanDown}
+        onMouseUp={handleMousePanUp}
+        onMouseMove={handleMousePanMove}
       />
-      <Flex sx={{ position: 'absolute', top: 2, left: '45%', gap: 2, margin: 'auto' }}>
+      <Flex sx={{ position: 'absolute', top: 2, left: '38%', gap: 2, margin: 'auto' }}>
+        <ButtonGroup>
+          <IconButton
+            icon={<PiScan />}
+            tooltip={`${t('showcase.resetView')}`}
+            aria-label={`${t('showcase.resetView')}`}
+            onClick={resetView}
+          />
+        </ButtonGroup>
         <ButtonGroup>
           <IconButton
             icon={<PiMagnifyingGlassPlusBold />}
@@ -67,6 +103,14 @@ const LightBox = (props: LightBoxProps) => {
             tooltip={`${t('showcase.zoomOut')}`}
             aria-label={`${t('showcase.zoomOut')}`}
             onClick={handleZoomOut}
+          />
+        </ButtonGroup>
+        <ButtonGroup>
+          <IconButton
+            icon={<PiArrowsIn />}
+            tooltip={`${t('showcase.resetPosition')}`}
+            aria-label={`${t('showcase.resetPosition')}`}
+            onClick={resetPan}
           />
         </ButtonGroup>
       </Flex>

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -1,0 +1,77 @@
+import { ButtonGroup, Flex, IconButton, Image } from '@invoke-ai/ui-library';
+import { useFocusedMouseWheel } from 'features/showcase/hooks/useFocusedMouseWheel';
+import { memo, useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiMagnifyingGlassFill, PiMagnifyingGlassMinusBold, PiMagnifyingGlassPlusBold } from 'react-icons/pi';
+import type { ImageDTO } from 'services/api/types';
+
+interface LightBoxProps {
+  imageDTO: ImageDTO;
+}
+
+const LightBox = (props: LightBoxProps) => {
+  const { imageDTO } = props;
+  const [zoomLevel, setZoomLevel] = useState(1);
+  const zoomPercent = 1 + 20 / 100; // 20% -> Feels okay. Don't need to expose I think
+  const { t } = useTranslation();
+  const lightBoxRef = useRef<HTMLDivElement | null>(null);
+
+  const handleZoomIn = useCallback(() => {
+    setZoomLevel(zoomLevel * zoomPercent);
+  }, [zoomLevel, zoomPercent]);
+
+  const handleZoomOut = useCallback(() => {
+    setZoomLevel(zoomLevel / zoomPercent);
+  }, [zoomLevel, zoomPercent]);
+
+  const resetZoom = useCallback(() => {
+    setZoomLevel(1);
+  }, [setZoomLevel]);
+
+  const handleZoomScroll = useCallback(
+    (e: WheelEvent) => {
+      e.preventDefault();
+      const zoomFactor = e.deltaY > 0 ? zoomPercent : 1 / zoomPercent;
+      setZoomLevel(zoomLevel * zoomFactor);
+    },
+    [zoomLevel, zoomPercent]
+  );
+
+  useFocusedMouseWheel(lightBoxRef, handleZoomScroll);
+
+  return (
+    <Flex sx={{ width: '100%', height: '100%', position: 'relative' }} ref={lightBoxRef}>
+      <Image
+        src={imageDTO.image_url}
+        w="auto"
+        h="auto"
+        objectFit="contain"
+        style={{ transform: `scale(${zoomLevel})`, transition: 'transform 0.3s ease' }}
+      />
+      <Flex sx={{ position: 'absolute', top: 2, left: '45%', gap: 2, margin: 'auto' }}>
+        <ButtonGroup>
+          <IconButton
+            icon={<PiMagnifyingGlassPlusBold />}
+            tooltip={`${t('showcase.zoomIn')}`}
+            aria-label={`${t('showcase.zoomIn')}`}
+            onClick={handleZoomIn}
+          />
+          <IconButton
+            icon={<PiMagnifyingGlassFill />}
+            tooltip={`${t('showcase.resetZoom')}`}
+            aria-label={`${t('showcase.resetZoom')}`}
+            onClick={resetZoom}
+          />
+          <IconButton
+            icon={<PiMagnifyingGlassMinusBold />}
+            tooltip={`${t('showcase.zoomOut')}`}
+            aria-label={`${t('showcase.zoomOut')}`}
+            onClick={handleZoomOut}
+          />
+        </ButtonGroup>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default memo(LightBox);

--- a/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/LightBox.tsx
@@ -76,7 +76,7 @@ const LightBox = (props: LightBoxProps) => {
         onMouseUp={handleMousePanUp}
         onMouseMove={handleMousePanMove}
       />
-      <Flex sx={{ position: 'absolute', top: 2, left: '38%', gap: 2, margin: 'auto' }}>
+      <Flex sx={{ position: 'absolute', top: 2, w: 'full', h: 'max-content', gap: 2, justifyContent: 'center' }}>
         <ButtonGroup>
           <IconButton
             icon={<PiScan />}

--- a/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
@@ -1,5 +1,6 @@
 import { Grid, Image } from '@invoke-ai/ui-library';
-import { useCallback, useEffect, useState } from 'react';
+import { useFocusedMouseWheel } from 'features/showcase/hooks/useFocusedMouseWheel';
+import { useCallback, useRef, useState } from 'react';
 import type { ImageDTO } from 'services/api/types';
 
 type SeamlessTextureViewerProps = {
@@ -9,11 +10,12 @@ type SeamlessTextureViewerProps = {
 export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps) {
   const [tileCount, setTileCount] = useState(150);
   const [gridWidth, setGridWidth] = useState(256);
+  const seamlessViewerRef = useRef<HTMLDivElement | null>(null);
 
   const tiles = Array.from({ length: tileCount }, (_, index) => index);
 
   const handleScroll = useCallback(
-    (e: WheelEvent, tileCount: number, gridWidth: number, props: { imageDTO: ImageDTO }) => {
+    (e: WheelEvent) => {
       e.preventDefault();
       const delta = e.deltaY;
       const zoomFactor = 0.25;
@@ -34,19 +36,18 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
       }
       setGridWidth(newGridWidth);
     },
-    []
+    [gridWidth, tileCount, props.imageDTO.width]
   );
 
-  useEffect(() => {
-    const handleWheel = (e: WheelEvent) => handleScroll(e, tileCount, gridWidth, props);
-    window.addEventListener('wheel', handleWheel, { passive: false });
-    return () => {
-      window.removeEventListener('wheel', handleWheel);
-    };
-  }, [handleScroll, tileCount, gridWidth, props]);
+  useFocusedMouseWheel(seamlessViewerRef, handleScroll);
 
   return (
-    <Grid width="100%" templateColumns={`repeat(auto-fill, minmax(${gridWidth}px, 1fr))`} position="relative">
+    <Grid
+      width="100%"
+      templateColumns={`repeat(auto-fill, minmax(${gridWidth}px, 1fr))`}
+      position="relative"
+      ref={seamlessViewerRef}
+    >
       {tiles.map((tileIndex) => (
         <Image
           key={tileIndex}

--- a/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
@@ -10,11 +10,12 @@ type SeamlessTextureViewerProps = {
 export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps) {
   const [tileCount, setTileCount] = useState(150);
   const [gridWidth, setGridWidth] = useState(256);
+
   const seamlessViewerRef = useRef<HTMLDivElement | null>(null);
 
   const tiles = Array.from({ length: tileCount }, (_, index) => index);
 
-  const calculateTotalTiles = (gridWidth: number) => {
+  const calculateTotalTiles = useCallback(() => {
     const seamlessViewerElement = seamlessViewerRef.current;
 
     if (!seamlessViewerElement) {
@@ -22,11 +23,11 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
     }
 
     const totalItems =
-      Math.ceil(seamlessViewerElement.offsetWidth / gridWidth) *
-      Math.ceil(seamlessViewerElement.offsetHeight / gridWidth);
+      Math.ceil(seamlessViewerElement.offsetWidth / (props.imageDTO.width / 10)) *
+      Math.ceil(seamlessViewerElement.offsetHeight / (props.imageDTO.height / 10));
 
     return totalItems;
-  };
+  }, [props.imageDTO.width, props.imageDTO.height]);
 
   useEffect(() => {
     const seamlessViewerElement = seamlessViewerRef.current;
@@ -35,7 +36,7 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
     }
 
     const seamlessViewerObserver = new ResizeObserver(() => {
-      const totalItems = calculateTotalTiles(gridWidth);
+      const totalItems = calculateTotalTiles();
       setTileCount(totalItems);
     });
 
@@ -44,7 +45,7 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
     return () => {
       seamlessViewerObserver.disconnect();
     };
-  }, [gridWidth]);
+  }, [calculateTotalTiles]);
 
   const handleScroll = useCallback(
     (e: WheelEvent) => {
@@ -59,12 +60,12 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
         maxGridWidth
       );
 
-      const totalItems = calculateTotalTiles(newGridWidth);
+      const totalItems = calculateTotalTiles();
 
       setGridWidth(newGridWidth);
       setTileCount(totalItems);
     },
-    [gridWidth, props.imageDTO.width]
+    [gridWidth, props.imageDTO.width, calculateTotalTiles]
   );
 
   useFocusedMouseWheel(seamlessViewerRef, handleScroll);

--- a/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
@@ -53,7 +53,7 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
           key={tileIndex}
           src={props.imageDTO.image_url}
           alt={`Tile ${tileIndex + 1}`}
-          sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          sx={{ width: '100%', height: 'auto', objectFit: 'cover' }}
         />
       ))}
     </Grid>

--- a/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
@@ -1,0 +1,60 @@
+import { Grid, Image } from '@invoke-ai/ui-library';
+import { useCallback, useEffect, useState } from 'react';
+import type { ImageDTO } from 'services/api/types';
+
+type SeamlessTextureViewerProps = {
+  imageDTO: ImageDTO;
+};
+
+export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps) {
+  const [tileCount, setTileCount] = useState(150);
+  const [gridWidth, setGridWidth] = useState(256);
+
+  const tiles = Array.from({ length: tileCount }, (_, index) => index);
+
+  const handleScroll = useCallback(
+    (e: WheelEvent, tileCount: number, gridWidth: number, props: { imageDTO: ImageDTO }) => {
+      e.preventDefault();
+      const delta = e.deltaY;
+      const zoomFactor = 0.25;
+
+      const minTileCount = 10;
+      const maxTileCount = 100;
+      const newTileCount = Math.min(Math.max(tileCount + Math.sign(delta) * 10, minTileCount), maxTileCount);
+
+      const minGridWidth = 100;
+      const maxGridWidth = props.imageDTO.width;
+      const newGridWidth = Math.min(
+        Math.max(gridWidth - Math.sign(delta) * zoomFactor * gridWidth, minGridWidth),
+        maxGridWidth
+      );
+
+      if (newGridWidth > props.imageDTO.width) {
+        setTileCount(newTileCount);
+      }
+      setGridWidth(newGridWidth);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent) => handleScroll(e, tileCount, gridWidth, props);
+    window.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      window.removeEventListener('wheel', handleWheel);
+    };
+  }, [handleScroll, tileCount, gridWidth, props]);
+
+  return (
+    <Grid width="100%" templateColumns={`repeat(auto-fill, minmax(${gridWidth}px, 1fr))`}>
+      {tiles.map((tileIndex) => (
+        <Image
+          key={tileIndex}
+          src={props.imageDTO.image_url}
+          alt={`Tile ${tileIndex + 1}`}
+          sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      ))}
+    </Grid>
+  );
+}

--- a/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/SeamlessTextureViewer.tsx
@@ -46,7 +46,7 @@ export default function SeamlessTextureViewer(props: SeamlessTextureViewerProps)
   }, [handleScroll, tileCount, gridWidth, props]);
 
   return (
-    <Grid width="100%" templateColumns={`repeat(auto-fill, minmax(${gridWidth}px, 1fr))`}>
+    <Grid width="100%" templateColumns={`repeat(auto-fill, minmax(${gridWidth}px, 1fr))`} position="relative">
       {tiles.map((tileIndex) => (
         <Image
           key={tileIndex}

--- a/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
@@ -1,12 +1,10 @@
-import { Flex, FormControl, FormLabel, IconButton, Image, Switch } from '@invoke-ai/ui-library';
+import { Flex, FormControl, FormLabel, Image, Switch } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import ProgressImage from 'features/gallery/components/CurrentImage/ProgressImage';
 import { setShowSeamless } from 'features/showcase/store/showcaseSlice';
-import { setShouldShowShowcase } from 'features/ui/store/uiSlice';
 import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiXBold } from 'react-icons/pi';
 import type { ImageDTO } from 'services/api/types';
 
 import SeamlessTextureViewer from './SeamlessTextureViewer';
@@ -23,9 +21,9 @@ function Showcase(props: ShowcaseProps) {
   const shouldShowProgressInViewer = useAppSelector((s) => s.ui.shouldShowProgressInViewer);
   const hasDenoiseProgress = useAppSelector((s) => Boolean(s.system.denoiseProgress));
 
-  const closeShowcase = useCallback(() => {
-    dispatch(setShouldShowShowcase(null));
-  }, [dispatch]);
+  // const closeShowcase = useCallback(() => {
+  //   dispatch(setShouldShowShowcase(null));
+  // }, [dispatch]);
 
   const handleShowSeamless = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => dispatch(setShowSeamless(e.target.checked)),
@@ -40,15 +38,13 @@ function Showcase(props: ShowcaseProps) {
         position: 'relative',
         background: 'base.850',
         flexDir: 'column',
-        gap: 2,
       }}
     >
-      <Flex sx={{ background: 'base.900', borderRadius: 'base', p: 2 }}>
+      <Flex sx={{ borderRadius: 'base', borderTopRadius: 0, p: 2, borderTop: '2px', borderColor: 'base.800' }}>
         <FormControl sx={{ gap: 0, pl: 2 }}>
           <FormLabel>{t('showcase.seamlessChecker')}</FormLabel>
           <Switch isChecked={showSeamless} onChange={handleShowSeamless} />
         </FormControl>
-        <IconButton icon={<PiXBold fontSize={12} />} onClick={closeShowcase} aria-label={t('common.close')} />
       </Flex>
       <Flex
         sx={{

--- a/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
@@ -21,10 +21,6 @@ function Showcase(props: ShowcaseProps) {
   const shouldShowProgressInViewer = useAppSelector((s) => s.ui.shouldShowProgressInViewer);
   const hasDenoiseProgress = useAppSelector((s) => Boolean(s.system.denoiseProgress));
 
-  // const closeShowcase = useCallback(() => {
-  //   dispatch(setShouldShowShowcase(null));
-  // }, [dispatch]);
-
   const handleShowSeamless = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => dispatch(setShowSeamless(e.target.checked)),
     [dispatch]
@@ -68,13 +64,14 @@ function Showcase(props: ShowcaseProps) {
         <Flex
           sx={{
             position: 'absolute',
-            top: 16,
+            top: '38px',
             left: 0,
             w: '256px',
             h: '256px',
             margin: 2,
             borderRadius: 4,
             overflow: 'clip',
+            bg: 'base.850',
           }}
         >
           <ProgressImage />

--- a/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
@@ -1,0 +1,91 @@
+import { Flex, FormControl, FormLabel, IconButton, Image, Switch } from '@invoke-ai/ui-library';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import ProgressImage from 'features/gallery/components/CurrentImage/ProgressImage';
+import { setShowSeamless } from 'features/showcase/store/showcaseSlice';
+import { setShouldShowShowcase } from 'features/ui/store/uiSlice';
+import type { ChangeEvent } from 'react';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiXBold } from 'react-icons/pi';
+import type { ImageDTO } from 'services/api/types';
+
+import SeamlessTextureViewer from './SeamlessTextureViewer';
+
+type ShowcaseProps = {
+  imageDTO: ImageDTO;
+};
+
+function Showcase(props: ShowcaseProps) {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const { imageDTO } = props;
+  const showSeamless = useAppSelector((s) => s.showcase.showSeamless);
+  const shouldShowProgressInViewer = useAppSelector((s) => s.ui.shouldShowProgressInViewer);
+  const hasDenoiseProgress = useAppSelector((s) => Boolean(s.system.denoiseProgress));
+
+  const closeShowcase = useCallback(() => {
+    dispatch(setShouldShowShowcase(null));
+  }, [dispatch]);
+
+  const handleShowSeamless = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => dispatch(setShowSeamless(e.target.checked)),
+    [dispatch]
+  );
+
+  return (
+    <Flex
+      sx={{
+        w: 'full',
+        h: 'full',
+        position: 'relative',
+        background: 'base.850',
+        flexDir: 'column',
+        gap: 2,
+      }}
+    >
+      <Flex sx={{ background: 'base.900', borderRadius: 'base', p: 2 }}>
+        <FormControl sx={{ gap: 0, pl: 2 }}>
+          <FormLabel>{t('showcase.seamlessChecker')}</FormLabel>
+          <Switch isChecked={showSeamless} onChange={handleShowSeamless} />
+        </FormControl>
+        <IconButton icon={<PiXBold fontSize={12} />} onClick={closeShowcase} aria-label={t('common.close')} />
+      </Flex>
+      <Flex
+        sx={{
+          w: 'full',
+          h: '100%',
+          justifyContent: 'center',
+          background: 'base.900',
+          borderRadius: 'base',
+          overflow: 'hidden',
+        }}
+      >
+        {showSeamless ? (
+          <SeamlessTextureViewer imageDTO={imageDTO} />
+        ) : (
+          <Flex p={4}>
+            <Image src={imageDTO.image_url} w="auto" h="auto" objectFit="contain" />
+          </Flex>
+        )}
+      </Flex>
+      {shouldShowProgressInViewer && hasDenoiseProgress && (
+        <Flex
+          sx={{
+            position: 'absolute',
+            top: 16,
+            left: 0,
+            w: '256px',
+            h: '256px',
+            margin: 2,
+            borderRadius: 4,
+            overflow: 'clip',
+          }}
+        >
+          <ProgressImage />
+        </Flex>
+      )}
+    </Flex>
+  );
+}
+
+export default memo(Showcase);

--- a/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
+++ b/invokeai/frontend/web/src/features/showcase/components/Showcase.tsx
@@ -1,4 +1,4 @@
-import { Flex, FormControl, FormLabel, Image, Switch } from '@invoke-ai/ui-library';
+import { Flex, FormControl, FormLabel, Switch } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import ProgressImage from 'features/gallery/components/CurrentImage/ProgressImage';
 import { setShowSeamless } from 'features/showcase/store/showcaseSlice';
@@ -7,6 +7,7 @@ import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ImageDTO } from 'services/api/types';
 
+import LightBox from './LightBox';
 import SeamlessTextureViewer from './SeamlessTextureViewer';
 
 type ShowcaseProps = {
@@ -56,7 +57,7 @@ function Showcase(props: ShowcaseProps) {
           <SeamlessTextureViewer imageDTO={imageDTO} />
         ) : (
           <Flex p={4}>
-            <Image src={imageDTO.image_url} w="auto" h="auto" objectFit="contain" />
+            <LightBox imageDTO={imageDTO} />
           </Flex>
         )}
       </Flex>

--- a/invokeai/frontend/web/src/features/showcase/hooks/useFocusedMouseWheel.ts
+++ b/invokeai/frontend/web/src/features/showcase/hooks/useFocusedMouseWheel.ts
@@ -1,0 +1,31 @@
+import type { MutableRefObject } from 'react';
+import { useEffect } from 'react';
+
+export const useFocusedMouseWheel = (
+  ref: MutableRefObject<HTMLDivElement | null>,
+  trigger: (e: WheelEvent, ...args: unknown[]) => void
+) => {
+  useEffect(() => {
+    const refElement = ref.current;
+    if (refElement) {
+      refElement.addEventListener('wheel', trigger);
+      refElement.addEventListener('focus', () => {
+        refElement.addEventListener('wheel', trigger);
+      });
+      refElement.addEventListener('blur', () => {
+        refElement.removeEventListener('wheel', trigger);
+      });
+    }
+    return () => {
+      if (refElement) {
+        refElement.removeEventListener('wheel', trigger);
+        refElement.removeEventListener('focus', () => {
+          refElement.removeEventListener('wheel', trigger);
+        });
+        refElement.removeEventListener('blur', () => {
+          refElement.removeEventListener('wheel', trigger);
+        });
+      }
+    };
+  }, [trigger, ref]);
+};

--- a/invokeai/frontend/web/src/features/showcase/hooks/useMousePan.ts
+++ b/invokeai/frontend/web/src/features/showcase/hooks/useMousePan.ts
@@ -1,0 +1,40 @@
+import type { MutableRefObject } from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+export const useMousePan = (ref: MutableRefObject<unknown>) => {
+  const [panPosition, setPanPosition] = useState({ x: 0, y: 0 });
+  const isPanningRef = useRef(false);
+  const prevMousePositionRef = useRef({ x: 0, y: 0 });
+
+  const handleMousePanDown = useCallback((e: React.MouseEvent<HTMLImageElement>) => {
+    e.preventDefault();
+    isPanningRef.current = true;
+    prevMousePositionRef.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const handleMousePanUp = useCallback((e: React.MouseEvent<HTMLImageElement>) => {
+    e.preventDefault();
+    isPanningRef.current = false;
+  }, []);
+
+  const handleMousePanMove = useCallback(
+    (e: React.MouseEvent<HTMLImageElement>) => {
+      if (isPanningRef.current && ref.current) {
+        const deltaX = e.clientX - prevMousePositionRef.current.x;
+        const deltaY = e.clientY - prevMousePositionRef.current.y;
+        prevMousePositionRef.current = { x: e.clientX, y: e.clientY };
+        setPanPosition((prevPosition) => ({
+          x: prevPosition.x + deltaX,
+          y: prevPosition.y + deltaY,
+        }));
+      }
+    },
+    [ref]
+  );
+
+  const resetPan = useCallback(() => {
+    setPanPosition({ x: 0, y: 0 });
+  }, []);
+
+  return { panPosition, handleMousePanDown, handleMousePanUp, handleMousePanMove, resetPan };
+};

--- a/invokeai/frontend/web/src/features/showcase/store/showcaseSlice.ts
+++ b/invokeai/frontend/web/src/features/showcase/store/showcaseSlice.ts
@@ -1,0 +1,27 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+import type { RootState } from 'app/store/store';
+
+export interface ShowcaseState {
+  showSeamless: boolean;
+}
+
+export const initialShowcaseState: ShowcaseState = {
+  showSeamless: false,
+};
+
+const initialState: ShowcaseState = initialShowcaseState;
+
+export const showcaseSlice = createSlice({
+  name: 'showcase',
+  initialState,
+  reducers: {
+    setShowSeamless: (state, action: PayloadAction<boolean>) => {
+      state.showSeamless = action.payload;
+    },
+  },
+});
+
+export const { setShowSeamless } = showcaseSlice.actions;
+
+export const selectShowcaseSlice = (state: RootState) => state.showcase;

--- a/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
+++ b/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
@@ -68,6 +68,11 @@ export const useHotkeyData = (): HotkeyGroup[] => {
           hotkeys: [['F']],
         },
         {
+          title: t('hotkeys.toggleShowcase.title'),
+          desc: t('hotkeys.toggleShowcase.desc'),
+          hotkeys: [['Shift', 'S']],
+        },
+        {
           title: t('hotkeys.changeTabs.title'),
           desc: t('hotkeys.changeTabs.desc'),
           hotkeys: [['1 - 6']],

--- a/invokeai/frontend/web/src/features/ui/store/uiSlice.ts
+++ b/invokeai/frontend/web/src/features/ui/store/uiSlice.ts
@@ -2,6 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PersistConfig, RootState } from 'app/store/store';
 import { initialImageChanged } from 'features/parameters/store/generationSlice';
+import type { ImageDTO } from 'services/api/types';
 
 import type { InvokeTabName } from './tabMap';
 import type { UIState } from './uiTypes';
@@ -11,6 +12,7 @@ export const initialUIState: UIState = {
   activeTab: 'txt2img',
   shouldShowImageDetails: false,
   shouldShowProgressInViewer: true,
+  showShowcase: null,
   panels: {},
   accordions: {},
   expanders: {},
@@ -28,6 +30,9 @@ export const uiSlice = createSlice({
     },
     setShouldShowProgressInViewer: (state, action: PayloadAction<boolean>) => {
       state.shouldShowProgressInViewer = action.payload;
+    },
+    setShouldShowShowcase: (state, action: PayloadAction<ImageDTO | null>) => {
+      state.showShowcase = action.payload;
     },
     panelsChanged: (state, action: PayloadAction<{ name: string; value: string }>) => {
       state.panels[action.payload.name] = action.payload.value;
@@ -52,6 +57,7 @@ export const {
   setActiveTab,
   setShouldShowImageDetails,
   setShouldShowProgressInViewer,
+  setShouldShowShowcase,
   panelsChanged,
   accordionStateChanged,
   expanderStateChanged,

--- a/invokeai/frontend/web/src/features/ui/store/uiTypes.ts
+++ b/invokeai/frontend/web/src/features/ui/store/uiTypes.ts
@@ -1,3 +1,5 @@
+import type { ImageDTO } from 'services/api/types';
+
 import type { InvokeTabName } from './tabMap';
 
 export interface UIState {
@@ -17,6 +19,10 @@ export interface UIState {
    * Whether or not to show progress in the viewer.
    */
   shouldShowProgressInViewer: boolean;
+  /**
+   * Whether or not to show the seamless checker.
+   */
+  showShowcase: ImageDTO | null;
   /**
    * The react-resizable-panels state. The shape is managed by react-resizable-panels.
    */


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Have you discussed this change with the InvokeAI team?
- [x] No, because: Coz I like playing with fire
      
## Have you updated all relevant documentation?
- [x] No - because I can't steal that from @Millu 

## Description

This is a draft PR that will implement Showcase (a.k.a Lightbox) back to InvokeAI. `Shift+S` hotkey to toggle Showcase on and off. Current Image area now has a new button that opens the Showcase. Inside the Showcase will live all features and options that allow previewing of your generations in all glory.

# Completed

## Lightbox

New implementation of a  Lightbox. 

https://github.com/invoke-ai/InvokeAI/assets/54517381/727d44d5-c457-422e-b195-a43679b7df8e

## Seamless Texture Checker

The first feature added to the Lightbox is the Seamless Checker Texture. Just check the box and your generation can be previewed as a tiled image allowing you to check if the Seamless worked as intended.

![opera_BFggu83iEZ](https://github.com/invoke-ai/InvokeAI/assets/54517381/4423238e-b7a8-45b9-9fc2-6e9e458f90f3)

## Live Progress Preview

Live Progress Preview is still available in a mini display if the user wishes to have it previewing their generations in the Showcase.

![opera_0cFlvw0rbi](https://github.com/invoke-ai/InvokeAI/assets/54517381/57276be8-8e0a-4715-b827-1b80c9f6dd9f)

### useFocusedMouseWheel hook

A new custom hook that lets you supply a ref element and a trigger function to control mouse up and down functionality when a particular element is focused. This was written to support zoom in the Lightbox and the Seamless Viewer without interfering with page zoom or scroll wheel settings on any other element when these are not in focus. 

### useMousePan

A new hook to pan an element. Generally applied to images. Used in the Lightbox.

# TODO

- More functionality to the image viewer
- Any other ideas anyone else wants to throw in.
