### PR TITLE
Fix invokeai-configure crash on next branch

### DIFF
--- a/invokeai/frontend/install/model_install.py
+++ b/invokeai/frontend/install/model_install.py
@@ -43,7 +43,7 @@ from invokeai.frontend.install.widgets import (
 warnings.filterwarnings("ignore", category=UserWarning)  # noqa: E402
 config = InvokeAIAppConfig.get_config()
 logger = InvokeAILogger.get_logger("ModelInstallService")
-logger.setLevel("WARNING")
+# logger.setLevel("WARNING")
 # logger.setLevel('DEBUG')
 
 # build a table mapping all non-printable characters to None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

- Removed a legacy function definition that was causing a crash after marshalling arguments.
- Fixed bug that was causing "auto" precision to revert to "float16" each time.

## Related Tickets & Documents

Problem first reported by `joshistoast` at https://discord.com/channels/1020123559063990373/1049495067846524939/1207914069324210196

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## QA Instructions, Screenshots, Recordings

After pulling this PR, run `invokeai-configure --root /path/to/root --yes`. Should download default models without crashing.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [X] No : Don't have unit tests for configure script - TO DO

## [optional] Are there any post deployment tasks we need to perform?
