### PR TITLE
Add a few convenience targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,33 +6,44 @@ default: help
 help:
 	@echo Developer commands:
 	@echo
-	@echo "ruff           Run ruff, fixing any safely-fixable errors and formatting"
-	@echo "ruff-unsafe    Run ruff, fixing all fixable errors and formatting"
-	@echo "mypy           Run mypy using the config in pyproject.toml to identify type mismatches and other coding errors"
-	@echo "mypy-all       Run mypy ignoring the config in pyproject.tom but still ignoring missing imports"
-	@echo "frontend-build Build the frontend in order to run on localhost:9090"
-	@echo "frontend-dev   Run the frontend in developer mode on localhost:5173"
-	@echo "installer-zip  Build the installer .zip file for the current version"
-	@echo "tag-release    Tag the GitHub repository with the current version (use at release time only!)"
+	@echo "ruff              Run ruff, fixing any safely-fixable errors and formatting"
+	@echo "ruff-unsafe       Run ruff, fixing all fixable errors and formatting"
+	@echo "mypy              Run mypy using the config in pyproject.toml to identify type mismatches and other coding errors"
+	@echo "mypy-all          Run mypy ignoring the config in pyproject.tom but still ignoring missing imports"
+	@echo "test"             Run the unit tests.
+	@echo "frontend-install" Install the pnpm modules needed for the front end
+	@echo "frontend-build    Build the frontend in order to run on localhost:9090"
+	@echo "frontend-dev      Run the frontend in developer mode on localhost:5173"
+	@echo "installer-zip     Build the installer .zip file for the current version"
+	@echo "tag-release       Tag the GitHub repository with the current version (use at release time only!)"
 
 # Runs ruff, fixing any safely-fixable errors and formatting
 ruff:
-		ruff check . --fix
-		ruff format .
+	ruff check . --fix
+	ruff format .
 
 # Runs ruff, fixing all errors it can fix and formatting
 ruff-unsafe:
-		ruff check . --fix --unsafe-fixes
-		ruff format .
+	ruff check . --fix --unsafe-fixes
+	ruff format .
 
 # Runs mypy, using the config in pyproject.toml
 mypy:
-		mypy scripts/invokeai-web.py
+	mypy scripts/invokeai-web.py
 
 # Runs mypy, ignoring the config in pyproject.toml but still ignoring missing (untyped) imports
 # (many files are ignored by the config, so this is useful for checking all files)
 mypy-all:
-		mypy scripts/invokeai-web.py --config-file= --ignore-missing-imports
+	mypy scripts/invokeai-web.py --config-file= --ignore-missing-imports
+
+# Run the unit tests
+test:
+	pytest ./tests
+
+# Install the pnpm modules needed for the front end
+frontend-install:
+	rm -rf invokeai/frontend/web/node_modules
+	cd invokeai/frontend/web && pnpm install
 
 # Build the frontend
 frontend-build:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: pretty trivial

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

This PR adds two new targets to the `Makefile`:

* `test` -- This runs `pytest tests` from the root directory
* `frontend-install` -- This empties the old `invokeai/frontend/web/node_modules` directory and reinstalls the most up-to-date node modules by running `pypm install`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Try:

```
make test
make frontend-install
make frontend-build
```

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

Can merge when approved.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
