### PR TITLE
Feat(Nodes): Add Gradient Mask node and denoising functions

### DIFF
--- a/invokeai/app/invocations/fields.py
+++ b/invokeai/app/invocations/fields.py
@@ -199,6 +199,7 @@ class DenoiseMaskField(BaseModel):
 
     mask_name: str = Field(description="The name of the mask image")
     masked_latents_name: Optional[str] = Field(default=None, description="The name of the masked image latents")
+    gradient: Optional[bool] = Field(default=False, description="Used for gradient inpainting")
 
 
 class LatentsField(BaseModel):

--- a/invokeai/app/invocations/fields.py
+++ b/invokeai/app/invocations/fields.py
@@ -199,7 +199,7 @@ class DenoiseMaskField(BaseModel):
 
     mask_name: str = Field(description="The name of the mask image")
     masked_latents_name: Optional[str] = Field(default=None, description="The name of the masked image latents")
-    gradient: Optional[bool] = Field(default=False, description="Used for gradient inpainting")
+    gradient: bool = Field(default=False, description="Used for gradient inpainting")
 
 
 class LatentsField(BaseModel):

--- a/invokeai/app/invocations/primitives.py
+++ b/invokeai/app/invocations/primitives.py
@@ -300,7 +300,7 @@ class DenoiseMaskOutput(BaseInvocationOutput):
 
     @classmethod
     def build(
-        cls, mask_name: str, masked_latents_name: Optional[str] = None, gradient: Optional[bool] = False
+        cls, mask_name: str, masked_latents_name: Optional[str] = None, gradient: bool = False
     ) -> "DenoiseMaskOutput":
         return cls(
             denoise_mask=DenoiseMaskField(

--- a/invokeai/app/invocations/primitives.py
+++ b/invokeai/app/invocations/primitives.py
@@ -299,9 +299,13 @@ class DenoiseMaskOutput(BaseInvocationOutput):
     denoise_mask: DenoiseMaskField = OutputField(description="Mask for denoise model run")
 
     @classmethod
-    def build(cls, mask_name: str, masked_latents_name: Optional[str] = None) -> "DenoiseMaskOutput":
+    def build(
+        cls, mask_name: str, masked_latents_name: Optional[str] = None, gradient: Optional[bool] = False
+    ) -> "DenoiseMaskOutput":
         return cls(
-            denoise_mask=DenoiseMaskField(mask_name=mask_name, masked_latents_name=masked_latents_name),
+            denoise_mask=DenoiseMaskField(
+                mask_name=mask_name, masked_latents_name=masked_latents_name, gradient=gradient
+            ),
         )
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
Adds a node for Gradient Masking (referred to as "Soft Inpainting" in webui Forge, or "Differential Diffusion" in the first known implementation). This node is designed to be easily integrated with our existing Compositing settings in the Canvas without adding more graph complexity.  Canvas integration to be done in a future PR.  
![image](https://github.com/invoke-ai/InvokeAI/assets/3298737/860d9aac-7bc2-4f72-97ab-6bf826fd1883)

Gradient Mask dynamically expands the masked area during the diffusion process based on the value of the mask. This improves edge coherence and can give better results than coherence pass while only requiring a single denoise stage.

Mask blurring is handled internally. This is to account for some special considerations that are otherwise hard to get right:  
* Masks blur outwards, not inwards. Particularly in small masked regions, blurring often erases too much of the mask for it to be usable. Noticeable on our existing implementation, but it becomes more of a problem with gradient denoise. This implementation clips and renormalizes the mask post-blur so that the entire masked area remains fully masked and any blur extends outwards from it.  
* Masking clips to a minimum denoise value. Using excessive blur with gradient masking can result in large areas with very small amounts of denoise applied at the end. When samplers tracking momentum of the unmasked area suddenly have input from the current denoise pipeline for the last step, it can cause an odd artifact that looks like two transparent images overlaid onto each other. Clipping to a minimum denoise value avoids this and makes the result act much more similar to our current Mask Edge coherence pass mode.  
* Staged mode clips the entire blur area to a single denoise value. This is the full analog for the Mask Edge coherence pass in a single denoise pass. If the denoise amount is lower than the minimum set in the mask node (i.e. denoise strength of 0.25 but the minimum is 0.3) then this effectively just increases the size of the mask.  
![image](https://github.com/invoke-ai/InvokeAI/assets/3298737/35a507d6-f5c2-4da4-abc1-ab445cd59cfe)

### Future PRs
Currently this mask node does not supply a masked_latents version of an input image, which is used by Inpainting models. The normal create_denoise_mask node does make one by taking in the input image and a VAE. This means every time an inpaint workflow is invoked we are encoding the input image through VAE an extra time, whether it gets used later or not. This operation should be moved inside of the Denoise Latents node instead and removed from the mask creation node, and that will break a lot of existing workflows. Since we will need to mess with the workflows anyway to integrate this in Canvas, that would be a good time to rework the older mask node as well.

## Related
This PR is a more robust implementation that supersedes an existing PR for gradient masking on main.  
- Closes #5612  

## Merge Plan

This PR can be merged when approved

## Added/updated tests?

- [ ] Yes
- [x] No : tests can be updated when we rework existing mask node and integrate into canvas