### PR TITLE
Several small model install enhancements and fixes

### DIFF
--- a/invokeai/app/api/routers/model_manager.py
+++ b/invokeai/app/api/routers/model_manager.py
@@ -350,8 +350,8 @@ async def add_model_record(
 
 
 @model_manager_router.post(
-    "/heuristic_import",
-    operation_id="heuristic_import_model",
+    "/heuristic_install",
+    operation_id="heuristic_install_model",
     responses={
         201: {"description": "The model imported successfully"},
         415: {"description": "Unrecognized file/folder format"},
@@ -360,12 +360,12 @@ async def add_model_record(
     },
     status_code=201,
 )
-async def heuristic_import(
+async def heuristic_install(
     source: str,
     config: Optional[Dict[str, Any]] = Body(
         description="Dict of fields that override auto-probed values in the model config record, such as name, description and prediction_type ",
         default=None,
-        example={"name": "modelT", "description": "antique cars"},
+        example={"name": "string", "description": "string"},
     ),
     access_token: Optional[str] = None,
 ) -> ModelInstallJob:

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -256,4 +256,4 @@ def test_404_download(mm2_installer: ModelInstallServiceBase, mm2_app_config: In
     assert job.error_type == "HTTPError"
     assert job.error
     assert "NOT FOUND" in job.error
-    assert "Traceback" in job.error
+    assert job.error_traceback.startswith("Traceback")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

This PR tidies up the model installer a bit.

- Support the extended HF repoid syntax previously discussed with @hipsterusername and @maryhipp. This allows easy installation of repo_id subfolders and files, and can be used to import a checkpoint file that is buried in a HF repo, as in `XpucT/Deliberate::Deliberate_v5.safetensors`
- Add `error` and `error_traceback` properties to the install job objects.
- Rename the `heuristic_import` route to `heuristic_install`.
- Fix the example `config` input in the `heuristic_install` route.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Start the webui and navigate to http://localhost:9091/docs#/model_manager/heuristic_install_model. Press "Try it Out" and paste in an extended repo_id. The following syntaxes should work:

```
foo/bar
foo/bar:fp16      # or fp32, onnx, openvino, etc
foo/bar:fp16:vae  # for the vae subfolder
foo/bar::vae      # default variant, vae subfolder
foo/bar::path/to/ckpt.safetensors   # any subfolder or file in the repo, relative to its root
```

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

Can merge when approved.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [x] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
