### PR TITLE
Gracefully recover from VRAM out of memory errors (next branch version)

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/model_cache_base.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache_base.py
@@ -111,7 +111,7 @@ class ModelCacheBase(ABC, Generic[T]):
         pass
 
     @abstractmethod
-    def move_model_to_device(self, cache_entry: CacheRecord[AnyModel], device: torch.device) -> None:
+    def move_model_to_device(self, cache_entry: CacheRecord[AnyModel], target_device: torch.device) -> None:
         """Move model into the indicated device."""
         pass
 

--- a/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
@@ -418,7 +418,7 @@ class ModelCache(ModelCacheBase[AnyModel]):
     def _check_free_vram(self, target_device: torch.device, needed_size: int) -> None:
         if target_device.type != "cuda":
             return
-        vram_device = ( # mem_get_info() needs an indexed device
+        vram_device = (  # mem_get_info() needs an indexed device
             target_device if target_device.index is not None else torch.device(str(target_device), index=0)
         )
         free_mem, _ = torch.cuda.mem_get_info(torch.device(vram_device))

--- a/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
@@ -294,6 +294,12 @@ class ModelCache(ModelCacheBase[AnyModel]):
                     f"{get_pretty_snapshot_diff(snapshot_before, snapshot_after)}"
                 )
 
+    def _clear_vram(self) -> None:
+        """Called on out of memory errors. Moves all our models out of VRAM."""
+        self.logger.warning('Resetting VRAM cache.')
+        for model in self._cached_models.values():
+            self.move_model_to_device(model, torch.device('cpu'))
+
     def print_cuda_stats(self) -> None:
         """Log CUDA diagnostics."""
         vram = "%4.2fG" % (torch.cuda.memory_allocated() / GIG)

--- a/invokeai/backend/model_manager/load/model_cache/model_locker.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_locker.py
@@ -2,8 +2,8 @@
 Base class and implementation of a class that moves models in and out of VRAM.
 """
 
+import torch
 from invokeai.backend.model_manager import AnyModel
-
 from .model_cache_base import CacheRecord, ModelCacheBase, ModelLockerBase
 
 
@@ -42,7 +42,9 @@ class ModelLocker(ModelLockerBase):
 
             self._cache.logger.debug(f"Locking {self._cache_entry.key} in {self._cache.execution_device}")
             self._cache.print_cuda_stats()
-
+        except torch.cuda.OutOfMemoryError:
+            self._cache._clear_vram()
+            raise
         except Exception:
             self._cache_entry.unlock()
             raise

--- a/invokeai/backend/model_manager/load/model_cache/model_locker.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_locker.py
@@ -3,7 +3,9 @@ Base class and implementation of a class that moves models in and out of VRAM.
 """
 
 import torch
+
 from invokeai.backend.model_manager import AnyModel
+
 from .model_cache_base import CacheRecord, ModelCacheBase, ModelLockerBase
 
 

--- a/invokeai/backend/model_manager/load/model_cache/model_locker.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_locker.py
@@ -43,7 +43,8 @@ class ModelLocker(ModelLockerBase):
             self._cache.logger.debug(f"Locking {self._cache_entry.key} in {self._cache.execution_device}")
             self._cache.print_cuda_stats()
         except torch.cuda.OutOfMemoryError:
-            self._cache._clear_vram()
+            self._cache.logger.warning("Insufficient GPU memory to load model. Aborting")
+            self._cache_entry.unlock()
             raise
         except Exception:
             self._cache_entry.unlock()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [X] No, because: straightforward fix

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

At least on my system, if the model manager runs out of VRAM while moving a model into the GPU, the partial model gets stuck in VRAM and can't easily be removed. This makes the model unusable, and uses precious VRAM.

I encountered this when playing with large language models on the same system, but I suspect it will also happen if a video game is being played. I tried various approaches to recover from this state, including clearing the vram cache, deleting the model object, and running garbage collection, but without success.

This PR avoids the issue by implementing a check for sufficient available VRAM before trying to move a model to a CUDA GPU. If there is insufficient room, it raises a `torch.cuda.OutOfMemoryError`. This message is propagated to the front end. If more VRAM becomes available later, invocations will begin to work again.

***Note:*** This pull request is against `next`. The model manager code has changed a bit, so I'm making a separate PR for `main`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Launch InvokeAI web service and another application that uses a lot of GPU VRAM. For my testing, I used ollama with a large model loaded. Run a generation and see if it generates an out of memory error. Try this repeatedly - should get the same error each time. Now kill the other application to free up VRAM and try to generate an image. It should work!

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan
Can merge when approved.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [X] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?

