### PR TITLE
feat(ui): Split the Canvas Mask Blur & Edge Size Setting

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1175,8 +1175,8 @@
             "unableToInvoke": "Unable to Invoke"
         },
         "maskAdjustmentsHeader": "Mask Adjustments",
-        "maskBlur": "Blur",
-        "maskBlurMethod": "Blur Method",
+        "maskBlur": "Mask Blur",
+        "maskBlurMethod": "Mask Blur Method",
         "maskEdge": "Mask Edge",
         "negativePromptPlaceholder": "Negative Prompt",
         "noiseSettings": "Noise",
@@ -1462,8 +1462,8 @@
                 "Scheduler defines how to iteratively add noise to an image or how to update a sample based on a model's output."
             ]
         },
-        "compositingBlur": {
-            "heading": "Blur",
+        "compositingMaskBlur": {
+            "heading": "Mask Blur",
             "paragraphs": ["The blur radius of the mask."]
         },
         "compositingBlurMethod": {

--- a/invokeai/frontend/web/src/common/components/InformationalPopover/constants.ts
+++ b/invokeai/frontend/web/src/common/components/InformationalPopover/constants.ts
@@ -6,7 +6,7 @@ export type Feature =
   | 'paramNegativeConditioning'
   | 'paramPositiveConditioning'
   | 'paramScheduler'
-  | 'compositingBlur'
+  | 'compositingMaskBlur'
   | 'compositingBlurMethod'
   | 'compositingCoherencePass'
   | 'compositingCoherenceMode'

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasInpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasInpaintGraph.ts
@@ -58,13 +58,13 @@ export const buildCanvasInpaintGraph = (
     seed,
     vaePrecision,
     shouldUseCpuNoise,
-
     clipSkip,
     seamlessXAxis,
     seamlessYAxis,
     canvasCoherenceMode,
     canvasCoherenceMinDenoise,
     canvasCoherenceEdgeSize,
+    maskBlur,
   } = state.generation;
 
   if (!model) {
@@ -156,7 +156,7 @@ export const buildCanvasInpaintGraph = (
         id: CANVAS_OUTPUT,
         is_intermediate: getIsIntermediate(state),
         board: getBoardField(state),
-        mask_blur: canvasCoherenceEdgeSize,
+        mask_blur: maskBlur,
         source_image: canvasInitImage,
       },
     },

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasOutpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasOutpaintGraph.ts
@@ -71,6 +71,7 @@ export const buildCanvasOutpaintGraph = (
     canvasCoherenceMode,
     canvasCoherenceMinDenoise,
     canvasCoherenceEdgeSize,
+    maskBlur,
   } = state.generation;
 
   if (!model) {
@@ -176,7 +177,7 @@ export const buildCanvasOutpaintGraph = (
         is_intermediate: getIsIntermediate(state),
         board: getBoardField(state),
         use_cache: false,
-        mask_blur: canvasCoherenceEdgeSize,
+        mask_blur: maskBlur,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLInpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLInpaintGraph.ts
@@ -64,6 +64,7 @@ export const buildCanvasSDXLInpaintGraph = (
     canvasCoherenceMode,
     canvasCoherenceMinDenoise,
     canvasCoherenceEdgeSize,
+    maskBlur,
   } = state.generation;
 
   const { refinerModel, refinerStart } = state.sdxl;
@@ -157,7 +158,7 @@ export const buildCanvasSDXLInpaintGraph = (
         id: CANVAS_OUTPUT,
         is_intermediate: getIsIntermediate(state),
         board: getBoardField(state),
-        mask_blur: canvasCoherenceEdgeSize,
+        mask_blur: maskBlur,
         source_image: canvasInitImage,
       },
     },

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLOutpaintGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildCanvasSDXLOutpaintGraph.ts
@@ -71,6 +71,7 @@ export const buildCanvasSDXLOutpaintGraph = (
     canvasCoherenceMode,
     canvasCoherenceMinDenoise,
     canvasCoherenceEdgeSize,
+    maskBlur,
   } = state.generation;
 
   const { refinerModel, refinerStart } = state.sdxl;
@@ -176,7 +177,7 @@ export const buildCanvasSDXLOutpaintGraph = (
         is_intermediate: getIsIntermediate(state),
         board: getBoardField(state),
         use_cache: false,
-        mask_blur: canvasCoherenceEdgeSize,
+        mask_blur: maskBlur,
       },
     },
     edges: [

--- a/invokeai/frontend/web/src/features/parameters/components/Canvas/Compositing/MaskAdjustment/ParamMaskBlur.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Canvas/Compositing/MaskAdjustment/ParamMaskBlur.tsx
@@ -26,7 +26,7 @@ const ParamMaskBlur = () => {
 
   return (
     <FormControl>
-      <InformationalPopover feature="compositingBlur">
+      <InformationalPopover feature="compositingMaskBlur">
         <FormLabel>{t('parameters.maskBlur')}</FormLabel>
       </InformationalPopover>
       <CompositeSlider

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/CompositingSettingsAccordion/CompositingSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/CompositingSettingsAccordion/CompositingSettingsAccordion.tsx
@@ -12,6 +12,7 @@ import {
 import ParamCanvasCoherenceEdgeSize from 'features/parameters/components/Canvas/Compositing/CoherencePass/ParamCanvasCoherenceEdgeSize';
 import ParamCanvasCoherenceMinDenoise from 'features/parameters/components/Canvas/Compositing/CoherencePass/ParamCanvasCoherenceMinDenoise';
 import ParamCanvasCoherenceMode from 'features/parameters/components/Canvas/Compositing/CoherencePass/ParamCanvasCoherenceMode';
+import ParamMaskBlur from 'features/parameters/components/Canvas/Compositing/MaskAdjustment/ParamMaskBlur';
 import ParamInfillMethod from 'features/parameters/components/Canvas/InfillAndScaling/ParamInfillMethod';
 import ParamInfillOptions from 'features/parameters/components/Canvas/InfillAndScaling/ParamInfillOptions';
 import { useStandaloneAccordionToggle } from 'features/settingsAccordions/hooks/useStandaloneAccordionToggle';
@@ -43,8 +44,9 @@ export const CompositingSettingsAccordion = memo(() => {
                 <ParamCanvasCoherenceMode />
                 <ParamCanvasCoherenceEdgeSize />
                 <ParamCanvasCoherenceMinDenoise />
+                <ParamMaskBlur />
                 {/* <ParamMaskBlurMethod />
-                <ParamMaskBlur /> */}
+                 */}
               </FormControlGroup>
             </Flex>
           </TabPanel>

--- a/invokeai/frontend/web/src/features/system/store/configSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/configSlice.ts
@@ -88,9 +88,9 @@ export const initialConfigState: AppConfig = {
     },
     canvasCoherenceEdgeSize: {
       initial: 16,
-      sliderMin: 16,
-      sliderMax: 512,
-      numberInputMin: 16,
+      sliderMin: 0,
+      sliderMax: 128,
+      numberInputMin: 0,
       numberInputMax: 1024,
       fineStep: 8,
       coarseStep: 16,
@@ -134,7 +134,7 @@ export const initialConfigState: AppConfig = {
     maskBlur: {
       initial: 16,
       sliderMin: 0,
-      sliderMax: 64,
+      sliderMax: 128,
       numberInputMin: 0,
       numberInputMax: 512,
       fineStep: 1,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Have you discussed this change with the InvokeAI team?
- [x] Yes

      
## Have you updated all relevant documentation?
- [x] Yes

## Description

- Canvas Mask Blur now has its own slider for independent control from the edge size of the coherence pass.
- Coherence Pass Edge Size can now be set to 0.

