### PR TITLE
Next: Fix TI Loading for sdxl prompt

### DIFF
--- a/invokeai/app/invocations/compel.py
+++ b/invokeai/app/invocations/compel.py
@@ -18,7 +18,6 @@ from invokeai.app.services.model_records import UnknownModelException
 from invokeai.app.services.shared.invocation_context import InvocationContext
 from invokeai.app.util.ti_utils import extract_ti_triggers_from_prompt
 from invokeai.backend.lora import LoRAModelRaw
-from invokeai.backend.model_manager import ModelType
 from invokeai.backend.model_patcher import ModelPatcher
 from invokeai.backend.stable_diffusion.diffusion.conditioning_data import (
     BasicConditioningInfo,

--- a/invokeai/app/invocations/compel.py
+++ b/invokeai/app/invocations/compel.py
@@ -193,11 +193,9 @@ class SDXLPromptInvocationBase:
         for trigger in extract_ti_triggers_from_prompt(prompt):
             name = trigger[1:-1]
             try:
-                ti_model = context.models.load_by_attrs(
-                    model_name=name, base_model=text_encoder_info.config.base, model_type=ModelType.TextualInversion
-                ).model
-                assert isinstance(ti_model, TextualInversionModelRaw)
-                ti_list.append((name, ti_model))
+                loaded_model = context.models.load(key=name).model
+                assert isinstance(loaded_model, TextualInversionModelRaw)
+                ti_list.append((name, loaded_model))
             except UnknownModelException:
                 # print(e)
                 # import traceback

--- a/invokeai/app/util/ti_utils.py
+++ b/invokeai/app/util/ti_utils.py
@@ -1,5 +1,4 @@
 import re
-
 from typing import List
 
 

--- a/invokeai/app/util/ti_utils.py
+++ b/invokeai/app/util/ti_utils.py
@@ -1,8 +1,10 @@
 import re
 
+from typing import List
 
-def extract_ti_triggers_from_prompt(prompt: str) -> list[str]:
-    ti_triggers = []
+
+def extract_ti_triggers_from_prompt(prompt: str) -> List[str]:
+    ti_triggers: List[str] = []
     for trigger in re.findall(r"<[a-zA-Z0-9., _-]+>", prompt):
-        ti_triggers.append(trigger)
+        ti_triggers.append(str(trigger))
     return ti_triggers


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

Currently the SDXLPromptInvocationBase reads TI triggers from the prompt as names instead of keys.
