### PR TITLE
update UI to display VAE override for model as dropdown of installed options

### DIFF
--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/Fields/VaeSelect.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/Fields/VaeSelect.tsx
@@ -1,0 +1,72 @@
+import type { ComboboxOnChange, ComboboxOption } from '@invoke-ai/ui-library';
+import { Combobox } from '@invoke-ai/ui-library';
+import { typedMemo } from 'common/util/typedMemo';
+import { useCallback, useMemo } from 'react';
+import type { UseControllerProps } from 'react-hook-form';
+import { useController, useWatch } from 'react-hook-form';
+import type { AnyModelConfig } from 'services/api/types';
+import { useGetVaeModelsQuery } from '../../../../../services/api/endpoints/models';
+import { useTranslation } from 'react-i18next';
+import { GroupBase } from 'chakra-react-select';
+import { map, reduce, groupBy } from 'lodash-es';
+
+const VaeSelect = (props: UseControllerProps<AnyModelConfig>) => {
+  const { t } = useTranslation();
+  const { field } = useController(props);
+  const { data } = useGetVaeModelsQuery();
+  const base = useWatch({ control: props.control, name: 'base' });
+
+  const onChange = useCallback<ComboboxOnChange>(
+    (value) => {
+      if (!value) {
+        field.onChange(null);
+        return;
+      }
+
+      field.onChange(value.value);
+    },
+    [field]
+  );
+
+  const options = useMemo<GroupBase<ComboboxOption>[]>(() => {
+    if (!data) {
+      return [];
+    }
+    const modelEntitiesArray = map(data.entities);
+    const groupedModels = groupBy(modelEntitiesArray, 'base');
+    const _options = reduce(
+      groupedModels,
+      (acc, val, label) => {
+        acc.push({
+          label,
+          options: val.map((model) => ({
+            label: model.name,
+            value: model.path,
+            isDisabled: base !== model.base,
+          })),
+        });
+        return acc;
+      },
+      [] as GroupBase<ComboboxOption>[]
+    );
+    _options.sort((a) => (a.label === base ? -1 : 1));
+    return _options;
+  }, [data, base]);
+
+  const value = useMemo(
+    () => options.flatMap((o) => o.options).find((m) => (field.value ? m.value === field.value : false)) ?? null,
+    [options, field.value]
+  );
+
+  return (
+    <Combobox
+      isClearable
+      value={value}
+      options={options}
+      onChange={onChange}
+      placeholder={value ? value.value : t('models.defaultVAE')}
+    />
+  );
+};
+
+export default typedMemo(VaeSelect);

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
@@ -29,6 +29,7 @@ import ModelTypeSelect from './Fields/ModelTypeSelect';
 import ModelVariantSelect from './Fields/ModelVariantSelect';
 import PredictionTypeSelect from './Fields/PredictionTypeSelect';
 import RepoVariantSelect from './Fields/RepoVariantSelect';
+import VaeSelect from './Fields/VaeSelect';
 
 export const ModelEdit = () => {
   const dispatch = useAppDispatch();
@@ -38,39 +39,6 @@ export const ModelEdit = () => {
   const [updateModel, { isLoading: isSubmitting }] = useUpdateModelsMutation();
 
   const { t } = useTranslation();
-
-  // const modelData = useMemo(() => {
-  //   if (!data) {
-  //     return null;
-  //   }
-  //   const modelFormat = data.format;
-  //   const modelType = data.type;
-
-  //   if (modelType === 'main') {
-  //     if (modelFormat === 'diffusers') {
-  //       return data as DiffusersModelConfig;
-  //     } else if (modelFormat === 'checkpoint') {
-  //       return data as CheckpointModelConfig;
-  //     }
-  //   }
-
-  //   switch (modelType) {
-  //     case 'lora':
-  //       return data as LoRAModelConfig;
-  //     case 'embedding':
-  //       return data as TextualInversionModelConfig;
-  //     case 't2i_adapter':
-  //       return data as T2IAdapterModelConfig;
-  //     case 'ip_adapter':
-  //       return data as IPAdapterModelConfig;
-  //     case 'controlnet':
-  //       return data as ControlNetModelConfig;
-  //     case 'vae':
-  //       return data as VAEModelConfig;
-  //     default:
-  //       return null;
-  //   }
-  // }, [data]);
 
   const {
     register,
@@ -91,6 +59,7 @@ export const ModelEdit = () => {
 
   const onSubmit = useCallback<SubmitHandler<AnyModelConfig>>(
     (values) => {
+      console.log({ values });
       if (!data?.key) {
         return;
       }
@@ -243,8 +212,8 @@ export const ModelEdit = () => {
                   <BooleanSelect<AnyModelConfig> control={control} name="ztsnr_training" />
                 </FormControl>
                 <FormControl flexDir="column" alignItems="flex-start" gap={1}>
-                  <FormLabel>{t('modelManager.vaeLocation')}</FormLabel>
-                  <Input {...register('vae')} />
+                  <FormLabel>{t('modelManager.vae')}</FormLabel>
+                  <VaeSelect control={control} name="vae" />
                 </FormControl>
               </Flex>
             </>

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
@@ -59,7 +59,6 @@ export const ModelEdit = () => {
 
   const onSubmit = useCallback<SubmitHandler<AnyModelConfig>>(
     (values) => {
-      console.log({ values });
       if (!data?.key) {
         return;
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
Updates the VAE dropdown on the model edit screen to display options as a list of installed models, instead of a text input for the path. 

Concerns:
* this will have weird behavior for models that already have `vae` override set to a path for a model that is not "installed"
* will require users to install any VAE that they want to use as an override

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
