### PR TITLE
Next: Remove deprecated app.on_event usage in api runner

### DIFF
--- a/invokeai/backend/model_manager/search.py
+++ b/invokeai/backend/model_manager/search.py
@@ -118,7 +118,7 @@ class ModelSearch(ModelSearchBase):
     """
 
     models_found: Set[Path] = Field(default_factory=set)
-    config: InvokeAIAppConfig =  InvokeAIAppConfig.get_config()
+    config: InvokeAIAppConfig = InvokeAIAppConfig.get_config()
 
     def search_started(self) -> None:
         self.models_found = set()
@@ -147,9 +147,11 @@ class ModelSearch(ModelSearchBase):
 
     def _walk_directory(self, path: Union[Path, str], max_depth: int = 20) -> None:
         absolute_path = Path(path)
-        if len(absolute_path.parts) - len(self._directory.parts) > max_depth \
-                or not absolute_path.exists() \
-                    or absolute_path.parent in self.models_found:
+        if (
+            len(absolute_path.parts) - len(self._directory.parts) > max_depth
+            or not absolute_path.exists()
+            or absolute_path.parent in self.models_found
+        ):
             return
         entries = os.scandir(absolute_path.as_posix())
         entries = [entry for entry in entries if not entry.name.startswith(".")]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description

FastAPI is deprecating app.on_event which we currently use as our startup and shutdown hooks. FastAPI recommends replacing it with this lifespan feature.
