### PR TITLE
fix: Assertion issue with SDXL Compel

### DIFF
--- a/invokeai/backend/model_manager/search.py
+++ b/invokeai/backend/model_manager/search.py
@@ -118,7 +118,7 @@ class ModelSearch(ModelSearchBase):
     """
 
     models_found: Set[Path] = Field(default_factory=set)
-    config: InvokeAIAppConfig =  InvokeAIAppConfig.get_config()
+    config: InvokeAIAppConfig = InvokeAIAppConfig.get_config()
 
     def search_started(self) -> None:
         self.models_found = set()
@@ -147,9 +147,11 @@ class ModelSearch(ModelSearchBase):
 
     def _walk_directory(self, path: Union[Path, str], max_depth: int = 20) -> None:
         absolute_path = Path(path)
-        if len(absolute_path.parts) - len(self._directory.parts) > max_depth \
-                or not absolute_path.exists() \
-                    or absolute_path.parent in self.models_found:
+        if (
+            len(absolute_path.parts) - len(self._directory.parts) > max_depth
+            or not absolute_path.exists()
+            or absolute_path.parent in self.models_found
+        ):
             return
         entries = os.scandir(absolute_path.as_posix())
         entries = [entry for entry in entries if not entry.name.startswith(".")]

--- a/invokeai/backend/model_patcher.py
+++ b/invokeai/backend/model_patcher.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import pickle
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 from diffusers import OnnxRuntimeModel, UNet2DConditionModel
-from transformers import CLIPTextModel, CLIPTokenizer
+from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
 
 from invokeai.app.shared.models import FreeUConfig
 from invokeai.backend.model_manager import AnyModel
@@ -168,7 +168,7 @@ class ModelPatcher:
     def apply_ti(
         cls,
         tokenizer: CLIPTokenizer,
-        text_encoder: CLIPTextModel,
+        text_encoder: Union[CLIPTextModel, CLIPTextModelWithProjection],
         ti_list: List[Tuple[str, TextualInversionModelRaw]],
     ) -> Iterator[Tuple[CLIPTokenizer, TextualInversionManager]]:
         init_tokens_count = None
@@ -265,7 +265,7 @@ class ModelPatcher:
     @contextmanager
     def apply_clip_skip(
         cls,
-        text_encoder: CLIPTextModel,
+        text_encoder: Union[CLIPTextModel, CLIPTextModelWithProjection],
         clip_skip: int,
     ) -> None:
         skipped_layers = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
    
## Description

Fix assertion issue in `compel.py`. Currently we check for just an instance of `CLIPTextModel` but SDXL text encoder can be either `CLIPTextModel` or `CLIPTextModelWithProjection`. This PR updates the assertion to permit either.
