### PR TITLE
Remove Training references from invoke script

### DIFF
--- a/installer/templates/invoke.bat.in
+++ b/installer/templates/invoke.bat.in
@@ -9,7 +9,7 @@ set INVOKEAI_ROOT=.
 :start
 echo Desired action:
 echo 1. Generate images with the browser-based interface
-echo 2. Run textual inversion training
+echo 2. Invoke Model Training
 echo 3. Merge models (diffusers type only)
 echo 4. Download and install models
 echo 5. Change InvokeAI startup options
@@ -25,8 +25,7 @@ IF /I "%choice%" == "1" (
     echo Starting the InvokeAI browser-based UI..
     python .venv\Scripts\invokeai-web.exe %*
 ) ELSE IF /I "%choice%" == "2" (
-    echo Starting textual inversion training..
-    python .venv\Scripts\invokeai-ti.exe --gui
+    echo To use Invoke Training for LoRA, TI, and more - Visit https://github.com/invoke-ai/invoke-training
 ) ELSE IF /I "%choice%" == "3" (
     echo Starting model merging script..
     python .venv\Scripts\invokeai-merge.exe --gui

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -59,8 +59,7 @@ do_choice() {
         ;;
     2)
         clear
-        printf "Textual inversion training\n"
-        invokeai-ti --gui $PARAMS
+        printf "To use Invoke Training for LoRA, TI, and more - Visit https://github.com/invoke-ai/invoke-training\n"
         ;;
     3)
         clear
@@ -118,7 +117,7 @@ do_choice() {
 do_dialog() {
     options=(
         1 "Generate images with a browser-based interface"
-        2 "Textual inversion training"
+        2 "Run Invoke Training"
         3 "Merge models (diffusers type only)"
         4 "Download and install models"
         5 "Change InvokeAI startup options"
@@ -151,7 +150,7 @@ do_line_input() {
     printf " ** For a more attractive experience, please install the 'dialog' utility using your package manager. **\n\n"
     printf "What would you like to do?\n"
     printf "1: Generate images using the browser-based interface\n"
-    printf "2: Run textual inversion training\n"
+    printf "2: Run Invoke Training\n"
     printf "3: Merge models (diffusers type only)\n"
     printf "4: Download and install models\n"
     printf "5: Change InvokeAI startup options\n"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because: 

      
## Have you updated all relevant documentation?
- [ ] Yes
- [X] No


## Description
We have the Invoke Training repo and need to ensure folks use that instead of running into errors/issues with the deprecated TI script.


## Merge Plan
We need to evaluate whether we want to keep the deprecated/unused code around for any reason, and also update any docs to point to training repo. 

## Added/updated tests?

- [ ] Yes
- [X] No : _please replace this line with details on why tests
      have not been included_