### PR TITLE
consolidate tabs for main model and concepts in generation panel

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -860,6 +860,7 @@
     "models": {
         "addLora": "Add LoRA",
         "allLoRAsAdded": "All LoRAs added",
+        "concepts": "Concepts",
         "loraAlreadyAdded": "LoRA already added",
         "esrganModel": "ESRGAN Model",
         "loading": "loading",

--- a/invokeai/frontend/web/src/features/lora/components/LoRASelect.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/LoRASelect.tsx
@@ -59,7 +59,7 @@ const LoRASelect = () => {
   return (
     <FormControl isDisabled={!options.length}>
       <InformationalPopover feature="lora">
-        <FormLabel>{t('models.lora')} </FormLabel>
+        <FormLabel>{t('models.concepts')} </FormLabel>
       </InformationalPopover>
       <Combobox
         placeholder={placeholder}

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ImportQueue/ImportQueueBadge.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ImportQueue/ImportQueueBadge.tsx
@@ -15,7 +15,7 @@ const STATUSES = {
 const ImportQueueBadge = ({ status, errorReason }: { status?: ModelInstallStatus; errorReason?: string | null }) => {
   const { t } = useTranslation();
 
-  if (!status) {
+  if (!status || !Object.keys(STATUSES).includes(status)) {
     return <></>;
   }
 

--- a/invokeai/frontend/web/src/features/parameters/components/MainModel/NavigateToModelManagerButton.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/MainModel/NavigateToModelManagerButton.tsx
@@ -1,0 +1,36 @@
+import type { IconButtonProps } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { setActiveTab } from 'features/ui/store/uiSlice';
+import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiGearSixBold } from 'react-icons/pi';
+
+export const NavigateToModelManagerButton = memo((props: Omit<IconButtonProps, 'aria-label'>) => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const disabledTabs = useAppSelector((s) => s.config.disabledTabs);
+  const shouldShowButton = useMemo(() => !disabledTabs.includes('modelManager'), [disabledTabs]);
+
+  const handleClick = useCallback(() => {
+    dispatch(setActiveTab('modelManager'));
+  }, [dispatch]);
+
+  if (!shouldShowButton) {
+    return null;
+  }
+
+  return (
+    <IconButton
+      icon={<PiGearSixBold />}
+      tooltip={t('modelManager.modelManager')}
+      aria-label={t('modelManager.modelManager')}
+      onClick={handleClick}
+      size="sm"
+      variant="ghost"
+      {...props}
+    />
+  );
+});
+
+NavigateToModelManagerButton.displayName = 'NavigateToModelManagerButton';

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
@@ -1,15 +1,5 @@
 import type { FormLabelProps } from '@invoke-ai/ui-library';
-import {
-  Expander,
-  Flex,
-  FormControlGroup,
-  StandaloneAccordion,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
-} from '@invoke-ai/ui-library';
+import { Box, Expander, Flex, FormControlGroup, StandaloneAccordion } from '@invoke-ai/ui-library';
 import { EMPTY_ARRAY } from 'app/store/constants';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppSelector } from 'app/store/storeHooks';
@@ -39,11 +29,11 @@ export const GenerationSettingsAccordion = memo(() => {
     () =>
       createMemoizedSelector(selectLoraSlice, (lora) => {
         const enabledLoRAsCount = filter(lora.loras, (l) => !!l.isEnabled).length;
-        const loraTabBadges = enabledLoRAsCount ? [enabledLoRAsCount] : EMPTY_ARRAY;
+        const loraTabBadges = enabledLoRAsCount ? [`${enabledLoRAsCount} ${t('models.concepts')}`] : EMPTY_ARRAY;
         const accordionBadges = modelConfig ? [modelConfig.name, modelConfig.base] : EMPTY_ARRAY;
         return { loraTabBadges, accordionBadges };
       }),
-    [modelConfig]
+    [modelConfig, t]
   );
   const { loraTabBadges, accordionBadges } = useAppSelector(selectBadges);
   const { isOpen: isOpenExpander, onToggle: onToggleExpander } = useExpanderToggle({
@@ -58,39 +48,31 @@ export const GenerationSettingsAccordion = memo(() => {
   return (
     <StandaloneAccordion
       label={t('accordions.generation.title')}
-      badges={accordionBadges}
+      badges={[...accordionBadges, ...loraTabBadges]}
       isOpen={isOpenAccordion}
       onToggle={onToggleAccordion}
     >
-      <Tabs variant="collapse">
-        <TabList>
-          <Tab>{t('accordions.generation.modelTab')}</Tab>
-          <Tab badges={loraTabBadges}>{t('accordions.generation.conceptsTab')}</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel overflow="visible" px={4} pt={4}>
-            <Flex gap={4} alignItems="center">
-              <ParamMainModelSelect />
-              <SyncModelsIconButton />
-            </Flex>
-            <Expander isOpen={isOpenExpander} onToggle={onToggleExpander}>
-              <Flex gap={4} flexDir="column" pb={4}>
-                <FormControlGroup formLabelProps={formLabelProps}>
-                  <ParamScheduler />
-                  <ParamSteps />
-                  <ParamCFGScale />
-                </FormControlGroup>
-              </Flex>
-            </Expander>
-          </TabPanel>
-          <TabPanel>
-            <Flex gap={4} p={4} flexDir="column">
-              <LoRASelect />
-              <LoRAList />
-            </Flex>
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+      <Box px={4} pt={4}>
+        <Flex gap={4} flexDir="column">
+          <Flex gap={4} alignItems="center">
+            <ParamMainModelSelect />
+            <SyncModelsIconButton />
+          </Flex>
+          <Flex gap={4} flexDir="column">
+            <LoRASelect />
+            <LoRAList />
+          </Flex>
+        </Flex>
+        <Expander isOpen={isOpenExpander} onToggle={onToggleExpander}>
+          <Flex gap={4} flexDir="column" pb={4}>
+            <FormControlGroup formLabelProps={formLabelProps}>
+              <ParamScheduler />
+              <ParamSteps />
+              <ParamCFGScale />
+            </FormControlGroup>
+          </Flex>
+        </Expander>
+      </Box>
     </StandaloneAccordion>
   );
 });

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/GenerationSettingsAccordion.tsx
@@ -10,6 +10,7 @@ import { SyncModelsIconButton } from 'features/modelManagerV2/components/SyncMod
 import ParamCFGScale from 'features/parameters/components/Core/ParamCFGScale';
 import ParamScheduler from 'features/parameters/components/Core/ParamScheduler';
 import ParamSteps from 'features/parameters/components/Core/ParamSteps';
+import { NavigateToModelManagerButton } from 'features/parameters/components/MainModel/NavigateToModelManagerButton';
 import ParamMainModelSelect from 'features/parameters/components/MainModel/ParamMainModelSelect';
 import { useExpanderToggle } from 'features/settingsAccordions/hooks/useExpanderToggle';
 import { useStandaloneAccordionToggle } from 'features/settingsAccordions/hooks/useStandaloneAccordionToggle';
@@ -56,7 +57,10 @@ export const GenerationSettingsAccordion = memo(() => {
         <Flex gap={4} flexDir="column">
           <Flex gap={4} alignItems="center">
             <ParamMainModelSelect />
-            <SyncModelsIconButton />
+            <Flex>
+              <SyncModelsIconButton />
+              <NavigateToModelManagerButton />
+            </Flex>
           </Flex>
           <Flex gap={4} flexDir="column">
             <LoRASelect />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
UI changes to consolidate the tabs in generation table - now main model and "concepts"/LoRAs appear alongside each other.
![Screenshot 2024-03-01 at 10 39 12 AM](https://github.com/invoke-ai/InvokeAI/assets/6750888/8eebc10f-755b-46af-a3b0-1059754d904f)
