### PR TITLE
updates for `defaultModel`

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
+++ b/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
@@ -210,26 +210,6 @@ export const generationSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(configChanged, (state, action) => {
-      const defaultModel = action.payload.sd?.defaultModel;
-
-      if (defaultModel && !state.model) {
-        const [base_model, model_type, model_name] = defaultModel.split('/');
-
-        const result = zParameterModel.safeParse({
-          model_name,
-          base_model,
-          model_type,
-        });
-
-        if (result.success) {
-          state.model = result.data;
-
-          const optimalDimension = getOptimalDimension(result.data);
-
-          state.width = optimalDimension;
-          state.height = optimalDimension;
-        }
-      }
       if (action.payload.sd?.scheduler) {
         state.scheduler = action.payload.sd.scheduler;
       }

--- a/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
+++ b/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
@@ -16,7 +16,6 @@ import type {
   ParameterScheduler,
   ParameterVAEModel,
 } from 'features/parameters/types/parameterSchemas';
-import { zParameterModel } from 'features/parameters/types/parameterSchemas';
 import { getIsSizeOptimal, getOptimalDimension } from 'features/parameters/util/optimalDimension';
 import { configChanged } from 'features/system/store/configSlice';
 import { clamp } from 'lodash-es';


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
* move `defaultModel` logic to modelsLoaded - if user does not have a model in their state already (typically after a web UI refresh or first load), it will use the passed in `defaultModel` key if it is in their list of main models. it will also fire the optimal width/height logic for that model type.
* update to work for key instead of name/base/type string
