### PR TITLE
fix(nodes): load config before doing anything else

### DIFF
--- a/invokeai/app/api_app.py
+++ b/invokeai/app/api_app.py
@@ -2,12 +2,9 @@
 # which are imported/used before parse_args() is called will get the default config values instead of the
 # values from the command line or config file.
 import sys
-from contextlib import asynccontextmanager
 
-from invokeai.app.api.no_cache_staticfiles import NoCacheStaticFiles
 from invokeai.version.invokeai_version import __version__
 
-from .invocations.fields import InputFieldJSONSchemaExtra, OutputFieldJSONSchemaExtra
 from .services.config import InvokeAIAppConfig
 
 app_config = InvokeAIAppConfig.get_config()
@@ -20,6 +17,7 @@ if True:  # hack to make flake8 happy with imports coming after setting up the c
     import asyncio
     import mimetypes
     import socket
+    from contextlib import asynccontextmanager
     from inspect import signature
     from pathlib import Path
     from typing import Any
@@ -40,6 +38,7 @@ if True:  # hack to make flake8 happy with imports coming after setting up the c
     # noinspection PyUnresolvedReferences
     import invokeai.backend.util.hotfixes  # noqa: F401 (monkeypatching on import)
     import invokeai.frontend.web as web_dir
+    from invokeai.app.api.no_cache_staticfiles import NoCacheStaticFiles
 
     from ..backend.util.logging import InvokeAILogger
     from .api.dependencies import ApiDependencies
@@ -59,6 +58,7 @@ if True:  # hack to make flake8 happy with imports coming after setting up the c
         BaseInvocation,
         UIConfigBase,
     )
+    from .invocations.fields import InputFieldJSONSchemaExtra, OutputFieldJSONSchemaExtra
 
     if is_mps_available():
         import invokeai.backend.util.mps_fixes  # noqa: F401 (monkeypatching on import)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

This was preventing custom nodes from loading if a custom nodes dir was specified

Closes #5862

## QA Instructions, Screenshots, Recordings

- Set a custom nodes dir in `invokeai.yaml` & put some nodes in it
- The custom nodes should load on startup

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->