### PR TITLE
feat(scripts): typegen improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ help:
 	@echo "ruff-unsafe       Run ruff, fixing all fixable errors and formatting"
 	@echo "mypy              Run mypy using the config in pyproject.toml to identify type mismatches and other coding errors"
 	@echo "mypy-all          Run mypy ignoring the config in pyproject.tom but still ignoring missing imports"
-	@echo "test"             Run the unit tests.
-	@echo "frontend-install" Install the pnpm modules needed for the front end
+	@echo "test              Run the unit tests."
+	@echo "frontend-install  Install the pnpm modules needed for the front end"
 	@echo "frontend-build    Build the frontend in order to run on localhost:9090"
 	@echo "frontend-dev      Run the frontend in developer mode on localhost:5173"
+	@echo "frontend-typegen  Generate types for the frontend from the OpenAPI schema"
 	@echo "installer-zip     Build the installer .zip file for the current version"
 	@echo "tag-release       Tag the GitHub repository with the current version (use at release time only!)"
 
@@ -52,6 +53,9 @@ frontend-build:
 # Run the frontend in dev mode
 frontend-dev:
 	cd invokeai/frontend/web && pnpm dev
+
+frontend-typegen:
+	cd invokeai/frontend/web && python ../../../scripts/generate_openapi_schema.py | pnpm typegen
 
 # Installer zip file
 installer-zip:

--- a/invokeai/frontend/web/scripts/typegen.js
+++ b/invokeai/frontend/web/scripts/typegen.js
@@ -5,18 +5,55 @@ import openapiTS from 'openapi-typescript';
 const OPENAPI_URL = 'http://127.0.0.1:9090/openapi.json';
 const OUTPUT_FILE = 'src/services/api/schema.ts';
 
-async function main() {
-  process.stdout.write(`Generating types "${OPENAPI_URL}" --> "${OUTPUT_FILE}"...`);
-  const types = await openapiTS(OPENAPI_URL, {
+async function generateTypes(schema) {
+  process.stdout.write(`Generating types ${OUTPUT_FILE}...`);
+  const types = await openapiTS(schema, {
     exportType: true,
     transform: (schemaObject) => {
       if ('format' in schemaObject && schemaObject.format === 'binary') {
         return schemaObject.nullable ? 'Blob | null' : 'Blob';
       }
+      if (schemaObject.title === 'MetadataField') {
+        // This is `Record<string, never>` by default, but it actually accepts any a dict of any valid JSON value.
+        return 'Record<string, unknown>';
+      }
     },
   });
   fs.writeFileSync(OUTPUT_FILE, types);
   process.stdout.write(`\nOK!\r\n`);
+}
+
+async function main() {
+  const encoding = 'utf-8';
+
+  if (process.stdin.isTTY) {
+    // Handle generating types with an arg (e.g. URL or path to file)
+    if (process.argv.length > 3) {
+      console.error('Usage: typegen.js <openapi.json>');
+      process.exit(1);
+    }
+    if (process.argv[2]) {
+      const schema = new Buffer.from(process.argv[2], encoding);
+      generateTypes(schema);
+    } else {
+      generateTypes(OPENAPI_URL);
+    }
+  } else {
+    // Handle generating types from stdin
+    let schema = '';
+    process.stdin.setEncoding(encoding);
+
+    process.stdin.on('readable', function () {
+      const chunk = process.stdin.read();
+      if (chunk !== null) {
+        schema += chunk;
+      }
+    });
+
+    process.stdin.on('end', function () {
+      generateTypes(JSON.parse(schema));
+    });
+  }
 }
 
 main();

--- a/scripts/generate_openapi_schema.py
+++ b/scripts/generate_openapi_schema.py
@@ -1,0 +1,17 @@
+import json
+import os
+import sys
+
+
+def main():
+    # Change working directory to the repo root
+    os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+    from invokeai.app.api_app import custom_openapi
+
+    schema = custom_openapi()
+    json.dump(schema, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

- Add python script that generates the openapi schema without needing to start up the application
- Update `typegen.js` to support piping in a schema from stdout or an arg with a URL or path to `openapi.json`
- Add `frontend-typegen` to `Makefile`

## QA Instructions, Screenshots, Recordings

You should be able to run `make frontend-typegen` from repo root, without the app running, and generate the frontend types.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
