### PR TITLE
migrate models on service start

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -186,7 +186,6 @@ class ModelInstallService(ModelInstallServiceBase):
         access_token: Optional[str] = None,
         inplace: Optional[bool] = False,
     ) -> ModelInstallJob:
-        print(f"starting import for model {source}")
         variants = "|".join(ModelRepoVariant.__members__.values())
         hf_repoid_re = f"^([^/:]+/[^/:]+)(?::({variants})?(?::/?([^:]+))?)?$"
         source_obj: Optional[StringLikeSource] = None

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -304,9 +304,13 @@ class ModelInstallService(ModelInstallServiceBase):
 
             for model_key, stanza in yaml.items():
                 if model_key == "__metadata__":
-                    assert (
-                        stanza["version"] == "3.0.0"
-                    ), f"This script works on version 3.0.0 yaml files, but your configuration points to a {stanza['version']} version"
+                    try:
+                        assert (
+                            stanza["version"] == "3.0.0"
+                        ), f"This script works on version 3.0.0 yaml files, but your configuration points to a {stanza['version']} version"
+                    except AssertionError:
+                        self._logger.warn(f"Skipping entry with path {stanza.get('path', '')} with outdated metadata version")
+                        continue
                     continue
 
                 _, _, model_name = str(model_key).split("/")

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -309,7 +309,9 @@ class ModelInstallService(ModelInstallServiceBase):
                             stanza["version"] == "3.0.0"
                         ), f"This script works on version 3.0.0 yaml files, but your configuration points to a {stanza['version']} version"
                     except AssertionError:
-                        self._logger.warn(f"Skipping entry with path {stanza.get('path', '')} with outdated metadata version")
+                        self._logger.warn(
+                            f"Skipping entry with path {stanza.get('path', '')} with outdated metadata version"
+                        )
                         continue
                     continue
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
On model manager startup, this will check if a user has 0 rows in their model table _and_ 1+ entries in their models yaml file. If so, we will attempt to add each of their yaml entries to the models DB. This is designed to run one time, when a user first starts their app after updating to 4.0.