### PR TITLE
fix: make Canvas compatible with inpainting models again

### DIFF
--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -684,7 +684,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
         if self.denoise_mask.masked_latents_name is not None:
             masked_latents = context.tensors.load(self.denoise_mask.masked_latents_name)
         else:
-            masked_latents = None
+            masked_latents = torch.where(mask < 0.5, 0.0, latents)
 
         return 1 - mask, masked_latents, self.denoise_mask.gradient
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [x] Yes
- [ ] No


## Description
Inpainting models have 9 input channels instead of 4  
[(4-channel latent), (1-channel mask), (4-channel masked_latents)]  
When using Gradient Mask, creating masked_latents is skipped, which breaks inpainting models.

Our existing Create Denoise Mask node zeros out the masked parts of the input image and then encodes the result to latent form using VAE.  
This implementation takes the already-encoded latent image and zeros out the masked parts.  
These two operations are not quite the same. However, I could not find any good description of which method is correct, and this is the way that the diffusers library code handles it for inpaint pipelines. As some consequence of the training, doing nothing to the original image latents does not allow the model to function.

We should consider if it is better to skip around the VAE encode and do this for all masked_latents situations (faster), or if that would introduce worse performance for inpaint models. For now this PR seems to work and allows the canvas graphs to execute.

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

## Added/updated tests?

- [ ] Yes
- [x] No : Should we add tests for inpainting-variant models? Currently I don't think we check them.

## [optional] Are there any post deployment tasks we need to perform?
