### PR TITLE
fix(app): include `config_path` in yaml -> DB migration

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -321,7 +321,8 @@ class ModelInstallService(ModelInstallServiceBase):
                     model_path = self._app_config.models_path / model_path
                 model_path = model_path.resolve()
                 description = stanza.get("description", "")
-                model_info = {"name": model_name, "description": description}
+                config_path =stanza.get("config_path", "")
+                model_info = {"name": model_name, "description": description, "config_path": config_path}
 
                 try:
                     id = self.register_path(model_path=model_path, config=model_info)
@@ -587,9 +588,8 @@ class ModelInstallService(ModelInstallServiceBase):
 
         # add 'main' specific fields
         if isinstance(info, CheckpointConfigBase):
-            # make config relative to our root
             legacy_conf = (self.app_config.root_dir / self.app_config.legacy_conf_dir / info.config_path).resolve()
-            info.config_path = legacy_conf.relative_to(self.app_config.root_dir).as_posix()
+            info.config_path = legacy_conf.as_posix()
         self.record_store.add_model(info)
         return info.key
 

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -321,7 +321,7 @@ class ModelInstallService(ModelInstallServiceBase):
                     model_path = self._app_config.models_path / model_path
                 model_path = model_path.resolve()
                 description = stanza.get("description", "")
-                config_path =stanza.get("config", "")
+                config_path = stanza.get("config", "")
                 model_info = {"name": model_name, "description": description, "config_path": config_path}
 
                 try:

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -321,7 +321,7 @@ class ModelInstallService(ModelInstallServiceBase):
                     model_path = self._app_config.models_path / model_path
                 model_path = model_path.resolve()
                 description = stanza.get("description", "")
-                config_path =stanza.get("config_path", "")
+                config_path =stanza.get("config", "")
                 model_info = {"name": model_name, "description": description, "config_path": config_path}
 
                 try:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
If yaml entry has a `config`, make sure that is migrated into DB as absolute `config_path` path