### PR TITLE
fix(mm): only move model files if necessary

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -513,10 +513,17 @@ class ModelInstallService(ModelInstallServiceBase):
         old_path = Path(model.path)
         models_dir = self.app_config.models_path
 
-        if not old_path.is_relative_to(models_dir):
+        try:
+            old_path.relative_to(models_dir)
             return model
+        except ValueError:
+            pass
 
         new_path = models_dir / model.base.value / model.type.value / model.name
+
+        if old_path == new_path:
+            return model
+
         self._logger.info(f"Moving {model.name} to {new_path}.")
         new_path = self._move_model(old_path, new_path)
         model.path = new_path.as_posix()


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Description

The old logic to check if a model needed to be moved relied on the model path being a relative path. Paths are now absolute, causing this check to fail. We then assumed the paths were different and moved the model from its current location to, well, its current location.

Use more resilient method to check if a model should be moved.

## QA Instructions, Screenshots, Recordings

- Start the app on `main` with memory db, note that it moves all your models on startup
- Try this PR - no extra moves.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->