### PR TITLE
fix(mm): do not erroneously rename files

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -329,7 +329,7 @@ class ModelInstallService(ModelInstallServiceBase):
 
         # Rename `models.yaml` to `models.yaml.bak` to prevent re-migration
         yaml_path = self._app_config.model_conf_path
-        yaml_path.rename(yaml_path.with_suffix(".bak"))
+        yaml_path.rename(yaml_path.with_suffix(".yaml.bak"))
 
     def scan_directory(self, scan_dir: Path, install: bool = False) -> List[str]:  # noqa D102
         self._cached_model_paths = {Path(x.path).absolute() for x in self.record_store.all_models()}

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -520,7 +520,7 @@ class ModelInstallService(ModelInstallServiceBase):
         except ValueError:
             pass
 
-        new_path = models_dir / model.base.value / model.type.value / model.name
+        new_path = models_dir / model.base.value / model.type.value / old_path.name
 
         if old_path == new_path:
             return model


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

Two fixes:

1. [fix(mm): fix models.yaml backup filename](https://github.com/invoke-ai/InvokeAI/commit/52872d383940903625906dacae3850ad91d85a9d)

Was erroneously `models.bak`, now `models.yaml.bak`

2. [fix(mm): models lose file extension when syncing](https://github.com/invoke-ai/InvokeAI/commit/1cfe56aac91f9c96ae84496a28af5e0132993c90)

We were stripping the file extension from file models when  moving them in `_sync_model_path`. For example, `some_model.safetensors` would be moved to `some_model`, which of course breaks things.

Instead of using the model's name as the new path, use the model's path's last segment. This is the same behaviour for directories, but for files, it retains the file extension.

## QA Instructions, Screenshots, Recordings

The issue was kinda side-stepped in 67163c2224007ceac38d804ebd708bf89da5cb62, but the root issue still existed.

To test this, _back up your models directory_, then check out f01e81d3824652907e425b10e2b2e8d684b9ed2d (the commit immediately before 67163c2224007ceac38d804ebd708bf89da5cb62).

Start up the app, and we expect to see a message that models are being moved. We expect to see all your non-diffusers models be renamed to have no file extension.

Then, restore your backed up models directory, check out this PR's branch and start the app. You should have no models moved or renamed.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->