### PR TITLE
Do not override log_memory_usage when debug logs are enabled

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
@@ -19,7 +19,6 @@ context. Use like this:
 """
 
 import gc
-import logging
 import math
 import sys
 import time
@@ -92,8 +91,7 @@ class ModelCache(ModelCacheBase[AnyModel]):
         self._execution_device: torch.device = execution_device
         self._storage_device: torch.device = storage_device
         self._logger = logger or InvokeAILogger.get_logger(self.__class__.__name__)
-        self._log_memory_usage = log_memory_usage or self._logger.level == logging.DEBUG
-        # used for stats collection
+        self._log_memory_usage = log_memory_usage
         self._stats: Optional[CacheStats] = None
 
         self._cached_models: Dict[str, CacheRecord[AnyModel]] = {}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission

## Description

A recent change was made to force `log_memory_usage=True` when debug logs are enabled (commit: https://github.com/invoke-ai/InvokeAI/commit/67eb71509370214a04d7f5512eb3663dc3df5a9d). This PR reverts that change.

The speed cost of log_memory_usage=True is large (as documented here: https://github.com/invoke-ai/InvokeAI/pull/5028). It is common to want debug logs without enabling `log_memory_usage`.