### PR TITLE
Allow lists of basemodel objects in omegaconf

### DIFF
--- a/invokeai/app/services/config/config_base.py
+++ b/invokeai/app/services/config/config_base.py
@@ -15,10 +15,10 @@ import os
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
-from pydantic import BaseModel
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Union, get_args, get_origin, get_type_hints
 
-from omegaconf import DictConfig, ListConfig, OmegaConf, DictKeyType
+from omegaconf import DictConfig, DictKeyType, ListConfig, OmegaConf
+from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from invokeai.app.services.config.config_common import PagingArgumentParser, int_or_float_or_str

--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -17,7 +17,7 @@ import warnings
 from argparse import Namespace
 from enum import Enum
 from pathlib import Path
-from shutil import get_terminal_size, copy, move, rmtree
+from shutil import copy, get_terminal_size, move
 from typing import Any, Optional, Set, Tuple, Type, get_args, get_type_hints
 from urllib import request
 

--- a/invokeai/backend/install/invokeai_configure.py
+++ b/invokeai/backend/install/invokeai_configure.py
@@ -932,7 +932,7 @@ def main() -> None:
     new_init_file = config.root_path / "invokeai.yaml"
     backup_init_file = new_init_file.with_suffix(".bak")
     if new_init_file.exists():
-        copy(new_init_file, new_init_file.with_suffix(".bak"))
+        copy(new_init_file, backup_init_file)
 
     try:
         # if we do a root migration/upgrade, then we are keeping previous


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
Prior to this PR, invokeai-configure crashes when it attempts to process the remote_api_tokens config due to it not containing primitive objects. This detects Basemodels as well as lists of BaseModels and converts them to dicts that omegaconf can handle.

## QA Instructions, Screenshots, Recordings

- Create an invokeai.yaml file with a list of remote_api_tokens similar to those below
``` yaml
  Model Install:
    remote_api_tokens:
    - url_regex: .*
      token: test1
    - url_regex: .*
      token: test2
    - url_regex: .*
      token: test3
    - url_regex: .*
      token: test4
```
- Run invokeai-configure defined on this branch. Validate the script neither crashes nor rewrites your invokeai.yaml file without the configs above.

## Merge Plan

This PR can be merged when approved

