### PR TITLE
Remove ability to pass remote_api_tokens via the CLI directly

### DIFF
--- a/invokeai/app/services/config/config_base.py
+++ b/invokeai/app/services/config/config_base.py
@@ -152,7 +152,7 @@ class InvokeAISettings(BaseSettings):
     @classmethod
     def _excluded(cls) -> List[str]:
         # internal fields that shouldn't be exposed as command line options
-        return ["type", "initconf"]
+        return ["type", "initconf", "remote_api_tokens"]
 
     @classmethod
     def _excluded_from_yaml(cls) -> List[str]:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
There are currently issues parsing remote_api_tokens via cli argparse. If a remote_api_tokens is attempted to be passed via the cli in invokeai-web, the app fails to start. To avoid having this push back the 4.0 release, we'll be excluding it as a cli arg in the short term.

## QA Instructions, Screenshots, Recordings

Attempt to run invokeai-web with this command
`invokeai-web --remote_api_tokens '[{"url_regex":".\*", "token":"t"}]'`
You should receive this message and have the app start normally after.
`Unknown args: ['--remote_api_tokens', '[{"url_regex":".\\*", "token":"t"}]']`

Previously it would crash with
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for InvokeAIAppConfig
remote_api_tokens
  Input should be a valid list [type=list_type, input_value='[{"url_regex":".\\*", "token":"t"}]', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/list_type
```

## Merge Plan

This PR can be merged when approved

