### PR TITLE
ci: add `always_run` input to checks & tests, use this on release workflow

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -1,7 +1,7 @@
 # Runs frontend code quality checks.
 #
 # Checks for changes to frontend files before running the checks.
-# When manually triggered or when called from another workflow, always runs the checks.
+# If always_run is true, always runs the checks.
 
 name: 'frontend checks'
 
@@ -16,7 +16,19 @@ on:
       - 'synchronize'
   merge_group:
   workflow_dispatch:
+    inputs:
+      always_run:
+        description: 'Always run the checks'
+        required: true
+        type: boolean
+        default: true
   workflow_call:
+    inputs:
+      always_run:
+        description: 'Always run the checks'
+        required: true
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -30,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: check for changed frontend files
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call' }}
+        if: ${{ inputs.always_run != true }}
         id: changed-files
         uses: tj-actions/changed-files@v42
         with:
@@ -39,30 +51,30 @@ jobs:
               - 'invokeai/frontend/web/**'
 
       - name: install dependencies
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         uses: ./.github/actions/install-frontend-deps
 
       - name: tsc
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         run: 'pnpm lint:tsc'
         shell: bash
 
       - name: dpdm
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         run: 'pnpm lint:dpdm'
         shell: bash
 
       - name: eslint
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         run: 'pnpm lint:eslint'
         shell: bash
 
       - name: prettier
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         run: 'pnpm lint:prettier'
         shell: bash
 
       - name: knip
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         run: 'pnpm lint:knip'
         shell: bash

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,7 +1,7 @@
 # Runs frontend tests.
 #
 # Checks for changes to frontend files before running the tests.
-# When manually triggered or called from another workflow, always runs the tests.
+# If always_run is true, always runs the tests.
 
 name: 'frontend tests'
 
@@ -16,7 +16,19 @@ on:
       - 'synchronize'
   merge_group:
   workflow_dispatch:
+    inputs:
+      always_run:
+        description: 'Always run the tests'
+        required: true
+        type: boolean
+        default: true
   workflow_call:
+    inputs:
+      always_run:
+        description: 'Always run the tests'
+        required: true
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -30,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: check for changed frontend files
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call' }}
+        if: ${{ inputs.always_run != true }}
         id: changed-files
         uses: tj-actions/changed-files@v42
         with:
@@ -39,10 +51,10 @@ jobs:
               - 'invokeai/frontend/web/**'
 
       - name: install dependencies
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         uses: ./.github/actions/install-frontend-deps
 
       - name: vitest
-        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.frontend_any_changed == 'true' || inputs.always_run == true }}
         run: 'pnpm test:no-watch'
         shell: bash

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -1,7 +1,7 @@
 # Runs python code quality checks.
 #
 # Checks for changes to python files before running the checks.
-# When manually triggered or called from another workflow, always runs the tests.
+# If always_run is true, always runs the checks.
 #
 # TODO: Add mypy or pyright to the checks.
 
@@ -18,7 +18,19 @@ on:
       - 'synchronize'
   merge_group:
   workflow_dispatch:
+    inputs:
+      always_run:
+        description: 'Always run the checks'
+        required: true
+        type: boolean
+        default: true
   workflow_call:
+    inputs:
+      always_run:
+        description: 'Always run the checks'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   python-checks:
@@ -29,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: check for changed python files
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call' }}
+        if: ${{ inputs.always_run != true }}
         id: changed-files
         uses: tj-actions/changed-files@v42
         with:
@@ -41,7 +53,7 @@ jobs:
               - 'tests/**'
 
       - name: setup python
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -49,16 +61,16 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: install ruff
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         run: pip install ruff
         shell: bash
 
       - name: ruff check
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         run: ruff check --output-format=github .
         shell: bash
 
       - name: ruff format
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         run: ruff format --check .
         shell: bash

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,7 @@
 # Runs python tests on a matrix of python versions and platforms.
 #
 # Checks for changes to python files before running the tests.
-# When manually triggered or called from another workflow, always runs the tests.
+# If always_run is true, always runs the tests.
 
 name: 'python tests'
 
@@ -16,7 +16,19 @@ on:
       - 'synchronize'
   merge_group:
   workflow_dispatch:
+    inputs:
+      always_run:
+        description: 'Always run the tests'
+        required: true
+        type: boolean
+        default: true
   workflow_call:
+    inputs:
+      always_run:
+        description: 'Always run the tests'
+        required: true
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -63,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: check for changed python files
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call' }}
+        if: ${{ inputs.always_run != true }}
         id: changed-files
         uses: tj-actions/changed-files@v42
         with:
@@ -75,7 +87,7 @@ jobs:
               - 'tests/**'
 
       - name: setup python
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -83,12 +95,12 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: install dependencies
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         env:
           PIP_EXTRA_INDEX_URL: ${{ matrix.extra-index-url }}
         run: >
           pip3 install --editable=".[test]"
 
       - name: run pytest
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         run: pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,23 @@ jobs:
 
   frontend-checks:
     uses: ./.github/workflows/frontend-checks.yml
+    with:
+      always_run: true
 
   frontend-tests:
     uses: ./.github/workflows/frontend-tests.yml
+    with:
+      always_run: true
 
   python-checks:
     uses: ./.github/workflows/python-checks.yml
+    with:
+      always_run: true
 
   python-tests:
     uses: ./.github/workflows/python-tests.yml
+    with:
+      always_run: true
 
   build:
     uses: ./.github/workflows/build-installer.yml


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] CI/CD

## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

## Description

ci: add `always_run` input to checks & tests, use this on release workflow

This bypasses the `changed-files` check, and forces the checks to run. The release workflow sets this flag to ensure that the checks and tests are always run for a release.