### PR TITLE
fix(ui): disable trigger phrase form if empty

### DIFF
--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/TriggerPhrases.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/TriggerPhrases.tsx
@@ -90,7 +90,7 @@ export const TriggerPhrases = () => {
                 size="sm"
                 type="submit"
                 onClick={addTriggerPhrase}
-                isDisabled={Boolean(errors.length)}
+                isDisabled={!phrase || Boolean(errors.length)}
                 isLoading={isLoading}
               >
                 {t('common.add')}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
Disables submission of the trigger phrase form if it is empty

## Related Tickets & Documents
 closes https://github.com/invoke-ai/InvokeAI/issues/5941
