### PR TITLE
fix(ui): force CustomSelect's to rerender when models load to update invalid state 

### DIFF
--- a/invokeai/frontend/web/src/features/controlAdapters/components/parameters/ParamControlAdapterModel.tsx
+++ b/invokeai/frontend/web/src/features/controlAdapters/components/parameters/ParamControlAdapterModel.tsx
@@ -52,7 +52,13 @@ const ParamControlAdapterModel = ({ id }: ParamControlAdapterModelProps) => {
 
   return (
     <FormControl isDisabled={!items.length || !isEnabled} isInvalid={!selectedItem || !items.length}>
-      <CustomSelect selectedItem={selectedItem} placeholder={placeholder} items={items} onChange={onChange} />
+      <CustomSelect
+        key={items.length}
+        selectedItem={selectedItem}
+        placeholder={placeholder}
+        items={items}
+        onChange={onChange}
+      />
     </FormControl>
   );
 };

--- a/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
@@ -18,7 +18,6 @@ const ParamMainModelSelect = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const selectedModel = useAppSelector(selectModel);
-  console.log({ selectedModel });
   const { data, isLoading } = useGetMainModelsQuery(NON_REFINER_BASE_MODELS);
 
   const _onChange = useCallback(

--- a/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
@@ -18,6 +18,7 @@ const ParamMainModelSelect = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const selectedModel = useAppSelector(selectModel);
+  console.log({ selectedModel });
   const { data, isLoading } = useGetMainModelsQuery(NON_REFINER_BASE_MODELS);
 
   const _onChange = useCallback(
@@ -46,7 +47,13 @@ const ParamMainModelSelect = () => {
       <InformationalPopover feature="paramModel">
         <FormLabel>{t('modelManager.model')}</FormLabel>
       </InformationalPopover>
-      <CustomSelect selectedItem={selectedItem} placeholder={placeholder} items={items} onChange={onChange} />
+      <CustomSelect
+        key={items.length}
+        selectedItem={selectedItem}
+        placeholder={placeholder}
+        items={items}
+        onChange={onChange}
+      />
     </FormControl>
   );
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
* In some environments, the initial invalid state of an empty CustomSelect seems to get memoized and not updated when the items/selectedItem load. There is probably a better fix to be done in the CustomSelect component itself but this worked for now.