### PR TITLE
(ui): fetch TIs on socket connect

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -4,6 +4,7 @@ import { $baseUrl } from 'app/store/nanostores/baseUrl';
 import { isEqual } from 'lodash-es';
 import { atom } from 'nanostores';
 import { api } from 'services/api';
+import { modelsApi } from 'services/api/endpoints/models';
 import { queueApi, selectQueueStatus } from 'services/api/endpoints/queue';
 import { socketConnected } from 'services/events/actions';
 
@@ -16,6 +17,9 @@ export const addSocketConnectedEventListener = (startAppListening: AppStartListe
     actionCreator: socketConnected,
     effect: async (action, { dispatch, getState, cancelActiveListeners, delay }) => {
       log.debug('Connected');
+
+      // query TIs so they are ready if user opens trigger phrases
+      dispatch(modelsApi.endpoints.getTextualInversionModels.initiate());
 
       /**
        * The rest of this listener has recovery logic for when the socket disconnects and reconnects.

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketConnected.ts
@@ -18,9 +18,6 @@ export const addSocketConnectedEventListener = (startAppListening: AppStartListe
     effect: async (action, { dispatch, getState, cancelActiveListeners, delay }) => {
       log.debug('Connected');
 
-      // query TIs so they are ready if user opens trigger phrases
-      dispatch(modelsApi.endpoints.getTextualInversionModels.initiate());
-
       /**
        * The rest of this listener has recovery logic for when the socket disconnects and reconnects.
        *
@@ -33,6 +30,12 @@ export const addSocketConnectedEventListener = (startAppListening: AppStartListe
 
       // Bail on the recovery logic if this is the first connection - we don't need to recover anything
       if ($isFirstConnection.get()) {
+        // The TI models are used in a component that is not always rendered, so when users open the prompt triggers
+        // box has a delay while it does the initial fetch. We need to both pre-fetch the data and maintain an RTK
+        // Query subscription to it, so the cache doesn't clear itself when the user closes the prompt triggers box.
+        // So, we explicitly do not unsubscribe from this query!
+        dispatch(modelsApi.endpoints.getTextualInversionModels.initiate());
+
         $isFirstConnection.set(false);
         return;
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [ ] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
Initiate TI query when socket connects so that user does not have to wait for results when they engage with prompt trigger phrase popover