### PR TITLE
Regional IP-Adapter (Backend Only)

### DIFF
--- a/invokeai/app/invocations/ip_adapter.py
+++ b/invokeai/app/invocations/ip_adapter.py
@@ -23,7 +23,7 @@ class IPAdapterField(BaseModel):
     image: Union[ImageField, List[ImageField]] = Field(description="The IP-Adapter image prompt(s).")
     ip_adapter_model: ModelIdentifierField = Field(description="The IP-Adapter model to use.")
     image_encoder_model: ModelIdentifierField = Field(description="The name of the CLIP image encoder model.")
-    weight: Union[float, List[float]] = Field(default=1, description="The weight given to the ControlNet")
+    weight: Union[float, List[float]] = Field(default=1, description="The weight given to the IP-Adapter.")
     begin_step_percent: float = Field(
         default=0, ge=0, le=1, description="When the IP-Adapter is first applied (% of total steps)"
     )

--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -56,6 +56,7 @@ from invokeai.backend.stable_diffusion import PipelineIntermediateState, set_sea
 from invokeai.backend.stable_diffusion.diffusion.conditioning_data import (
     BasicConditioningInfo,
     IPAdapterConditioningInfo,
+    IPAdapterData,
     Range,
     SDXLConditioningInfo,
     TextConditioningData,
@@ -66,7 +67,6 @@ from invokeai.backend.util.silence_warnings import SilenceWarnings
 
 from ...backend.stable_diffusion.diffusers_pipeline import (
     ControlNetData,
-    IPAdapterData,
     StableDiffusionGeneratorPipeline,
     T2IAdapterData,
     image_resized_to_grid_as_tensor,

--- a/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
@@ -1,7 +1,10 @@
+import math
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
 import torch
+
+from invokeai.backend.ip_adapter.ip_adapter import IPAdapter
 
 
 @dataclass
@@ -43,6 +46,27 @@ class IPAdapterConditioningInfo:
     """IP-Adapter image encoding embeddings to use for unconditional generation.
     Shape: (num_images, num_tokens, encoding_dim).
     """
+
+
+@dataclass
+class IPAdapterData:
+    ip_adapter_model: IPAdapter
+    ip_adapter_conditioning: IPAdapterConditioningInfo
+
+    # Either a single weight applied to all steps, or a list of weights for each step.
+    weight: Union[float, List[float]] = 1.0
+    begin_step_percent: float = 0.0
+    end_step_percent: float = 1.0
+
+    def scale_for_step(self, step_index: int, total_steps: int) -> float:
+        first_adapter_step = math.floor(self.begin_step_percent * total_steps)
+        last_adapter_step = math.ceil(self.end_step_percent * total_steps)
+        weight = self.weight[step_index] if isinstance(self.weight, List) else self.weight
+        if step_index >= first_adapter_step and step_index <= last_adapter_step:
+            # Only apply this IP-Adapter if the current step is within the IP-Adapter's begin/end step range.
+            return weight
+        # Otherwise, set the IP-Adapter's scale to 0, so it has no effect.
+        return 0.0
 
 
 @dataclass

--- a/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
@@ -52,6 +52,7 @@ class IPAdapterConditioningInfo:
 class IPAdapterData:
     ip_adapter_model: IPAdapter
     ip_adapter_conditioning: IPAdapterConditioningInfo
+    mask: torch.Tensor
 
     # Either a single weight applied to all steps, or a list of weights for each step.
     weight: Union[float, List[float]] = 1.0

--- a/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
+++ b/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
@@ -129,7 +129,7 @@ class CustomAttnProcessor2_0(AttnProcessor2_0):
         # End unmodified block from AttnProcessor2_0.
 
         # Apply IP-Adapter conditioning.
-        if is_cross_attention and self._is_ip_adapter_enabled():
+        if is_cross_attention:
             if self._is_ip_adapter_enabled():
                 assert regional_ip_data is not None
                 ip_masks = regional_ip_data.get_masks(query_seq_len=query_seq_len)

--- a/invokeai/backend/stable_diffusion/diffusion/regional_ip_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/regional_ip_data.py
@@ -1,0 +1,20 @@
+import torch
+
+
+class RegionalIPData:
+    """A class to manage the data for regional IP-Adapter conditioning."""
+
+    def __init__(
+        self,
+        image_prompt_embeds: list[torch.Tensor],
+        scales: list[float],
+    ):
+        """Initialize a `IPAdapterConditioningData` object."""
+        # The image prompt embeddings.
+        # regional_ip_data[i] contains the image prompt embeddings for the i'th IP-Adapter. Each tensor
+        # has shape (batch_size, num_ip_images, seq_len, ip_embedding_len).
+        self.image_prompt_embeds = image_prompt_embeds
+
+        # The scales for the IP-Adapter attention.
+        # scales[i] contains the attention scale for the i'th IP-Adapter.
+        self.scales = scales

--- a/invokeai/backend/stable_diffusion/diffusion/regional_ip_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/regional_ip_data.py
@@ -8,8 +8,14 @@ class RegionalIPData:
         self,
         image_prompt_embeds: list[torch.Tensor],
         scales: list[float],
+        masks: list[torch.Tensor],
+        dtype: torch.dtype,
+        device: torch.device,
+        max_downscale_factor: int = 8,
     ):
         """Initialize a `IPAdapterConditioningData` object."""
+        assert len(image_prompt_embeds) == len(scales) == len(masks)
+
         # The image prompt embeddings.
         # regional_ip_data[i] contains the image prompt embeddings for the i'th IP-Adapter. Each tensor
         # has shape (batch_size, num_ip_images, seq_len, ip_embedding_len).
@@ -18,3 +24,46 @@ class RegionalIPData:
         # The scales for the IP-Adapter attention.
         # scales[i] contains the attention scale for the i'th IP-Adapter.
         self.scales = scales
+
+        # The IP-Adapter masks.
+        # self._masks_by_seq_len[s] contains the spatial masks for the downsampling level with query sequence length of
+        # s. It has shape (batch_size, num_ip_images, query_seq_len, 1). The masks have values of 1.0 for included
+        # regions and 0.0 for excluded regions.
+        self._masks_by_seq_len = self._prepare_masks(masks, max_downscale_factor, device, dtype)
+
+    def _prepare_masks(
+        self, masks: list[torch.Tensor], max_downscale_factor: int, device: torch.device, dtype: torch.dtype
+    ) -> dict[int, torch.Tensor]:
+        """Prepare the masks for the IP-Adapter attention."""
+        # Concatenate the masks so that they can be processed more efficiently.
+        mask_tensor = torch.cat(masks, dim=1)
+
+        mask_tensor = mask_tensor.to(device=device, dtype=dtype)
+
+        masks_by_seq_len: dict[int, torch.Tensor] = {}
+
+        # Downsample the spatial dimensions by factors of 2 until max_downscale_factor is reached.
+        downscale_factor = 1
+        while downscale_factor <= max_downscale_factor:
+            b, num_ip_adapters, h, w = mask_tensor.shape
+            # Assert that the batch size is 1, because I haven't thought through batch handling for this feature yet.
+            assert b == 1
+
+            # The IP-Adapters are applied in the cross-attention layers, where the query sequence length is the h * w of
+            # the spatial features.
+            query_seq_len = h * w
+
+            masks_by_seq_len[query_seq_len] = mask_tensor.view((b, num_ip_adapters, -1, 1))
+
+            downscale_factor *= 2
+            if downscale_factor <= max_downscale_factor:
+                # We use max pooling because we downscale to a pretty low resolution, so we don't want small mask
+                # regions to be lost entirely.
+                # TODO(ryand): In the future, we may want to experiment with other downsampling methods.
+                mask_tensor = torch.nn.functional.max_pool2d(mask_tensor, kernel_size=2, stride=2)
+
+        return masks_by_seq_len
+
+    def get_masks(self, query_seq_len: int) -> torch.Tensor:
+        """Get the mask for the given query sequence length."""
+        return self._masks_by_seq_len[query_seq_len]

--- a/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
+++ b/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
@@ -286,7 +286,10 @@ class InvokeAIDiffuserComponent:
                 for ipa_conditioning in ip_adapter_conditioning
             ]
             scales = [ipa.scale_for_step(step_index, total_step_count) for ipa in ip_adapter_data]
-            regional_ip_data = RegionalIPData(image_prompt_embeds=image_prompt_embeds, scales=scales)
+            ip_masks = [ipa.mask for ipa in ip_adapter_data]
+            regional_ip_data = RegionalIPData(
+                image_prompt_embeds=image_prompt_embeds, scales=scales, masks=ip_masks, dtype=x.dtype, device=x.device
+            )
             cross_attention_kwargs["regional_ip_data"] = regional_ip_data
 
         added_cond_kwargs = None
@@ -404,7 +407,10 @@ class InvokeAIDiffuserComponent:
             ]
 
             scales = [ipa.scale_for_step(step_index, total_step_count) for ipa in ip_adapter_data]
-            regional_ip_data = RegionalIPData(image_prompt_embeds=image_prompt_embeds, scales=scales)
+            ip_masks = [ipa.mask for ipa in ip_adapter_data]
+            regional_ip_data = RegionalIPData(
+                image_prompt_embeds=image_prompt_embeds, scales=scales, masks=ip_masks, dtype=x.dtype, device=x.device
+            )
             cross_attention_kwargs["regional_ip_data"] = regional_ip_data
 
         # Prepare SDXL conditioning kwargs for the unconditioned pass.
@@ -449,7 +455,10 @@ class InvokeAIDiffuserComponent:
             ]
 
             scales = [ipa.scale_for_step(step_index, total_step_count) for ipa in ip_adapter_data]
-            regional_ip_data = RegionalIPData(image_prompt_embeds=image_prompt_embeds, scales=scales)
+            ip_masks = [ipa.mask for ipa in ip_adapter_data]
+            regional_ip_data = RegionalIPData(
+                image_prompt_embeds=image_prompt_embeds, scales=scales, masks=ip_masks, dtype=x.dtype, device=x.device
+            )
             cross_attention_kwargs["regional_ip_data"] = regional_ip_data
 
         # Prepare SDXL conditioning kwargs for the conditioned pass.

--- a/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
+++ b/invokeai/backend/stable_diffusion/diffusion/shared_invokeai_diffusion.py
@@ -8,11 +8,12 @@ from typing_extensions import TypeAlias
 
 from invokeai.app.services.config.config_default import get_config
 from invokeai.backend.stable_diffusion.diffusion.conditioning_data import (
-    IPAdapterConditioningInfo,
+    IPAdapterData,
     Range,
     TextConditioningData,
     TextConditioningRegions,
 )
+from invokeai.backend.stable_diffusion.diffusion.regional_ip_data import RegionalIPData
 from invokeai.backend.stable_diffusion.diffusion.regional_prompt_data import RegionalPromptData
 
 ModelForwardCallback: TypeAlias = Union[
@@ -169,15 +170,13 @@ class InvokeAIDiffuserComponent:
         sample: torch.Tensor,
         timestep: torch.Tensor,
         conditioning_data: TextConditioningData,
-        ip_adapter_conditioning: Optional[list[IPAdapterConditioningInfo]],
+        ip_adapter_data: Optional[list[IPAdapterData]],
         step_index: int,
         total_step_count: int,
         down_block_additional_residuals: Optional[torch.Tensor] = None,  # for ControlNet
         mid_block_additional_residual: Optional[torch.Tensor] = None,  # for ControlNet
         down_intrablock_additional_residuals: Optional[torch.Tensor] = None,  # for T2I-Adapter
     ):
-        percent_through = step_index / total_step_count
-
         if self.sequential_guidance:
             (
                 unconditioned_next_x,
@@ -186,8 +185,9 @@ class InvokeAIDiffuserComponent:
                 x=sample,
                 sigma=timestep,
                 conditioning_data=conditioning_data,
-                ip_adapter_conditioning=ip_adapter_conditioning,
-                percent_through=percent_through,
+                ip_adapter_data=ip_adapter_data,
+                step_index=step_index,
+                total_step_count=total_step_count,
                 down_block_additional_residuals=down_block_additional_residuals,
                 mid_block_additional_residual=mid_block_additional_residual,
                 down_intrablock_additional_residuals=down_intrablock_additional_residuals,
@@ -200,8 +200,9 @@ class InvokeAIDiffuserComponent:
                 x=sample,
                 sigma=timestep,
                 conditioning_data=conditioning_data,
-                ip_adapter_conditioning=ip_adapter_conditioning,
-                percent_through=percent_through,
+                ip_adapter_data=ip_adapter_data,
+                step_index=step_index,
+                total_step_count=total_step_count,
                 down_block_additional_residuals=down_block_additional_residuals,
                 mid_block_additional_residual=mid_block_additional_residual,
                 down_intrablock_additional_residuals=down_intrablock_additional_residuals,
@@ -260,15 +261,16 @@ class InvokeAIDiffuserComponent:
 
     def _apply_standard_conditioning(
         self,
-        x,
-        sigma,
+        x: torch.Tensor,
+        sigma: torch.Tensor,
         conditioning_data: TextConditioningData,
-        ip_adapter_conditioning: Optional[list[IPAdapterConditioningInfo]],
-        percent_through: float,
+        ip_adapter_data: Optional[list[IPAdapterData]],
+        step_index: int,
+        total_step_count: int,
         down_block_additional_residuals: Optional[torch.Tensor] = None,  # for ControlNet
         mid_block_additional_residual: Optional[torch.Tensor] = None,  # for ControlNet
         down_intrablock_additional_residuals: Optional[torch.Tensor] = None,  # for T2I-Adapter
-    ):
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Runs the conditioned and unconditioned UNet forward passes in a single batch for faster inference speed at
         the cost of higher memory usage.
         """
@@ -276,12 +278,16 @@ class InvokeAIDiffuserComponent:
         sigma_twice = torch.cat([sigma] * 2)
 
         cross_attention_kwargs = {}
-        if ip_adapter_conditioning is not None:
+        if ip_adapter_data is not None:
+            ip_adapter_conditioning = [ipa.ip_adapter_conditioning for ipa in ip_adapter_data]
             # Note that we 'stack' to produce tensors of shape (batch_size, num_ip_images, seq_len, token_len).
-            cross_attention_kwargs["ip_adapter_image_prompt_embeds"] = [
+            image_prompt_embeds = [
                 torch.stack([ipa_conditioning.uncond_image_prompt_embeds, ipa_conditioning.cond_image_prompt_embeds])
                 for ipa_conditioning in ip_adapter_conditioning
             ]
+            scales = [ipa.scale_for_step(step_index, total_step_count) for ipa in ip_adapter_data]
+            regional_ip_data = RegionalIPData(image_prompt_embeds=image_prompt_embeds, scales=scales)
+            cross_attention_kwargs["regional_ip_data"] = regional_ip_data
 
         added_cond_kwargs = None
         if conditioning_data.is_sdxl():
@@ -326,7 +332,7 @@ class InvokeAIDiffuserComponent:
             cross_attention_kwargs["regional_prompt_data"] = RegionalPromptData(
                 regions=regions, device=x.device, dtype=x.dtype
             )
-            cross_attention_kwargs["percent_through"] = percent_through
+            cross_attention_kwargs["percent_through"] = step_index / total_step_count
 
         both_conditionings, encoder_attention_mask = self._concat_conditionings_for_batch(
             conditioning_data.uncond_text.embeds, conditioning_data.cond_text.embeds
@@ -350,8 +356,9 @@ class InvokeAIDiffuserComponent:
         x: torch.Tensor,
         sigma,
         conditioning_data: TextConditioningData,
-        ip_adapter_conditioning: Optional[list[IPAdapterConditioningInfo]],
-        percent_through: float,
+        ip_adapter_data: Optional[list[IPAdapterData]],
+        step_index: int,
+        total_step_count: int,
         down_block_additional_residuals: Optional[torch.Tensor] = None,  # for ControlNet
         mid_block_additional_residual: Optional[torch.Tensor] = None,  # for ControlNet
         down_intrablock_additional_residuals: Optional[torch.Tensor] = None,  # for T2I-Adapter
@@ -388,12 +395,17 @@ class InvokeAIDiffuserComponent:
         cross_attention_kwargs = {}
 
         # Prepare IP-Adapter cross-attention kwargs for the unconditioned pass.
-        if ip_adapter_conditioning is not None:
+        if ip_adapter_data is not None:
+            ip_adapter_conditioning = [ipa.ip_adapter_conditioning for ipa in ip_adapter_data]
             # Note that we 'unsqueeze' to produce tensors of shape (batch_size=1, num_ip_images, seq_len, token_len).
-            cross_attention_kwargs["ip_adapter_image_prompt_embeds"] = [
+            image_prompt_embeds = [
                 torch.unsqueeze(ipa_conditioning.uncond_image_prompt_embeds, dim=0)
                 for ipa_conditioning in ip_adapter_conditioning
             ]
+
+            scales = [ipa.scale_for_step(step_index, total_step_count) for ipa in ip_adapter_data]
+            regional_ip_data = RegionalIPData(image_prompt_embeds=image_prompt_embeds, scales=scales)
+            cross_attention_kwargs["regional_ip_data"] = regional_ip_data
 
         # Prepare SDXL conditioning kwargs for the unconditioned pass.
         added_cond_kwargs = None
@@ -408,7 +420,7 @@ class InvokeAIDiffuserComponent:
             cross_attention_kwargs["regional_prompt_data"] = RegionalPromptData(
                 regions=[conditioning_data.uncond_regions], device=x.device, dtype=x.dtype
             )
-            cross_attention_kwargs["percent_through"] = percent_through
+            cross_attention_kwargs["percent_through"] = step_index / total_step_count
 
         # Run unconditioned UNet denoising (i.e. negative prompt).
         unconditioned_next_x = self.model_forward_callback(
@@ -428,13 +440,17 @@ class InvokeAIDiffuserComponent:
 
         cross_attention_kwargs = {}
 
-        # Prepare IP-Adapter cross-attention kwargs for the conditioned pass.
-        if ip_adapter_conditioning is not None:
+        if ip_adapter_data is not None:
+            ip_adapter_conditioning = [ipa.ip_adapter_conditioning for ipa in ip_adapter_data]
             # Note that we 'unsqueeze' to produce tensors of shape (batch_size=1, num_ip_images, seq_len, token_len).
-            cross_attention_kwargs["ip_adapter_image_prompt_embeds"] = [
+            image_prompt_embeds = [
                 torch.unsqueeze(ipa_conditioning.cond_image_prompt_embeds, dim=0)
                 for ipa_conditioning in ip_adapter_conditioning
             ]
+
+            scales = [ipa.scale_for_step(step_index, total_step_count) for ipa in ip_adapter_data]
+            regional_ip_data = RegionalIPData(image_prompt_embeds=image_prompt_embeds, scales=scales)
+            cross_attention_kwargs["regional_ip_data"] = regional_ip_data
 
         # Prepare SDXL conditioning kwargs for the conditioned pass.
         added_cond_kwargs = None
@@ -449,7 +465,7 @@ class InvokeAIDiffuserComponent:
             cross_attention_kwargs["regional_prompt_data"] = RegionalPromptData(
                 regions=[conditioning_data.cond_regions], device=x.device, dtype=x.dtype
             )
-            cross_attention_kwargs["percent_through"] = percent_through
+            cross_attention_kwargs["percent_through"] = step_index / total_step_count
 
         # Run conditioned UNet denoising (i.e. positive prompt).
         conditioned_next_x = self.model_forward_callback(

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -12,10 +12,6 @@ class UNetAttentionPatcher:
 
     def __init__(self, ip_adapters: Optional[list[IPAdapter]]):
         self._ip_adapters = ip_adapters
-        self._ip_adapter_scales = None
-
-        if self._ip_adapters is not None:
-            self._ip_adapter_scales = [1.0] * len(self._ip_adapters)
 
     def _prepare_attention_processors(self, unet: UNet2DConditionModel):
         """Prepare a dict of attention processors that can be injected into a unet, and load the IP-Adapter attention
@@ -32,7 +28,6 @@ class UNetAttentionPatcher:
                 # Collect the weights from each IP Adapter for the idx'th attention processor.
                 attn_procs[name] = CustomAttnProcessor2_0(
                     [ip_adapter.attn_weights.get_attention_processor_weights(idx) for ip_adapter in self._ip_adapters],
-                    self._ip_adapter_scales,
                 )
         return attn_procs
 

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -17,9 +17,6 @@ class UNetAttentionPatcher:
         if self._ip_adapters is not None:
             self._ip_adapter_scales = [1.0] * len(self._ip_adapters)
 
-    def set_scale(self, idx: int, value: float):
-        self._ip_adapter_scales[idx] = value
-
     def _prepare_attention_processors(self, unet: UNet2DConditionModel):
         """Prepare a dict of attention processors that can be injected into a unet, and load the IP-Adapter attention
         weights into them (if IP-Adapters are being applied).


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because

## Description

This PR adds support for applying region masks to IP-Adapter conditioning.

Sample workflow:
<img width="1136" alt="image" src="https://github.com/invoke-ai/InvokeAI/assets/14897797/eb0aeb81-a724-41c8-88ed-4dbc69a780f7">

Sample results:
![image](https://github.com/invoke-ai/InvokeAI/assets/14897797/0c2a09f4-99c8-4126-8588-b45e51ec179e)
![image](https://github.com/invoke-ai/InvokeAI/assets/14897797/98b41a47-114d-474f-9648-f767f127c508)

## QA Instructions, Screenshots, Recordings

I tested the following:
- [x] IP-Adapter + mask + standard conditioning
- [x] IP-Adapter + mask + sequential conditioning
- [x] IP-Adapter without a mask
- [x] Basic generation without an IP-Adapter 

## Merge Plan

- [x] Merge earlier PRs and change target branch to `main` before merging.

## Added/updated tests?

- [ ] Yes
- [x] No. The relevant IP-Adapter unit tests (have the `slow` tag, so not run in CI workflows) were broken in the recent MM refactor. I'll have to fix those up in another PR before I could add tests for this feature.
