### PR TITLE
fix(ui): initial main model in dropdown

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/modelsLoaded.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/modelsLoaded.ts
@@ -55,14 +55,13 @@ const handleMainModels: ModelHandler = (models, state, dispatch, log) => {
     return;
   }
 
-  const isCurrentMainModelAvailable = currentModel ? models.some((m) => m.key === currentModel.key) : false;
-
+  const isCurrentMainModelAvailable = currentModel ? mainModels.some((m) => m.key === currentModel.key) : false;
   if (isCurrentMainModelAvailable) {
     return;
   }
 
   const defaultModel = state.config.sd.defaultModel;
-  const defaultModelInList = defaultModel ? models.find((m) => m.key === defaultModel) : false;
+  const defaultModelInList = defaultModel ? mainModels.find((m) => m.key === defaultModel) : false;
 
   if (defaultModelInList) {
     const result = zParameterModel.safeParse(defaultModelInList);
@@ -84,7 +83,7 @@ const handleMainModels: ModelHandler = (models, state, dispatch, log) => {
     }
   }
 
-  const result = zParameterModel.safeParse(models[0]);
+  const result = zParameterModel.safeParse(mainModels[0]);
 
   if (!result.success) {
     log.error({ error: result.error.format() }, 'Failed to parse main model');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
The switch to one model list introduced a bug in the main model logic where it was using the whole list of models and not just the main model list. When storage was cleared, this mean that model that was not type=main could get set as main model, and that manifested as an invalid main model select.