### PR TITLE
Stop registering and moving models which have symlinks in the models dir

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -520,7 +520,7 @@ class ModelInstallService(ModelInstallServiceBase):
 
         new_path = models_dir / model.base.value / model.type.value / old_path.name
 
-        if old_path == new_path:
+        if old_path == new_path or new_path.exists() and old_path == new_path.resolve():
             return model
 
         self._logger.info(f"Moving {model.name} to {new_path}.")
@@ -530,7 +530,7 @@ class ModelInstallService(ModelInstallServiceBase):
         return model
 
     def _scan_register(self, model: Path) -> bool:
-        if model in self._cached_model_paths:
+        if any(model == m.resolve() for m in self._cached_model_paths):
             return True
         try:
             id = self.register_path(model)

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -328,7 +328,7 @@ class ModelInstallService(ModelInstallServiceBase):
         yaml_path.rename(yaml_path.with_suffix(".yaml.bak"))
 
     def scan_directory(self, scan_dir: Path, install: bool = False) -> List[str]:  # noqa D102
-        self._cached_model_paths = {Path(x.path).absolute() for x in self.record_store.all_models()}
+        self._cached_model_paths = {Path(x.path).resolve() for x in self.record_store.all_models()}
         callback = self._scan_install if install else self._scan_register
         search = ModelSearch(on_model_found=callback)
         self._models_installed.clear()
@@ -530,7 +530,7 @@ class ModelInstallService(ModelInstallServiceBase):
         return model
 
     def _scan_register(self, model: Path) -> bool:
-        if any(model == m.resolve() for m in self._cached_model_paths):
+        if model in self._cached_model_paths:
             return True
         try:
             id = self.register_path(model)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [x] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [x] No


## Description
Currently, if there's a model in your models directory that was added via symlink, the model install service will resolve the symlink and move the model. This will stop that behavior and leave it in place.

If a user symlinks the model to the wrong directory in the models dir, it will still move the model. Not sure how we want to handle that situation.

## QA Instructions, Screenshots, Recordings

Add a model to your models dir using a symlink and start the app. On main, it'd resolve the symlink and move the model. Now it should handle it as expected.

## Merge Plan

This PR can be merged when approved
