### PR TITLE
Update pytorch and xFormers 2.1.2 -> 2.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ dependencies = [
   "pytorch-lightning==2.1.3",
   "safetensors==0.4.2",
   "timm==0.6.13",               # needed to override timm latest in controlnet_aux, see  https://github.com/isl-org/ZoeDepth/issues/26
-  "torch==2.1.2",
+  "torch==2.2.1",
   "torchmetrics==0.11.4",
   "torchsde==0.2.6",
-  "torchvision==0.16.2",
+  "torchvision==0.17.1",
   "transformers==4.38.2",
 
   # Core application dependencies, pinned for reproducible builds.
@@ -98,7 +98,7 @@ dependencies = [
 [project.optional-dependencies]
 "xformers" = [
   # Core generation dependencies, pinned for reproducible builds.
-  "xformers==0.0.23.post1; sys_platform!='darwin'",
+  "xformers==0.0.25; sys_platform!='darwin'",
   # Auxiliary dependencies, pinned only if necessary.
   "triton; sys_platform=='linux'",
 ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [ ] Yes
- [ ] No


## Description
Successor of my mess here https://github.com/invoke-ai/InvokeAI/pull/5860 

Greetings,

diffusers 0.27.0 finally got released. It was the last obstacle for Pytorch 2.2.
This PR updates Pytorch to the most recent version 2.2.1. Same for xFormers and their compatible version 0.0.25.

I was able to test this. It runs smoothly, however, I am limited to my Nvidia 3060 Windows setup here, and I am not able to test it on other device. Mac users are welcome to test.

Once Pytorch 2.2.2 is released, it will then be the last version for 2.2. Then the cycle begins anew.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [ ] Yes
- [ ] No : _please replace this line with details on why tests
      have not been included_

## [optional] Are there any post deployment tasks we need to perform?
