### PR TITLE
fix(ui): model list refreshes after changes

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketModelInstall.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketModelInstall.ts
@@ -1,5 +1,5 @@
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
-import { api } from 'services/api';
+import { api, LIST_TAG } from 'services/api';
 import { modelsApi } from 'services/api/endpoints/models';
 import {
   socketModelInstallCancelled,
@@ -42,7 +42,7 @@ export const addModelInstallEventListener = (startAppListening: AppStartListenin
           return draft;
         })
       );
-      dispatch(api.util.invalidateTags(['Model']));
+      dispatch(api.util.invalidateTags([{ type: 'ModelConfig', id: LIST_TAG }]));
     },
   });
 

--- a/invokeai/frontend/web/src/services/api/endpoints/models.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/models.ts
@@ -118,7 +118,7 @@ export const modelsApi = api.injectEndpoints({
           body: formData,
         };
       },
-      invalidatesTags: ['Model'],
+      invalidatesTags: [{ type: 'ModelConfig', id: LIST_TAG }],
     }),
     installModel: build.mutation<InstallModelResponse, InstallModelArg>({
       query: ({ source, inplace = true }) => {
@@ -128,7 +128,7 @@ export const modelsApi = api.injectEndpoints({
           method: 'POST',
         };
       },
-      invalidatesTags: ['Model', 'ModelInstalls'],
+      invalidatesTags: ['ModelInstalls'],
     }),
     deleteModels: build.mutation<DeleteModelResponse, DeleteModelArg>({
       query: ({ key }) => {
@@ -137,7 +137,7 @@ export const modelsApi = api.injectEndpoints({
           method: 'DELETE',
         };
       },
-      invalidatesTags: ['Model'],
+      invalidatesTags: [{ type: 'ModelConfig', id: LIST_TAG }],
     }),
     deleteModelImage: build.mutation<DeleteModelImageResponse, string>({
       query: (key) => {
@@ -146,7 +146,7 @@ export const modelsApi = api.injectEndpoints({
           method: 'DELETE',
         };
       },
-      invalidatesTags: ['Model'],
+      invalidatesTags: [{ type: 'ModelConfig', id: LIST_TAG }],
     }),
     getModelImage: build.query<string, string>({
       query: (key) => buildModelsUrl(`i/${key}/image`),
@@ -158,12 +158,12 @@ export const modelsApi = api.injectEndpoints({
           method: 'PUT',
         };
       },
-      invalidatesTags: ['ModelConfig'],
+      invalidatesTags: [{ type: 'ModelConfig', id: LIST_TAG }],
     }),
     getModelConfig: build.query<GetModelConfigResponse, string>({
       query: (key) => buildModelsUrl(`i/${key}`),
       providesTags: (result) => {
-        const tags: ApiTagDescription[] = ['Model'];
+        const tags: ApiTagDescription[] = [];
 
         if (result) {
           tags.push({ type: 'ModelConfig', id: result.key });
@@ -175,7 +175,7 @@ export const modelsApi = api.injectEndpoints({
     getModelConfigByAttrs: build.query<AnyModelConfig, GetByAttrsArg>({
       query: (arg) => buildModelsUrl(`get_by_attrs?${queryString.stringify(arg)}`),
       providesTags: (result) => {
-        const tags: ApiTagDescription[] = ['Model'];
+        const tags: ApiTagDescription[] = [];
 
         if (result) {
           tags.push({ type: 'ModelConfig', id: result.key });
@@ -192,7 +192,7 @@ export const modelsApi = api.injectEndpoints({
           method: 'PATCH',
         };
       },
-      invalidatesTags: ['Model'],
+      invalidatesTags: [{ type: 'ModelConfig', id: LIST_TAG }],
     }),
     scanFolder: build.query<ScanFolderResponse, ScanFolderArg>({
       query: (arg) => {

--- a/invokeai/frontend/web/src/services/api/index.ts
+++ b/invokeai/frontend/web/src/services/api/index.ts
@@ -26,7 +26,6 @@ export const tagTypes = [
   'NextSessionQueueItem',
   'BatchStatus',
   'InvocationCacheStatus',
-  'Model',
   'ModelConfig',
   'ModelInstalls',
   'T2IAdapterModel',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Description

When consolidating all the model queries I messed up the query tags. Fixed now, so that when a model is installed, removed, or changed, the list refreshes.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #5975
- Closes #5907 

## QA Instructions, Screenshots, Recordings

Install/update/delete a model and the list should refresh.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

This PR can be merged when approved

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->
