### PR TITLE
Fix race condition causing hangs during model install unit tests

### DIFF
--- a/invokeai/app/services/events/events_base.py
+++ b/invokeai/app/services/events/events_base.py
@@ -386,6 +386,17 @@ class EventServiceBase:
             },
         )
 
+    def emit_model_install_downloads_done(self, source: str) -> None:
+        """
+        Emit once when all parts are downloaded, but before the probing and registration start.
+
+        :param source: Source of the model; local path, repo_id or url
+        """
+        self.__emit_model_event(
+            event_name="model_install_downloads_done",
+            payload={"source": source},
+        )
+
     def emit_model_install_running(self, source: str) -> None:
         """
         Emit once when an install job becomes active.

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -124,14 +124,27 @@ class ModelInstallService(ModelInstallServiceBase):
             if not self._running:
                 raise Exception("Attempt to stop the install service before it was started")
             self._stop_event.set()
-            with self._install_queue.mutex:
-                self._install_queue.queue.clear()  # get rid of pending jobs
-            active_jobs = [x for x in self.list_jobs() if x.running]
-            if active_jobs:
-                self._logger.warning("Waiting for active install job to complete")
-            self.wait_for_installs()
+            self._clear_pending_jobs()
             self._download_cache.clear()
             self._running = False
+
+    def _clear_pending_jobs(self) -> None:
+        for job in self.list_jobs():
+            if not job.in_terminal_state:
+                self._logger.warning("Cancelling job {job.id}")
+                self.cancel_job(job)
+        while True:
+            try:
+                job = self._install_queue.get(block=False)
+                self._install_queue.task_done()
+            except Empty:
+                break
+
+    def _put_in_queue(self, job: ModelInstallJob) -> None:
+        if self._stop_event.is_set():
+            self.cancel_job(job)
+        else:
+            self._install_queue.put(job)
 
     def register_path(
         self,
@@ -218,7 +231,7 @@ class ModelInstallService(ModelInstallServiceBase):
 
         if isinstance(source, LocalModelSource):
             install_job = self._import_local_model(source, config)
-            self._install_queue.put(install_job)  # synchronously install
+            self._put_in_queue(install_job)  # synchronously install
         elif isinstance(source, HFModelSource):
             install_job = self._import_from_hf(source, config)
         elif isinstance(source, URLModelSource):
@@ -253,7 +266,6 @@ class ModelInstallService(ModelInstallServiceBase):
                 raise TimeoutError("Timeout exceeded")
         return job
 
-    # TODO: Better name? Maybe wait_for_jobs()? Maybe too easily confused with above
     def wait_for_installs(self, timeout: int = 0) -> List[ModelInstallJob]:  # noqa D102
         """Block until all installation jobs are done."""
         start = time.time()
@@ -412,7 +424,6 @@ class ModelInstallService(ModelInstallServiceBase):
                 job = self._install_queue.get(timeout=1)
             except Empty:
                 continue
-
             assert job.local_path is not None
             try:
                 if job.cancelled:
@@ -453,7 +464,8 @@ class ModelInstallService(ModelInstallServiceBase):
 
             except (OSError, DuplicateModelException) as excp:
                 job.set_error(excp)
-                self._signal_job_errored(job)
+                with self._lock:
+                    self._signal_job_errored(job)
 
             finally:
                 # if this is an install of a remote file, then clean up the temporary directory
@@ -461,8 +473,6 @@ class ModelInstallService(ModelInstallServiceBase):
                     rmtree(job._install_tmpdir)
                 self._install_completed_event.set()
                 self._install_queue.task_done()
-
-        self._logger.info("Install thread exiting")
 
     # --------------------------------------------------------------------------------------------
     # Internal functions that manage the models directory
@@ -779,14 +789,14 @@ class ModelInstallService(ModelInstallServiceBase):
         self._logger.info(f"{download_job.source}: model download complete")
         with self._lock:
             install_job = self._download_cache[download_job.source]
-            self._download_cache.pop(download_job.source, None)
 
             # are there any more active jobs left in this task?
-            if install_job.downloading and all(x.complete for x in install_job.download_parts):
-                install_job.status = InstallStatus.DOWNLOADS_DONE
-                self._install_queue.put(install_job)
+            if install_job and install_job.downloading and all(x.complete for x in install_job.download_parts):
+                self._signal_job_downloads_done(install_job)
+                self._put_in_queue(install_job)
 
             # Let other threads know that the number of downloads has changed
+            self._download_cache.pop(download_job.source, None)
             self._downloads_changed_event.set()
 
     def _download_error_callback(self, download_job: DownloadJob, excp: Optional[Exception] = None) -> None:
@@ -826,7 +836,7 @@ class ModelInstallService(ModelInstallServiceBase):
 
         if all(x.in_terminal_state for x in install_job.download_parts):
             # When all parts have reached their terminal state, we finalize the job to clean up the temporary directory and other resources
-            self._install_queue.put(install_job)
+            self._put_in_queue(install_job)
 
     # ------------------------------------------------------------------------------------------------
     # Internal methods that put events on the event bus
@@ -858,6 +868,12 @@ class ModelInstallService(ModelInstallServiceBase):
                 total_bytes=job.total_bytes,
                 id=job.id,
             )
+
+    def _signal_job_downloads_done(self, job: ModelInstallJob) -> None:
+        job.status = InstallStatus.DOWNLOADS_DONE
+        self._logger.info(f"{job.source}: all parts of this model are downloaded")
+        if self._event_bus:
+            self._event_bus.emit_model_install_downloads_done(str(job.source))
 
     def _signal_job_completed(self, job: ModelInstallJob) -> None:
         job.status = InstallStatus.COMPLETED

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -221,9 +221,14 @@ def test_simple_download(mm2_installer: ModelInstallServiceBase, mm2_app_config:
     model_record = store.get_model(key)
     assert Path(model_record.path).exists()
 
-    assert len(bus.events) == 3
+    assert len(bus.events) == 4
     event_names = [x.event_name for x in bus.events]
-    assert event_names == ["model_install_downloading", "model_install_running", "model_install_completed"]
+    assert event_names == [
+        "model_install_downloading",
+        "model_install_downloads_done",
+        "model_install_running",
+        "model_install_completed",
+    ]
 
 
 @pytest.mark.timeout(timeout=20, method="thread")
@@ -250,7 +255,12 @@ def test_huggingface_download(mm2_installer: ModelInstallServiceBase, mm2_app_co
     assert hasattr(bus, "events")  # the dummyeventservice has this
     assert len(bus.events) >= 3
     event_names = {x.event_name for x in bus.events}
-    assert event_names == {"model_install_downloading", "model_install_running", "model_install_completed"}
+    assert event_names == {
+        "model_install_downloading",
+        "model_install_downloads_done",
+        "model_install_running",
+        "model_install_completed",
+    }
 
 
 def test_404_download(mm2_installer: ModelInstallServiceBase, mm2_app_config: InvokeAIAppConfig) -> None:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Community Node Submission


## Have you discussed this change with the InvokeAI team?
- [X] Yes
- [ ] No, because:

      
## Have you updated all relevant documentation?
- [X] Yes
- [ ] No


## Description

This fixes a race condition that caused haphazard timeouts to occur during `test_model_install` unit tests. It also makes the following changes:

1. It puts a new install-related event onto the event bus. This event is named `model_install_downloads_done` and indicates that all parts of a multi-file model have downloaded. The next step will be `model_install_running`, indicating that the probe and registration process has started.
2. It changes the behavior of `installer.stop()`. Previously this would block until the last pending installation job was completed. Now it cancels pending install jobs and returns immediately.

## Related Tickets & Documents

Extensive thread at: https://discord.com/channels/1020123559063990373/1149513647022948483/1219360539696824420

<!--
For pull requests that relate or close an issue, please include them
below. 

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Run the `tests/app/services/model_install/test_model_install` unit test multiple times. There should be no timeouts or hangs.

<!-- 
Please provide steps on how to test changes, any hardware or 
software specifications as well as any other pertinent information. 
-->

## Merge Plan

Merge when approved.

<!--
A merge plan describes how this PR should be handled after it is approved.

Example merge plans:
- "This PR can be merged when approved"
- "This must be squash-merged when approved"
- "DO NOT MERGE - I will rebase and tidy commits before merging"
- "#dev-chat on discord needs to be advised of this change when it is merged"

A merge plan is particularly important for large PRs or PRs that touch the
database in any way.
-->

## Added/updated tests?

- [X] Yes -- Brandon's PR #5970 has a unit test that exposes the bug. Suggest testing after this is merged.
- [ ] No : 

## [optional] Are there any post deployment tasks we need to perform?
