### PR TITLE
fix(ui): handle seamless with refiner

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/addVAEToGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/addVAEToGraph.ts
@@ -18,6 +18,7 @@ import {
   SDXL_CANVAS_TEXT_TO_IMAGE_GRAPH,
   SDXL_IMAGE_TO_IMAGE_GRAPH,
   SDXL_REFINER_INPAINT_CREATE_MASK,
+  SDXL_REFINER_SEAMLESS,
   SDXL_TEXT_TO_IMAGE_GRAPH,
   SEAMLESS,
   TEXT_TO_IMAGE_GRAPH,
@@ -38,6 +39,8 @@ export const addVAEToGraph = async (
 
   const isAutoVae = !vae;
   const isSeamlessEnabled = seamlessXAxis || seamlessYAxis;
+  const isSDXL = Boolean(graph.id?.includes('sdxl'));
+  const isUsingRefiner = isSDXL && Boolean(refinerModel);
 
   if (!isAutoVae && !isSeamlessEnabled) {
     graph.nodes[VAE_LOADER] = {
@@ -56,7 +59,13 @@ export const addVAEToGraph = async (
   ) {
     graph.edges.push({
       source: {
-        node_id: isSeamlessEnabled ? SEAMLESS : isAutoVae ? modelLoaderNodeId : VAE_LOADER,
+        node_id: isSeamlessEnabled
+          ? isUsingRefiner
+            ? SDXL_REFINER_SEAMLESS
+            : SEAMLESS
+          : isAutoVae
+            ? modelLoaderNodeId
+            : VAE_LOADER,
         field: 'vae',
       },
       destination: {
@@ -74,7 +83,13 @@ export const addVAEToGraph = async (
   ) {
     graph.edges.push({
       source: {
-        node_id: isSeamlessEnabled ? SEAMLESS : isAutoVae ? modelLoaderNodeId : VAE_LOADER,
+        node_id: isSeamlessEnabled
+          ? isUsingRefiner
+            ? SDXL_REFINER_SEAMLESS
+            : SEAMLESS
+          : isAutoVae
+            ? modelLoaderNodeId
+            : VAE_LOADER,
         field: 'vae',
       },
       destination: {
@@ -92,7 +107,13 @@ export const addVAEToGraph = async (
   ) {
     graph.edges.push({
       source: {
-        node_id: isSeamlessEnabled ? SEAMLESS : isAutoVae ? modelLoaderNodeId : VAE_LOADER,
+        node_id: isSeamlessEnabled
+          ? isUsingRefiner
+            ? SDXL_REFINER_SEAMLESS
+            : SEAMLESS
+          : isAutoVae
+            ? modelLoaderNodeId
+            : VAE_LOADER,
         field: 'vae',
       },
       destination: {
@@ -111,7 +132,13 @@ export const addVAEToGraph = async (
     graph.edges.push(
       {
         source: {
-          node_id: isSeamlessEnabled ? SEAMLESS : isAutoVae ? modelLoaderNodeId : VAE_LOADER,
+          node_id: isSeamlessEnabled
+            ? isUsingRefiner
+              ? SDXL_REFINER_SEAMLESS
+              : SEAMLESS
+            : isAutoVae
+              ? modelLoaderNodeId
+              : VAE_LOADER,
           field: 'vae',
         },
         destination: {
@@ -122,7 +149,13 @@ export const addVAEToGraph = async (
 
       {
         source: {
-          node_id: isSeamlessEnabled ? SEAMLESS : isAutoVae ? modelLoaderNodeId : VAE_LOADER,
+          node_id: isSeamlessEnabled
+            ? isUsingRefiner
+              ? SDXL_REFINER_SEAMLESS
+              : SEAMLESS
+            : isAutoVae
+              ? modelLoaderNodeId
+              : VAE_LOADER,
           field: 'vae',
         },
         destination: {
@@ -137,7 +170,13 @@ export const addVAEToGraph = async (
     if (graph.id === SDXL_CANVAS_INPAINT_GRAPH || graph.id === SDXL_CANVAS_OUTPAINT_GRAPH) {
       graph.edges.push({
         source: {
-          node_id: isSeamlessEnabled ? SEAMLESS : isAutoVae ? modelLoaderNodeId : VAE_LOADER,
+          node_id: isSeamlessEnabled
+            ? isUsingRefiner
+              ? SDXL_REFINER_SEAMLESS
+              : SEAMLESS
+            : isAutoVae
+              ? modelLoaderNodeId
+              : VAE_LOADER,
           field: 'vae',
         },
         destination: {


### PR DESCRIPTION
## Summary

When handling adding VAE to the graph, we need to manage the possible VAE sources. We might get the VAE from a VAE node or a Seamless node, which modifies the VAE. We weren't handling this correctly for SDXL graphs with Refiner.

## Related Issues / Discussions

<!--List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

Closes  #5995

## QA Instructions

Test cases:
- SD1.5 without seamless
- SD1.5 with seamless
- SDXL without seamless
- SDXL with seamless
- SDXL with Refiner & without seamless
- SDXL with Refiner & with seamless

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

n/a
<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [ ] Tests added / updated (n/a)
- [ ] Documentation added / updated (n/a)
