### PR TITLE
tidy(installer): remove references to removed scripts from installer/launcher

### DIFF
--- a/docs/installation/010_INSTALL_AUTOMATED.md
+++ b/docs/installation/010_INSTALL_AUTOMATED.md
@@ -122,9 +122,9 @@ experimental versions later.
     [latest release](https://github.com/invoke-ai/InvokeAI/releases/latest),
     and look for a file named:
 
-    - InvokeAI-installer-v3.X.X.zip
+    - InvokeAI-installer-v4.X.X.zip
 
-    where "3.X.X" is the latest released version. The file is located
+    where "4.X.X" is the latest released version. The file is located
     at the very bottom of the release page, under **Assets**.
 
 4.  **Unpack the installer**: Unpack the zip file into a convenient directory. This will create a new
@@ -199,136 +199,7 @@ experimental versions later.
     ![initial-settings-screenshot](../assets/installer-walkthrough/settings-form.png)
     </figure>
 
-10. **Post-install Configuration**: After installation completes, the
-    installer will launch the configuration form, which will guide you
-    through the first-time process of adjusting some of InvokeAI's
-    startup settings. To move around this form use ctrl-N for
-    &lt;N&gt;ext and ctrl-P for &lt;P&gt;revious, or use &lt;tab&gt;
-    and shift-&lt;tab&gt; to move forward and back. Once you are in a
-    multi-checkbox field use the up and down cursor keys to select the
-    item you want, and &lt;space&gt; to toggle it on and off.  Within
-    a directory field, pressing &lt;tab&gt; will provide autocomplete
-    options.
-
-    Generally the defaults are fine, and you can come back to this screen at
-    any time to tweak your system. Here are the options you can adjust:
-
-    - ***HuggingFace Access Token***
-      InvokeAI has the ability to download embedded styles and subjects
-      from the HuggingFace Concept Library on-demand. However, some of
-      the concept library files are password protected. To make download
-      smoother, you can set up an account at huggingface.co, obtain an
-      access token, and paste it into this field. Note that you paste
-      to this screen using ctrl-shift-V
-
-    - ***Free GPU memory after each generation***
-        This is useful for low-memory machines and helps minimize the
-	amount of GPU VRAM used by InvokeAI.
-
-    - ***Enable xformers support if available***
-        If the xformers library was successfully installed, this will activate
-	it to reduce memory consumption and increase rendering speed noticeably.
-	Note that xformers has the side effect of generating slightly different
-	images even when presented with the same seed and other settings.
-
-    - ***Force CPU to be used on GPU systems***
-        This will use the (slow) CPU rather than the accelerated GPU. This
-	can be used to generate images on systems that don't have a compatible
-	GPU.
-
-    - ***Precision***
-        This controls whether to use float32 or float16 arithmetic.
-	float16 uses less memory but is also slightly less accurate.
-	Ordinarily the right arithmetic is picked automatically ("auto"),
-	but you may have to use float32 to get images on certain systems
-	and graphics cards. The "autocast" option is deprecated and
-	shouldn't be used unless you are asked to by a member of the team.
-
-    - **Size of the RAM cache used for fast model switching***
-        This allows you to keep models in memory and switch rapidly among
-	them rather than having them load from disk each time. This slider
-	controls how many models to keep loaded at once. A typical SD-1 or SD-2 model
-	uses 2-3 GB of memory. A typical SDXL model uses 6-7 GB. Providing more
-	RAM will allow more models to be co-resident.
-
-    - ***Output directory for images***
-      This is the path to a directory in which InvokeAI will store all its
-      generated images.
-
-    - ***Autoimport Folder***
-      This is the directory in which you can place models you have
-	  downloaded and wish to load into InvokeAI. You can place a variety
-	  of models in this directory, including diffusers folders, .ckpt files,
-	  .safetensors files, as well as LoRAs, ControlNet and Textual Inversion
-	  files (both folder and file versions). To help organize this folder,
-	  you can create several levels of subfolders and drop your models into
-      whichever ones you want.
-	
-    - ***LICENSE***     
-
-    At the bottom of the screen you will see a checkbox for accepting
-    the CreativeML Responsible AI Licenses. You need to accept the license
-    in order to download Stable Diffusion models from the next screen.
-
-    _You can come back to the startup options form_ as many times as you like.
-    From the `invoke.sh` or `invoke.bat` launcher, select option (6) to relaunch
-    this script. On the command line, it is named `invokeai-configure`.
-
-11. **Downloading Models**: After you press `[NEXT]` on the screen, you will be taken
-    to another screen that prompts you to download a series of starter models. The ones
-    we recommend are preselected for you, but you are encouraged to use the checkboxes to
-    pick and choose.
-    You will probably wish to download `autoencoder-840000` for use with models that
-    were trained with an older version of the Stability VAE.
-
-    <figure markdown>
-    ![select-models-screenshot](../assets/installer-walkthrough/installing-models.png)
-    </figure>
-    
-    Below the preselected list of starter models is a large text field which you can use
-    to specify a series of models to import. You can specify models in a variety of formats,
-    each separated by a space or newline. The formats accepted are:
-
-    - The path to a .ckpt or .safetensors file. On most systems, you can drag a file from
-      the file browser to the textfield to automatically paste the path. Be sure to remove
-      extraneous quotation marks and other things that come along for the ride.
-
-    - The path to a directory containing a combination of `.ckpt` and `.safetensors` files.
-      The directory will be scanned from top to bottom (including subfolders) and any
-      file that can be imported will be.
-
-    - A URL pointing to a `.ckpt` or `.safetensors` file. You can cut
-      and paste directly from a web page, or simply drag the link from the web page
-      or navigation bar. (You can also use ctrl-shift-V to paste into this field)
-      The file will be downloaded and installed.
-      
-    - The HuggingFace repository ID (repo_id) for a `diffusers` model. These IDs have
-       the format _author_name/model_name_, as in `andite/anything-v4.0`
-      
-    - The path to a local directory containing a `diffusers`
-      model. These directories always have the file `model_index.json`
-      at their top level.
-
-    _Select a directory for models to import_ You may select a local
-    directory for autoimporting at startup time. If you select this
-    option, the directory you choose will be scanned for new
-    .ckpt/.safetensors files each time InvokeAI starts up, and any new
-    files will be automatically imported and made available for your
-    use.
-
-    _Convert imported models into diffusers_ When legacy checkpoint
-    files are imported, you may select to use them unmodified (the
-    default) or to convert them into `diffusers` models. The latter
-    load much faster and have slightly better rendering performance,
-    but not all checkpoint files can be converted. Note that Stable Diffusion
-    Version 2.X files are **only** supported in `diffusers` format and will
-    be converted regardless.
-     
-     _You can come back to the model install form_ as many times as you like.
-     From the `invoke.sh` or `invoke.bat` launcher, select option (5) to relaunch
-     this script. On the command line, it is named `invokeai-model-install`.
-
-12. **Running InvokeAI for the first time**: The script will now exit and you'll be ready to generate some images. Look
+10. **Running InvokeAI for the first time**: The script will now exit and you'll be ready to generate some images. Look
     for the directory `invokeai` installed in the location you chose at the
     beginning of the install session. Look for a shell script named `invoke.sh`
     (Linux/Mac) or `invoke.bat` (Windows). Launch the script by double-clicking
@@ -349,14 +220,14 @@ experimental versions later.
       http://localhost:9090. Click on this link to open up a browser
       and start exploring InvokeAI's features.
 
-12. **InvokeAI Options**: You can launch InvokeAI with several different command-line arguments that
-    customize its behavior. For example, you can change the location of the
+12. **InvokeAI Options**: You can configure using the `invokeai.yaml` config file.
+    For example, you can change the location of the
     image output directory or balance memory usage vs performance. See
     [Configuration](../features/CONFIGURATION.md) for a full list of the options.
 
     - To set defaults that will take effect every time you launch InvokeAI,
       use a text editor (e.g. Notepad) to exit the file
-      `invokeai\invokeai.init`. It contains a variety of examples that you can
+      `invokeai\invokeai.yaml`. It contains a variety of examples that you can
       follow to add and modify launch options.
 
     - The launcher script also offers you an option labeled "open the developer
@@ -394,7 +265,6 @@ rm .\.venv -r -force
 python -mvenv .venv
 .\.venv\Scripts\activate
 pip install invokeai
-invokeai-configure --yes --root .
 ```
 
 If you see anything marked as an error during this process please stop
@@ -426,16 +296,10 @@ error messages:
 This failure mode occurs when there is a network glitch during
 downloading the very large SDXL model.
 
-To address this, first go to the Web Model Manager and delete the
-Stable-Diffusion-XL-base-1.X model. Then navigate to HuggingFace and
-manually download the .safetensors version of the model. The 1.0
-version is located at
-https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/tree/main
-and the file is named `sd_xl_base_1.0.safetensors`.
-
-Save this file to disk and then reenter the Model Manager. Navigate to
-Import Models->Add Model, then type (or drag-and-drop) the path to the
-.safetensors file. Press "Add Model".
+To address this, first go to the Model Manager and delete the
+Stable-Diffusion-XL-base-1.X model. Then, click the HuggingFace tab,
+ paste the Repo ID stabilityai/stable-diffusion-xl-base-1.0 and install
+ the model.
 
 ### _Package dependency conflicts_
 
@@ -488,15 +352,7 @@ download models, etc), but this doesn't fix the problem.
 
 This issue is often caused by a misconfigured configuration directive in the
 `invokeai\invokeai.init` initialization file that contains startup settings. The
-easiest way to fix the problem is to move the file out of the way and re-run
-`invokeai-configure`. Enter the developer's console (option 3 of the launcher
-script) and run this command:
-
-```cmd
-invokeai-configure --root=.
-```
-
-Note the dot (.) after `--root`. It is part of the command.
+easiest way to fix the problem is to move the file out of the way and restart the app.
 
 _If none of these maneuvers fixes the problem_ then please report the problem to
 the [InvokeAI Issues](https://github.com/invoke-ai/InvokeAI/issues) section, or
@@ -565,16 +421,4 @@ This distribution is changing rapidly, and we add new features
 regularly. Releases are announced at
 http://github.com/invoke-ai/InvokeAI/releases, and at
 https://pypi.org/project/InvokeAI/ To update to the latest released
-version (recommended), follow these steps:
-
-1. Start the `invoke.sh`/`invoke.bat` launch script from within the
-   `invokeai` root directory.
-
-2. Choose menu item (10) "Update InvokeAI".
-
-3. This will launch a menu that gives you the option of:
-
-   1. Updating to the latest official release;
-   2. Updating to the bleeding-edge development version; or
-   3. Manually entering the tag or branch name of a version of
-      InvokeAI you wish to try out.
+version (recommended), download the latest release and run the installer.

--- a/docs/installation/INSTALLATION.md
+++ b/docs/installation/INSTALLATION.md
@@ -26,7 +26,7 @@ driver).
 
 🖥️ **Download the latest installer .zip file here** : https://github.com/invoke-ai/InvokeAI/releases/latest
   
-- *Look for the file labelled "InvokeAI-installer-v3.X.X.zip" at the bottom of the page*
+- *Look for the file labelled "InvokeAI-installer-v4.X.X.zip" at the bottom of the page*
 - If you experience issues, read through the full [installation instructions](010_INSTALL_AUTOMATED.md) to make sure you have met all of the installation requirements. If you need more help, join the [Discord](discord.gg/invoke-ai) or create an issue on [Github](https://github.com/invoke-ai/InvokeAI).
 
 

--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -149,9 +149,6 @@ class Installer:
         # install the launch/update scripts into the runtime directory
         self.instance.install_user_scripts()
 
-        # run through the configuration flow
-        self.instance.configure()
-
 
 class InvokeAiInstance:
     """
@@ -241,53 +238,6 @@ class InvokeAiInstance:
                 "Could not install InvokeAI. Please try downloading the latest version of the installer and install again."
             )
             sys.exit(1)
-
-    def configure(self):
-        """
-        Configure the InvokeAI runtime directory
-        """
-
-        auto_install = False
-        # set sys.argv to a consistent state
-        new_argv = [sys.argv[0]]
-        for i in range(1, len(sys.argv)):
-            el = sys.argv[i]
-            if el in ["-r", "--root"]:
-                new_argv.append(el)
-                new_argv.append(sys.argv[i + 1])
-            elif el in ["-y", "--yes", "--yes-to-all"]:
-                auto_install = True
-        sys.argv = new_argv
-
-        import messages
-        import requests  # to catch download exceptions
-
-        auto_install = auto_install or messages.user_wants_auto_configuration()
-        if auto_install:
-            sys.argv.append("--yes")
-        else:
-            messages.introduction()
-
-        from invokeai.frontend.install.invokeai_configure import invokeai_configure
-
-        # NOTE: currently the config script does its own arg parsing! this means the command-line switches
-        # from the installer will also automatically propagate down to the config script.
-        # this may change in the future with config refactoring!
-        succeeded = False
-        try:
-            invokeai_configure()
-            succeeded = True
-        except requests.exceptions.ConnectionError as e:
-            print(f"\nA network error was encountered during configuration and download: {str(e)}")
-        except OSError as e:
-            print(f"\nAn OS error was encountered during configuration and download: {str(e)}")
-        except Exception as e:
-            print(f"\nA problem was encountered during the configuration and download steps: {str(e)}")
-        finally:
-            if not succeeded:
-                print('To try again, find the "invokeai" directory, run the script "invoke.sh" or "invoke.bat"')
-                print("and choose option 7 to fix a broken install, optionally followed by option 5 to install models.")
-                print("Alternatively you can relaunch the installer.")
 
     def install_user_scripts(self):
         """

--- a/installer/lib/messages.py
+++ b/installer/lib/messages.py
@@ -8,7 +8,7 @@ import platform
 from enum import Enum
 from pathlib import Path
 
-from prompt_toolkit import HTML, prompt
+from prompt_toolkit import prompt
 from prompt_toolkit.completion import FuzzyWordCompleter, PathCompleter
 from prompt_toolkit.validation import Validator
 from rich import box, print
@@ -96,39 +96,6 @@ def choose_version(available_releases: tuple | None = None) -> str:
     console.line()
 
     return "stable" if response == "" else response
-
-
-def user_wants_auto_configuration() -> bool:
-    """Prompt the user to choose between manual and auto configuration."""
-    console.rule("InvokeAI Configuration Section")
-    console.print(
-        Panel(
-            Group(
-                "\n".join(
-                    [
-                        "Libraries are installed and InvokeAI will now set up its root directory and configuration. Choose between:",
-                        "",
-                        "  * AUTOMATIC configuration:  install reasonable defaults and a minimal set of starter models.",
-                        "  * MANUAL configuration: manually inspect and adjust configuration options and pick from a larger set of starter models.",
-                        "",
-                        "Later you can fine tune your configuration by selecting option [6] 'Change InvokeAI startup options' from the invoke.bat/invoke.sh launcher script.",
-                    ]
-                ),
-            ),
-            box=box.MINIMAL,
-            padding=(1, 1),
-        )
-    )
-    choice = (
-        prompt(
-            HTML("Choose <b>&lt;a&gt;</b>utomatic or <b>&lt;m&gt;</b>anual configuration [a/m] (a): "),
-            validator=Validator.from_callable(
-                lambda n: n == "" or n.startswith(("a", "A", "m", "M")), error_message="Please select 'a' or 'm'"
-            ),
-        )
-        or "a"
-    )
-    return choice.lower().startswith("a")
 
 
 def confirm_install(dest: Path) -> bool:
@@ -349,34 +316,6 @@ def windows_long_paths_registry() -> None:
             padding=(1, 1),
         )
     )
-
-
-def introduction() -> None:
-    """
-    Display a banner when starting configuration of the InvokeAI application
-    """
-
-    console.rule()
-
-    console.print(
-        Panel(
-            title=":art: Configuring InvokeAI :art:",
-            renderable=Group(
-                "",
-                "[b]This script will:",
-                "",
-                "1. Configure the InvokeAI application directory",
-                "2. Help download the Stable Diffusion weight files",
-                "   and other large models that are needed for text to image generation",
-                "3. Create initial configuration files.",
-                "",
-                "[i]At any point you may interrupt this program and resume later.",
-                "",
-                "[b]For the best user experience, please enlarge or maximize this window",
-            ),
-        )
-    )
-    console.line(2)
 
 
 def _platform_specific_help() -> Text | None:

--- a/installer/templates/invoke.bat.in
+++ b/installer/templates/invoke.bat.in
@@ -9,15 +9,10 @@ set INVOKEAI_ROOT=.
 :start
 echo Desired action:
 echo 1. Generate images with the browser-based interface
-echo 2. Run textual inversion training
-echo 3. Merge models (diffusers type only)
-echo 4. Download and install models
-echo 5. Change InvokeAI startup options
-echo 6. Re-run the configure script to fix a broken install or to complete a major upgrade
-echo 7. Open the developer console
-echo 8. Update InvokeAI (DEPRECATED - please use the installer)
-echo 9. Run the InvokeAI image database maintenance script
-echo 10. Command-line help
+echo 2. Open the developer console
+echo 3. Update InvokeAI (DEPRECATED - please use the installer)
+echo 4. Run the InvokeAI image database maintenance script
+echo 5. Command-line help
 echo Q - Quit
 set /P choice="Please enter 1-10, Q: [1] "
 if not defined choice set choice=1
@@ -25,21 +20,6 @@ IF /I "%choice%" == "1" (
     echo Starting the InvokeAI browser-based UI..
     python .venv\Scripts\invokeai-web.exe %*
 ) ELSE IF /I "%choice%" == "2" (
-    echo Starting textual inversion training..
-    python .venv\Scripts\invokeai-ti.exe --gui
-) ELSE IF /I "%choice%" == "3" (
-    echo Starting model merging script..
-    python .venv\Scripts\invokeai-merge.exe --gui
-) ELSE IF /I "%choice%" == "4" (
-    echo Running invokeai-model-install...
-    python .venv\Scripts\invokeai-model-install.exe
-) ELSE IF /I "%choice%" == "5" (
-    echo Running invokeai-configure...
-    python .venv\Scripts\invokeai-configure.exe --skip-sd-weight --skip-support-models
-) ELSE IF /I "%choice%" == "6" (
-    echo Running invokeai-configure...
-    python .venv\Scripts\invokeai-configure.exe --yes --skip-sd-weight
-) ELSE IF /I "%choice%" == "7" (
     echo Developer Console
     echo Python command is:
     where python
@@ -51,15 +31,15 @@ IF /I "%choice%" == "1" (
     echo *************************
     echo *** Type `exit` to quit this shell and deactivate the Python virtual environment ***
     call cmd /k
-) ELSE IF /I "%choice%" == "8" (
+) ELSE IF /I "%choice%" == "3" (
     echo UPDATING FROM WITHIN THE APP IS BEING DEPRECATED.
     echo Please download the installer from https://github.com/invoke-ai/InvokeAI/releases/latest and run it to update your installation.
     timeout 4
     python -m invokeai.frontend.install.invokeai_update
-) ELSE IF /I "%choice%" == "9" (
+) ELSE IF /I "%choice%" == "4" (
    echo Running the db maintenance script...
    python .venv\Scripts\invokeai-db-maintenance.exe
-) ELSE IF /I "%choice%" == "10" (
+) ELSE IF /I "%choice%" == "5" (
     echo Displaying command line help...
     python .venv\Scripts\invokeai-web.exe --help %*
     pause

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -59,48 +59,23 @@ do_choice() {
         ;;
     2)
         clear
-        printf "Textual inversion training\n"
-        invokeai-ti --gui $PARAMS
-        ;;
-    3)
-        clear
-        printf "Merge models (diffusers type only)\n"
-        invokeai-merge --gui $PARAMS
-        ;;
-    4)
-        clear
-        printf "Download and install models\n"
-        invokeai-model-install --root ${INVOKEAI_ROOT}
-        ;;
-    5)
-        clear
-        printf "Change InvokeAI startup options\n"
-        invokeai-configure --root ${INVOKEAI_ROOT} --skip-sd-weights --skip-support-models
-        ;;
-    6)
-        clear
-        printf "Re-run the configure script to fix a broken install or to complete a major upgrade\n"
-        invokeai-configure --root ${INVOKEAI_ROOT} --yes --default_only --skip-sd-weights
-        ;;
-    7)
-        clear
         printf "Open the developer console\n"
         file_name=$(basename "${BASH_SOURCE[0]}")
         bash --init-file "$file_name"
         ;;
-    8)
+    3)
         clear
         printf "UPDATING FROM WITHIN THE APP IS BEING DEPRECATED\n"
         printf "Please download the installer from https://github.com/invoke-ai/InvokeAI/releases/latest and run it to update your installation.\n"
         sleep 4
         python -m invokeai.frontend.install.invokeai_update
         ;;
-    9)
+    4)
         clear
         printf "Running the db maintenance script\n"
         invokeai-db-maintenance --root ${INVOKEAI_ROOT}
         ;;
-    10)
+    5)
         clear
         printf "Command-line help\n"
         invokeai-web --help
@@ -118,15 +93,10 @@ do_choice() {
 do_dialog() {
     options=(
         1 "Generate images with a browser-based interface"
-        2 "Textual inversion training"
-        3 "Merge models (diffusers type only)"
-        4 "Download and install models"
-        5 "Change InvokeAI startup options"
-        6 "Re-run the configure script to fix a broken install or to complete a major upgrade"
-        7 "Open the developer console"
-        8 "Update InvokeAI (DEPRECATED - please use the installer)"
-	9 "Run the InvokeAI image database maintenance script"
-	10 "Command-line help"
+        2 "Open the developer console"
+        3 "Update InvokeAI (DEPRECATED - please use the installer)"
+        4 "Run the InvokeAI image database maintenance script"
+        5 "Command-line help"
     )
 
     choice=$(dialog --clear \
@@ -151,15 +121,10 @@ do_line_input() {
     printf " ** For a more attractive experience, please install the 'dialog' utility using your package manager. **\n\n"
     printf "What would you like to do?\n"
     printf "1: Generate images using the browser-based interface\n"
-    printf "2: Run textual inversion training\n"
-    printf "3: Merge models (diffusers type only)\n"
-    printf "4: Download and install models\n"
-    printf "5: Change InvokeAI startup options\n"
-    printf "6: Re-run the configure script to fix a broken install\n"
-    printf "7: Open the developer console\n"
-    printf "8: Update InvokeAI\n"
-    printf "9: Run the InvokeAI image database maintenance script\n"
-    printf "10: Command-line help\n"
+    printf "2: Open the developer console\n"
+    printf "3: Update InvokeAI\n"
+    printf "4: Run the InvokeAI image database maintenance script\n"
+    printf "5: Command-line help\n"
     printf "Q: Quit\n\n"
     read -p "Please enter 1-10, Q: [1] " yn
     choice=${yn:='1'}


### PR DESCRIPTION
<!--Thanks for contributing!-->

## Summary

Remove references to configure and other removed scripts from installer and launcher.

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [ ] Tests added / updated (n/a)
- [x] Documentation added / updated
