### PR TITLE
Remove no longer used pwinput dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,6 @@ dependencies = [
   "picklescan",
   "pillow",
   "prompt-toolkit",
-  # This fork allows Ctrl + C to interrupt the password input. It is pending merge to the original package.
-  "pwinput@https://github.com/binbash23/pwinput/archive/24af675b08b9916486239e59a37f63d58b694ca8.zip",
   "pympler~=1.0.1",
   "pypatchmatch",
   'pyperclip',


### PR DESCRIPTION
## Summary

This package was mistakenly commited to main but isn't actually used. This PR simply removes it from the toml.

## QA Instructions

Ensure no impact on pytests or ability to start `invokeai-web`

## Merge Plan

Can be merged as approved.

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [ ] Tests added / updated : Removing unused dependency. Nothing valuable to test.
- [x] Documentation added / updated
