### PR TITLE
Fix running under Docker following 4.0.0rc4 config changes

### DIFF
--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -2,17 +2,25 @@
 ## Any environment variables supported by InvokeAI can be specified here,
 ## in addition to the examples below.
 
-# HOST_INVOKEAI_ROOT is the path on the docker host's filesystem where InvokeAI will store data.
-# Outputs will also be stored here by default.
-# If relative, it will be relative to the docker directory in which the docker-compose.yml file is located
-#HOST_INVOKEAI_ROOT=../../invokeai-data
-
-# INVOKEAI_ROOT is the path to the root of the InvokeAI repository within the container.
+## INVOKEAI_ROOT is the path *on the host system* where Invoke will store its data.
+## It is mounted into the container and allows both containerized and non-containerized usage of Invoke.
+# Usually this is the only variable you need to set. It can be relative or absolute.
 # INVOKEAI_ROOT=~/invokeai
 
-# Get this value from your HuggingFace account settings page.
-# HUGGING_FACE_HUB_TOKEN=
+## HOST_INVOKEAI_ROOT and CONTAINER_INVOKEAI_ROOT can be used to control the on-host
+## and in-container paths separately, if needed.
+## HOST_INVOKEAI_ROOT is the path on the docker host's filesystem where Invoke will store data.
+## If relative, it will be relative to the docker directory in which the docker-compose.yml file is located
+## CONTAINER_INVOKEAI_ROOT is the path within the container where Invoke will expect to find the runtime directory.
+## It MUST be absolute. There is usually no need to change this.
+# HOST_INVOKEAI_ROOT=../../invokeai-data
+# CONTAINER_INVOKEAI_ROOT=/invokeai
 
-## optional variables specific to the docker setup.
+## INVOKEAI_PORT is the port on which the InvokeAI web interface will be available
+# INVOKEAI_PORT=9090
+
+## GPU_DRIVER can be set to either `nvidia` or `rocm` to enable GPU support in the container accordingly.
 # GPU_DRIVER=nvidia #| rocm
+
+## CONTAINER_UID can be set to the UID of the user on the host system that should own the files in the container.
 # CONTAINER_UID=1000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,6 @@ ENV INVOKEAI_SRC=/opt/invokeai
 ENV VIRTUAL_ENV=/opt/venv/invokeai
 
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-ARG TORCH_VERSION=2.1.2
-ARG TORCHVISION_VERSION=0.16.2
 ARG GPU_DRIVER=cuda
 ARG TARGETPLATFORM="linux/amd64"
 # unused but available
@@ -27,7 +25,12 @@ ARG BUILDPLATFORM
 
 WORKDIR ${INVOKEAI_SRC}
 
-# Install pytorch before all other pip packages
+COPY invokeai ./invokeai
+COPY pyproject.toml ./
+
+# Editable mode helps use the same image for development:
+# the local working copy can be bind-mounted into the image
+# at path defined by ${INVOKEAI_SRC}
 # NOTE: there are no pytorch builds for arm64 + cuda, only cpu
 # x86_64/CUDA is default
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -39,20 +42,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     else \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu121"; \
     fi &&\
-    pip install $extra_index_url_arg \
-        torch==$TORCH_VERSION \
-        torchvision==$TORCHVISION_VERSION
 
-# Install the local package.
-# Editable mode helps use the same image for development:
-# the local working copy can be bind-mounted into the image
-# at path defined by ${INVOKEAI_SRC}
-COPY invokeai ./invokeai
-COPY pyproject.toml ./
-RUN --mount=type=cache,target=/root/.cache/pip \
     # xformers + triton fails to install on arm64
     if [ "$GPU_DRIVER" = "cuda" ] && [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        pip install -e ".[xformers]"; \
+        pip install $extra_index_url_arg -e ".[xformers]"; \
     else \
         pip install $extra_index_url_arg -e "."; \
     fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,6 +94,8 @@ RUN apt update && apt install -y --no-install-recommends \
 ENV INVOKEAI_SRC=/opt/invokeai
 ENV VIRTUAL_ENV=/opt/venv/invokeai
 ENV INVOKEAI_ROOT=/invokeai
+ENV INVOKEAI_HOST=0.0.0.0
+ENV INVOKEAI_PORT=9090
 ENV PATH="$VIRTUAL_ENV/bin:$INVOKEAI_SRC:$PATH"
 ENV CONTAINER_UID=${CONTAINER_UID:-1000}
 ENV CONTAINER_GID=${CONTAINER_GID:-1000}
@@ -118,4 +120,4 @@ RUN mkdir -p ${INVOKEAI_ROOT} && chown -R ${CONTAINER_UID}:${CONTAINER_GID} ${IN
 
 COPY docker/docker-entrypoint.sh ./
 ENTRYPOINT ["/opt/invokeai/docker-entrypoint.sh"]
-CMD ["invokeai-web", "--host", "0.0.0.0"]
+CMD ["invokeai-web"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ x-invokeai: &invokeai
       - INVOKEAI_ROOT=${CONTAINER_INVOKEAI_ROOT:-/invokeai}
       - HF_HOME
     ports:
-      - "${INVOKEAI_PORT:-9090}:9090"
+      - "${INVOKEAI_PORT:-9090}:${INVOKEAI_PORT:-9090}"
     volumes:
       - type: bind
         source: ${HOST_INVOKEAI_ROOT:-${INVOKEAI_ROOT:-~/invokeai}}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,18 +27,9 @@ x-invokeai: &invokeai
         bind:
           create_host_path: true
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
-      # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}
-      # - ${INVOKEAI_MODELS_CONFIG_PATH:-${INVOKEAI_ROOT:-/invokeai/configs/models.yaml}}
     tty: true
     stdin_open: true
 
-    # # Example of running alternative commands/scripts in the container
-    # command:
-    #   - bash
-    #   - -c
-    #   - |
-    #     invokeai-model-install --yes --default-only --config_file ${INVOKEAI_ROOT}/config_custom.yaml
-    #     invokeai-nodes-web --host 0.0.0.0
 
 services:
   invokeai-nvidia:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,22 +8,24 @@ x-invokeai: &invokeai
       context: ..
       dockerfile: docker/Dockerfile
 
-    # variables without a default will automatically inherit from the host environment
-    environment:
-      - INVOKEAI_ROOT
-      - HF_HOME
-
     # Create a .env file in the same directory as this docker-compose.yml file
     # and populate it with environment variables. See .env.sample
     env_file:
       - .env
 
+    # variables without a default will automatically inherit from the host environment
+    environment:
+      # if set, CONTAINER_INVOKEAI_ROOT will override the Invoke runtime directory location *inside* the container
+      - INVOKEAI_ROOT=${CONTAINER_INVOKEAI_ROOT:-/invokeai}
+      - HF_HOME
     ports:
       - "${INVOKEAI_PORT:-9090}:9090"
     volumes:
       - type: bind
         source: ${HOST_INVOKEAI_ROOT:-${INVOKEAI_ROOT:-~/invokeai}}
-        target: ${INVOKEAI_ROOT:-/invokeai}
+        target: ${CONTAINER_INVOKEAI_ROOT:-/invokeai}
+        bind:
+          create_host_path: true
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
       # - ${INVOKEAI_MODELS_DIR:-${INVOKEAI_ROOT:-/invokeai/models}}
       # - ${INVOKEAI_MODELS_CONFIG_PATH:-${INVOKEAI_ROOT:-/invokeai/configs/models.yaml}}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -33,7 +33,8 @@ if [[ -v "PUBLIC_KEY" ]] && [[ ! -d "${HOME}/.ssh" ]]; then
     service ssh start
 fi
 
-
+mkdir -p "${INVOKEAI_ROOT}"
+chown --recursive ${USER} "${INVOKEAI_ROOT}"
 cd "${INVOKEAI_ROOT}"
 
 # Run the CMD as the Container User (not root).


### PR DESCRIPTION
<!--Thanks for contributing!-->

## Summary

- A new container without an existing root directory would fail to start due to permission issues and being unable to create the config file - this is fixed.

- The `--host` CLI argument was removed as part of config optimization, and we were using it in the Dockerfile. Because the default bind host is 127.0.0.1, the app would not be accessible from outside the container (even from local host). Anyway, this PR adds `INVOKEAI_HOST` and `INVOKEAI_PORT` to the Dockerfile to provide working defaults that do not require additional intervention from the user.

A couple of other improvements to the dockerized experience:
- `INVOKEAI_ROOT` can now be set to a relative path without using a dedicated env var pair for this purpose. The original (`HOST_` and `CONTAINER_`) root dir environment variables are retained because we know some users have these special use cases. The `env.sample` file now explains their use more thoroughly.
- No longer pre-install Torch in a separate Docker layer.  Thich reduces the image size and removes the need to manually bump Torch/torchvision versions in the Dockerfile - we now just let `pip` do its thing. We do however still need to maintain the `extra-index-url` logic in the Dockerfile to ensure cross-GPU compatibility.

## QA Instructions

- on Linux (CUDA and/or ROCm), enter the `docker` dir, and either execute `run.sh` or `docker compose up` - this will run with all defaults. 
- terminate the container (`docker compose down`), then try to set `INVOKEAI_ROOT` to a new path on the filesystem, and run it again. In all cases, the container should start and the new 4.0 UI should be usable as expected. 

## Merge Plan

Merge at will

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [ ] Tests added / updated - N/A
- [x] Documentation added / updated
