### PR TITLE
pkg: pin version of `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,8 @@ dependencies = [
 ]
 "dev" = ["jurigged", "pudb", "snakeviz", "gprof2dot"]
 "test" = [
-  "ruff",
-  "ruff-lsp",
+  "ruff>=0.3.3",
+  "ruff-lsp>=0.0.53",
   "mypy",
   "pre-commit",
   "pytest>6.0.0",


### PR DESCRIPTION
## Summary

If you switch between different branches, by the time you get back to `main`, a different version of `ruff` might be installed that has slightly different formatting rules. This leads to incorrect formatting changes.

Pinning `ruff` avoids this issue.

## Related Issues / Discussions

N/A

## QA Instructions

N/A

## Merge Plan

Smersh that merge button!

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [ ] Tests added / updated N/A
- [ ] Documentation added / updated N/A
