### PR TITLE
Wait for threads to exit after stopping model installer/downloader

### DIFF
--- a/invokeai/app/services/download/download_default.py
+++ b/invokeai/app/services/download/download_default.py
@@ -87,6 +87,8 @@ class DownloadQueueService(DownloadQueueServiceBase):
                 self._queue.queue.clear()
             self.join()  # wait for all active jobs to finish
             self._stop_event.set()
+            for thread in self._worker_pool:
+                thread.join()
             self._worker_pool.clear()
 
     def submit_download_job(

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -425,11 +425,11 @@ class ModelInstallService(ModelInstallServiceBase):
         self._running = True
 
     def _install_next_item(self) -> None:
-        self._logger.info(f"Installer thread {threading.get_ident()} starting")
+        self._logger.debug(f"Installer thread {threading.get_ident()} starting")
         while True:
             if self._stop_event.is_set():
                 break
-            self._logger.info(f"Installer thread {threading.get_ident()} running")
+            self._logger.debug(f"Installer thread {threading.get_ident()} polling")
             try:
                 job = self._install_queue.get(timeout=1)
             except Empty:

--- a/tests/app/services/download/test_download_queue.py
+++ b/tests/app/services/download/test_download_queue.py
@@ -51,6 +51,7 @@ def session() -> Session:
     return sess
 
 
+@pytest.mark.timeout(timeout=20, method="thread")
 def test_basic_queue_download(tmp_path: Path, session: Session) -> None:
     events = set()
 
@@ -80,6 +81,7 @@ def test_basic_queue_download(tmp_path: Path, session: Session) -> None:
     queue.stop()
 
 
+@pytest.mark.timeout(timeout=20, method="thread")
 def test_errors(tmp_path: Path, session: Session) -> None:
     queue = DownloadQueueService(
         requests_session=session,
@@ -101,6 +103,7 @@ def test_errors(tmp_path: Path, session: Session) -> None:
     queue.stop()
 
 
+@pytest.mark.timeout(timeout=20, method="thread")
 def test_event_bus(tmp_path: Path, session: Session) -> None:
     event_bus = TestEventService()
 
@@ -136,6 +139,7 @@ def test_event_bus(tmp_path: Path, session: Session) -> None:
     queue.stop()
 
 
+@pytest.mark.timeout(timeout=20, method="thread")
 def test_broken_callbacks(tmp_path: Path, session: Session, capsys) -> None:
     queue = DownloadQueueService(
         requests_session=session,

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -5,6 +5,7 @@ Test the model installer
 import platform
 import uuid
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 from pydantic import ValidationError
@@ -276,48 +277,48 @@ def test_404_download(mm2_installer: ModelInstallServiceBase, mm2_app_config: In
 
 
 # TODO: Fix bug in model install causing jobs to get installed multiple times then uncomment this test
-# @pytest.mark.parametrize(
-#     "model_params",
-#     [
-#         # SDXL, Lora
-#         {
-#             "repo_id": "InvokeAI-test/textual_inversion_tests::learned_embeds-steps-1000.safetensors",
-#             "name": "test_lora",
-#             "type": "embedding",
-#         },
-#         # SDXL, Lora - incorrect type
-#         {
-#             "repo_id": "InvokeAI-test/textual_inversion_tests::learned_embeds-steps-1000.safetensors",
-#             "name": "test_lora",
-#             "type": "lora",
-#         },
-#     ],
-# )
-# @pytest.mark.timeout(timeout=40, method="thread")
-# def test_heuristic_import_with_type(mm2_installer: ModelInstallServiceBase, model_params: Dict[str, str]):
-#     """Test whether or not type is respected on configs when passed to heuristic import."""
-#     assert "name" in model_params and "type" in model_params
-#     config1: Dict[str, Any] = {
-#         "name": f"{model_params['name']}_1",
-#         "type": model_params["type"],
-#         "hash": "placeholder1",
-#     }
-#     config2: Dict[str, Any] = {
-#         "name": f"{model_params['name']}_2",
-#         "type": ModelType(model_params["type"]),
-#         "hash": "placeholder2",
-#     }
-#     assert "repo_id" in model_params
-#     install_job1 = mm2_installer.heuristic_import(source=model_params["repo_id"], config=config1)
-#     mm2_installer.wait_for_job(install_job1, timeout=20)
-#     if model_params["type"] != "embedding":
-#         assert install_job1.errored
-#         assert install_job1.error_type == "InvalidModelConfigException"
-#         return
-#     assert install_job1.complete
-#     assert install_job1.config_out if model_params["type"] == "embedding" else not install_job1.config_out
+@pytest.mark.parametrize(
+    "model_params",
+    [
+        # SDXL, Lora
+        {
+            "repo_id": "InvokeAI-test/textual_inversion_tests::learned_embeds-steps-1000.safetensors",
+            "name": "test_lora",
+            "type": "embedding",
+        },
+        # SDXL, Lora - incorrect type
+        {
+            "repo_id": "InvokeAI-test/textual_inversion_tests::learned_embeds-steps-1000.safetensors",
+            "name": "test_lora",
+            "type": "lora",
+        },
+    ],
+)
+@pytest.mark.timeout(timeout=40, method="thread")
+def test_heuristic_import_with_type(mm2_installer: ModelInstallServiceBase, model_params: Dict[str, str]):
+    """Test whether or not type is respected on configs when passed to heuristic import."""
+    assert "name" in model_params and "type" in model_params
+    config1: Dict[str, Any] = {
+        "name": f"{model_params['name']}_1",
+        "type": model_params["type"],
+        "hash": "placeholder1",
+    }
+    config2: Dict[str, Any] = {
+        "name": f"{model_params['name']}_2",
+        "type": ModelType(model_params["type"]),
+        "hash": "placeholder2",
+    }
+    assert "repo_id" in model_params
+    install_job1 = mm2_installer.heuristic_import(source=model_params["repo_id"], config=config1)
+    mm2_installer.wait_for_job(install_job1, timeout=20)
+    if model_params["type"] != "embedding":
+        assert install_job1.errored
+        assert install_job1.error_type == "InvalidModelConfigException"
+        return
+    assert install_job1.complete
+    assert install_job1.config_out if model_params["type"] == "embedding" else not install_job1.config_out
 
-#     install_job2 = mm2_installer.heuristic_import(source=model_params["repo_id"], config=config2)
-#     mm2_installer.wait_for_job(install_job2, timeout=20)
-#     assert install_job2.complete
-#     assert install_job2.config_out if model_params["type"] == "embedding" else not install_job2.config_out
+    install_job2 = mm2_installer.heuristic_import(source=model_params["repo_id"], config=config2)
+    mm2_installer.wait_for_job(install_job2, timeout=20)
+    assert install_job2.complete
+    assert install_job2.config_out if model_params["type"] == "embedding" else not install_job2.config_out

--- a/tests/backend/model_manager/model_manager_fixtures.py
+++ b/tests/backend/model_manager/model_manager_fixtures.py
@@ -2,13 +2,11 @@
 
 import os
 import shutil
-import time
 from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
 from pydantic import BaseModel
-from pytest import FixtureRequest
 from requests.sessions import Session
 from requests_testadapter import TestAdapter, TestSession
 
@@ -99,15 +97,11 @@ def mm2_app_config(mm2_root_dir: Path) -> InvokeAIAppConfig:
 
 
 @pytest.fixture
-def mm2_download_queue(mm2_session: Session, request: FixtureRequest) -> DownloadQueueServiceBase:
+def mm2_download_queue(mm2_session: Session) -> DownloadQueueServiceBase:
     download_queue = DownloadQueueService(requests_session=mm2_session)
     download_queue.start()
-
-    def stop_queue() -> None:
-        download_queue.stop()
-
-    request.addfinalizer(stop_queue)
-    return download_queue
+    yield download_queue
+    download_queue.stop()
 
 
 @pytest.fixture
@@ -130,7 +124,6 @@ def mm2_installer(
     mm2_app_config: InvokeAIAppConfig,
     mm2_download_queue: DownloadQueueServiceBase,
     mm2_session: Session,
-    request: FixtureRequest,
 ) -> ModelInstallServiceBase:
     logger = InvokeAILogger.get_logger()
     db = create_mock_sqlite_database(mm2_app_config, logger)
@@ -145,13 +138,8 @@ def mm2_installer(
         session=mm2_session,
     )
     installer.start()
-
-    def stop_installer() -> None:
-        installer.stop()
-        time.sleep(0.1)  # avoid error message from the logger when it is closed before thread prints final message
-
-    request.addfinalizer(stop_installer)
-    return installer
+    yield installer
+    installer.stop()
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--Thanks for contributing!-->

## Summary

This PR causes the model_installer and download_queue `stop()` methods to block until their worker threads have exited. Previously `stop()` returned immediately.

This fix addresses an issue in the model installer unit test, where the installer is created and torn down in a pytest fixture.  Because a new installer was created immediately after the previous installer was torn down, it was possible for the old installer’s threads to intermix with the current ones, causing unpredictable results. This may fix the sporadic hangs and timeouts observed in the model installer unit test.

The downside of this is that the `test_model_install` and `test_download` unit tests now run noticeably slower than they used to due to waiting for the threads to exit. The alternative, of scoping the install fixture to the module or session level, is undesirable because we want each test function to start out with a clean install directory and registry.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

See discord https://discord.com/channels/1020123559063990373/1149513695567810630/1219777315148664882
<!--List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

If this PR fixes the problem, we will no longer see sporadic timeouts during unit testing. It is a very hard bug to reproduce, however, so time will tell.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [X] The PR has a short but descriptive title
- [X] Tests added / updated
- [X] Documentation added / updated
