### PR TITLE
fix(ui): use the old combobox component for dropdowns

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
@@ -1,12 +1,12 @@
-import { CustomSelect, FormControl, FormLabel } from '@invoke-ai/ui-library';
+import { Combobox, FormControl, FormLabel, Tooltip } from '@invoke-ai/ui-library';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
-import { useModelCustomSelect } from 'common/hooks/useModelCustomSelect';
+import { useGroupedModelCombobox } from 'common/hooks/useGroupedModelCombobox';
 import { zModelIdentifierField } from 'features/nodes/types/common';
 import { modelSelected } from 'features/parameters/store/actions';
 import { selectGenerationSlice } from 'features/parameters/store/generationSlice';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMainModels } from 'services/api/hooks/modelsByType';
 import type { MainModelConfig } from 'services/api/types';
@@ -18,7 +18,12 @@ const ParamMainModelSelect = () => {
   const { t } = useTranslation();
   const selectedModel = useAppSelector(selectModel);
   const [modelConfigs, { isLoading }] = useMainModels();
-
+  const tooltipLabel = useMemo(() => {
+    if (!modelConfigs.length || !selectedModel) {
+      return;
+    }
+    return modelConfigs.find((m) => m.key === selectedModel?.key)?.description;
+  }, [modelConfigs, selectedModel]);
   const _onChange = useCallback(
     (model: MainModelConfig | null) => {
       if (!model) {
@@ -33,26 +38,28 @@ const ParamMainModelSelect = () => {
     [dispatch]
   );
 
-  const { items, selectedItem, onChange, placeholder } = useModelCustomSelect({
+  const { options, value, onChange, placeholder, noOptionsMessage } = useGroupedModelCombobox({
     modelConfigs,
-    isLoading,
     selectedModel,
     onChange: _onChange,
+    isLoading,
   });
 
   return (
-    <FormControl isDisabled={!items.length} isInvalid={!selectedItem || !items.length}>
-      <InformationalPopover feature="paramModel">
-        <FormLabel>{t('modelManager.model')}</FormLabel>
-      </InformationalPopover>
-      <CustomSelect
-        key={items.length}
-        selectedItem={selectedItem}
-        placeholder={placeholder}
-        items={items}
-        onChange={onChange}
-      />
-    </FormControl>
+    <Tooltip label={tooltipLabel}>
+      <FormControl isDisabled={!modelConfigs.length} isInvalid={!value || !modelConfigs.length}>
+        <InformationalPopover feature="paramModel">
+          <FormLabel>{t('modelManager.model')}</FormLabel>
+        </InformationalPopover>
+        <Combobox
+          value={value}
+          placeholder={placeholder}
+          options={options}
+          onChange={onChange}
+          noOptionsMessage={noOptionsMessage}
+        />
+      </FormControl>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
## Summary

Use the old Combobox component for main model and control adapter model dropdowns.

## Related Issues / Discussions

Closes #6011

## QA Instructions

Both dropdowns should still work.

## Merge Plan

N/A

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [x] Tests added / updated (N/A)
- [x] Documentation added / updated (N/A)
