### PR TITLE
fix(ui): set aspect ratio to free when using default model settings

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/setDefaultSettings.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/setDefaultSettings.ts
@@ -1,14 +1,14 @@
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import { setDefaultSettings } from 'features/parameters/store/actions';
 import {
-  heightChanged,
+  heightRecalled,
   setCfgRescaleMultiplier,
   setCfgScale,
   setScheduler,
   setSteps,
   vaePrecisionChanged,
   vaeSelected,
-  widthChanged,
+  widthRecalled,
 } from 'features/parameters/store/generationSlice';
 import {
   isParameterCFGRescaleMultiplier,
@@ -100,13 +100,13 @@ export const addSetDefaultSettingsListener = (startAppListening: AppStartListeni
 
         if (width) {
           if (isParameterWidth(width)) {
-            dispatch(widthChanged(width));
+            dispatch(widthRecalled(width));
           }
         }
 
         if (height) {
           if (isParameterHeight(height)) {
-            dispatch(heightChanged(height));
+            dispatch(heightRecalled(height));
           }
         }
 


### PR DESCRIPTION
## Summary

We need to use the `widthRecalled` and `heightRecalled` actions, which handle the aspect ratio.

## Related Issues / Discussions

Closes  #5974

## QA Instructions

Use model default settings. It should set the aspect ratio to Free

## Merge Plan

N/A

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [x] The PR has a short but descriptive title
- [x] Tests added / updated (N/A)
- [x] Documentation added / updated (N/A)
