### PR TITLE
Allow checkpoint config files to use root-relative paths

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/controlnet.py
+++ b/invokeai/backend/model_manager/load/model_loaders/controlnet.py
@@ -44,7 +44,7 @@ class ControlNetLoader(GenericDiffusersLoader):
         )
 
         self._logger.info(f"Converting {model_path} to diffusers format")
-        with open(config.config_path, "r") as config_stream:
+        with open(self._app_config.root_path / config.config_path, "r") as config_stream:
             convert_controlnet_to_diffusers(
                 model_path,
                 output_path,

--- a/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
+++ b/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
@@ -91,7 +91,7 @@ class StableDiffusionDiffusersModel(GenericDiffusersLoader):
             model_path,
             output_path,
             model_type=self.model_base_to_model_type[base],
-            original_config_file=config.config_path,
+            original_config_file=self._app_config.root_path / config.config_path,
             extract_ema=True,
             from_safetensors=model_path.suffix == ".safetensors",
             precision=self._torch_dtype,

--- a/invokeai/backend/model_manager/load/model_loaders/vae.py
+++ b/invokeai/backend/model_manager/load/model_loaders/vae.py
@@ -44,7 +44,7 @@ class VAELoader(GenericDiffusersLoader):
             raise Exception(f"VAE conversion not supported for model type: {config.base}")
         else:
             assert isinstance(config, CheckpointConfigBase)
-            config_file = config.config_path
+            config_file = self._app_config.root_path / config.config_path
 
         if model_path.suffix == ".safetensors":
             checkpoint = safetensors_load_file(model_path, device="cpu")
@@ -55,7 +55,7 @@ class VAELoader(GenericDiffusersLoader):
         if "state_dict" in checkpoint:
             checkpoint = checkpoint["state_dict"]
 
-        ckpt_config = OmegaConf.load(self._app_config.root_path / config_file)
+        ckpt_config = OmegaConf.load(config_file)
         assert isinstance(ckpt_config, DictConfig)
         self._logger.info(f"Converting {model_path} to diffusers format")
         vae_model = convert_ldm_vae_to_diffusers(


### PR DESCRIPTION
<!--Thanks for contributing!-->

## Summary

Folks who used `main` prior to rc2 to install models will have root-relative paths to the original checkpoint config files. This PR converts the paths into absolute paths that can be passed to the checkpoint->diffusers convert scripts.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

Problem reported at https://discord.com/channels/1020123559063990373/1149506274971631688/1220371502264750150

<!--List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Remove the convert `.cache` directory to force checkpoint conversions. Try to load a checkpoint model that was installed in main prior to `rc2`. It should convert and load.

Now try to install a new checkpoint model. It should convert and load as well.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

<!--If any of these are not completed or not applicable to the change, please add a note.-->

- [X] The PR has a short but descriptive title
- [X] Tests added / updated
- [X] Documentation added / updated
