### PR TITLE
Catch ^C at startup time while models are being registered

### DIFF
--- a/invokeai/app/services/download/download_default.py
+++ b/invokeai/app/services/download/download_default.py
@@ -85,7 +85,7 @@ class DownloadQueueService(DownloadQueueServiceBase):
                 self._logger.info(f"Waiting for {len(active_jobs)} active download jobs to complete")
             with self._queue.mutex:
                 self._queue.queue.clear()
-            self.join()  # wait for all active jobs to finish
+            self.cancel_all_jobs()
             self._stop_event.set()
             for thread in self._worker_pool:
                 thread.join()

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -135,7 +135,6 @@ class ModelInstallService(ModelInstallServiceBase):
 
     def stop(self, invoker: Optional[Invoker] = None) -> None:
         """Stop the installer thread; after this the object can be deleted and garbage collected."""
-        # do manual acquire() so as to receive signals
         if not self._running:
             raise Exception("Attempt to stop the install service before it was started")
         self._logger.debug("calling stop_event.set()")


### PR DESCRIPTION
## Summary

Something about Python's thread implementation prevents the main thread from receiving the interrupt signal (sigINT) while waiting for a lock. The effect of this was to make it impossible to interrupt the server startup process with ^C during the potentially long model registration period when using an in-memory database and models are being hashed  and registered.

This PR contains an ugly workaround that installs a sigINT handler during the model installer startup method. When a sigINT is received, it shuts down the installer threads, reinstalls the default sigINT, and then raises the signal to the main process. The main process can then shut down in an orderly fashion.

I've tested this on Linux and Windows, and it seems to work ok. I had to remove a `lock.acquire()` from the installer's shutdown routine, which means there may be race conditions that occur just as model installer is exiting, but I doubt anyone will notice or care.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

* Closes #5960 

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

See #5960 for a recipe to demonstrate the original problem of uninterruptable model registration. Confirm that the registration process is interruptable.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
