### PR TITLE
Docker compose changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ installer/install.sh
 installer/update.bat
 installer/update.sh
 installer/InvokeAI-Installer/
+
+# Docker
+docker/compose.override.yaml

--- a/docker/compose.override.yaml
+++ b/docker/compose.override.yaml
@@ -1,0 +1,9 @@
+services:
+  invokeai-cuda:
+    restart: unless-stopped
+    labels:
+    - traefik.enable=true
+    - traefik.http.routers.invokeai-cuda.rule=Host(`invokeai.example.com`)
+    - traefik.http.routers.invokeai-cuda.entrypoints=websecure
+    - traefik.http.middlewares.invokeai-cuda-ipwhitelist.ipwhitelist.sourcerange=0.0.0.0/0
+    - traefik.http.routers.invokeai-cuda.middlewares=invokeai-cuda-ipwhitelist

--- a/docker/compose.override.yaml
+++ b/docker/compose.override.yaml
@@ -1,9 +1,0 @@
-services:
-  invokeai-cuda:
-    restart: unless-stopped
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.invokeai-cuda.rule=Host(`invokeai.example.com`)
-    - traefik.http.routers.invokeai-cuda.entrypoints=websecure
-    - traefik.http.middlewares.invokeai-cuda-ipwhitelist.ipwhitelist.sourcerange=0.0.0.0/0
-    - traefik.http.routers.invokeai-cuda.middlewares=invokeai-cuda-ipwhitelist

--- a/docker/compose.override.yaml.sample
+++ b/docker/compose.override.yaml.sample
@@ -1,0 +1,9 @@
+services:
+  invokeai-cuda:
+    restart: unless-stopped
+    labels:
+    - traefik.enable=true
+    - traefik.http.routers.invokeai-cuda.rule=Host(`invokeai.example.com`)
+    - traefik.http.routers.invokeai-cuda.entrypoints=websecure
+    - traefik.http.middlewares.invokeai-cuda-ipwhitelist.ipwhitelist.sourcerange=0.0.0.0/0
+    - traefik.http.routers.invokeai-cuda.middlewares=invokeai-cuda-ipwhitelist

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ x-invokeai: &invokeai
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
     tty: true
     stdin_open: true
-
+    labels: []
 
 services:
   invokeai-nvidia:
@@ -41,7 +41,7 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
-
+      
   invokeai-cpu:
     <<: *invokeai
     profiles:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,7 @@ x-invokeai: &invokeai
     labels: []
 
 services:
-  invokeai-nvidia:
+  invokeai-cuda:
     <<: *invokeai
     deploy:
       resources:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ x-invokeai: &invokeai
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
     tty: true
     stdin_open: true
-    labels: []
+
 
 services:
   invokeai-cuda:
@@ -41,7 +41,7 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
-      
+
   invokeai-cpu:
     <<: *invokeai
     profiles:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ x-invokeai: &invokeai
       - ${HF_HOME:-~/.cache/huggingface}:${HF_HOME:-/invokeai/.cache/huggingface}
     tty: true
     stdin_open: true
-
+    labels: []
 
 services:
   invokeai-cuda:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,7 +30,9 @@ run() {
   unset build_args
 
   printf "%s\n" "starting service $service_name"
-  docker compose --profile "$profile" up -d "$service_name"
+  # `touch compose.override.yaml` in case user doesn't use it
+  touch compose.override.yaml
+  docker compose --profile "$profile" -f docker-compose.yml -f compose.override.yaml up -d "$service_name"
   docker compose logs -f
 }
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,7 +9,12 @@ run() {
   local profile=""
 
   touch .env
-  build_args=$(awk '$1 ~ /=[^$]/ && $0 !~ /^#/ {print "--build-arg " $0 " "}' .env) &&
+  while IFS='=' read -r key value; do
+    if [[ ! $key =~ ^# && ! -z $value ]]; then
+      build_args+=" --build-arg $key=$value"
+      export "$key=$value"
+    fi
+  done < .env
   profile="$(awk -F '=' '/GPU_DRIVER/ {print $2}' .env)"
 
   [[ -z "$profile" ]] && profile="nvidia"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,7 +30,9 @@ run() {
   unset build_args
 
   printf "%s\n" "starting service $service_name"
-  docker compose --profile "$profile" up -d "$service_name"
+  # `touch compose.override.yaml` in case user doesn't use it (i.e., doesn't have it)
+  touch compose.override.yaml
+  docker compose --profile "$profile" -f docker-compose.yml -f compose.override.yaml up -d "$service_name"
   docker compose logs -f
 }
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,9 +30,7 @@ run() {
   unset build_args
 
   printf "%s\n" "starting service $service_name"
-  # `touch compose.override.yaml` in case user doesn't use it
-  touch compose.override.yaml
-  docker compose --profile "$profile" -f docker-compose.yml -f compose.override.yaml up -d "$service_name"
+  docker compose --profile "$profile" up -d "$service_name"
   docker compose logs -f
 }
 


### PR DESCRIPTION
## Summary

**_I'm not a coder so these changes definitely need to be reviewed before being accepted!_**

1. I couldn't get run.sh to succeed, and it looked like [this line](https://github.com/invoke-ai/InvokeAI/blob/0f02a72cb9fe9d7ac8a7e4be142737ab7a6b6c26/docker/run.sh#L12) was building the `--build-args` statement but the following lines needed the values in those args as well. So I replaced that line with a `while` that builds the `--build-args` statement _and_ assigns the vals to the vars.
2. I also had to change the service name from `invokeai-nvidia` to `invokeai-cuda`. Despite the [comment in the `.env` file](https://github.com/invoke-ai/InvokeAI/blob/0f02a72cb9fe9d7ac8a7e4be142737ab7a6b6c26/docker/.env.sample#L22-L23) saying that the values should be "nvidia" or "rocm", "nvidia" doesn't work but "cuda" does. [This line](https://github.com/invoke-ai/InvokeAI/blob/0f02a72cb9fe9d7ac8a7e4be142737ab7a6b6c26/docker/Dockerfile#L47) may be the reason that "cuda" is required. And since `$GPU_DRIVER` must be set to "cuda" for an Nvidia GPU, `$profile` is set based on `$GPU_DRIVER`, and `$service_name` is set based on `$profile`, `$service_name` ends up being `invokeai-cuda` (not `invokeai-nvidia`). 
3. I also added `compose.override.yaml` to `run.sh` in case a user has such a need. I use Traefik as proxy and middleware plugins ipwhitelist and traefik-forward-auth, so I use `compose.override.yaml` so that I don't have to modify `docker-compose.yaml` and thus have git telling me I need to commit a change.

## Related Issues / Discussions

NA

## QA Instructions

NA

## Merge Plan

NA

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
