### PR TITLE
fix(mm): default settings pydantic error

### DIFF
--- a/invokeai/backend/model_manager/config.py
+++ b/invokeai/backend/model_manager/config.py
@@ -146,10 +146,14 @@ class MainModelDefaultSettings(BaseModel):
     width: int | None = Field(default=None, multiple_of=8, ge=64, description="Default width for this model")
     height: int | None = Field(default=None, multiple_of=8, ge=64, description="Default height for this model")
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class ControlAdapterDefaultSettings(BaseModel):
     # This could be narrowed to controlnet processor nodes, but they change. Leaving this a string is safer.
     preprocessor: str | None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class ModelConfigBase(BaseModel):

--- a/tests/app/services/model_records/test_model_records_sql.py
+++ b/tests/app/services/model_records/test_model_records_sql.py
@@ -18,7 +18,9 @@ from invokeai.app.services.model_records import (
 from invokeai.app.services.model_records.model_records_base import ModelRecordChanges
 from invokeai.backend.model_manager.config import (
     BaseModelType,
+    ControlAdapterDefaultSettings,
     MainDiffusersConfig,
+    MainModelDefaultSettings,
     ModelFormat,
     ModelSourceType,
     ModelType,
@@ -288,3 +290,12 @@ def test_filter_2(store: ModelRecordServiceBase):
         model_name="dup_name1",
     )
     assert len(matches) == 1
+
+
+def test_model_record_changes():
+    # This test guards against some unexpected behaviours from pydantic's union evaluation. See #6035
+    changes = ModelRecordChanges.model_validate({"default_settings": {"preprocessor": "value"}})
+    assert isinstance(changes.default_settings, ControlAdapterDefaultSettings)
+
+    changes = ModelRecordChanges.model_validate({"default_settings": {"vae": "value"}})
+    assert isinstance(changes.default_settings, MainModelDefaultSettings)


### PR DESCRIPTION
## Summary

Add `extra="forbid"` to the default settings models.

Pydantic has some quirks related to unions. This affected how the union of default settings was evaluated. See https://github.com/pydantic/pydantic/issues/9095 for a detailed description of the behaviour that this change addresses.

## Related Issues / Discussions

Closes #6035.

## QA Instructions

Make and save changes to a ControlNet and T2I Adapter. 

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_ N/A
