### PR TITLE
tidy: launcher

### DIFF
--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -83,7 +83,7 @@ do_line_input() {
     printf "4: Run the InvokeAI image database maintenance script\n"
     printf "5: Command-line help\n"
     printf "Q: Quit\n\n"
-    read -p "Please enter 1-10, Q: [1] " yn
+    read -p "Please enter 1-5, Q: [1] " yn
     choice=${yn:='1'}
     do_choice $choice
     clear

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -25,7 +25,7 @@ cd "$scriptdir"
 export INVOKEAI_ROOT="$scriptdir"
 PARAMS=$@
 
-# Set required env var for torch on mac MPS
+# This setting allows torch to fall back to CPU for operations that are not supported by MPS on macOS.
 if [ "$(uname -s)" == "Darwin" ]; then
     export PYTORCH_ENABLE_MPS_FALLBACK=1
 fi

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -25,22 +25,6 @@ cd "$scriptdir"
 export INVOKEAI_ROOT="$scriptdir"
 PARAMS=$@
 
-# Check to see if dialog is installed (it seems to be fairly standard, but good to check regardless) and if the user has passed the --no-tui argument to disable the dialog TUI
-tui=true
-if command -v dialog &>/dev/null; then
-    # This must use $@ to properly loop through the arguments passed by the user
-    for arg in "$@"; do
-        if [ "$arg" == "--no-tui" ]; then
-            tui=false
-            # Remove the --no-tui argument to avoid errors later on when passing arguments to InvokeAI
-            PARAMS=$(echo "$PARAMS" | sed 's/--no-tui//')
-            break
-        fi
-    done
-else
-    tui=false
-fi
-
 # Set required env var for torch on mac MPS
 if [ "$(uname -s)" == "Darwin" ]; then
     export PYTORCH_ENABLE_MPS_FALLBACK=1
@@ -89,36 +73,9 @@ do_choice() {
     clear
 }
 
-# Dialog-based TUI for launcing Invoke functions
-do_dialog() {
-    options=(
-        1 "Generate images with a browser-based interface"
-        2 "Open the developer console"
-        3 "Update InvokeAI (DEPRECATED - please use the installer)"
-        4 "Run the InvokeAI image database maintenance script"
-        5 "Command-line help"
-    )
-
-    choice=$(dialog --clear \
-        --backtitle "\Zb\Zu\Z3InvokeAI" \
-        --colors \
-        --title "What would you like to do?" \
-        --ok-label "Run" \
-        --cancel-label "Exit" \
-        --help-button \
-        --help-label "CLI Help" \
-        --menu "Select an option:" \
-        0 0 0 \
-        "${options[@]}" \
-        2>&1 >/dev/tty) || clear
-    do_choice "$choice"
-    clear
-}
-
 # Command-line interface for launching Invoke functions
 do_line_input() {
     clear
-    printf " ** For a more attractive experience, please install the 'dialog' utility using your package manager. **\n\n"
     printf "What would you like to do?\n"
     printf "1: Generate images using the browser-based interface\n"
     printf "2: Open the developer console\n"
@@ -132,16 +89,10 @@ do_line_input() {
     clear
 }
 
-# Main IF statement for launching Invoke with either the TUI or CLI, and for checking if the user is in the developer console
+# Main IF statement for launching Invoke, and for checking if the user is in the developer console
 if [ "$0" != "bash" ]; then
     while true; do
-        if $tui; then
-            # .dialogrc must be located in the same directory as the invoke.sh script
-            export DIALOGRC="./.dialogrc"
-            do_dialog
-        else
-            do_line_input
-        fi
+        do_line_input
     done
 else # in developer console
     python --version


### PR DESCRIPTION
## Summary

Minor cleanup for the launcher script.

This does remove the `--no-tui` arg for the launcher, which only presented the launcher options a slightly different way but which added extra surface area to the launcher. So this is a breaking change, if anybody actually uses that arg.

## Related Issues / Discussions

N/A

## QA Instructions

N/A

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_ N/A
- [x] _Documentation added / updated (if applicable)_
