### PR TITLE
fix(mm): prevent installer softlock when an unhandled error occurs

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -457,11 +457,10 @@ class ModelInstallService(ModelInstallServiceBase):
                 elif job.waiting or job.downloads_done:
                     self._register_or_install(job)
 
-            except InvalidModelConfigException as excp:
-                self._set_error(job, excp)
-
-            except (OSError, DuplicateModelException) as excp:
-                self._set_error(job, excp)
+            except Exception as e:
+                # Expected errors include InvalidModelConfigException, DuplicateModelException, OSError, but we must
+                # gracefully handle _any_ error here.
+                self._set_error(job, e)
 
             finally:
                 # if this is an install of a remote file, then clean up the temporary directory

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -910,7 +910,7 @@ class ModelInstallService(ModelInstallServiceBase):
             self._event_bus.emit_model_install_completed(str(job.source), key, id=job.id)
 
     def _signal_job_errored(self, job: ModelInstallJob) -> None:
-        self._logger.info(f"Model install error: {job.source}, {job.error_type}\n{job.error}")
+        self._logger.error(f"Model install error: {job.source}\n{job.error_type}: {job.error}")
         if self._event_bus:
             error_type = job.error_type
             error = job.error

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -288,6 +288,24 @@ def test_404_download(mm2_installer: ModelInstallServiceBase, mm2_app_config: In
     assert job.error_traceback.startswith("Traceback")
 
 
+def test_other_error_during_install(
+    monkeypatch: pytest.MonkeyPatch, mm2_installer: ModelInstallServiceBase, mm2_app_config: InvokeAIAppConfig
+) -> None:
+    def raise_runtime_error(*args, **kwargs):
+        raise RuntimeError("Test error")
+    monkeypatch.setattr(
+        "invokeai.app.services.model_install.model_install_default.ModelInstallService._register_or_install",
+        raise_runtime_error,
+    )
+    source = LocalModelSource(path=Path("tests/data/embedding/test_embedding.safetensors"))
+    job = mm2_installer.import_model(source)
+    mm2_installer.wait_for_installs(timeout=10)
+    assert job.status == InstallStatus.ERROR
+    assert job.errored
+    assert job.error_type == "RuntimeError"
+    assert job.error == "Test error"
+
+
 # TODO: Fix bug in model install causing jobs to get installed multiple times then uncomment this test
 @pytest.mark.parametrize(
     "model_params",

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -293,6 +293,7 @@ def test_other_error_during_install(
 ) -> None:
     def raise_runtime_error(*args, **kwargs):
         raise RuntimeError("Test error")
+
     monkeypatch.setattr(
         "invokeai.app.services.model_install.model_install_default.ModelInstallService._register_or_install",
         raise_runtime_error,


### PR DESCRIPTION
## Summary

Previously we only handled expected error types. If a different error was raised, the install job would end up in an unexpected state where it has failed and isn't doing anything, but its status is still running.

This indirectly prevents the installer threads from exiting - they are waiting for all jobs to be completed, including the failed-but-still-running job.

We need to handle any error here to prevent this.

## Related Issues / Discussions

Related:  #6044 - we also need to fix what appears to be a problematic embedding format for this issue.

## QA Instructions

First, edit `invokeai/app/services/model_install/model_install_default.py` to raise an error in `_register_or_install`:

```diff
diff --git a/invokeai/app/services/model_install/model_install_default.py b/invokeai/app/services/model_install/model_install_default.py
index ea1992274..f4a3f8a33 100644
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -478,6 +478,8 @@ class ModelInstallService(ModelInstallServiceBase):
         job.config_in["source"] = str(job.source)
         job.config_in["source_type"] = MODEL_SOURCE_TO_TYPE_MAP[job.source.__class__]
         # enter the metadata, if there is any
+
+        raise RuntimeError("artificial runtime error")
         if isinstance(job.source_metadata, (HuggingFaceMetadata)):
             job.config_in["source_api_response"] = job.source_metadata.api_response
```

Next, install any model. It should immediately fail. An unhandled error is expected in the terminal:

```
Exception in thread Thread-6 (_install_next_item):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/bat/Documents/Code/InvokeAI/invokeai/app/services/model_install/model_install_default.py", line 458, in _install_next_item
    self._register_or_install(job)
  File "/home/bat/Documents/Code/InvokeAI/invokeai/app/services/model_install/model_install_default.py", line 485, in _register_or_install
    raise RuntimeError("artificial runtime error")
RuntimeError: artificial runtime error
```

Attempt to kill the app with `Ctrl+C`. You should see this warning, but the app will hang after printing it:
```
[2024-03-25 18:59:38,795]::[ModelInstallService]::WARNING --> Cancelling job {job.id}
```

Check out this PR and follow the same steps. Instead of the unhandled error, we expect an error log message:

```
[2024-03-25 19:02:26,953]::[ModelInstallService]::ERROR --> Model install error: https://huggingface.co/cyberdelia/CyberRealistic_Negative/resolve/main/CyberRealistic_Negative_v3.pt
RuntimeError: artificial runtime error
```

Pressing `Ctrl+C` should work, and actually end the app.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
