### PR TITLE
fix(ui): load default workflows mutation error

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/workflow/migrations.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/migrations.ts
@@ -11,7 +11,7 @@ import { zWorkflowV2 } from 'features/nodes/types/v2/workflow';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
 import { zWorkflowV3 } from 'features/nodes/types/workflow';
 import { t } from 'i18next';
-import { forEach } from 'lodash-es';
+import { cloneDeep, forEach } from 'lodash-es';
 import { z } from 'zod';
 
 /**
@@ -89,7 +89,7 @@ export const parseAndMigrateWorkflow = (data: unknown): WorkflowV3 => {
     throw new WorkflowVersionError(t('nodes.unableToGetWorkflowVersion'));
   }
 
-  let workflow = data as WorkflowV1 | WorkflowV2 | WorkflowV3;
+  let workflow = cloneDeep(data) as WorkflowV1 | WorkflowV2 | WorkflowV3;
 
   if (workflow.meta.version === '1.0.0') {
     const v1 = zWorkflowV1.parse(workflow);


### PR DESCRIPTION
## Summary

Loading default workflows sometimes requires we mutate the workflow object in order to change the category or ID of the workflow.

This happens in `invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts`

The data we get back from the query hooks is frozen and sealed by redux, because they are part of redux state. We need to clone the workflow before operating on it.

It's not clear how this ever worked in the past, because redux state has always been frozen and sealed.

## Related Issues / Discussions

N/A

## QA Instructions

Load a default workflow or old workflow. It should work.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_ N/A (no test coverage in this area)
- [x] _Documentation added / updated (if applicable)_ N/A (bugfix)
