### PR TITLE
fix(mm): handle integer state dict keys in probe

### DIFF
--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -28,7 +28,7 @@ from .config import (
 )
 from .util.model_util import lora_token_vector_length, read_checkpoint_meta
 
-CkptType = Dict[str, Any]
+CkptType = Dict[str | int, Any]
 
 LEGACY_CONFIGS: Dict[BaseModelType, Dict[ModelVariantType, Union[str, Dict[SchedulerPredictionType, str]]]] = {
     BaseModelType.StableDiffusion1: {
@@ -219,7 +219,7 @@ class ModelProbe(object):
         ckpt = checkpoint if checkpoint else read_checkpoint_meta(model_path, scan=True)
         ckpt = ckpt.get("state_dict", ckpt)
 
-        for key in ckpt.keys():
+        for key in [str(k) for k in ckpt.keys()]:
             if any(key.startswith(v) for v in {"cond_stage_model.", "first_stage_model.", "model.diffusion_model."}):
                 return ModelType.Main
             elif any(key.startswith(v) for v in {"encoder.conv_in", "decoder.conv_in"}):


### PR DESCRIPTION
## Summary

It's possible for a model's state dict to have integer keys, though we do not actually support such models.

As part of probing, we call `key.startswith(...)` on the state dict keys. This raises an `AttributeError` for integer keys.

This logic is in `invokeai/backend/model_manager/probe.py:get_model_type_from_checkpoint`

To fix this, we can cast the keys to strings first. The models w/ integer keys will still fail to be probed, but we'll get a `InvalidModelConfigException` instead of `AttributeError`.

## Related Issues / Discussions

Closes #6044

## QA Instructions

I'd like to get approval from @ljleb that this fixes the problem, but no worries if that's a bit too much work. I'm fairly confident that this change plus #6048 will resolve #6044 satisfactorily.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_ N/A
