### PR TITLE
Allow embeddings and loras to have different names

### DIFF
--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -147,6 +147,7 @@ class ModelProbe(object):
 
         probe = probe_class(model_path)
         model_path = probe.model_path
+        format_type = probe.get_format()
         fields["source_type"] = fields.get("source_type") or ModelSourceType.Path
         fields["source"] = fields.get("source") or model_path.as_posix()
         fields["key"] = fields.get("key", uuid_string())
@@ -160,7 +161,8 @@ class ModelProbe(object):
         fields["description"] = (
             fields.get("description") or f"{fields['base'].value} {model_type.value} model {fields['name']}"
         )
-        fields["format"] = fields.get("format") or probe.get_format()
+        fields["format"] = fields.get("format") or format_type
+
         fields["hash"] = fields.get("hash") or ModelHash(algorithm=hash_algo).hash(model_path)
 
         fields["default_settings"] = fields.get("default_settings")

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -146,11 +146,11 @@ class ModelProbe(object):
             raise InvalidModelConfigException(f"Unhandled combination of {format_type} and {model_type}")
 
         probe = probe_class(model_path)
-
+        model_path = probe.model_path
         fields["source_type"] = fields.get("source_type") or ModelSourceType.Path
         fields["source"] = fields.get("source") or model_path.as_posix()
         fields["key"] = fields.get("key", uuid_string())
-        fields["path"] = probe.model_path.as_posix() or model_path.as_posix()
+        fields["path"] = model_path.as_posix()
         fields["type"] = fields.get("type") or model_type
         fields["base"] = fields.get("base") or probe.get_base_type()
         fields["variant"] = fields.get("variant") or probe.get_variant_type()

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -644,18 +644,15 @@ class VaeFolderProbe(FolderProbeBase):
         return name
 
 
-class TextualInversionFolderProbe(FolderProbeBase):
-    def get_format(self) -> ModelFormat:
-        return ModelFormat.EmbeddingFolder
-
-    def get_base_type(self) -> BaseModelType:
-        files = os.scandir(self.model_path)
+class TextualInversionFolderProbe(TextualInversionCheckpointProbe):
+    def __init__(self, model_path: Path):
+        files = os.scandir(model_path)
         files = [Path(f.path) for f in files if f.is_file() and f.name.endswith((".ckpt", ".pt", ".pth", ".bin", ".safetensors"))]
         if len(files) != 1:
             raise InvalidModelConfigException(
-                f"Unable to determine base type for {self.model_path}: expected exactly one valid model file, found {[f.name for f in files]}."
+                f"Unable to determine base type for {model_path}: expected exactly one valid model file, found {[f.name for f in files]}."
             )
-        return TextualInversionCheckpointProbe(files.pop()).get_base_type()
+        super().__init__(model_path)
 
 
 class ONNXFolderProbe(PipelineFolderProbe):
@@ -701,19 +698,16 @@ class ControlNetFolderProbe(FolderProbeBase):
         return base_model
 
 
-class LoRAFolderProbe(FolderProbeBase):
-    def get_base_type(self) -> BaseModelType:
-        model_file = None
-        files = os.scandir(self.model_path)
+class LoRAFolderProbe(LoRACheckpointProbe):
+    def __init__(self, model_path: Path):
+        files = os.scandir(model_path)
         files = [Path(f.path) for f in files if f.is_file() and f.name.endswith((".bin", ".safetensors"))]
         if len(files) != 1:
             raise InvalidModelConfigException(
-                f"Unable to determine base type for {self.model_path}: expected exactly one valid model file, found {[f.name for f in files]}."
+                f"Unable to determine base type for lora {model_path}: expected exactly one valid model file, found {[f.name for f in files]}."
             )
         model_file = files.pop()
-        if not model_file:
-            raise InvalidModelConfigException("Unknown LoRA format encountered")
-        return LoRACheckpointProbe(model_file).get_base_type()
+        super().__init__(model_file)
 
 
 class IPAdapterFolderProbe(FolderProbeBase):

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -150,7 +150,7 @@ class ModelProbe(object):
         fields["source_type"] = fields.get("source_type") or ModelSourceType.Path
         fields["source"] = fields.get("source") or model_path.as_posix()
         fields["key"] = fields.get("key", uuid_string())
-        fields["path"] = model_path.as_posix()
+        fields["path"] = probe.model_path.as_posix() or model_path.as_posix()
         fields["type"] = fields.get("type") or model_type
         fields["base"] = fields.get("base") or probe.get_base_type()
         fields["variant"] = fields.get("variant") or probe.get_variant_type()
@@ -652,7 +652,7 @@ class TextualInversionFolderProbe(TextualInversionCheckpointProbe):
             raise InvalidModelConfigException(
                 f"Unable to determine base type for {model_path}: expected exactly one valid model file, found {[f.name for f in files]}."
             )
-        super().__init__(model_path)
+        super().__init__(files.pop())
 
 
 class ONNXFolderProbe(PipelineFolderProbe):

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -649,7 +649,11 @@ class VaeFolderProbe(FolderProbeBase):
 class TextualInversionFolderProbe(TextualInversionCheckpointProbe):
     def __init__(self, model_path: Path):
         files = os.scandir(model_path)
-        files = [Path(f.path) for f in files if f.is_file() and f.name.endswith((".ckpt", ".pt", ".pth", ".bin", ".safetensors"))]
+        files = [
+            Path(f.path)
+            for f in files
+            if f.is_file() and f.name.endswith((".ckpt", ".pt", ".pth", ".bin", ".safetensors"))
+        ]
         if len(files) != 1:
             raise InvalidModelConfigException(
                 f"Unable to determine base type for {model_path}: expected exactly one valid model file, found {[f.name for f in files]}."


### PR DESCRIPTION
## Summary

Currently LoRA folders will only named if they're named precisely pytorch_lora_weights.bin or pytorch_lora_weights.safetensors, and embedding folders will only load if they're named "learned_embeds.bin". This PR is an attempt to support different lora/embedding types if they are installed as a folder. Even though we have this naming convention for the files in the folder, our backend supports many more types of models for embeddings, and loras seem to be rarely named "correctly" in Huggingface.

## QA Instructions

Test this by copying one of your already existing embeddings into a folder under the same directory in your models. Ensure it's scanned correctly on startup and is usable forgeneration.

## Merge Plan

Can be merged if approved by code owners. @lstein may know some reason why we had this naming requirement. If so, we can look for different ways to handle this.
