### PR TITLE
fix(mm): handle depth and inpaint ckpt conversion

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
+++ b/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
@@ -14,11 +14,17 @@ from invokeai.backend.model_manager import (
     SchedulerPredictionType,
     SubModelType,
 )
-from invokeai.backend.model_manager.config import CheckpointConfigBase, MainCheckpointConfig
+from invokeai.backend.model_manager.config import CheckpointConfigBase, MainCheckpointConfig, ModelVariantType
 from invokeai.backend.model_manager.convert_ckpt_to_diffusers import convert_ckpt_to_diffusers
 
 from .. import ModelLoaderRegistry
 from .generic_diffusers import GenericDiffusersLoader
+
+VARIANT_TO_IN_CHANNEL_MAP = {
+    ModelVariantType.Normal: 4,
+    ModelVariantType.Depth: 5,
+    ModelVariantType.Inpaint: 9,
+}
 
 
 @ModelLoaderRegistry.register(base=BaseModelType.Any, type=ModelType.Main, format=ModelFormat.Diffusers)
@@ -87,6 +93,7 @@ class StableDiffusionDiffusersModel(GenericDiffusersLoader):
         )
 
         self._logger.info(f"Converting {model_path} to diffusers format")
+
         convert_ckpt_to_diffusers(
             model_path,
             output_path,
@@ -99,5 +106,6 @@ class StableDiffusionDiffusersModel(GenericDiffusersLoader):
             image_size=image_size,
             upcast_attention=upcast_attention,
             load_safety_checker=False,
+            num_in_channels=VARIANT_TO_IN_CHANNEL_MAP[config.variant],
         )
         return output_path

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -37,7 +37,6 @@ LEGACY_CONFIGS: Dict[BaseModelType, Dict[ModelVariantType, Union[str, Dict[Sched
             SchedulerPredictionType.VPrediction: "v1-inference-v.yaml",
         },
         ModelVariantType.Inpaint: "v1-inpainting-inference.yaml",
-        ModelVariantType.Depth: "v2-midas-inference.yaml",
     },
     BaseModelType.StableDiffusion2: {
         ModelVariantType.Normal: {
@@ -48,6 +47,7 @@ LEGACY_CONFIGS: Dict[BaseModelType, Dict[ModelVariantType, Union[str, Dict[Sched
             SchedulerPredictionType.Epsilon: "v2-inpainting-inference.yaml",
             SchedulerPredictionType.VPrediction: "v2-inpainting-inference-v.yaml",
         },
+        ModelVariantType.Depth: "v2-midas-inference.yaml",
     },
     BaseModelType.StableDiffusionXL: {
         ModelVariantType.Normal: "sd_xl_base.yaml",

--- a/invokeai/configs/stable-diffusion/v2-midas-inference.yaml
+++ b/invokeai/configs/stable-diffusion/v2-midas-inference.yaml
@@ -1,0 +1,74 @@
+model:
+  base_learning_rate: 5.0e-07
+  target: ldm.models.diffusion.ddpm.LatentDepth2ImageDiffusion
+  params:
+    linear_start: 0.00085
+    linear_end: 0.0120
+    num_timesteps_cond: 1
+    log_every_t: 200
+    timesteps: 1000
+    first_stage_key: "jpg"
+    cond_stage_key: "txt"
+    image_size: 64
+    channels: 4
+    cond_stage_trainable: false
+    conditioning_key: hybrid
+    scale_factor: 0.18215
+    monitor: val/loss_simple_ema
+    finetune_keys: null
+    use_ema: False
+
+    depth_stage_config:
+      target: ldm.modules.midas.api.MiDaSInference
+      params:
+        model_type: "dpt_hybrid"
+
+    unet_config:
+      target: ldm.modules.diffusionmodules.openaimodel.UNetModel
+      params:
+        use_checkpoint: True
+        image_size: 32 # unused
+        in_channels: 5
+        out_channels: 4
+        model_channels: 320
+        attention_resolutions: [ 4, 2, 1 ]
+        num_res_blocks: 2
+        channel_mult: [ 1, 2, 4, 4 ]
+        num_head_channels: 64 # need to fix for flash-attn
+        use_spatial_transformer: True
+        use_linear_in_transformer: True
+        transformer_depth: 1
+        context_dim: 1024
+        legacy: False
+
+    first_stage_config:
+      target: ldm.models.autoencoder.AutoencoderKL
+      params:
+        embed_dim: 4
+        monitor: val/rec_loss
+        ddconfig:
+          #attn_type: "vanilla-xformers"
+          double_z: true
+          z_channels: 4
+          resolution: 256
+          in_channels: 3
+          out_ch: 3
+          ch: 128
+          ch_mult:
+            - 1
+            - 2
+            - 4
+            - 4
+          num_res_blocks: 2
+          attn_resolutions: [ ]
+          dropout: 0.0
+        lossconfig:
+          target: torch.nn.Identity
+
+    cond_stage_config:
+      target: ldm.modules.encoders.modules.FrozenOpenCLIPEmbedder
+      params:
+        freeze: True
+        layer: "penultimate"
+
+


### PR DESCRIPTION
## Summary

I assume this was handled by our own conversion logic until it was removed recently.

- Specify `num_in_channels` as needed when converting ckpt to diffusers
- Fix a typo in the legacy config map
- Add missing legacy config file for depth

## Related Issues / Discussions

Closes  #6058

## QA Instructions

Install a normal checkpoint and these two test models:
- Inpaint: https://huggingface.co/runwayml/stable-diffusion-inpainting/resolve/main/sd-v1-5-inpainting.ckpt
- Depth: https://huggingface.co/stabilityai/stable-diffusion-2-depth/resolve/main/512-depth-ema.safetensors

To test conversion, do a normal t2i generation with each model.

The inpaint model should work fully, but we don't expect the depth model to generate (separate issue).

You should see this message in the terminal for the depth model, then other non-error messages:

```
[2024-03-27 19:26:52,803]::[ModelLoadService]::INFO --> Converting /home/bat/invokeai-4.0.0/models/sd-2/main/512-depth-ema.safetensors to diffusers format
```

This indicates the conversion was successful, which is the purpose of this PR.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_ N/A (kinda not testable unless we add tests around model conversion)
- [x] _Documentation added / updated (if applicable)_ N/A
