### PR TITLE
Flip default ordering of workflow library; #5477

### DIFF
--- a/invokeai/frontend/web/src/features/workflowLibrary/components/WorkflowLibraryList.tsx
+++ b/invokeai/frontend/web/src/features/workflowLibrary/components/WorkflowLibraryList.tsx
@@ -73,7 +73,7 @@ const WorkflowLibraryList = () => {
   }, [projectId, ORDER_BY_OPTIONS]);
 
   const [order_by, setOrderBy] = useState<WorkflowRecordOrderBy>(orderByOptions[0]?.value as WorkflowRecordOrderBy);
-  const [direction, setDirection] = useState<SQLiteDirection>('ASC');
+  const [direction, setDirection] = useState<SQLiteDirection>('DESC');
   const [debouncedQuery] = useDebounce(query, 500);
 
   const queryArg = useMemo<Parameters<typeof useListWorkflowsQuery>[0]>(() => {


### PR DESCRIPTION
## Summary

Simple fix for #5477, changing the default ordering of the workflow library to descending.

## Related Issues / Discussions

Closes #5477 unless it would be better to do that with something more comprehensive.

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
