### PR TITLE
fix(nodes): workaround seamless multi gpu error

### DIFF
--- a/invokeai/backend/stable_diffusion/seamless.py
+++ b/invokeai/backend/stable_diffusion/seamless.py
@@ -28,6 +28,10 @@ def _conv_forward_asymmetric(self, input, weight, bias):
 
 @contextmanager
 def set_seamless(model: Union[UNet2DConditionModel, AutoencoderKL, AutoencoderTiny], seamless_axes: List[str]):
+    if not seamless_axes:
+        yield
+        return
+
     # Callable: (input: Tensor, weight: Tensor, bias: Optional[Tensor]) -> Tensor
     to_restore: list[tuple[nn.Conv2d | nn.ConvTranspose2d, Callable]] = []
     try:


### PR DESCRIPTION
## Summary

Note: This is a partial fix. It doesn't fix seamless in a multi-GPU setup, but it will fix non-seamless generation on a multi-GPU setup.

---

The seamless logic errors when a second GPU is selected. I don't understand why, but a workaround is to skip the model patching when there there are no seamless axes specified.

This is also just a good practice regardless - don't patch the model unless we need to. Probably a negligible perf impact.

## Related Issues / Discussions

Partial fix for #6010

## QA Instructions

Needs a machine w/ 2 GPUs to test. Normal generation should work on the second GPU (though we expect the same error if you enable seamless).

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
