### PR TITLE
Only cancel session processor if current generating queue item is can…

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -70,13 +70,18 @@ class DefaultSessionProcessor(SessionProcessorBase):
     async def _on_queue_event(self, event: FastAPIEvent) -> None:
         event_name = event[1]["event"]
 
-
-        if event_name == "session_canceled" and self._queue_item\
-              and self._queue_item.item_id == event[1]["data"]["queue_item_id"]:
+        if (
+            event_name == "session_canceled"
+            and self._queue_item
+            and self._queue_item.item_id == event[1]["data"]["queue_item_id"]
+        ):
             self._cancel_event.set()
             self._poll_now()
-        elif event_name == "queue_cleared" and self._queue_item\
-              and self._queue_item.queue_id == event[1]["data"]["queue_id"]:
+        elif (
+            event_name == "queue_cleared"
+            and self._queue_item
+            and self._queue_item.queue_id == event[1]["data"]["queue_id"]
+        ):
             self._cancel_event.set()
             self._poll_now()
         elif event_name == "batch_enqueued":

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -70,8 +70,13 @@ class DefaultSessionProcessor(SessionProcessorBase):
     async def _on_queue_event(self, event: FastAPIEvent) -> None:
         event_name = event[1]["event"]
 
-        if event_name == "session_canceled" or event_name == "queue_cleared":
-            # These both mean we should cancel the current session.
+
+        if event_name == "session_canceled" and self._queue_item\
+              and self._queue_item.item_id == event[1]["data"]["queue_item_id"]:
+            self._cancel_event.set()
+            self._poll_now()
+        elif event_name == "queue_cleared" and self._queue_item\
+              and self._queue_item.queue_id == event[1]["data"]["queue_id"]:
             self._cancel_event.set()
             self._poll_now()
         elif event_name == "batch_enqueued":


### PR DESCRIPTION
…celled

## Summary

Currently if you cancel a queue item from the queue menu, it will cancel the active generation even if a different queue item is cancelled.

## Related Issues / Discussions

Closes #6049

## QA Instructions

Start a batch with 5 generations, wait for inferencing to start, proceed to the queue menu and cancel the last item in the queue. Ensure the current inferencing does not stop.

## Merge Plan

Can be merged when approved
