### PR TITLE
Use defaults for db_dir and outdir since config no longer writes defa…

### DIFF
--- a/invokeai/backend/util/db_maintenance.py
+++ b/invokeai/backend/util/db_maintenance.py
@@ -31,6 +31,9 @@ class ConfigMapper:
     YAML_FILENAME = "invokeai.yaml"
     DATABASE_FILENAME = "invokeai.db"
 
+    DEFAULT_OUTDIR = "outputs"
+    DEFAULT_DB_DIR = "databases"
+
     database_path = None
     database_backup_dir = None
     outputs_path = None
@@ -50,12 +53,18 @@ class ConfigMapper:
     def __load_from_root_config(self, invoke_root):
         """Validate a yaml path exists, confirm the user wants to use it and load config."""
         yaml_path = os.path.join(invoke_root, self.YAML_FILENAME)
+        if not os.path.exists(yaml_path):
+            print(f"Unable to find invokeai.yaml at {yaml_path}!")
+            return False
         if os.path.exists(yaml_path):
             db_dir, outdir = self.__load_paths_from_yaml_file(yaml_path)
 
-            if db_dir is None or outdir is None:
-                print("The invokeai.yaml file was found but is missing the db_dir and/or outdir setting!")
-                return False
+            if db_dir is None:
+                db_dir = self.DEFAULT_DB_DIR
+                print(f"The invokeai.yaml file was found but is missing the db_dir setting! Defaulting to {db_dir}")
+            if outdir is None:
+                outdir = self.DEFAULT_OUTDIR
+                print(f"The invokeai.yaml file was found but is missing the outdir setting! Defaulting to {outdir}")
 
             if os.path.isabs(db_dir):
                 self.database_path = os.path.join(db_dir, self.DATABASE_FILENAME)


### PR DESCRIPTION
…ults to invokeai.yaml

## Summary

Our config service no longer writes default values to the invokeai.yaml file. This PR simply assumes those default values in the event it discovers an invokeai.yaml file in the directory it's run.

## QA Instructions

Delete images from your output dir, run this maintenance script and ensure DB is cleaned appropriately.

Run from a directory not containing invokeai.yaml to ensure it fails quickly with logging.

## Merge Plan

Can be merged when approved

