### PR TITLE
Drop model_config table during database version 7 migration.

### DIFF
--- a/invokeai/app/services/shared/sqlite_migrator/migrations/migration_7.py
+++ b/invokeai/app/services/shared/sqlite_migrator/migrations/migration_7.py
@@ -11,7 +11,7 @@ class Migration7Callback:
     def _drop_old_models_tables(self, cursor: sqlite3.Cursor) -> None:
         """Drops the old model_records, model_metadata, model_tags and tags tables."""
 
-        tables = ["model_records", "model_metadata", "model_tags", "tags"]
+        tables = ["model_config", "model_metadata", "model_tags", "tags"]
 
         for table in tables:
             cursor.execute(f"DROP TABLE IF EXISTS {table};")


### PR DESCRIPTION
## Summary

Due to a typo, the unused `model_config` table is not dropped during `migration_7`. This fixes the issue for users still on database version 6. For those who have already migrated to 7, we will need to remember to drop the `model_config` table again in migration 8, but seems like overkill to create a new migration just to correct this.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

* closes #6080
<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Should not be needed to QA, but restore database to version 6 and then start the web app under this PR.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
