### PR TITLE
feat(mm): restore relative paths for invoke-managed models

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -368,11 +368,13 @@ class ModelInstallService(ModelInstallServiceBase):
     def delete(self, key: str) -> None:  # noqa D102
         """Unregister the model. Delete its files only if they are within our models directory."""
         model = self.record_store.get_model(key)
-        models_dir = self.app_config.models_path
-        model_path = models_dir / Path(model.path)  # handle legacy relative model paths
-        if model_path.is_relative_to(models_dir):
+        model_path = self.app_config.models_path / model.path
+
+        if model_path.is_relative_to(self.app_config.models_path):
+            # If the models is in the Invoke-managed models dir, we delete it
             self.unconditionally_delete(key)
         else:
+            # Else we only unregister it, leaving the file in place
             self.unregister(key)
 
     def unconditionally_delete(self, key: str) -> None:  # noqa D102
@@ -500,9 +502,9 @@ class ModelInstallService(ModelInstallServiceBase):
     def _scan_for_missing_models(self) -> list[AnyModelConfig]:
         """Scan the models directory for missing models and return a list of them."""
         missing_models: list[AnyModelConfig] = []
-        for x in self.record_store.all_models():
-            if not Path(x.path).resolve().exists():
-                missing_models.append(x)
+        for model_config in self.record_store.all_models():
+            if not (self.app_config.models_path / model_config.path).resolve().exists():
+                missing_models.append(model_config)
         return missing_models
 
     def _register_orphaned_models(self) -> None:
@@ -548,10 +550,11 @@ class ModelInstallService(ModelInstallServiceBase):
         May raise an UnknownModelException.
         """
         model = self.record_store.get_model(key)
-        old_path = Path(model.path).resolve()
-        models_dir = self.app_config.models_path.resolve()
+        models_dir = self.app_config.models_path
+        old_path = self.app_config.models_path / model.path
 
         if not old_path.is_relative_to(models_dir):
+            # The model is not in the models directory - we don't need to move it.
             return model
 
         new_path = (models_dir / model.base.value / model.type.value / model.name).with_suffix(old_path.suffix)
@@ -561,7 +564,7 @@ class ModelInstallService(ModelInstallServiceBase):
 
         self._logger.info(f"Moving {model.name} to {new_path}.")
         new_path = self._move_model(old_path, new_path)
-        model.path = new_path.as_posix()
+        model.path = new_path.relative_to(models_dir).as_posix()
         self.record_store.update_model(key, ModelRecordChanges(path=model.path))
         return model
 
@@ -600,12 +603,19 @@ class ModelInstallService(ModelInstallServiceBase):
 
         model_path = model_path.resolve()
 
+        # Models in the Invoke-managed models dir should use relative paths.
+        if model_path.is_relative_to(self.app_config.models_path):
+            model_path = model_path.relative_to(self.app_config.models_path)
+
         info.path = model_path.as_posix()
 
-        # Checkpoints have a config file needed for conversion - resolve this to an absolute path
         if isinstance(info, CheckpointConfigBase):
-            legacy_conf = (self.app_config.legacy_conf_path / info.config_path).resolve()
-            info.config_path = legacy_conf.as_posix()
+            # Checkpoints have a config file needed for conversion. Same handling as the model weights - if it's in the
+            # invoke-managed legacy config dir, we use a relative path.
+            legacy_config_path = Path(info.config_path).resolve()
+            if legacy_config_path.is_relative_to(self.app_config.legacy_conf_path):
+                legacy_config_path = legacy_config_path.relative_to(self.app_config.legacy_conf_path)
+            info.config_path = legacy_config_path.as_posix()
         self.record_store.add_model(info)
         return info.key
 

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -514,7 +514,9 @@ class ModelInstallService(ModelInstallServiceBase):
         only situations in which we may have orphaned models in the models directory.
         """
 
-        installed_model_paths = {Path(x.path).resolve() for x in self.record_store.all_models()}
+        installed_model_paths = {
+            (self._app_config.models_path / x.path).resolve() for x in self.record_store.all_models()
+        }
 
         # The bool returned by this callback determines if the model is added to the list of models found by the search
         def on_model_found(model_path: Path) -> bool:

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -612,7 +612,7 @@ class ModelInstallService(ModelInstallServiceBase):
         if isinstance(info, CheckpointConfigBase):
             # Checkpoints have a config file needed for conversion. Same handling as the model weights - if it's in the
             # invoke-managed legacy config dir, we use a relative path.
-            legacy_config_path = Path(info.config_path).resolve()
+            legacy_config_path = self.app_config.legacy_conf_path / info.config_path
             if legacy_config_path.is_relative_to(self.app_config.legacy_conf_path):
                 legacy_config_path = legacy_config_path.relative_to(self.app_config.legacy_conf_path)
             info.config_path = legacy_config_path.as_posix()

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -348,8 +348,13 @@ class ModelInstallService(ModelInstallServiceBase):
                     config: dict[str, Any] = {}
                     config["name"] = model_name
                     config["description"] = stanza.get("description")
-                    config["config_path"] = stanza.get("config")
-
+                    legacy_config_path = stanza.get("config")
+                    if legacy_config_path:
+                        # In v3, these paths were relative to the root. Migrate them to be relative to the legacy_conf_dir.
+                        legacy_config_path: Path = self._app_config.root_path / legacy_config_path
+                        if legacy_config_path.is_relative_to(self._app_config.legacy_conf_path):
+                            legacy_config_path = legacy_config_path.relative_to(self._app_config.legacy_conf_path)
+                        config["config_path"] = str(legacy_config_path)
                     try:
                         id = self.register_path(model_path=model_path, config=config)
                         self._logger.info(f"Migrated {model_name} with id {id}")

--- a/invokeai/app/services/shared/sqlite/sqlite_util.py
+++ b/invokeai/app/services/shared/sqlite/sqlite_util.py
@@ -38,6 +38,7 @@ def init_db(config: InvokeAIAppConfig, logger: Logger, image_files: ImageFileSto
     migrator.register_migration(build_migration_5())
     migrator.register_migration(build_migration_6())
     migrator.register_migration(build_migration_7())
+    print("DEBUG: HERE I AM")
     migrator.register_migration(build_migration_8(app_config=config))
     migrator.run_migrations()
 

--- a/invokeai/app/services/shared/sqlite/sqlite_util.py
+++ b/invokeai/app/services/shared/sqlite/sqlite_util.py
@@ -10,6 +10,7 @@ from invokeai.app.services.shared.sqlite_migrator.migrations.migration_4 import 
 from invokeai.app.services.shared.sqlite_migrator.migrations.migration_5 import build_migration_5
 from invokeai.app.services.shared.sqlite_migrator.migrations.migration_6 import build_migration_6
 from invokeai.app.services.shared.sqlite_migrator.migrations.migration_7 import build_migration_7
+from invokeai.app.services.shared.sqlite_migrator.migrations.migration_8 import build_migration_8
 from invokeai.app.services.shared.sqlite_migrator.sqlite_migrator_impl import SqliteMigrator
 
 
@@ -37,6 +38,7 @@ def init_db(config: InvokeAIAppConfig, logger: Logger, image_files: ImageFileSto
     migrator.register_migration(build_migration_5())
     migrator.register_migration(build_migration_6())
     migrator.register_migration(build_migration_7())
+    migrator.register_migration(build_migration_8(app_config=config))
     migrator.run_migrations()
 
     return db

--- a/invokeai/app/services/shared/sqlite_migrator/migrations/migration_8.py
+++ b/invokeai/app/services/shared/sqlite_migrator/migrations/migration_8.py
@@ -1,0 +1,83 @@
+import sqlite3
+from pathlib import Path
+
+from invokeai.app.services.config.config_default import InvokeAIAppConfig
+from invokeai.app.services.shared.sqlite_migrator.sqlite_migrator_common import Migration
+
+
+class Migration8Callback:
+    def __init__(self, app_config: InvokeAIAppConfig) -> None:
+        self._app_config = app_config
+
+    def __call__(self, cursor: sqlite3.Cursor) -> None:
+        self._drop_model_config_table(cursor)
+        self._migrate_abs_models_to_rel(cursor)
+
+    def _drop_model_config_table(self, cursor: sqlite3.Cursor) -> None:
+        """Drops the old model_config table. This was missed in a previous migration."""
+
+        cursor.execute("DROP TABLE IF EXISTS model_config;")
+
+    def _migrate_abs_models_to_rel(self, cursor: sqlite3.Cursor) -> None:
+        """Check all model paths & legacy config paths to determine if they are inside Invoke-managed directories. If
+        they are, update the paths to be relative to the managed directories.
+
+        This migration is a no-op for normal users (their paths will already be relative), but is necessary for users
+        who have been testing the RCs with their live databases. The paths were made absolute in the initial RC, but this
+        change was reverted. To smooth over the revert for our tests, we can migrate the paths back to relative.
+        """
+
+        models_dir = self._app_config.models_path
+        legacy_conf_dir = self._app_config.legacy_conf_path
+
+        stmt = """---sql
+        SELECT
+            id,
+            path,
+            json_extract(config, '$.config_path') as config_path
+        FROM models;
+        """
+
+        all_models = cursor.execute(stmt).fetchall()
+
+        for model_id, model_path, model_config_path in all_models:
+            # If the model path is inside the models directory, update it to be relative to the models directory.
+            if model_path.startswith(str(models_dir)):
+                new_path = Path(model_path).relative_to(models_dir)
+                cursor.execute(
+                    """--sql
+                    UPDATE models
+                    SET config = json_set(config, '$.path', ?)
+                    WHERE id = ?;
+                    """,
+                    (str(new_path), model_id),
+                )
+            # If the model has a legacy config path and it is inside the legacy conf directory, update it to be
+            # relative to the legacy conf directory.
+            if model_config_path and model_config_path.startswith(str(legacy_conf_dir)):
+                new_config_path = Path(model_config_path).relative_to(legacy_conf_dir)
+                cursor.execute(
+                    """--sql
+                    UPDATE models
+                    SET config = json_set(config, '$.config_path', ?)
+                    WHERE id = ?;
+                    """,
+                    (str(new_config_path), model_id),
+                )
+
+
+def build_migration_8(app_config: InvokeAIAppConfig) -> Migration:
+    """
+    Build the migration from database version 7 to 8.
+
+    This migration does the following:
+    - Removes the `model_config` table.
+    - Migrates absolute model & legacy config paths to be relative to the models directory.
+    """
+    migration_8 = Migration(
+        from_version=7,
+        to_version=8,
+        callback=Migration8Callback(app_config),
+    )
+
+    return migration_8

--- a/invokeai/app/services/shared/sqlite_migrator/migrations/migration_8.py
+++ b/invokeai/app/services/shared/sqlite_migrator/migrations/migration_8.py
@@ -43,7 +43,7 @@ class Migration8Callback:
 
         for model_id, model_path, model_config_path in all_models:
             # If the model path is inside the models directory, update it to be relative to the models directory.
-            if model_path.startswith(str(models_path)):
+            if Path(model_path).is_relative_to(models_path):
                 new_path = Path(model_path).relative_to(models_path)
                 cursor.execute(
                     """--sql
@@ -54,11 +54,12 @@ class Migration8Callback:
                     (str(new_path), model_id),
                 )
             # If the model has a legacy config path and it is inside the legacy conf directory, update it to be
-            # relative to the legacy conf directory.
+            # relative to the legacy conf directory. This also fixes up cases in which the config path was
+            # incorrectly relativized to the root directory. It will now be relativized to the legacy conf directory.
             if model_config_path:
-                if model_config_path.startswith(str(legacy_conf_path)):  # for absolute version
+                if Path(model_config_path).is_relative_to(legacy_conf_path):
                     new_config_path = Path(model_config_path).relative_to(legacy_conf_path)
-                elif model_config_path.startswith(str(legacy_conf_dir)):  # for incorrect root-relative version
+                elif Path(model_config_path).is_relative_to(legacy_conf_dir):
                     new_config_path = Path(*Path(model_config_path).parts[1:])
                 else:
                     new_config_path = None

--- a/invokeai/backend/model_manager/load/model_loaders/controlnet.py
+++ b/invokeai/backend/model_manager/load/model_loaders/controlnet.py
@@ -44,7 +44,7 @@ class ControlNetLoader(GenericDiffusersLoader):
         )
 
         self._logger.info(f"Converting {model_path} to diffusers format")
-        with open(self._app_config.root_path / config.config_path, "r") as config_stream:
+        with open(self._app_config.legacy_conf_path / config.config_path, "r") as config_stream:
             convert_controlnet_to_diffusers(
                 model_path,
                 output_path,

--- a/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
+++ b/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
@@ -98,7 +98,7 @@ class StableDiffusionDiffusersModel(GenericDiffusersLoader):
             model_path,
             output_path,
             model_type=self.model_base_to_model_type[base],
-            original_config_file=self._app_config.root_path / config.config_path,
+            original_config_file=self._app_config.legacy_conf_path / config.config_path,
             extract_ema=True,
             from_safetensors=model_path.suffix == ".safetensors",
             precision=self._torch_dtype,

--- a/invokeai/backend/model_manager/load/model_loaders/vae.py
+++ b/invokeai/backend/model_manager/load/model_loaders/vae.py
@@ -44,7 +44,7 @@ class VAELoader(GenericDiffusersLoader):
             raise Exception(f"VAE conversion not supported for model type: {config.base}")
         else:
             assert isinstance(config, CheckpointConfigBase)
-            config_file = self._app_config.root_path / config.config_path
+            config_file = self._app_config.legacy_conf_path / config.config_path
 
         if model_path.suffix == ".safetensors":
             checkpoint = safetensors_load_file(model_path, device="cpu")

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -43,8 +43,7 @@ def test_registration_meta(mm2_installer: ModelInstallServiceBase, embedding_fil
     assert model_record is not None
     assert model_record.name == "test_embedding"
     assert model_record.type == ModelType.TextualInversion
-    assert model_record.path.endswith(embedding_file.as_posix())
-    assert Path(model_record.path).is_absolute()
+    assert Path(model_record.path) == embedding_file
     assert Path(model_record.path).exists()
     assert model_record.base == BaseModelType("sd-1")
     assert model_record.description is not None
@@ -77,8 +76,7 @@ def test_install(
     key = mm2_installer.install_path(embedding_file)
     model_record = store.get_model(key)
     assert model_record.path.endswith("sd-1/embedding/test_embedding.safetensors")
-    assert Path(model_record.path).is_absolute()
-    assert Path(model_record.path).exists()
+    assert (mm2_app_config.models_path / model_record.path).exists()
     assert model_record.source == embedding_file.as_posix()
 
 
@@ -147,10 +145,7 @@ def test_background_install(
     model_record = mm2_installer.record_store.get_model(key)
     assert model_record is not None
     assert model_record.path.endswith(destination)
-    assert Path(model_record.path).is_absolute()
-    assert Path(model_record.path).exists()
-    assert model_record.key != "<NOKEY>"
-    assert Path(model_record.path).exists()
+    assert (mm2_app_config.models_path / model_record.path).exists()
 
     # see if metadata was properly passed through
     assert model_record.description == description
@@ -172,7 +167,7 @@ def test_not_inplace_install(
     assert job is not None
     assert job.config_out is not None
     assert Path(job.config_out.path) != embedding_file
-    assert Path(job.config_out.path).exists()
+    assert (mm2_app_config.models_path / job.config_out.path).exists()
 
 
 def test_inplace_install(
@@ -184,16 +179,21 @@ def test_inplace_install(
     assert job is not None
     assert job.config_out is not None
     assert Path(job.config_out.path) == embedding_file
+    assert Path(job.config_out.path).exists()
 
 
-def test_delete_install(mm2_installer: ModelInstallServiceBase, embedding_file: Path) -> None:
+def test_delete_install(
+    mm2_installer: ModelInstallServiceBase, embedding_file: Path, mm2_app_config: InvokeAIAppConfig
+) -> None:
     store = mm2_installer.record_store
     key = mm2_installer.install_path(embedding_file)
     model_record = store.get_model(key)
-    assert Path(model_record.path).exists()
+    assert (mm2_app_config.models_path / model_record.path).exists()
     assert embedding_file.exists()  # original should still be there after installation
     mm2_installer.delete(key)
-    assert not Path(model_record.path).exists()  # after deletion, installed copy should not exist
+    assert not (
+        mm2_app_config.models_path / model_record.path
+    ).exists()  # after deletion, installed copy should not exist
     assert embedding_file.exists()  # but original should still be there
     with pytest.raises(UnknownModelException):
         store.get_model(key)
@@ -232,7 +232,7 @@ def test_simple_download(mm2_installer: ModelInstallServiceBase, mm2_app_config:
 
     key = job.config_out.key
     model_record = store.get_model(key)
-    assert Path(model_record.path).exists()
+    assert (mm2_app_config.models_path / model_record.path).exists()
 
     assert len(bus.events) == 4
     event_names = [x.event_name for x in bus.events]
@@ -261,7 +261,7 @@ def test_huggingface_download(mm2_installer: ModelInstallServiceBase, mm2_app_co
 
     key = job.config_out.key
     model_record = store.get_model(key)
-    assert Path(model_record.path).exists()
+    assert (mm2_app_config.models_path / model_record.path).exists()
     assert model_record.type == ModelType.Main
     assert model_record.format == ModelFormat.Diffusers
 


### PR DESCRIPTION
## Summary

See first commit message for why. 

Includes a DB migration as a convenience for RC users whose databases are now full of absolute paths.

## Related Issues / Discussions

Discord thread: https://discord.com/channels/1020123559063990373/1049495067846524939/1223169963624366080

## QA Instructions

Test against:
- v3 install w/ a models.yaml and no db
- v4 RC6 or earlier

Both test cases must have some checkpoint models to test the legacy config paths, which have the same issue.

I've done this testing already using some local DB fixtures, but I'm tired and don't trust my own work yet. I'd like to test again tomorrow, or somebody else can pick it up from here.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
