### PR TITLE
fix(queue): pause & resume

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -121,9 +121,15 @@ class DefaultSessionProcessor(SessionProcessorBase):
                 poll_now_event.clear()
                 # Middle processor try block; any unhandled exception is a non-fatal processor error
                 try:
-                    # Get the next session to process
-                    self._queue_item = self._invoker.services.session_queue.dequeue()
-                    if self._queue_item is not None and resume_event.is_set():
+                    # If we are paused, wait for resume event
+                    if resume_event.is_set():
+                        # Get the next session to process
+                        self._queue_item = self._invoker.services.session_queue.dequeue()
+
+                        if self._queue_item is None:
+                            # Empty queue, wait for next polling interval or event to try again
+                            continue
+
                         self._invoker.services.logger.debug(f"Executing queue item {self._queue_item.item_id}")
                         cancel_event.clear()
 


### PR DESCRIPTION
## Summary

This must not have been tested after the processors were unified. Needed to shift the logic around so the resume event is handled correctly. Clear and easy fix.

## Related Issues / Discussions

Closes #6090

## QA Instructions

Queue up some generations and pause and resume. Should work fine.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a (no e2e coverage :/ )
- [ ] _Documentation added / updated (if applicable)_ n/a
