### PR TITLE
Fix 100% CPU load in `session_processor_default._process()`

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -128,6 +128,7 @@ class DefaultSessionProcessor(SessionProcessorBase):
 
                         if self._queue_item is None:
                             # Empty queue, wait for next polling interval or event to try again
+                            poll_now_event.wait(self._polling_interval)
                             continue
 
                         self._invoker.services.logger.debug(f"Executing queue item {self._queue_item.item_id}")

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -126,148 +126,148 @@ class DefaultSessionProcessor(SessionProcessorBase):
                         # Get the next session to process
                         self._queue_item = self._invoker.services.session_queue.dequeue()
 
-                        if self._queue_item is None:
-                            # Empty queue, wait for next polling interval or event to try again
-                            poll_now_event.wait(self._polling_interval)
-                            continue
+                        if self._queue_item is not None:
+                            self._invoker.services.logger.debug(f"Executing queue item {self._queue_item.item_id}")
+                            cancel_event.clear()
 
-                        self._invoker.services.logger.debug(f"Executing queue item {self._queue_item.item_id}")
-                        cancel_event.clear()
+                            # If profiling is enabled, start the profiler
+                            if self._profiler is not None:
+                                self._profiler.start(profile_id=self._queue_item.session_id)
 
-                        # If profiling is enabled, start the profiler
-                        if self._profiler is not None:
-                            self._profiler.start(profile_id=self._queue_item.session_id)
+                            # Prepare invocations and take the first
+                            self._invocation = self._queue_item.session.next()
 
-                        # Prepare invocations and take the first
-                        self._invocation = self._queue_item.session.next()
+                            # Loop over invocations until the session is complete or canceled
+                            while self._invocation is not None and not cancel_event.is_set():
+                                # get the source node id to provide to clients (the prepared node id is not as useful)
+                                source_invocation_id = self._queue_item.session.prepared_source_mapping[
+                                    self._invocation.id
+                                ]
 
-                        # Loop over invocations until the session is complete or canceled
-                        while self._invocation is not None and not cancel_event.is_set():
-                            # get the source node id to provide to clients (the prepared node id is not as useful)
-                            source_invocation_id = self._queue_item.session.prepared_source_mapping[self._invocation.id]
+                                # Send starting event
+                                self._invoker.services.events.emit_invocation_started(
+                                    queue_batch_id=self._queue_item.batch_id,
+                                    queue_item_id=self._queue_item.item_id,
+                                    queue_id=self._queue_item.queue_id,
+                                    graph_execution_state_id=self._queue_item.session_id,
+                                    node=self._invocation.model_dump(),
+                                    source_node_id=source_invocation_id,
+                                )
 
-                            # Send starting event
-                            self._invoker.services.events.emit_invocation_started(
-                                queue_batch_id=self._queue_item.batch_id,
-                                queue_item_id=self._queue_item.item_id,
-                                queue_id=self._queue_item.queue_id,
-                                graph_execution_state_id=self._queue_item.session_id,
-                                node=self._invocation.model_dump(),
-                                source_node_id=source_invocation_id,
-                            )
+                                # Innermost processor try block; any unhandled exception is an invocation error & will fail the graph
+                                try:
+                                    with self._invoker.services.performance_statistics.collect_stats(
+                                        self._invocation, self._queue_item.session.id
+                                    ):
+                                        # Build invocation context (the node-facing API)
+                                        data = InvocationContextData(
+                                            invocation=self._invocation,
+                                            source_invocation_id=source_invocation_id,
+                                            queue_item=self._queue_item,
+                                        )
+                                        context = build_invocation_context(
+                                            data=data,
+                                            services=self._invoker.services,
+                                            cancel_event=self._cancel_event,
+                                        )
 
-                            # Innermost processor try block; any unhandled exception is an invocation error & will fail the graph
-                            try:
-                                with self._invoker.services.performance_statistics.collect_stats(
-                                    self._invocation, self._queue_item.session.id
-                                ):
-                                    # Build invocation context (the node-facing API)
-                                    data = InvocationContextData(
-                                        invocation=self._invocation,
-                                        source_invocation_id=source_invocation_id,
-                                        queue_item=self._queue_item,
+                                        # Invoke the node
+                                        outputs = self._invocation.invoke_internal(
+                                            context=context, services=self._invoker.services
+                                        )
+
+                                        # Save outputs and history
+                                        self._queue_item.session.complete(self._invocation.id, outputs)
+
+                                        # Send complete event
+                                        self._invoker.services.events.emit_invocation_complete(
+                                            queue_batch_id=self._queue_item.batch_id,
+                                            queue_item_id=self._queue_item.item_id,
+                                            queue_id=self._queue_item.queue_id,
+                                            graph_execution_state_id=self._queue_item.session.id,
+                                            node=self._invocation.model_dump(),
+                                            source_node_id=source_invocation_id,
+                                            result=outputs.model_dump(),
+                                        )
+
+                                except KeyboardInterrupt:
+                                    # TODO(MM2): Create an event for this
+                                    pass
+
+                                except CanceledException:
+                                    # When the user cancels the graph, we first set the cancel event. The event is checked
+                                    # between invocations, in this loop. Some invocations are long-running, and we need to
+                                    # be able to cancel them mid-execution.
+                                    #
+                                    # For example, denoising is a long-running invocation with many steps. A step callback
+                                    # is executed after each step. This step callback checks if the canceled event is set,
+                                    # then raises a CanceledException to stop execution immediately.
+                                    #
+                                    # When we get a CanceledException, we don't need to do anything - just pass and let the
+                                    # loop go to its next iteration, and the cancel event will be handled correctly.
+                                    pass
+
+                                except Exception as e:
+                                    error = traceback.format_exc()
+
+                                    # Save error
+                                    self._queue_item.session.set_node_error(self._invocation.id, error)
+                                    self._invoker.services.logger.error(
+                                        f"Error while invoking session {self._queue_item.session_id}, invocation {self._invocation.id} ({self._invocation.get_type()}):\n{e}"
                                     )
-                                    context = build_invocation_context(
-                                        data=data,
-                                        services=self._invoker.services,
-                                        cancel_event=self._cancel_event,
-                                    )
+                                    self._invoker.services.logger.error(error)
 
-                                    # Invoke the node
-                                    outputs = self._invocation.invoke_internal(
-                                        context=context, services=self._invoker.services
-                                    )
-
-                                    # Save outputs and history
-                                    self._queue_item.session.complete(self._invocation.id, outputs)
-
-                                    # Send complete event
-                                    self._invoker.services.events.emit_invocation_complete(
-                                        queue_batch_id=self._queue_item.batch_id,
+                                    # Send error event
+                                    self._invoker.services.events.emit_invocation_error(
+                                        queue_batch_id=self._queue_item.session_id,
                                         queue_item_id=self._queue_item.item_id,
                                         queue_id=self._queue_item.queue_id,
                                         graph_execution_state_id=self._queue_item.session.id,
                                         node=self._invocation.model_dump(),
                                         source_node_id=source_invocation_id,
-                                        result=outputs.model_dump(),
+                                        error_type=e.__class__.__name__,
+                                        error=error,
                                     )
+                                    pass
 
-                            except KeyboardInterrupt:
-                                # TODO(MM2): Create an event for this
-                                pass
-
-                            except CanceledException:
-                                # When the user cancels the graph, we first set the cancel event. The event is checked
-                                # between invocations, in this loop. Some invocations are long-running, and we need to
-                                # be able to cancel them mid-execution.
-                                #
-                                # For example, denoising is a long-running invocation with many steps. A step callback
-                                # is executed after each step. This step callback checks if the canceled event is set,
-                                # then raises a CanceledException to stop execution immediately.
-                                #
-                                # When we get a CanceledException, we don't need to do anything - just pass and let the
-                                # loop go to its next iteration, and the cancel event will be handled correctly.
-                                pass
-
-                            except Exception as e:
-                                error = traceback.format_exc()
-
-                                # Save error
-                                self._queue_item.session.set_node_error(self._invocation.id, error)
-                                self._invoker.services.logger.error(
-                                    f"Error while invoking session {self._queue_item.session_id}, invocation {self._invocation.id} ({self._invocation.get_type()}):\n{e}"
-                                )
-                                self._invoker.services.logger.error(error)
-
-                                # Send error event
-                                self._invoker.services.events.emit_invocation_error(
-                                    queue_batch_id=self._queue_item.session_id,
-                                    queue_item_id=self._queue_item.item_id,
-                                    queue_id=self._queue_item.queue_id,
-                                    graph_execution_state_id=self._queue_item.session.id,
-                                    node=self._invocation.model_dump(),
-                                    source_node_id=source_invocation_id,
-                                    error_type=e.__class__.__name__,
-                                    error=error,
-                                )
-                                pass
-
-                            # The session is complete if the all invocations are complete or there was an error
-                            if self._queue_item.session.is_complete() or cancel_event.is_set():
-                                # Send complete event
-                                self._invoker.services.events.emit_graph_execution_complete(
-                                    queue_batch_id=self._queue_item.batch_id,
-                                    queue_item_id=self._queue_item.item_id,
-                                    queue_id=self._queue_item.queue_id,
-                                    graph_execution_state_id=self._queue_item.session.id,
-                                )
-                                # If we are profiling, stop the profiler and dump the profile & stats
-                                if self._profiler:
-                                    profile_path = self._profiler.stop()
-                                    stats_path = profile_path.with_suffix(".json")
-                                    self._invoker.services.performance_statistics.dump_stats(
-                                        graph_execution_state_id=self._queue_item.session.id, output_path=stats_path
+                                # The session is complete if the all invocations are complete or there was an error
+                                if self._queue_item.session.is_complete() or cancel_event.is_set():
+                                    # Send complete event
+                                    self._invoker.services.events.emit_graph_execution_complete(
+                                        queue_batch_id=self._queue_item.batch_id,
+                                        queue_item_id=self._queue_item.item_id,
+                                        queue_id=self._queue_item.queue_id,
+                                        graph_execution_state_id=self._queue_item.session.id,
                                     )
-                                # We'll get a GESStatsNotFoundError if we try to log stats for an untracked graph, but in the processor
-                                # we don't care about that - suppress the error.
-                                with suppress(GESStatsNotFoundError):
-                                    self._invoker.services.performance_statistics.log_stats(self._queue_item.session.id)
-                                    self._invoker.services.performance_statistics.reset_stats()
+                                    # If we are profiling, stop the profiler and dump the profile & stats
+                                    if self._profiler:
+                                        profile_path = self._profiler.stop()
+                                        stats_path = profile_path.with_suffix(".json")
+                                        self._invoker.services.performance_statistics.dump_stats(
+                                            graph_execution_state_id=self._queue_item.session.id, output_path=stats_path
+                                        )
+                                    # We'll get a GESStatsNotFoundError if we try to log stats for an untracked graph, but in the processor
+                                    # we don't care about that - suppress the error.
+                                    with suppress(GESStatsNotFoundError):
+                                        self._invoker.services.performance_statistics.log_stats(
+                                            self._queue_item.session.id
+                                        )
+                                        self._invoker.services.performance_statistics.reset_stats()
 
-                                # Set the invocation to None to prepare for the next session
-                                self._invocation = None
-                            else:
-                                # Prepare the next invocation
-                                self._invocation = self._queue_item.session.next()
+                                    # Set the invocation to None to prepare for the next session
+                                    self._invocation = None
+                                else:
+                                    # Prepare the next invocation
+                                    self._invocation = self._queue_item.session.next()
 
-                        # The session is complete, immediately poll for next session
-                        self._queue_item = None
-                        poll_now_event.set()
-                    else:
-                        # The queue was empty, wait for next polling interval or event to try again
-                        self._invoker.services.logger.debug("Waiting for next polling interval or event")
-                        poll_now_event.wait(self._polling_interval)
-                        continue
+                            # The session is complete, immediately poll for next session
+                            self._queue_item = None
+                            poll_now_event.set()
+                        else:
+                            # The queue was empty, wait for next polling interval or event to try again
+                            self._invoker.services.logger.debug("Waiting for next polling interval or event")
+                            poll_now_event.wait(self._polling_interval)
+                            continue
                 except Exception:
                     # Non-fatal error in processor
                     self._invoker.services.logger.error(


### PR DESCRIPTION
## Summary

This fixes a state in which the invokeai web server goes into a fast spin loop, consuming 100% CPU.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

Related to the fix for generation pause/resume in commit `9a1b35fa372fcfe99a43cda1e93c17dfba76786f`. I have tested that pause/resume/cancel still work.

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Launch `invokeai-web` and monitor its CPU usage with top or similar system profiling tool. It should settle down at near 0% CPU usage when not actively generating an image.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
