### PR TITLE
fix(mm): vae conversion

### DIFF
--- a/invokeai/backend/model_manager/convert_ckpt_to_diffusers.py
+++ b/invokeai/backend/model_manager/convert_ckpt_to_diffusers.py
@@ -3,10 +3,10 @@
 """Conversion script for the Stable Diffusion checkpoints."""
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
-from diffusers import AutoencoderKL
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
 from diffusers.pipelines.stable_diffusion.convert_from_ckpt import (
     convert_ldm_vae_checkpoint,
     create_vae_diffusers_config,
@@ -19,9 +19,10 @@ from . import AnyModel
 
 
 def convert_ldm_vae_to_diffusers(
-    checkpoint: Dict[str, torch.Tensor],
+    checkpoint: torch.Tensor | dict[str, torch.Tensor],
     vae_config: DictConfig,
     image_size: int,
+    dump_path: Optional[Path] = None,
     precision: torch.dtype = torch.float16,
 ) -> AutoencoderKL:
     """Convert a checkpoint-style VAE into a Diffusers VAE"""
@@ -30,7 +31,12 @@ def convert_ldm_vae_to_diffusers(
 
     vae = AutoencoderKL(**vae_config)
     vae.load_state_dict(converted_vae_checkpoint)
-    return vae.to(precision)
+    vae.to(precision)
+
+    if dump_path:
+        vae.save_pretrained(dump_path, safe_serialization=True)
+
+    return vae
 
 
 def convert_ckpt_to_diffusers(

--- a/invokeai/backend/model_manager/load/model_loaders/vae.py
+++ b/invokeai/backend/model_manager/load/model_loaders/vae.py
@@ -65,4 +65,4 @@ class VAELoader(GenericDiffusersLoader):
             precision=self._torch_dtype,
         )
         vae_model.save_pretrained(output_path, safe_serialization=True)
-        return output_path
+        return vae_model

--- a/invokeai/backend/model_manager/load/model_loaders/vae.py
+++ b/invokeai/backend/model_manager/load/model_loaders/vae.py
@@ -2,6 +2,7 @@
 """Class for VAE model loading in InvokeAI."""
 
 from pathlib import Path
+from typing import Optional
 
 import torch
 from omegaconf import DictConfig, OmegaConf
@@ -13,7 +14,7 @@ from invokeai.backend.model_manager import (
     ModelFormat,
     ModelType,
 )
-from invokeai.backend.model_manager.config import CheckpointConfigBase
+from invokeai.backend.model_manager.config import AnyModel, CheckpointConfigBase
 from invokeai.backend.model_manager.convert_ckpt_to_diffusers import convert_ldm_vae_to_diffusers
 
 from .. import ModelLoaderRegistry
@@ -38,7 +39,7 @@ class VAELoader(GenericDiffusersLoader):
         else:
             return True
 
-    def _convert_model(self, config: AnyModelConfig, model_path: Path, output_path: Path) -> Path:
+    def _convert_model(self, config: AnyModelConfig, model_path: Path, output_path: Optional[Path] = None) -> AnyModel:
         # TODO(MM2): check whether sdxl VAE models convert.
         if config.base not in {BaseModelType.StableDiffusion1, BaseModelType.StableDiffusion2}:
             raise Exception(f"VAE conversion not supported for model type: {config.base}")

--- a/invokeai/backend/model_manager/load/model_loaders/vae.py
+++ b/invokeai/backend/model_manager/load/model_loaders/vae.py
@@ -64,6 +64,6 @@ class VAELoader(GenericDiffusersLoader):
             vae_config=ckpt_config,
             image_size=512,
             precision=self._torch_dtype,
+            dump_path=output_path,
         )
-        vae_model.save_pretrained(output_path, safe_serialization=True)
         return vae_model


### PR DESCRIPTION
## Summary

Fix VAE conversion. See commits for details.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1224117693532213369

## QA Instructions

Empty your disk conversion cache and use a non-diffusers VAE. On `main`, we expect an assertion error when loading the VAE. On this branch, no error.

Here's a safetensors VAE you can test with: https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
