### PR TITLE
fix: handle custom node errors on startup, clear session queue via migration

### DIFF
--- a/invokeai/app/invocations/custom_nodes/init.py
+++ b/invokeai/app/invocations/custom_nodes/init.py
@@ -3,6 +3,7 @@ Invoke-managed custom node loader. See README.md for more information.
 """
 
 import sys
+import traceback
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
@@ -41,11 +42,15 @@ for d in Path(__file__).parent.iterdir():
 
     logger.info(f"Loading node pack {module_name}")
 
-    module = module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        module = module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
 
-    loaded_count += 1
+        loaded_count += 1
+    except Exception:
+        full_error = traceback.format_exc()
+        logger.error(f"Failed to load node pack {module_name}:\n{full_error}")
 
     del init, module_name
 

--- a/invokeai/app/services/shared/sqlite/sqlite_util.py
+++ b/invokeai/app/services/shared/sqlite/sqlite_util.py
@@ -11,6 +11,7 @@ from invokeai.app.services.shared.sqlite_migrator.migrations.migration_5 import 
 from invokeai.app.services.shared.sqlite_migrator.migrations.migration_6 import build_migration_6
 from invokeai.app.services.shared.sqlite_migrator.migrations.migration_7 import build_migration_7
 from invokeai.app.services.shared.sqlite_migrator.migrations.migration_8 import build_migration_8
+from invokeai.app.services.shared.sqlite_migrator.migrations.migration_9 import build_migration_9
 from invokeai.app.services.shared.sqlite_migrator.sqlite_migrator_impl import SqliteMigrator
 
 
@@ -39,6 +40,7 @@ def init_db(config: InvokeAIAppConfig, logger: Logger, image_files: ImageFileSto
     migrator.register_migration(build_migration_6())
     migrator.register_migration(build_migration_7())
     migrator.register_migration(build_migration_8(app_config=config))
+    migrator.register_migration(build_migration_9())
     migrator.run_migrations()
 
     return db

--- a/invokeai/app/services/shared/sqlite_migrator/migrations/migration_9.py
+++ b/invokeai/app/services/shared/sqlite_migrator/migrations/migration_9.py
@@ -1,0 +1,29 @@
+import sqlite3
+
+from invokeai.app.services.shared.sqlite_migrator.sqlite_migrator_common import Migration
+
+
+class Migration9Callback:
+    def __call__(self, cursor: sqlite3.Cursor) -> None:
+        self._empty_session_queue(cursor)
+
+    def _empty_session_queue(self, cursor: sqlite3.Cursor) -> None:
+        """Empties the session queue. This is done to prevent any lingering session queue items from causing pydantic errors due to changed schemas."""
+
+        cursor.execute("DELETE FROM session_queue;")
+
+
+def build_migration_9() -> Migration:
+    """
+    Build the migration from database version 8 to 9.
+
+    This migration does the following:
+    - Empties the session queue. This is done to prevent any lingering session queue items from causing pydantic errors due to changed schemas.
+    """
+    migration_9 = Migration(
+        from_version=8,
+        to_version=9,
+        callback=Migration9Callback(),
+    )
+
+    return migration_9


### PR DESCRIPTION
## Summary

- Custom node import errors could crash the app on startup. For example, if a custom node isn't updated for v4.0.0, it might try to import an nonexistent class from the invokeai python package. These errors are how handled gracefully - an error message is printed to the python terminal and the app startups up normally.
  
  ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/7e75ee3e-b205-4c62-87a2-f4c7a117d17f)

- Empty the session queue during data migration. This prevents pydantic errors from spamming the terminal on startup, if the queue items are no longer valid. This can occur if we change any pydantic schemas from `SessionQueueItem` and on downward.

## Related Issues / Discussions

Discord thread: https://discord.com/channels/1020123559063990373/1020123559831539744/1224527169753976956

(thanks for raising @empessah)

## QA Instructions

Node error:
- Add an outdated custom node to the custom nodes dir. I used [this node pack, from the linked commit](https://github.com/mickr777/multiImagesfromboard/commit/a5aaaeaa9be38ae64968c7741efe16a12eaba3ce)
- Start up v4.0.0, expect it to error and exit
- Check out this PR, startup, should not exit

Session Queue:
- Load up a v3.7.0 db
- Queue up some stuff
- Kill the app before the queue is empty
- Change to v4, start app, expect constant errors in terminal
- Check out he PR, start the app, no errors in terminal and your queue should be empty

## Merge Plan

The release notes should include a blurb about the queue being cleared on first run. Probably a good idea to do this for every release.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
