### PR TITLE
fix(config): handle windows paths in invokeai.yaml migration for legacy_conf_dir

### DIFF
--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -373,13 +373,16 @@ def migrate_v3_config_dict(config_dict: dict[str, Any]) -> InvokeAIAppConfig:
             if k == "conf_path":
                 parsed_config_dict["legacy_models_yaml_path"] = v
             if k == "legacy_conf_dir":
-                # The old default for this was "configs/stable-diffusion". If if the incoming config has that as the value, we won't set it.
-                # Else if the path ends in "stable-diffusion", we assume the parent is the new correct path.
-                # Else we do not attempt to migrate this setting
-                if v != "configs/stable-diffusion":
-                    parsed_config_dict["legacy_conf_dir"] = v
+                # The old default for this was "configs/stable-diffusion" ("configs\stable-diffusion" on Windows).
+                if v == "configs/stable-diffusion" or v == "configs\\stable-diffusion":
+                    # If if the incoming config has the default value, skip
+                    continue
                 elif Path(v).name == "stable-diffusion":
+                    # Else if the path ends in "stable-diffusion", we assume the parent is the new correct path.
                     parsed_config_dict["legacy_conf_dir"] = str(Path(v).parent)
+                else:
+                    # Else we do not attempt to migrate this setting
+                    parsed_config_dict["legacy_conf_dir"] = v
             elif k in InvokeAIAppConfig.model_fields:
                 # skip unknown fields
                 parsed_config_dict[k] = v


### PR DESCRIPTION
## Summary

The logic incorrectly set the `legacy_conf_dir` on windows, where the slashes go the other direction. Handle this case and update tests to catch it.

## Related Issues / Discussions

An issue where the conversion YAML configs were not located correctly started the investigation:
https://discord.com/channels/1020123559063990373/1224562758469681272

## QA Instructions

- Set a v3-style `invokeai.yaml` with `legacy_conf_dir` set to `configs\stable-diffusion` (note the slash)
- Start the app up, it will migrate the file
- Check `invokeai.yaml` again, there should be no `legacy_conf_dir` setting now (because we detected it was using the default value)

## Merge Plan

It'd be nice if @empessah could confirm deleting the `legacy_conf_dir` in the new `invokeai.yaml` file fixes the issue, but this is definitely a bug regardless.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
