### PR TITLE
fix(ui): add default coherence mode to generation slice migration

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
+++ b/invokeai/frontend/web/src/features/parameters/store/generationSlice.ts
@@ -280,6 +280,7 @@ const migrateGenerationState = (state: any): GenerationState => {
     // The signature of the model has changed, so we need to reset it
     state._version = 2;
     state.model = null;
+    state.canvasCoherenceMode = initialGenerationState.canvasCoherenceMode;
   }
   return state;
 };


### PR DESCRIPTION
## Summary

![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/4d16559e-e308-4fb0-88df-dfdc451c3a89)

The valid values for this parameter changed when inpainting changed to gradient denoise. The generation slice's redux migration wasn't updated, resulting in a generation error until you change the setting or reset web UI.

## Related Issues / Discussions

Multiple discord reports:
- https://discord.com/channels/1020123559063990373/1149506274971631688/1224769870135033937
- https://discord.com/channels/1020123559063990373/1149506274971631688/1224828774504468561

## QA Instructions

You can test it by booting up 3.7.0 and setting the coherence mode, then upgrade to 4.0.0. We expect an error when you inpaint on canvas, until you reset web UI or change the setting once. 

This PR fixes it so the default value is correct and you don't have to reset or change the setting

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
