### PR TITLE
feat(mm): include needed vs free in OOM

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache_default.py
@@ -429,4 +429,8 @@ class ModelCache(ModelCacheBase[AnyModel]):
         )
         free_mem, _ = torch.cuda.mem_get_info(torch.device(vram_device))
         if needed_size > free_mem:
-            raise torch.cuda.OutOfMemoryError
+            needed_gb = round(needed_size / GIG, 2)
+            free_gb = round(free_mem / GIG, 2)
+            raise torch.cuda.OutOfMemoryError(
+                f"Insufficient VRAM to load model, requested {needed_gb}GB but only had {free_gb}GB free"
+            )


### PR DESCRIPTION
## Summary

Gives us a bit more visibility into these errors, which seem to be popping up more frequently with the new MM.

## Related Issues / Discussions

#6106 is an example of an issue where this would be useful

## QA Instructions

Induce an OOM, and you should get a more informative error message, like this:

```
torch.cuda.OutOfMemoryError: Insufficient VRAM to load model, requested 5.15GB but only had 3.30GB free
```

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
