### PR TITLE
fix(mm): do not rename model file when model record is renamed

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -564,7 +564,7 @@ class ModelInstallService(ModelInstallServiceBase):
             # The model is not in the models directory - we don't need to move it.
             return model
 
-        new_path = (models_dir / model.base.value / model.type.value / model.name).with_suffix(old_path.suffix)
+        new_path = models_dir / model.base.value / model.type.value / old_path.name
 
         if old_path == new_path or new_path.exists() and old_path == new_path.resolve():
             return model

--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -87,9 +87,11 @@ def test_rename(
     key = mm2_installer.install_path(embedding_file)
     model_record = store.get_model(key)
     assert model_record.path.endswith("sd-1/embedding/test_embedding.safetensors")
-    store.update_model(key, ModelRecordChanges(name="new_name.safetensors", base=BaseModelType("sd-2")))
+    store.update_model(key, ModelRecordChanges(name="new model name", base=BaseModelType("sd-2")))
     new_model_record = mm2_installer.sync_model_path(key)
-    assert new_model_record.path.endswith("sd-2/embedding/new_name.safetensors")
+    # Renaming the model record shouldn't rename the file
+    assert new_model_record.name == "new model name"
+    assert new_model_record.path.endswith("sd-2/embedding/test_embedding.safetensors")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Renaming the model file to the model name introduces unnecessary contraints on model names.

For example, a model name can technically be any length, but a model _filename_ can be too long.

There are also constraints on valid characters for filenames which shouldn't be applied to model record names.

I believe the old behaviour is a holdover from the old system.

## Related Issues / Discussions

n/a

## QA Instructions

- On `main`, rename a model. Observe that the model file or folder are renamed. Try renaming to something really long - you'll get an error.
- On this PR, rename a model. Observe taht the model file is not renamed.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_ n/a
