### PR TITLE
fix(config): fix find_root to use venv parent if no CLI arg or env var

### DIFF
--- a/docs/installation/020_INSTALL_MANUAL.md
+++ b/docs/installation/020_INSTALL_MANUAL.md
@@ -40,11 +40,11 @@ Before you start, go through the [installation requirements].
 
 1. Enter the root (invokeai) directory and create a virtual Python environment within it named `.venv`.
 
-    !!! info "Virtual Environment Location"
+    !!! warning "Virtual Environment Location"
 
         While you may create the virtual environment anywhere in the file system, we recommend that you create it within the root directory as shown here. This allows the application to automatically detect its data directories.
 
-        If you choose a different location for the venv, then you must set the `INVOKEAI_ROOT` environment variable or pass the directory using the `--root` CLI arg.
+        If you choose a different location for the venv, then you _must_ set the `INVOKEAI_ROOT` environment variable or specify the root directory using the `--root` CLI arg.
 
     ```terminal
     cd $INVOKEAI_ROOT
@@ -126,16 +126,9 @@ Before you start, go through the [installation requirements].
 
     Run `invokeai-web` to start the UI. You must activate the virtual environment before running the app.
 
-    If the virtual environment you selected is NOT inside `INVOKEAI_ROOT`, then you must specify the path to the root directory by adding
-    `--root_dir \path\to\invokeai`.
+    !!! warning
 
-    !!! tip
-
-        You can permanently set the location of the runtime directory
-        by setting the environment variable `INVOKEAI_ROOT` to the
-        path of the directory. As mentioned previously, this is
-        recommended if your virtual environment is located outside of
-        your runtime directory.
+        If the virtual environment is _not_ inside the root directory, then you _must_ specify the path to the root directory with `--root_dir \path\to\invokeai` or the `INVOKEAI_ROOT` environment variable.
 
 ## Unsupported Conda Install
 

--- a/docs/installation/020_INSTALL_MANUAL.md
+++ b/docs/installation/020_INSTALL_MANUAL.md
@@ -6,11 +6,7 @@
 
 ## Introduction
 
-!!! tip "Conda"
-
-    As of InvokeAI v2.3.0 installation using the `conda` package manager is no longer being supported. It will likely still work, but we are not testing this installation method.
-
-InvokeAI is distributed as a python package on PyPI, installable with `pip`. There are a few things that are handled by the installer that you'll need to manage manually, described in this guide.
+InvokeAI is distributed as a python package on PyPI, installable with `pip`. There are a few things that are handled by the installer and launcher that you'll need to manage manually, described in this guide.
 
 ### Requirements
 
@@ -81,31 +77,23 @@ Before you start, go through the [installation requirements].
     python3 -m pip install --upgrade pip
     ```
 
-1. Install the InvokeAI Package. The `--extra-index-url` option is used to select the correct `torch` backend:
+1. Install the InvokeAI Package. The base command is `pip install InvokeAI --use-pep517`, but you may need to change this depending on your system and the desired features.
 
-    === "CUDA (NVidia)"
+    - You may need to provide an [extra index URL]. Select your platform configuration using [this tool on the PyTorch website]. Copy the `--extra-index-url` string from this and append it to your install command.
 
-         ```bash
-         pip install "InvokeAI[xformers]" --use-pep517 --extra-index-url https://download.pytorch.org/whl/cu121
-         ```
+        !!! example "Install with an extra index URL"
 
-    === "ROCm (AMD)"
+            ```bash
+            pip install InvokeAI --use-pep517 --extra-index-url https://download.pytorch.org/whl/cu121
+            ```
 
-         ```bash
-         pip install InvokeAI --use-pep517 --extra-index-url https://download.pytorch.org/whl/rocm5.6
-         ```
+    - If you have a CUDA GPU and want to install with `xformers`, you need to add an option to the package name. Note that `xformers` is not necessary. PyTorch includes an implementation of the SDP attention algorithm with the same performance.
 
-    === "CPU (Intel Macs & non-GPU systems)"
+        !!! example "Install with `xformers`"
 
-         ```bash
-         pip install InvokeAI --use-pep517 --extra-index-url https://download.pytorch.org/whl/cpu
-         ```
-
-    === "MPS (Apple Silicon)"
-
-         ```bash
-         pip install InvokeAI --use-pep517
-         ```
+            ```bash
+            pip install "InvokeAI[xformers]" --use-pep517
+            ```
 
 1. Deactivate and reactivate your runtime directory so that the invokeai-specific commands become available in the environment:
 
@@ -153,3 +141,5 @@ Note that if you run into problems with the Conda installation, the InvokeAI
 staff will **not** be able to help you out. Caveat Emptor!
 
 [installation requirements]: INSTALL_REQUIREMENTS.md
+[this tool on the PyTorch website]: https://pytorch.org/get-started/locally/#start-locally
+[extra index URL]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -317,11 +317,10 @@ class InvokeAIAppConfig(BaseSettings):
     @staticmethod
     def find_root() -> Path:
         """Choose the runtime root directory when not specified on command line or init file."""
-        venv = Path(os.environ.get("VIRTUAL_ENV") or ".")
         if os.environ.get("INVOKEAI_ROOT"):
             root = Path(os.environ["INVOKEAI_ROOT"])
-        elif any((venv.parent / x).exists() for x in [INIT_FILE, LEGACY_INIT_FILE]):
-            root = (venv.parent).resolve()
+        elif venv := os.environ.get("VIRTUAL_ENV", None):
+            root = Path(venv).parent.resolve()
         else:
             root = Path("~/invokeai").expanduser().resolve()
         return root


### PR DESCRIPTION
## Summary

This logic was a bit wonky. It only selected the `venv` parent if there was already an `invokeai.yaml` file in it. Removed this constraint.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1020123559831539744/1224932249737101393

## QA Instructions

Run `invokeai-web` with an active, fresh virtual environment. It should use the `venv`'s parent as the root dir.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ It's very tricky to create and activate a venv in pytest in a cross-platform way. Not sure how to test this.
- [ ] _Documentation added / updated (if applicable)_ n/a
