### PR TITLE
feat(mm): restore missing models

### DIFF
--- a/docs/help/FAQ.md
+++ b/docs/help/FAQ.md
@@ -18,6 +18,22 @@ Note that any releases marked as _pre-release_ are in a beta state. You may expe
 
 The Model Manager tab in the UI provides a few ways to install models, including using your already-downloaded models. You'll see a popup directing you there on first startup. For more information, see the [model install docs].
 
+## Missing models after updating to v4
+
+If you find some models are missing after updating to v4, it's likely they weren't correctly registered before the update and didn't get picked up in the migration.
+
+You can use the `Scan Folder` tab in the Model Manager UI to fix this. The models will either be in the old, now-unused `autoimport` folder, or your `models` folder.
+
+- Find and copy your install's old `autoimport` folder path, install the main install folder.
+- Go to the Model Manager and click `Scan Folder`.
+- Paste the path and scan.
+- IMPORTANT: Uncheck `Inplace install`.
+- Click `Install All` to install all found models, or just install the models you want.
+
+Next, find and copy your install's `models` folder path (this could be your custom models folder path, or the `models` folder inside the main install folder).
+
+Follow the same steps to scan and import the missing models.
+
 ## Slow generation
 
 - Check the [system requirements] to ensure that your system is capable of generating images.

--- a/invokeai/app/api/routers/model_manager.py
+++ b/invokeai/app/api/routers/model_manager.py
@@ -219,28 +219,13 @@ async def scan_for_models(
         non_core_model_paths = [p for p in found_model_paths if not p.is_relative_to(core_models_path)]
 
         installed_models = ApiDependencies.invoker.services.model_manager.store.search_by_attr()
-        resolved_installed_model_paths: list[str] = []
-        installed_model_sources: list[str] = []
-
-        # This call lists all installed models.
-        for model in installed_models:
-            path = pathlib.Path(model.path)
-            # If the model has a source, we need to add it to the list of installed sources.
-            if model.source:
-                installed_model_sources.append(model.source)
-            # If the path is not absolute, that means it is in the app models directory, and we need to join it with
-            # the models path before resolving.
-            if not path.is_absolute():
-                resolved_installed_model_paths.append(str(pathlib.Path(models_path, path).resolve()))
-                continue
-            resolved_installed_model_paths.append(str(path.resolve()))
 
         scan_results: list[FoundModel] = []
 
-        # Check if the model is installed by comparing the resolved paths, appending to the scan result.
+        # Check if the model is installed by comparing paths, appending to the scan result.
         for p in non_core_model_paths:
             path = str(p)
-            is_installed = path in resolved_installed_model_paths or path in installed_model_sources
+            is_installed = any(str(models_path / m.path) == path for m in installed_models)
             found_model = FoundModel(path=path, is_installed=is_installed)
             scan_results.append(found_model)
     except Exception as e:

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketModelInstall.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketModelInstall.ts
@@ -43,6 +43,7 @@ export const addModelInstallEventListener = (startAppListening: AppStartListenin
         })
       );
       dispatch(api.util.invalidateTags([{ type: 'ModelConfig', id: LIST_TAG }]));
+      dispatch(api.util.invalidateTags([{ type: 'ModelScanFolderResults', id: LIST_TAG }]));
     },
   });
 

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ModelInstallQueue/ModelInstallQueueItem.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ModelInstallQueue/ModelInstallQueueItem.tsx
@@ -87,6 +87,10 @@ export const ModelInstallQueueItem = (props: ModelListItemProps) => {
   }, [installJob.source]);
 
   const progressValue = useMemo(() => {
+    if (installJob.status === 'completed' || installJob.status === 'error' || installJob.status === 'cancelled') {
+      return 100;
+    }
+
     if (isNil(installJob.bytes) || isNil(installJob.total_bytes)) {
       return null;
     }
@@ -96,7 +100,7 @@ export const ModelInstallQueueItem = (props: ModelListItemProps) => {
     }
 
     return (installJob.bytes / installJob.total_bytes) * 100;
-  }, [installJob.bytes, installJob.total_bytes]);
+  }, [installJob.bytes, installJob.status, installJob.total_bytes]);
 
   return (
     <Flex gap={3} w="full" alignItems="center">

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ScanFolder/ScanFolderResultItem.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ScanFolder/ScanFolderResultItem.tsx
@@ -1,48 +1,19 @@
 import { Badge, Box, Flex, IconButton, Text } from '@invoke-ai/ui-library';
-import { useAppDispatch } from 'app/store/storeHooks';
-import { addToast } from 'features/system/store/systemSlice';
-import { makeToast } from 'features/system/util/makeToast';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiPlusBold } from 'react-icons/pi';
 import type { ScanFolderResponse } from 'services/api/endpoints/models';
-import { useInstallModelMutation } from 'services/api/endpoints/models';
 
 type Props = {
   result: ScanFolderResponse[number];
+  installModel: (source: string) => void;
 };
-export const ScanModelResultItem = ({ result }: Props) => {
+export const ScanModelResultItem = ({ result, installModel }: Props) => {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
 
-  const [installModel] = useInstallModelMutation();
-
-  const handleQuickAdd = useCallback(() => {
-    installModel({ source: result.path })
-      .unwrap()
-      .then((_) => {
-        dispatch(
-          addToast(
-            makeToast({
-              title: t('toast.modelAddedSimple'),
-              status: 'success',
-            })
-          )
-        );
-      })
-      .catch((error) => {
-        if (error) {
-          dispatch(
-            addToast(
-              makeToast({
-                title: `${error.data.detail} `,
-                status: 'error',
-              })
-            )
-          );
-        }
-      });
-  }, [installModel, result, dispatch, t]);
+  const handleInstall = useCallback(() => {
+    installModel(result.path);
+  }, [installModel, result]);
 
   return (
     <Flex alignItems="center" justifyContent="space-between" w="100%" gap={3}>
@@ -54,7 +25,7 @@ export const ScanModelResultItem = ({ result }: Props) => {
         {result.is_installed ? (
           <Badge>{t('common.installed')}</Badge>
         ) : (
-          <IconButton aria-label={t('modelManager.install')} icon={<PiPlusBold />} onClick={handleQuickAdd} size="sm" />
+          <IconButton aria-label={t('modelManager.install')} icon={<PiPlusBold />} onClick={handleInstall} size="sm" />
         )}
       </Box>
     </Flex>

--- a/invokeai/frontend/web/src/services/api/endpoints/models.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/models.ts
@@ -195,6 +195,7 @@ export const modelsApi = api.injectEndpoints({
           url: buildModelsUrl(`scan_folder?${folderQueryStr}`),
         };
       },
+      providesTags: [{ type: 'ModelScanFolderResults', id: LIST_TAG }],
     }),
     getHuggingFaceModels: build.query<GetHuggingFaceModelsResponse, string>({
       query: (hugging_face_repo) => {

--- a/invokeai/frontend/web/src/services/api/index.ts
+++ b/invokeai/frontend/web/src/services/api/index.ts
@@ -29,6 +29,7 @@ const tagTypes = [
   'InvocationCacheStatus',
   'ModelConfig',
   'ModelInstalls',
+  'ModelScanFolderResults',
   'T2IAdapterModel',
   'MainModel',
   'VaeModel',


### PR DESCRIPTION
## Summary

A common issue coming up for users who install v4 is missing models.

The root cause is the models aren't in the v3 `models.yaml` and thus don't get migrated to v4.

In v3, the MM would scan the `autoimport` dir and the `models_dir` for models on startup. It would add found models to its memory store, but not write them to `models.yaml`.

There's an easy fix: use `Scan Folder` on the `autoimport` dir and/or the `models_dir` to pick up missing models.

- Added an `inplace` checkbox to the `Scan Folder` UI. This allows users to scan `autoimport`, _disable_ inplace, and have the MM move the models into the invoke-managed models directory.
- Improved the scan folder endpoint to prevent incorrect results when detecting if a found model is already installed or not.
- Added a how-to to the FAQ.
- Fixed model install progress sometimes not showing 100%.
- Fixed scan results not refreshing when a found model is installed.

## Related Issues / Discussions

Numerous discord threads from today. Socialnetwooky and ausbitbank both had this issue: https://discord.com/channels/1020123559063990373/1149506274971631688/1224963422203019335

## QA Instructions

Copy some model files into `autoimport` and the `models_dir` folders. Follow the new FAQ to install these models.

## Merge Plan

We should update the release notes to link to the FAQ entry.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [x] _Documentation added / updated (if applicable)_
