### PR TITLE
feat(installer): remove extra GPU options

### DIFF
--- a/docs/installation/010_INSTALL_AUTOMATED.md
+++ b/docs/installation/010_INSTALL_AUTOMATED.md
@@ -44,7 +44,7 @@ The installation process is simple, with a few prompts:
 
 - Select the version to install. Unless you have a specific reason to install a specific version, select the default (the latest version).
 - Select location for the install. Be sure you have enough space in this folder for the base application, as described in the [installation requirements].
-- Select a GPU device. If you are unsure, you can let the installer figure it out.
+- Select a GPU device.
 
 !!! info "Slow Installation"
 

--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -404,22 +404,29 @@ def get_torch_source() -> Tuple[str | None, str | None]:
     # device can be one of: "cuda", "rocm", "cpu", "cuda_and_dml, autodetect"
     device = select_gpu()
 
+    # The correct extra index URLs for torch are inconsistent, see https://pytorch.org/get-started/locally/#start-locally
+
     url = None
-    optional_modules = "[onnx]"
+    optional_modules: str | None = None
     if OS == "Linux":
         if device.value == "rocm":
             url = "https://download.pytorch.org/whl/rocm5.6"
         elif device.value == "cpu":
             url = "https://download.pytorch.org/whl/cpu"
-
+        elif device.value == "cuda":
+            # CUDA uses the default PyPi index
+            optional_modules = "[xformers,onnx-cuda]"
     elif OS == "Windows":
         if device.value == "cuda":
             url = "https://download.pytorch.org/whl/cu121"
             optional_modules = "[xformers,onnx-cuda]"
-        if device.value == "cuda_and_dml":
-            url = "https://download.pytorch.org/whl/cu121"
-            optional_modules = "[xformers,onnx-directml]"
+        elif device.value == "cpu":
+            # CPU  uses the default PyPi index, no optional modules
+            pass
+    elif OS == "Darwin":
+        # macOS uses the default PyPi index, no optional modules
+        pass
 
-    # in all other cases, Torch wheels should be coming from PyPi as of Torch 1.13
+    # Fall back to defaults
 
     return (url, optional_modules)

--- a/installer/lib/messages.py
+++ b/installer/lib/messages.py
@@ -207,10 +207,8 @@ def dest_path(dest: Optional[str | Path] = None) -> Path | None:
 
 class GpuType(Enum):
     CUDA = "cuda"
-    CUDA_AND_DML = "cuda_and_dml"
     ROCM = "rocm"
     CPU = "cpu"
-    AUTODETECT = "autodetect"
 
 
 def select_gpu() -> GpuType:
@@ -226,10 +224,6 @@ def select_gpu() -> GpuType:
         "an [gold1 b]NVIDIA[/] GPU (using CUDA™)",
         GpuType.CUDA,
     )
-    nvidia_with_dml = (
-        "an [gold1 b]NVIDIA[/] GPU (using CUDA™, and DirectML™ for ONNX) -- ALPHA",
-        GpuType.CUDA_AND_DML,
-    )
     amd = (
         "an [gold1 b]AMD[/] GPU (using ROCm™)",
         GpuType.ROCM,
@@ -238,26 +232,18 @@ def select_gpu() -> GpuType:
         "Do not install any GPU support, use CPU for generation (slow)",
         GpuType.CPU,
     )
-    autodetect = (
-        "I'm not sure what to choose",
-        GpuType.AUTODETECT,
-    )
 
     options = []
     if OS == "Windows":
-        options = [nvidia, nvidia_with_dml, cpu]
+        options = [nvidia, cpu]
     if OS == "Linux":
         options = [nvidia, amd, cpu]
     elif OS == "Darwin":
         options = [cpu]
-        # future CoreML?
 
     if len(options) == 1:
         print(f'Your platform [gold1]{OS}-{ARCH}[/] only supports the "{options[0][1]}" driver. Proceeding with that.')
         return options[0][1]
-
-    # "I don't know" is always added the last option
-    options.append(autodetect)  # type: ignore
 
     options = {str(i): opt for i, opt in enumerate(options, 1)}
 
@@ -291,11 +277,6 @@ def select_gpu() -> GpuType:
             lambda n: n in options.keys(), error_message="Please select one the above options"
         ),
     )
-
-    if options[choice][1] is GpuType.AUTODETECT:
-        console.print(
-            "No problem. We will install CUDA support first :crossed_fingers: If Invoke does not detect a GPU, please re-run the installer and select one of the other GPU types."
-        )
 
     return options[choice][1]
 


### PR DESCRIPTION
## Summary

- Remove `CUDA_AND_DML`. This was for onnx, which we have since removed.
- Remove `AUTODETECT`. This option causes problems for windows users, as it falls back on default pypi index resulting in a non-CUDA torch being installed.
- Add more explicit settings for extra index URL, based on the torch website
- Fix bug where `xformers` wasn't installed on linux and/or windows when autodetect was selected

## Related Issues / Discussions

Discord thread where the user ended up with an incompatible version of `torchaudio` (? why this was installed, I do not know) after choosing the autodetect option:
https://discord.com/channels/1020123559063990373/1020123559831539744/1224998262100983829

Also another user at the same time had a problem with autodetect.

## QA Instructions

Run the `install.sh.in` script to test the installer. 

I tested macOS and Linux (CUDA).

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [x] _Documentation added / updated (if applicable)_
