### PR TITLE
Add a config variable that disable VRAM OOM conditions

### DIFF
--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -103,6 +103,7 @@ class InvokeAIAppConfig(BaseSettings):
         convert_cache: Maximum size of on-disk converted models cache (GB).
         lazy_offload: Keep models in VRAM until their space is needed.
         log_memory_usage: If True, a memory snapshot will be captured before and after every model cache operation, and the result will be logged (at debug level). There is a time cost to capturing the memory snapshots, so it is recommended to only enable this feature if you are actively inspecting the model cache's behaviour.
+        disable_vram_check: If True, disable the check for sufficient VRAM memory prior to loading a model. This may lead to unpredictable behavior, so use for debugging memory problems only.
         device: Preferred execution device. `auto` will choose the device depending on the hardware platform and the installed torch capabilities.<br>Valid values: `auto`, `cpu`, `cuda`, `cuda:1`, `mps`
         precision: Floating point precision. `float16` will consume half the memory of `float32` but produce slightly lower-quality images. The `auto` setting will guess the proper precision based on your video card and operating system.<br>Valid values: `auto`, `float16`, `bfloat16`, `float32`, `autocast`
         sequential_guidance: Whether to calculate guidance in serial instead of in parallel, lowering memory requirements.
@@ -171,6 +172,7 @@ class InvokeAIAppConfig(BaseSettings):
     convert_cache:                float = Field(default=DEFAULT_CONVERT_CACHE, ge=0, description="Maximum size of on-disk converted models cache (GB).")
     lazy_offload:                  bool = Field(default=True,               description="Keep models in VRAM until their space is needed.")
     log_memory_usage:              bool = Field(default=False,              description="If True, a memory snapshot will be captured before and after every model cache operation, and the result will be logged (at debug level). There is a time cost to capturing the memory snapshots, so it is recommended to only enable this feature if you are actively inspecting the model cache's behaviour.")
+    disable_vram_check:            bool = Field(default=False,              description="If True, disable the check for sufficient VRAM memory prior to loading a model. This may lead to unpredictable behavior, so use for debugging memory problems only.")
 
     # DEVICE
     device:                      DEVICE = Field(default="auto",             description="Preferred execution device. `auto` will choose the device depending on the hardware platform and the installed torch capabilities.")

--- a/invokeai/app/services/model_manager/model_manager_default.py
+++ b/invokeai/app/services/model_manager/model_manager_default.py
@@ -82,6 +82,7 @@ class ModelManagerService(ModelManagerServiceBase):
             max_vram_cache_size=app_config.vram,
             logger=logger,
             execution_device=execution_device,
+            disable_memory_check=app_config.disable_vram_check,
         )
         convert_cache = ModelConvertCache(cache_path=app_config.convert_cache_path, max_size=app_config.convert_cache)
         loader = ModelLoadService(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -3,7 +3,7 @@ from scripts.update_config_docstring import generate_config_docstrings
 
 
 def test_app_config_docstrings_are_current():
-    # If this test fails, run `python scripts/generate_config_docstring.py`. See the comments in that script for
+    # If this test fails, run `python scripts/update_config_docstring.py`. See the comments in that script for
     # an explanation of why this is necessary.
     #
     # A make target is provided to run the script: `make update-config-docstring`.


### PR DESCRIPTION
## Summary

This adds a `invokeai.yaml` variable that will disable the VRAM out of memory checks:

```
disable_vram_check: true
```

It is intended to debug situations in which a generation worked with pre-4.0 but now gives OOM errors.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

For a workflow that used to work but no longer does, try enabling this option (setting "disable" to true!) and reload the server.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Do not merge until the team has discussed whether this shoot-yourself-in-the-foot parameter is a good idea.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
