### PR TITLE
Update probe to always use cpu for loading models

### DIFF
--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -324,7 +324,7 @@ class ModelProbe(object):
         with SilenceWarnings():
             if model_path.suffix.endswith((".ckpt", ".pt", ".pth", ".bin")):
                 cls._scan_model(model_path.name, model_path)
-                model = torch.load(model_path)
+                model = torch.load(model_path, map_location="cpu")
                 assert isinstance(model, dict)
                 return model
             else:


### PR DESCRIPTION
## Summary

Currently, the base model probe class doesn't identify a map device on torch loads. Due to this, if a model with gpu tensors is imported, it will attempt to use cuda whether or not it exists on the device

## QA Instructions

Attempt to install [this model](https://huggingface.co/stablediffusionapi/load_lora_embeddings/blob/6e2d802d3780fd60d3ea8512034341a77ac54007/badhandv4.pt) on a device with no GPU. 

Prior to this change (on MacOS):
<img width="1012" alt="Screenshot 2024-04-03 at 3 19 43 PM" src="https://github.com/invoke-ai/InvokeAI/assets/58442074/88b82562-c663-4beb-a8dc-10a45d5c7827">

After this change (on MacOS):
<img width="992" alt="Screenshot 2024-04-03 at 3 20 06 PM" src="https://github.com/invoke-ai/InvokeAI/assets/58442074/e6868a4e-c069-47e9-8dd5-d77a578edeb5">

## Merge Plan

Can be merged when approved

