### PR TITLE
fix(ui): discarding last single canvas image breaks canvas

### DIFF
--- a/invokeai/frontend/web/src/features/canvas/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/canvas/store/canvasSlice.ts
@@ -289,11 +289,18 @@ export const canvasSlice = createSlice({
       const { images, selectedImageIndex } = state.layerState.stagingArea;
       pushToPrevLayerStates(state);
 
-      if (!images.length) {
-        return;
-      }
-
       images.splice(selectedImageIndex, 1);
+
+      if (images.length === 0) {
+        pushToPrevLayerStates(state);
+
+        state.layerState.stagingArea = deepClone(initialLayerState.stagingArea);
+
+        state.futureLayerStates = [];
+        state.shouldShowStagingOutline = true;
+        state.shouldShowStagingImage = true;
+        state.batchIds = [];
+      }
 
       if (selectedImageIndex >= images.length) {
         state.layerState.stagingArea.selectedImageIndex = images.length - 1;


### PR DESCRIPTION
## Summary

We need to reset the staging area if we are discarding the last image.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
