### PR TITLE
fix(ui): handle multipleOf on number fields

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/NumberFieldInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/NumberFieldInputComponent.tsx
@@ -37,34 +37,50 @@ const NumberFieldInputComponent = (
   );
 
   const min = useMemo(() => {
+    let min = -NUMPY_RAND_MAX;
     if (!isNil(fieldTemplate.minimum)) {
-      return fieldTemplate.minimum;
+      min = fieldTemplate.minimum;
     }
     if (!isNil(fieldTemplate.exclusiveMinimum)) {
-      return fieldTemplate.exclusiveMinimum + 0.01;
+      min = fieldTemplate.exclusiveMinimum + 0.01;
     }
-    return;
+    return min;
   }, [fieldTemplate.exclusiveMinimum, fieldTemplate.minimum]);
 
   const max = useMemo(() => {
+    let max = NUMPY_RAND_MAX;
     if (!isNil(fieldTemplate.maximum)) {
-      return fieldTemplate.maximum;
+      max = fieldTemplate.maximum;
     }
     if (!isNil(fieldTemplate.exclusiveMaximum)) {
-      return fieldTemplate.exclusiveMaximum - 0.01;
+      max = fieldTemplate.exclusiveMaximum - 0.01;
     }
-    return;
+    return max;
   }, [fieldTemplate.exclusiveMaximum, fieldTemplate.maximum]);
+
+  const step = useMemo(() => {
+    if (isNil(fieldTemplate.multipleOf)) {
+      return isIntegerField ? 1 : 0.1;
+    }
+    return fieldTemplate.multipleOf;
+  }, [fieldTemplate.multipleOf, isIntegerField]);
+
+  const fineStep = useMemo(() => {
+    if (isNil(fieldTemplate.multipleOf)) {
+      return isIntegerField ? 1 : 0.01;
+    }
+    return fieldTemplate.multipleOf;
+  }, [fieldTemplate.multipleOf, isIntegerField]);
 
   return (
     <CompositeNumberInput
       defaultValue={fieldTemplate.default}
       onChange={handleValueChanged}
       value={field.value}
-      min={min ?? -NUMPY_RAND_MAX}
-      max={max ?? NUMPY_RAND_MAX}
-      step={isIntegerField ? 1 : 0.1}
-      fineStep={isIntegerField ? 1 : 0.01}
+      min={min}
+      max={max}
+      step={step}
+      fineStep={fineStep}
       className="nodrag"
     />
   );


### PR DESCRIPTION
## Summary

This data is already in the template but it wasn't ever used.

One big place where this improves UX is the noise node. Previously, the UI let you change width and height in increments of 1, despite the template requiring a multiple of 8. It now works in multiples of 8.

https://github.com/invoke-ai/InvokeAI/assets/4822129/725939cd-86f6-4c2f-ba6a-ffaba1916353

Fields without the multipleOf attribute are unchanged

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [ ] _Documentation added / updated (if applicable)_ n/a
