### PR TITLE
(feat) add a method to get the path of an image from invocationcontext

### DIFF
--- a/invokeai/app/services/shared/invocation_context.py
+++ b/invokeai/app/services/shared/invocation_context.py
@@ -245,6 +245,18 @@ class ImagesInterface(InvocationContextInterface):
         """
         return self._services.images.get_dto(image_name)
 
+    def get_path(self, image_name: str, thumbnail: bool = False) -> Path:
+        """Gets the internal path to an image or thumbnail.
+
+        Args:
+            image_name: The name of the image to get the path of.
+            thumbnail: Get the path of the thumbnail instead of the full image
+
+        Returns:
+            The local path of the image or thumbnail.
+        """
+        return self._services.images.get_path(image_name, thumbnail)
+
 
 class TensorsInterface(InvocationContextInterface):
     def save(self, tensor: Tensor) -> str:


### PR DESCRIPTION

## Summary

This PR adds a `get_path` method to the invocation context, so that nodes can access local files. 

Access to the local image path can be useful for nodes that need access to the image file for further processing with external tools (instead of directly dealing with the PIL pixel data).

## Related Issues / Discussions

Fixes #6175
/sa https://discord.com/channels/1020123559063990373/1049495067846524939/1226635058299797666

## QA Instructions

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

This PR only adds a new method and does not change any existing code.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
