### PR TITLE
fix(ui): always enqueue with fresh staging area bbox

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/addCommitStagingAreaImageListener.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/addCommitStagingAreaImageListener.ts
@@ -1,12 +1,18 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
-import { canvasBatchIdsReset, commitStagingAreaImage, discardStagedImages } from 'features/canvas/store/canvasSlice';
+import {
+  canvasBatchIdsReset,
+  commitStagingAreaImage,
+  discardStagedImages,
+  resetCanvas,
+  setInitialCanvasImage,
+} from 'features/canvas/store/canvasSlice';
 import { addToast } from 'features/system/store/systemSlice';
 import { t } from 'i18next';
 import { queueApi } from 'services/api/endpoints/queue';
 
-const matcher = isAnyOf(commitStagingAreaImage, discardStagedImages);
+const matcher = isAnyOf(commitStagingAreaImage, discardStagedImages, resetCanvas, setInitialCanvasImage);
 
 export const addCommitStagingAreaImageListener = (startAppListening: AppStartListening) => {
   startAppListening({

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedCanvas.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedCanvas.ts
@@ -123,14 +123,16 @@ export const addEnqueueRequestedCanvasListener = (startAppListening: AppStartLis
         const batchId = enqueueResult.batch.batch_id as string; // we know the is a string, backend provides it
 
         // Prep the canvas staging area if it is not yet initialized
-        dispatch(
-          stagingAreaInitialized({
-            boundingBox: {
-              ...state.canvas.boundingBoxCoordinates,
-              ...state.canvas.boundingBoxDimensions,
-            },
-          })
-        );
+        if (!state.canvas.layerState.stagingArea.boundingBox) {
+          dispatch(
+            stagingAreaInitialized({
+              boundingBox: {
+                ...state.canvas.boundingBoxCoordinates,
+                ...state.canvas.boundingBoxDimensions,
+              },
+            })
+          );
+        }
 
         // Associate the session with the canvas session ID
         dispatch(canvasBatchIdAdded(batchId));

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedCanvas.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedCanvas.ts
@@ -123,16 +123,14 @@ export const addEnqueueRequestedCanvasListener = (startAppListening: AppStartLis
         const batchId = enqueueResult.batch.batch_id as string; // we know the is a string, backend provides it
 
         // Prep the canvas staging area if it is not yet initialized
-        if (!state.canvas.layerState.stagingArea.boundingBox) {
-          dispatch(
-            stagingAreaInitialized({
-              boundingBox: {
-                ...state.canvas.boundingBoxCoordinates,
-                ...state.canvas.boundingBoxDimensions,
-              },
-            })
-          );
-        }
+        dispatch(
+          stagingAreaInitialized({
+            boundingBox: {
+              ...state.canvas.boundingBoxCoordinates,
+              ...state.canvas.boundingBoxDimensions,
+            },
+          })
+        );
 
         // Associate the session with the canvas session ID
         dispatch(canvasBatchIdAdded(batchId));

--- a/invokeai/frontend/web/src/features/canvas/components/IAICanvasStagingAreaToolbar.tsx
+++ b/invokeai/frontend/web/src/features/canvas/components/IAICanvasStagingAreaToolbar.tsx
@@ -49,14 +49,20 @@ const selector = createMemoizedSelector(selectCanvasSlice, (canvas) => {
 const ClearStagingIntermediatesIconButton = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
+  const totalStagedImages = useAppSelector((s) => s.canvas.layerState.stagingArea.images.length);
 
   const handleDiscardStagingArea = useCallback(() => {
     dispatch(discardStagedImages());
   }, [dispatch]);
 
   const handleDiscardStagingImage = useCallback(() => {
-    dispatch(discardStagedImage());
-  }, [dispatch]);
+    // Discarding all staged images triggers cancelation of all canvas batches. It's too easy to accidentally
+    // click the discard button, so to prevent accidental cancelation of all batches, we only discard the current
+    // image if there are more than one staged images.
+    if (totalStagedImages > 1) {
+      dispatch(discardStagedImage());
+    }
+  }, [dispatch, totalStagedImages]);
 
   return (
     <>
@@ -67,6 +73,7 @@ const ClearStagingIntermediatesIconButton = () => {
         onClick={handleDiscardStagingImage}
         colorScheme="invokeBlue"
         fontSize={16}
+        isDisabled={totalStagedImages <= 1}
       />
       <IconButton
         tooltip={`${t('unifiedCanvas.discardAll')} (Esc)`}


### PR DESCRIPTION
## Summary

When a canvas invocation was canceled, the next invocation would use the previous "staging area", including the bounding box settings. This change will make sure that every requested enqueue uses the current bounding box.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->
Closes https://github.com/invoke-ai/InvokeAI/issues/5969

## QA Instructions

Put an image on canvas
Set bounding box
Invoke
Cancel before it can finish
Move bounding box
Invoke again

Previously, the second invocation would use the bounding box from invocation #1.  With this fix, it should use the bounding box from invocation #2 as expected. 

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
