### PR TITLE
Fix regional prompt mask padding

### DIFF
--- a/invokeai/backend/stable_diffusion/diffusion/regional_ip_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/regional_ip_data.py
@@ -59,8 +59,11 @@ class RegionalIPData:
             if downscale_factor <= max_downscale_factor:
                 # We use max pooling because we downscale to a pretty low resolution, so we don't want small mask
                 # regions to be lost entirely.
+                #
+                # ceil_mode=True is set to mirror the downsampling behavior of SD and SDXL.
+                #
                 # TODO(ryand): In the future, we may want to experiment with other downsampling methods.
-                mask_tensor = torch.nn.functional.max_pool2d(mask_tensor, kernel_size=2, stride=2)
+                mask_tensor = torch.nn.functional.max_pool2d(mask_tensor, kernel_size=2, stride=2, ceil_mode=True)
 
         return masks_by_seq_len
 

--- a/invokeai/backend/stable_diffusion/diffusion/regional_prompt_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/regional_prompt_data.py
@@ -61,9 +61,12 @@ class RegionalPromptData:
                 if downscale_factor <= max_downscale_factor:
                     # We use max pooling because we downscale to a pretty low resolution, so we don't want small prompt
                     # regions to be lost entirely.
+                    #
+                    # ceil_mode=True is set to mirror the downsampling behavior of SD and SDXL.
+                    #
                     # TODO(ryand): In the future, we may want to experiment with other downsampling methods (e.g.
                     # nearest interpolation), and could potentially use a weighted mask rather than a binary mask.
-                    batch_sample_masks = F.max_pool2d(batch_sample_masks, kernel_size=2, stride=2)
+                    batch_sample_masks = F.max_pool2d(batch_sample_masks, kernel_size=2, stride=2, ceil_mode=True)
 
         return batch_sample_masks_by_seq_len
 


### PR DESCRIPTION
## Summary

This PR fixes a bug with regional prompting and regional IP-Adapter. Prior to this change, using regional prompts with input latent dimensions that aren't evenly divisible by 8 would raise an exception.

This issue was reported here: https://discord.com/channels/1020123559063990373/1049495067846524939/1227274512685338714

The root cause was that region mask downscaling did not mirror the downscaling padding behvaior of the SD/SDXL UNets.

## QA Instructions

I tested the following:
- Regional prompts, image resolution of 368x696, SD1.5
- Regional prompts, image resolution of 368x696, SDXL
- Regional IP-Adapter, image resolution of 368x696, SD1.5
- Regional IP-Adapter, image resolution of 368x696, SDXL

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_ Test coverage is low - hence how this bug made it in.
- [x] _Documentation added / updated (if applicable)_ N/A
