### PR TITLE
fix(queue): poll queue on finished queue item

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -86,6 +86,12 @@ class DefaultSessionProcessor(SessionProcessorBase):
             self._poll_now()
         elif event_name == "batch_enqueued":
             self._poll_now()
+        elif event_name == "queue_item_status_changed" and event[1]["data"]["queue_item"]["status"] in [
+            "completed",
+            "failed",
+            "canceled",
+        ]:
+            self._poll_now()
 
     def resume(self) -> SessionProcessorStatus:
         if not self._resume_event.is_set():


### PR DESCRIPTION
## Summary

When a queue item is finished (completed, canceled, failed), immediately poll the queue for the next queue item.

## Related Issues / Discussions

Closes #6189

## QA Instructions

Run on `main` and then this branch. Note the delay between a queue item finishing and the next one starting.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a (no test coverage for processor)
- [ ] _Documentation added / updated (if applicable)_ n/a
