### PR TITLE
fix(nodes): refined fixes for refiner inpainting

### DIFF
--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -964,7 +964,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
                 mps.empty_cache()
 
             name = context.tensors.save(tensor=result_latents)
-        return LatentsOutput.build(latents_name=name, latents=result_latents, seed=seed)
+        return LatentsOutput.build(latents_name=name, latents=result_latents, seed=None)
 
 
 @invocation(


### PR DESCRIPTION
## Summary

Two fixes here. Both contribute noticeably to the results when inpainting with refiner.

### [fix(nodes): do not set seed on output latents from denoise latents](https://github.com/invoke-ai/InvokeAI/pull/6197/commits/29876c3bf9dd33deaa97a5372fa20e26c5acb1e4)

`LatentsField` objects have an optional `seed` field. This should only be populated when the latents are noise, generated from a seed.

`DenoiseLatentsInvocation` needs a seed value for scheduler initialization. It's used in a few places, and there is some logic for determining the seed to use with a series of fallbacks:
- Use the seed from the noise (a `LatentsField` object)
- Use the seed from the latents (a `LatentsField` object - normally it won't have a seed)
- Use `0` as a final fallback

In `DenoisLatentsInvocation`, we set the seed in the `LatentsOutput`, even though the output latents are not noise.

This is normally fine, but when we use refiner, we re-use the those same latents for the refiner denoise. This causes that characteristic same-seed-fried look on the refiner pass.

Simple fix - do not set the field in the output latents.

#### Example outputs

These include the doubly-noised latents fix from below. The output is much worse without that.

Initial image:
![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/d17843b4-a430-4df8-a5ab-0655783b2db8)

| Before | After |
| --- | --- |
| ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/576fedb3-5502-4ca7-aa25-2156c594e4e1) | ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/c3806d9e-a764-41d7-9b27-a8036963321c) |
| ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/6b49a9ba-f626-4ff3-a7af-532d1dc5aee4) | ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/11e3e748-2015-4a21-9847-705dd00ad20f) |
| ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/49a03744-8bde-4b7c-9ebb-f5d82c5efb37) | ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/32711fad-27a5-4fd2-a1a2-fd5bafe76213) |

### [fix(nodes): doubly-noised latents](https://github.com/invoke-ai/InvokeAI/pull/6197/commits/8c537bb040e56ce5e900ccf4795e40462be7e870)

When using refiner with a mask (i.e. inpainting), we don't have noise provided as an input to the node.

This situation uniquely hits a code path that wasn't reviewed when gradient denoising was implemented.

That code path does two things wrong:
- It lerp'd the input latents. This was fixed in https://github.com/invoke-ai/InvokeAI/commit/5a1f4cb1ce43049c2ff1054257132f53b6b34409.
- It added noise to the latents an extra time. This is fixed in this change.

We don't need to add noise in `latents_from_embeddings` because we do it just a lines later in `AddsMaskGuidance`.

- Remove the extraneous call to `add_noise`
- Make `seed` a required arg. We never call the function without seed anyways. If we refactor this in the future, it will be clearer that we need to look at how seed is handled.
- Move the call to create the noise to a deeper conditional, just before we call `AddsMaskGuidance`. The created noise tensor is now only used in that function, no need to create it every time.

Note: Whether or not having both noise and latents as inputs on the node is correct is a separate conversation. This change just fixes the issue with the current setup.

#### Example outputs

Initial image:
![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/2f3c02b6-b5a1-4753-9583-25d1c8bce55d)


| Before | After |
| --- | --- |
| ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/9c85bb3c-7832-4ebc-b73d-0cf588867330) | ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/0be51770-aca8-417a-9843-59fb79321db8) |
| ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/bb7b9b4b-d52f-4d13-9874-b8ce1463c96d) | ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/8a856de0-4c34-4a8b-a9f9-4b86d31eda7f) |
| ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/8c23d313-3b66-4118-8965-d51239d4f685) | ![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/e226de02-c294-49dc-a30a-7b6895185d96) |


## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149513625321603162/1227798332567715953

## QA Instructions

Do some inpainting w/ refiner (and non-refiner). Should work great.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ n/a
- [x] _Documentation added / updated (if applicable)_ (added comments)
