### PR TITLE
Fix "recall all" when loras, controls, or high res fix are not present

### DIFF
--- a/invokeai/frontend/web/src/features/metadata/util/parsers.ts
+++ b/invokeai/frontend/web/src/features/metadata/util/parsers.ts
@@ -156,8 +156,13 @@ const parseSteps: MetadataParseFunc<ParameterSteps> = (metadata) => getProperty(
 const parseStrength: MetadataParseFunc<ParameterStrength> = (metadata) =>
   getProperty(metadata, 'strength', isParameterStrength);
 
-const parseHRFEnabled: MetadataParseFunc<ParameterHRFEnabled> = (metadata) =>
-  getProperty(metadata, 'hrf_enabled', isParameterHRFEnabled);
+const parseHRFEnabled: MetadataParseFunc<ParameterHRFEnabled> = async (metadata) => {
+  try {
+    return await getProperty(metadata, 'hrf_enabled', isParameterHRFEnabled);
+  } catch {
+    return false;
+  }
+};
 
 const parseHRFStrength: MetadataParseFunc<ParameterStrength> = (metadata) =>
   getProperty(metadata, 'hrf_strength', isParameterStrength);
@@ -224,12 +229,16 @@ const parseLoRA: MetadataParseFunc<LoRA> = async (metadataItem) => {
 };
 
 const parseAllLoRAs: MetadataParseFunc<LoRA[]> = async (metadata) => {
-  const lorasRaw = await getProperty(metadata, 'loras', isArray);
-  const parseResults = await Promise.allSettled(lorasRaw.map((lora) => parseLoRA(lora)));
-  const loras = parseResults
-    .filter((result): result is PromiseFulfilledResult<LoRA> => result.status === 'fulfilled')
-    .map((result) => result.value);
-  return loras;
+  try {
+    const lorasRaw = await getProperty(metadata, 'loras', isArray);
+    const parseResults = await Promise.allSettled(lorasRaw.map((lora) => parseLoRA(lora)));
+    const loras = parseResults
+      .filter((result): result is PromiseFulfilledResult<LoRA> => result.status === 'fulfilled')
+      .map((result) => result.value);
+    return loras;
+  } catch {
+    return [];
+  }
 };
 
 const parseControlNet: MetadataParseFunc<ControlNetConfigMetadata> = async (metadataItem) => {
@@ -288,12 +297,16 @@ const parseControlNet: MetadataParseFunc<ControlNetConfigMetadata> = async (meta
 };
 
 const parseAllControlNets: MetadataParseFunc<ControlNetConfigMetadata[]> = async (metadata) => {
-  const controlNetsRaw = await getProperty(metadata, 'controlnets', isArray);
-  const parseResults = await Promise.allSettled(controlNetsRaw.map((cn) => parseControlNet(cn)));
-  const controlNets = parseResults
-    .filter((result): result is PromiseFulfilledResult<ControlNetConfigMetadata> => result.status === 'fulfilled')
-    .map((result) => result.value);
-  return controlNets;
+  try {
+    const controlNetsRaw = await getProperty(metadata, 'controlnets', isArray || undefined);
+    const parseResults = await Promise.allSettled(controlNetsRaw.map((cn) => parseControlNet(cn)));
+    const controlNets = parseResults
+      .filter((result): result is PromiseFulfilledResult<ControlNetConfigMetadata> => result.status === 'fulfilled')
+      .map((result) => result.value);
+    return controlNets;
+  } catch {
+    return [];
+  }
 };
 
 const parseT2IAdapter: MetadataParseFunc<T2IAdapterConfigMetadata> = async (metadataItem) => {
@@ -348,12 +361,16 @@ const parseT2IAdapter: MetadataParseFunc<T2IAdapterConfigMetadata> = async (meta
 };
 
 const parseAllT2IAdapters: MetadataParseFunc<T2IAdapterConfigMetadata[]> = async (metadata) => {
-  const t2iAdaptersRaw = await getProperty(metadata, 't2iAdapters', isArray);
-  const parseResults = await Promise.allSettled(t2iAdaptersRaw.map((t2iAdapter) => parseT2IAdapter(t2iAdapter)));
-  const t2iAdapters = parseResults
-    .filter((result): result is PromiseFulfilledResult<T2IAdapterConfigMetadata> => result.status === 'fulfilled')
-    .map((result) => result.value);
-  return t2iAdapters;
+  try {
+    const t2iAdaptersRaw = await getProperty(metadata, 't2iAdapters', isArray);
+    const parseResults = await Promise.allSettled(t2iAdaptersRaw.map((t2iAdapter) => parseT2IAdapter(t2iAdapter)));
+    const t2iAdapters = parseResults
+      .filter((result): result is PromiseFulfilledResult<T2IAdapterConfigMetadata> => result.status === 'fulfilled')
+      .map((result) => result.value);
+    return t2iAdapters;
+  } catch {
+    return [];
+  }
 };
 
 const parseIPAdapter: MetadataParseFunc<IPAdapterConfigMetadata> = async (metadataItem) => {
@@ -394,12 +411,16 @@ const parseIPAdapter: MetadataParseFunc<IPAdapterConfigMetadata> = async (metada
 };
 
 const parseAllIPAdapters: MetadataParseFunc<IPAdapterConfigMetadata[]> = async (metadata) => {
-  const ipAdaptersRaw = await getProperty(metadata, 'ipAdapters', isArray);
-  const parseResults = await Promise.allSettled(ipAdaptersRaw.map((ipAdapter) => parseIPAdapter(ipAdapter)));
-  const ipAdapters = parseResults
-    .filter((result): result is PromiseFulfilledResult<IPAdapterConfigMetadata> => result.status === 'fulfilled')
-    .map((result) => result.value);
-  return ipAdapters;
+  try {
+    const ipAdaptersRaw = await getProperty(metadata, 'ipAdapters', isArray);
+    const parseResults = await Promise.allSettled(ipAdaptersRaw.map((ipAdapter) => parseIPAdapter(ipAdapter)));
+    const ipAdapters = parseResults
+      .filter((result): result is PromiseFulfilledResult<IPAdapterConfigMetadata> => result.status === 'fulfilled')
+      .map((result) => result.value);
+    return ipAdapters;
+  } catch {
+    return [];
+  }
 };
 
 export const parsers = {

--- a/invokeai/frontend/web/src/features/metadata/util/recallers.ts
+++ b/invokeai/frontend/web/src/features/metadata/util/recallers.ts
@@ -177,11 +177,11 @@ const recallLoRA: MetadataRecallFunc<LoRA> = (lora) => {
 };
 
 const recallAllLoRAs: MetadataRecallFunc<LoRA[]> = (loras) => {
+  const { dispatch } = getStore();
+  dispatch(lorasReset());
   if (!loras.length) {
     return;
   }
-  const { dispatch } = getStore();
-  dispatch(lorasReset());
   loras.forEach((lora) => {
     dispatch(loraRecalled(lora));
   });
@@ -192,11 +192,11 @@ const recallControlNet: MetadataRecallFunc<ControlNetConfigMetadata> = (controlN
 };
 
 const recallControlNets: MetadataRecallFunc<ControlNetConfigMetadata[]> = (controlNets) => {
+  const { dispatch } = getStore();
+  dispatch(controlNetsReset());
   if (!controlNets.length) {
     return;
   }
-  const { dispatch } = getStore();
-  dispatch(controlNetsReset());
   controlNets.forEach((controlNet) => {
     dispatch(controlAdapterRecalled(controlNet));
   });
@@ -207,11 +207,11 @@ const recallT2IAdapter: MetadataRecallFunc<T2IAdapterConfigMetadata> = (t2iAdapt
 };
 
 const recallT2IAdapters: MetadataRecallFunc<T2IAdapterConfigMetadata[]> = (t2iAdapters) => {
+  const { dispatch } = getStore();
+  dispatch(t2iAdaptersReset());
   if (!t2iAdapters.length) {
     return;
   }
-  const { dispatch } = getStore();
-  dispatch(t2iAdaptersReset());
   t2iAdapters.forEach((t2iAdapter) => {
     dispatch(controlAdapterRecalled(t2iAdapter));
   });
@@ -222,11 +222,11 @@ const recallIPAdapter: MetadataRecallFunc<IPAdapterConfigMetadata> = (ipAdapter)
 };
 
 const recallIPAdapters: MetadataRecallFunc<IPAdapterConfigMetadata[]> = (ipAdapters) => {
+  const { dispatch } = getStore();
+  dispatch(ipAdaptersReset());
   if (!ipAdapters.length) {
     return;
   }
-  const { dispatch } = getStore();
-  dispatch(ipAdaptersReset());
   ipAdapters.forEach((ipAdapter) => {
     dispatch(controlAdapterRecalled(ipAdapter));
   });


### PR DESCRIPTION
## Summary
Currently "recall all" won't remove controls or hrf when they aren't used in the image, updates to set them to false or an empty array when not present. Loras were the same way but caught downstream elsewhere so also updated those
<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions
Closes #6210 
<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
