### PR TITLE
Fix up Knip config & enable --production mode

### DIFF
--- a/invokeai/frontend/web/knip.ts
+++ b/invokeai/frontend/web/knip.ts
@@ -1,6 +1,7 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
+  project: ['src/**/*.{ts,tsx}!'],
   ignore: [
     // This file is only used during debugging
     'src/app/store/middleware/debugLoggerMiddleware.ts',

--- a/invokeai/frontend/web/knip.ts
+++ b/invokeai/frontend/web/knip.ts
@@ -10,6 +10,9 @@ const config: KnipConfig = {
     'src/features/nodes/types/v2/**',
   ],
   ignoreBinaries: ['only-allow'],
+  paths: {
+    'public/*': ['public/*'],
+  },
 };
 
 export default config;

--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -24,7 +24,7 @@
     "build": "pnpm run lint && vite build",
     "typegen": "node scripts/typegen.js",
     "preview": "vite preview",
-    "lint:knip": "knip --tags=-@knipignore",
+    "lint:knip": "knip",
     "lint:dpdm": "dpdm --no-warning --no-tree --transform --exit-code circular:1 src/main.tsx",
     "lint:eslint": "eslint --max-warnings=0 .",
     "lint:prettier": "prettier --check .",

--- a/invokeai/frontend/web/src/common/components/Loading/Loading.tsx
+++ b/invokeai/frontend/web/src/common/components/Loading/Loading.tsx
@@ -1,5 +1,4 @@
 import { Flex, Image, Spinner } from '@invoke-ai/ui-library';
-/** @knipignore */
 import InvokeLogoWhite from 'public/assets/images/invoke-symbol-wht-lrg.svg';
 import { memo } from 'react';
 

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
@@ -6,7 +6,6 @@ import type { RemoveFromBoardDropData } from 'features/dnd/types';
 import AutoAddIcon from 'features/gallery/components/Boards/AutoAddIcon';
 import BoardContextMenu from 'features/gallery/components/Boards/BoardContextMenu';
 import { autoAddBoardIdChanged, boardIdSelected } from 'features/gallery/store/gallerySlice';
-/** @knipignore */
 import InvokeLogoSVG from 'public/assets/images/invoke-symbol-wht-lrg.svg';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/viewMode/EmptyState.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/viewMode/EmptyState.tsx
@@ -1,7 +1,6 @@
 import { Button, Flex, Image, Text } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { workflowModeChanged } from 'features/nodes/store/workflowSlice';
-/** @knipignore */
 import InvokeLogoSVG from 'public/assets/images/invoke-symbol-wht-lrg.svg';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/invokeai/frontend/web/src/features/system/components/AboutModal/AboutModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/AboutModal/AboutModal.tsx
@@ -21,7 +21,6 @@ import {
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
 import { discordLink, githubLink, websiteLink } from 'features/system/store/constants';
 import { map } from 'lodash-es';
-/** @knipignore */
 import InvokeLogoYellow from 'public/assets/images/invoke-tag-lrg.svg';
 import type { ReactElement } from 'react';
 import { cloneElement, memo, useCallback } from 'react';

--- a/invokeai/frontend/web/src/features/system/components/InvokeAILogoComponent.tsx
+++ b/invokeai/frontend/web/src/features/system/components/InvokeAILogoComponent.tsx
@@ -2,7 +2,6 @@
 import { Image, Text, Tooltip } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { $logo } from 'app/store/nanostores/logo';
-/** @knipignore */
 import InvokeLogoYellow from 'public/assets/images/invoke-symbol-ylw-lrg.svg';
 import { memo, useMemo, useRef } from 'react';
 import { useGetAppVersionQuery } from 'services/api/endpoints/appInfo';


### PR DESCRIPTION
## Summary

The other day [someone asked](https://github.com/webpro/knip/issues/591#issuecomment-2053498743) for an example of Knip + Storybook including production mode. GitHub search led me to this repo. And then I was happy to see Knip being used in a great manner :)

One thing struck me, though, so here I am proposing a small change so Knip will stay out of your way even more.

This also enables `knip --production`, which to me seems to reveal some unused exports you might to remove as well, but I'm leaving that up to you.

## Related Issues / Discussions

N/A

## QA Instructions

CI should still pass. You could consider adding another task to additionally run `knip --production` as well.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
