### PR TITLE
Remove dangling temporary directories from `outputs/tensors` at startup time

### DIFF
--- a/invokeai/app/api/dependencies.py
+++ b/invokeai/app/api/dependencies.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2022 Kyle Schouviller (https://github.com/kyle0654)
 
-import shutil
 from logging import Logger
-from pathlib import Path
 
 import torch
 
@@ -54,14 +52,6 @@ def check_internet() -> bool:
         return False
 
 
-def cleanup_tmpdirs(parent_folder: Path) -> None:
-    # Remove dangling tempdirs that might have been left over
-    # from an earlier unplanned shutdown.
-    for d in parent_folder.glob("tmp*"):
-        if d.is_dir():
-            shutil.rmtree(d)
-
-
 logger = InvokeAILogger.get_logger()
 
 
@@ -88,7 +78,6 @@ class ApiDependencies:
         configuration = config
         logger = logger
 
-        cleanup_tmpdirs(tensor_folder)
         board_image_records = SqliteBoardImageRecordStorage(db=db)
         board_images = BoardImagesService()
         board_records = SqliteBoardRecordStorage(db=db)

--- a/invokeai/app/api/dependencies.py
+++ b/invokeai/app/api/dependencies.py
@@ -70,7 +70,7 @@ class ApiDependencies:
             raise ValueError("Output folder is not set")
 
         image_files = DiskImageFileStorage(f"{output_folder}/images")
-        tensor_folder = output_folder / "tensors"
+
         model_images_folder = config.models_path
 
         db = init_db(config=config, logger=logger, image_files=image_files)
@@ -87,7 +87,9 @@ class ApiDependencies:
         image_records = SqliteImageRecordStorage(db=db)
         images = ImageService()
         invocation_cache = MemoryInvocationCache(max_cache_size=config.node_cache_size)
-        tensors = ObjectSerializerForwardCache(ObjectSerializerDisk[torch.Tensor](tensor_folder, ephemeral=True))
+        tensors = ObjectSerializerForwardCache(
+            ObjectSerializerDisk[torch.Tensor](output_folder / "tensors", ephemeral=True)
+        )
         conditioning = ObjectSerializerForwardCache(
             ObjectSerializerDisk[ConditioningFieldData](output_folder / "conditioning", ephemeral=True)
         )

--- a/invokeai/app/services/object_serializer/object_serializer_disk.py
+++ b/invokeai/app/services/object_serializer/object_serializer_disk.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 import typing
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, TypeVar
 
@@ -16,12 +15,6 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
-
-
-@dataclass
-class DeleteAllResult:
-    deleted_count: int
-    freed_space_bytes: float
 
 
 class ObjectSerializerDisk(ObjectSerializerBase[T]):

--- a/tests/test_object_serializer_disk.py
+++ b/tests/test_object_serializer_disk.py
@@ -99,6 +99,20 @@ def test_obj_serializer_ephemeral_writes_to_tempdir(tmp_path: Path):
     assert not Path(tmp_path, obj_1_name).exists()
 
 
+def test_obj_serializer_ephemeral_deletes_dangling_tempdirs_on_init(tmp_path: Path):
+    tempdir = tmp_path / "tmpdir"
+    tempdir.mkdir()
+    ObjectSerializerDisk[MockDataclass](tmp_path, ephemeral=True)
+    assert not tempdir.exists()
+
+
+def test_obj_serializer_does_not_delete_tempdirs_on_init(tmp_path: Path):
+    tempdir = tmp_path / "tmpdir"
+    tempdir.mkdir()
+    ObjectSerializerDisk[MockDataclass](tmp_path, ephemeral=False)
+    assert tempdir.exists()
+
+
 def test_obj_serializer_disk_different_types(tmp_path: Path):
     obj_serializer_1 = ObjectSerializerDisk[MockDataclass](tmp_path)
     obj_1 = MockDataclass(foo="bar")


### PR DESCRIPTION
## Summary

If the web app exits unexpectedly it may not run its shutdown routine, which removes temporary directories, among other things. At initialization time, this PR checks the base directories used by `ObjectSerializerDisk` for temporary directories left dangling from previous runs, and removes them.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

See #6242 for background on a bug that led to a large number of dangling temporary directories in `outputs/tensors`. 

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

If you have been running earlier versions of `invokeai-web` you probably have a lot of dangling temporary directories in `outputs/tensors`. When you run this PR, these directories should be removed.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
