### PR TITLE
feat(ui): regional prompting followups

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/addRegionalPromptsToGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/addRegionalPromptsToGraph.ts
@@ -24,7 +24,7 @@ export const addRegionalPromptsToGraph = async (state: RootState, graph: NonNull
   }
   const { dispatch } = getStore();
   // TODO: Handle non-SDXL
-  // const isSDXL = state.generation.model?.base === 'sdxl';
+  const isSDXL = state.generation.model?.base === 'sdxl';
   const layers = state.regionalPrompts.present.layers
     .filter(isRPLayer) // We only want the prompt region layers
     .filter((l) => l.isVisible) // Only visible layers are rendered on the canvas
@@ -125,12 +125,18 @@ export const addRegionalPromptsToGraph = async (state: RootState, graph: NonNull
 
     if (layer.positivePrompt) {
       // The main positive conditioning node
-      const regionalPositiveCondNode: S['SDXLCompelPromptInvocation'] = {
-        type: 'sdxl_compel_prompt',
-        id: `${PROMPT_REGION_POSITIVE_COND_PREFIX}_${layer.id}`,
-        prompt: layer.positivePrompt,
-        style: layer.positivePrompt, // TODO: Should we put the positive prompt in both fields?
-      };
+      const regionalPositiveCondNode: S['SDXLCompelPromptInvocation'] | S['CompelInvocation'] = isSDXL
+        ? {
+            type: 'sdxl_compel_prompt',
+            id: `${PROMPT_REGION_POSITIVE_COND_PREFIX}_${layer.id}`,
+            prompt: layer.positivePrompt,
+            style: layer.positivePrompt, // TODO: Should we put the positive prompt in both fields?
+          }
+        : {
+            type: 'compel',
+            id: `${PROMPT_REGION_POSITIVE_COND_PREFIX}_${layer.id}`,
+            prompt: layer.positivePrompt,
+          };
       graph.nodes[regionalPositiveCondNode.id] = regionalPositiveCondNode;
 
       // Connect the mask to the conditioning
@@ -158,12 +164,18 @@ export const addRegionalPromptsToGraph = async (state: RootState, graph: NonNull
 
     if (layer.negativePrompt) {
       // The main negative conditioning node
-      const regionalNegativeCondNode: S['SDXLCompelPromptInvocation'] = {
-        type: 'sdxl_compel_prompt',
-        id: `${PROMPT_REGION_NEGATIVE_COND_PREFIX}_${layer.id}`,
-        prompt: layer.negativePrompt,
-        style: layer.negativePrompt,
-      };
+      const regionalNegativeCondNode: S['SDXLCompelPromptInvocation'] | S['CompelInvocation'] = isSDXL
+        ? {
+            type: 'sdxl_compel_prompt',
+            id: `${PROMPT_REGION_NEGATIVE_COND_PREFIX}_${layer.id}`,
+            prompt: layer.negativePrompt,
+            style: layer.negativePrompt,
+          }
+        : {
+            type: 'compel',
+            id: `${PROMPT_REGION_NEGATIVE_COND_PREFIX}_${layer.id}`,
+            prompt: layer.negativePrompt,
+          };
       graph.nodes[regionalNegativeCondNode.id] = regionalNegativeCondNode;
 
       // Connect the mask to the conditioning
@@ -212,12 +224,18 @@ export const addRegionalPromptsToGraph = async (state: RootState, graph: NonNull
 
       // Create the conditioning node. It's going to be connected to the negative cond collector, but it uses the
       // positive prompt
-      const regionalPositiveCondInvertedNode: S['SDXLCompelPromptInvocation'] = {
-        type: 'sdxl_compel_prompt',
-        id: `${PROMPT_REGION_POSITIVE_COND_INVERTED_PREFIX}_${layer.id}`,
-        prompt: layer.positivePrompt,
-        style: layer.positivePrompt,
-      };
+      const regionalPositiveCondInvertedNode: S['SDXLCompelPromptInvocation'] | S['CompelInvocation'] = isSDXL
+        ? {
+            type: 'sdxl_compel_prompt',
+            id: `${PROMPT_REGION_POSITIVE_COND_INVERTED_PREFIX}_${layer.id}`,
+            prompt: layer.positivePrompt,
+            style: layer.positivePrompt,
+          }
+        : {
+            type: 'compel',
+            id: `${PROMPT_REGION_POSITIVE_COND_INVERTED_PREFIX}_${layer.id}`,
+            prompt: layer.positivePrompt,
+          };
       graph.nodes[regionalPositiveCondInvertedNode.id] = regionalPositiveCondInvertedNode;
       // Connect the inverted mask to the conditioning
       graph.edges.push({

--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearTextToImageGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildLinearTextToImageGraph.ts
@@ -1,6 +1,7 @@
 import { logger } from 'app/logging/logger';
 import type { RootState } from 'app/store/store';
 import { fetchModelConfigWithTypeGuard } from 'features/metadata/util/modelFetchingHelpers';
+import { addRegionalPromptsToGraph } from 'features/nodes/util/graph/addRegionalPromptsToGraph';
 import { getBoardField, getIsIntermediate } from 'features/nodes/util/graph/graphBuilderUtils';
 import { isNonRefinerMainModelConfig, type NonNullableGraph } from 'services/api/types';
 
@@ -254,6 +255,8 @@ export const buildLinearTextToImageGraph = async (state: RootState): Promise<Non
   await addIPAdapterToLinearGraph(state, graph, DENOISE_LATENTS);
 
   await addT2IAdaptersToLinearGraph(state, graph, DENOISE_LATENTS);
+
+  await addRegionalPromptsToGraph(state, graph, DENOISE_LATENTS);
 
   // High resolution fix.
   if (state.hrf.hrfEnabled) {

--- a/invokeai/frontend/web/src/features/regionalPrompts/components/RegionalPromptingEditor.stories.tsx
+++ b/invokeai/frontend/web/src/features/regionalPrompts/components/RegionalPromptingEditor.stories.tsx
@@ -12,7 +12,11 @@ export default meta;
 type Story = StoryObj<typeof RegionalPromptsEditor>;
 
 const Component = () => {
-  return <Flex w={1500} h={1500}><RegionalPromptsEditor /></Flex>
+  return (
+    <Flex w={1500} h={1500}>
+      <RegionalPromptsEditor />
+    </Flex>
+  );
 };
 
 export const Default: Story = {

--- a/invokeai/frontend/web/src/features/regionalPrompts/components/RegionalPromptingEditor.stories.tsx
+++ b/invokeai/frontend/web/src/features/regionalPrompts/components/RegionalPromptingEditor.stories.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@invoke-ai/ui-library';
 import type { Meta, StoryObj } from '@storybook/react';
 import { RegionalPromptsEditor } from 'features/regionalPrompts/components/RegionalPromptsEditor';
 
@@ -11,7 +12,7 @@ export default meta;
 type Story = StoryObj<typeof RegionalPromptsEditor>;
 
 const Component = () => {
-  return <RegionalPromptsEditor />;
+  return <Flex w={1500} h={1500}><RegionalPromptsEditor /></Flex>
 };
 
 export const Default: Story = {

--- a/invokeai/frontend/web/src/features/regionalPrompts/components/StageComponent.tsx
+++ b/invokeai/frontend/web/src/features/regionalPrompts/components/StageComponent.tsx
@@ -49,7 +49,7 @@ const useStageRenderer = (container: HTMLDivElement | null, wrapper: HTMLDivElem
   );
 
   const onBboxChanged = useCallback(
-    (layerId: string, bbox: IRect) => {
+    (layerId: string, bbox: IRect | null) => {
       dispatch(rpLayerBboxChanged({ layerId, bbox }));
     },
     [dispatch]
@@ -138,8 +138,8 @@ const useStageRenderer = (container: HTMLDivElement | null, wrapper: HTMLDivElem
     if (!stage) {
       return;
     }
-    renderBbox(stage, tool, state.selectedLayerId, onBboxChanged);
-  }, [dispatch, stage, tool, state.selectedLayerId, onBboxChanged]);
+    renderBbox(stage, state.layers, state.selectedLayerId, tool, onBboxChanged);
+  }, [dispatch, stage, state.layers, state.selectedLayerId, tool, onBboxChanged]);
 };
 
 const $container = atom<HTMLDivElement | null>(null);

--- a/invokeai/frontend/web/src/features/regionalPrompts/components/StageComponent.tsx
+++ b/invokeai/frontend/web/src/features/regionalPrompts/components/StageComponent.tsx
@@ -9,6 +9,7 @@ import {
   $tool,
   isRPLayer,
   rpLayerBboxChanged,
+  rpLayerSelected,
   rpLayerTranslated,
   selectRegionalPromptsSlice,
 } from 'features/regionalPrompts/store/regionalPromptsSlice';
@@ -51,6 +52,13 @@ const useStageRenderer = (container: HTMLDivElement | null, wrapper: HTMLDivElem
   const onBboxChanged = useCallback(
     (layerId: string, bbox: IRect | null) => {
       dispatch(rpLayerBboxChanged({ layerId, bbox }));
+    },
+    [dispatch]
+  );
+
+  const onBboxMouseDown = useCallback(
+    (layerId: string) => {
+      dispatch(rpLayerSelected(layerId));
     },
     [dispatch]
   );
@@ -138,8 +146,8 @@ const useStageRenderer = (container: HTMLDivElement | null, wrapper: HTMLDivElem
     if (!stage) {
       return;
     }
-    renderBbox(stage, state.layers, state.selectedLayerId, tool, onBboxChanged);
-  }, [dispatch, stage, state.layers, state.selectedLayerId, tool, onBboxChanged]);
+    renderBbox(stage, state.layers, state.selectedLayerId, tool, onBboxChanged, onBboxMouseDown);
+  }, [dispatch, stage, state.layers, state.selectedLayerId, tool, onBboxChanged, onBboxMouseDown]);
 };
 
 const $container = atom<HTMLDivElement | null>(null);

--- a/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
@@ -229,8 +229,8 @@ export const regionalPromptsSlice = createSlice({
             strokeWidth: state.brushSize,
           });
           layer.bboxNeedsUpdate = true;
-          if (!layer.hasEraserStrokes) {
-            layer.hasEraserStrokes = tool === 'eraser';
+          if (!layer.hasEraserStrokes && tool === 'eraser') {
+            layer.hasEraserStrokes = true;
           }
         }
       },

--- a/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
@@ -355,7 +355,6 @@ const getRPLayerId = (layerId: string) => `rp_layer_${layerId}`;
 const getRPLayerLineId = (layerId: string, lineId: string) => `${layerId}.line_${lineId}`;
 export const getRPLayerObjectGroupId = (layerId: string, groupId: string) => `${layerId}.objectGroup_${groupId}`;
 export const getPRLayerBboxId = (layerId: string) => `${layerId}.bbox`;
-export const getRPLayerTransparencyRectId = (layerId: string) => `${layerId}.transparency_rect`;
 
 export const regionalPromptsPersistConfig: PersistConfig<RegionalPromptsState> = {
   name: regionalPromptsSlice.name,

--- a/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
@@ -363,7 +363,8 @@ const undoableGroupByMatcher = isAnyOf(
   isEnabledChanged,
   rpLayerPositivePromptChanged,
   rpLayerNegativePromptChanged,
-  rpLayerTranslated
+  rpLayerTranslated,
+  rpLayerColorChanged,
 );
 
 const LINE_1 = 'LINE_1';

--- a/invokeai/frontend/web/src/features/regionalPrompts/util/renderers.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/util/renderers.ts
@@ -217,7 +217,6 @@ const renderRPLayer = (
 
   if (konvaObjectGroup.opacity() !== layerOpacity) {
     konvaObjectGroup.opacity(layerOpacity);
-    groupNeedsCache = true;
   }
 
   // Remove deleted objects
@@ -265,8 +264,8 @@ const renderRPLayer = (
       groupNeedsCache = true;
     }
     // Only update layer visibility if it has changed.
-    if (konvaObject.visible() !== rpLayer.isVisible) {
-      konvaObject.visible(rpLayer.isVisible);
+    if (konvaLayer.visible() !== rpLayer.isVisible) {
+      konvaLayer.visible(rpLayer.isVisible);
       groupNeedsCache = true;
     }
   }

--- a/invokeai/frontend/web/src/features/regionalPrompts/util/renderers.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/util/renderers.ts
@@ -16,7 +16,6 @@ import {
 } from 'features/regionalPrompts/store/regionalPromptsSlice';
 import { getKonvaLayerBbox } from 'features/regionalPrompts/util/bbox';
 import Konva from 'konva';
-import type { Node, NodeConfig } from 'konva/lib/Node';
 import type { IRect, Vector2d } from 'konva/lib/types';
 import type { RgbColor } from 'react-colorful';
 import { assert } from 'tsafe';
@@ -30,9 +29,6 @@ const BRUSH_PREVIEW_BORDER_OUTER_COLOR = 'rgba(255,255,255,0.8)';
 const GET_CLIENT_RECT_CONFIG = { skipTransform: true };
 
 const mapId = (object: { id: string }) => object.id;
-const selectPromptLayerObjectGroup = (item: Node<NodeConfig>) => {
-  return item.name() !== REGIONAL_PROMPT_LAYER_OBJECT_GROUP_NAME;
-};
 const getIsSelected = (layerId?: string | null) => {
   if (!layerId) {
     return false;
@@ -345,7 +341,7 @@ export const renderBbox = (
     if (reduxLayer.bboxNeedsUpdate && reduxLayer.objects.length) {
       // We only need to use the pixel-perfect bounding box if the layer has eraser strokes
       bbox = reduxLayer.hasEraserStrokes
-        ? getKonvaLayerBbox(konvaLayer, selectPromptLayerObjectGroup)
+        ? getKonvaLayerBbox(konvaLayer)
         : konvaLayer.getClientRect(GET_CLIENT_RECT_CONFIG);
 
       // Update the layer's bbox in the redux store
@@ -382,6 +378,7 @@ export const renderBbox = (
       });
       konvaLayer.add(rect);
     }
+
     rect.setAttrs({
       visible: true,
       listening: true,


### PR DESCRIPTION
## Summary

- Hook up SD1.5 graphs. HRF doesn't break, but I'm not sure if it really does what you want... I haven't attempted to integrate regions into HRF.
- Fix undo history with layer color picker to group these changes
- Less eye-stabbing default colors
- Some perf improvements to bbox calculations
- You can now select layers with the move tool to drag em around

https://github.com/invoke-ai/InvokeAI/assets/4822129/0a4f0b0a-5408-479e-bd79-fa9ea7807f3c

## Related Issues / Discussions

n/a

## QA Instructions

Have a play

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
