### PR TITLE
feat(ui): regional control canvas feedback

### DIFF
--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -51,6 +51,7 @@
     }
   },
   "dependencies": {
+    "@chakra-ui/react-use-size": "^2.1.0",
     "@dagrejs/dagre": "^1.1.1",
     "@dagrejs/graphlib": "^2.2.1",
     "@dnd-kit/core": "^6.1.0",

--- a/invokeai/frontend/web/pnpm-lock.yaml
+++ b/invokeai/frontend/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@chakra-ui/react':
     specifier: ^2.8.2
     version: 2.8.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.59)(framer-motion@11.0.6)(react-dom@18.2.0)(react@18.2.0)
+  '@chakra-ui/react-use-size':
+    specifier: ^2.1.0
+    version: 2.1.0(react@18.2.0)
   '@dagrejs/dagre':
     specifier: ^1.1.1
     version: 1.1.1

--- a/invokeai/frontend/web/src/features/parameters/components/ImageSize/AspectRatioCanvasPreview.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/ImageSize/AspectRatioCanvasPreview.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@invoke-ai/ui-library';
 import { StageComponent } from 'features/regionalPrompts/components/StageComponent';
 import { memo } from 'react';
 
-export const AspectRatioPreview = memo(() => {
+export const AspectRatioCanvasPreview = memo(() => {
   return (
     <Flex w="full" h="full" alignItems="center" justifyContent="center" position="relative">
       <StageComponent asPreview />
@@ -10,4 +10,4 @@ export const AspectRatioPreview = memo(() => {
   );
 });
 
-AspectRatioPreview.displayName = 'AspectRatioPreview';
+AspectRatioCanvasPreview.displayName = 'AspectRatioCanvasPreview';

--- a/invokeai/frontend/web/src/features/parameters/components/ImageSize/AspectRatioIconPreview.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/ImageSize/AspectRatioIconPreview.tsx
@@ -1,0 +1,75 @@
+import { useSize } from '@chakra-ui/react-use-size';
+import { Flex, Icon } from '@invoke-ai/ui-library';
+import { useImageSizeContext } from 'features/parameters/components/ImageSize/ImageSizeContext';
+import { AnimatePresence, motion } from 'framer-motion';
+import { memo, useMemo, useRef } from 'react';
+import { PiFrameCorners } from 'react-icons/pi';
+
+import {
+  BOX_SIZE_CSS_CALC,
+  ICON_CONTAINER_STYLES,
+  ICON_HIGH_CUTOFF,
+  ICON_LOW_CUTOFF,
+  MOTION_ICON_ANIMATE,
+  MOTION_ICON_EXIT,
+  MOTION_ICON_INITIAL,
+} from './constants';
+
+export const AspectRatioIconPreview = memo(() => {
+  const ctx = useImageSizeContext();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const containerSize = useSize(containerRef);
+
+  const shouldShowIcon = useMemo(
+    () => ctx.aspectRatioState.value < ICON_HIGH_CUTOFF && ctx.aspectRatioState.value > ICON_LOW_CUTOFF,
+    [ctx.aspectRatioState.value]
+  );
+
+  const { width, height } = useMemo(() => {
+    if (!containerSize) {
+      return { width: 0, height: 0 };
+    }
+
+    let width = ctx.width;
+    let height = ctx.height;
+
+    if (ctx.width > ctx.height) {
+      width = containerSize.width;
+      height = width / ctx.aspectRatioState.value;
+    } else {
+      height = containerSize.height;
+      width = height * ctx.aspectRatioState.value;
+    }
+
+    return { width, height };
+  }, [containerSize, ctx.width, ctx.height, ctx.aspectRatioState.value]);
+
+  return (
+    <Flex w="full" h="full" alignItems="center" justifyContent="center" ref={containerRef}>
+      <Flex
+        bg="blackAlpha.400"
+        borderRadius="base"
+        width={`${width}px`}
+        height={`${height}px`}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <AnimatePresence>
+          {shouldShowIcon && (
+            <Flex
+              as={motion.div}
+              initial={MOTION_ICON_INITIAL}
+              animate={MOTION_ICON_ANIMATE}
+              exit={MOTION_ICON_EXIT}
+              style={ICON_CONTAINER_STYLES}
+            >
+              <Icon as={PiFrameCorners} color="base.700" boxSize={BOX_SIZE_CSS_CALC} />
+            </Flex>
+          )}
+        </AnimatePresence>
+      </Flex>
+    </Flex>
+  );
+});
+
+AspectRatioIconPreview.displayName = 'AspectRatioIconPreview';

--- a/invokeai/frontend/web/src/features/parameters/components/ImageSize/ImageSize.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/ImageSize/ImageSize.tsx
@@ -1,6 +1,5 @@
 import type { FormLabelProps } from '@invoke-ai/ui-library';
 import { Flex, FormControlGroup } from '@invoke-ai/ui-library';
-import { AspectRatioPreview } from 'features/parameters/components/ImageSize/AspectRatioPreview';
 import { AspectRatioSelect } from 'features/parameters/components/ImageSize/AspectRatioSelect';
 import type { ImageSizeContextInnerValue } from 'features/parameters/components/ImageSize/ImageSizeContext';
 import { ImageSizeContext } from 'features/parameters/components/ImageSize/ImageSizeContext';
@@ -13,10 +12,11 @@ import { memo } from 'react';
 type ImageSizeProps = ImageSizeContextInnerValue & {
   widthComponent: ReactNode;
   heightComponent: ReactNode;
+  previewComponent: ReactNode;
 };
 
 export const ImageSize = memo((props: ImageSizeProps) => {
-  const { widthComponent, heightComponent, ...ctx } = props;
+  const { widthComponent, heightComponent, previewComponent, ...ctx } = props;
   return (
     <ImageSizeContext.Provider value={ctx}>
       <Flex gap={4} alignItems="center">
@@ -33,7 +33,7 @@ export const ImageSize = memo((props: ImageSizeProps) => {
           </FormControlGroup>
         </Flex>
         <Flex w="108px" h="108px" flexShrink={0} flexGrow={0}>
-          <AspectRatioPreview />
+          {previewComponent}
         </Flex>
       </Flex>
     </ImageSizeContext.Provider>

--- a/invokeai/frontend/web/src/features/parameters/components/ImageSize/constants.ts
+++ b/invokeai/frontend/web/src/features/parameters/components/ImageSize/constants.ts
@@ -4,8 +4,8 @@ import type { AspectRatioID, AspectRatioState } from './types';
 // When the aspect ratio is between these two values, we show the icon (experimentally determined)
 export const ICON_LOW_CUTOFF = 0.23;
 export const ICON_HIGH_CUTOFF = 1 / ICON_LOW_CUTOFF;
-export const ICON_SIZE_PX = 64;
-export const ICON_PADDING_PX = 16;
+const ICON_SIZE_PX = 64;
+const ICON_PADDING_PX = 16;
 export const BOX_SIZE_CSS_CALC = `min(${ICON_SIZE_PX}px, calc(100% - ${ICON_PADDING_PX}px))`;
 export const MOTION_ICON_INITIAL = {
   opacity: 0,

--- a/invokeai/frontend/web/src/features/parameters/components/ImageSize/constants.ts
+++ b/invokeai/frontend/web/src/features/parameters/components/ImageSize/constants.ts
@@ -1,7 +1,29 @@
 import type { ComboboxOption } from '@invoke-ai/ui-library';
 
 import type { AspectRatioID, AspectRatioState } from './types';
-
+// When the aspect ratio is between these two values, we show the icon (experimentally determined)
+export const ICON_LOW_CUTOFF = 0.23;
+export const ICON_HIGH_CUTOFF = 1 / ICON_LOW_CUTOFF;
+export const ICON_SIZE_PX = 64;
+export const ICON_PADDING_PX = 16;
+export const BOX_SIZE_CSS_CALC = `min(${ICON_SIZE_PX}px, calc(100% - ${ICON_PADDING_PX}px))`;
+export const MOTION_ICON_INITIAL = {
+  opacity: 0,
+};
+export const MOTION_ICON_ANIMATE = {
+  opacity: 1,
+  transition: { duration: 0.1 },
+};
+export const MOTION_ICON_EXIT = {
+  opacity: 0,
+  transition: { duration: 0.1 },
+};
+export const ICON_CONTAINER_STYLES = {
+  width: '100%',
+  height: '100%',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
 export const ASPECT_RATIO_OPTIONS: ComboboxOption[] = [
   { label: 'Free' as const, value: 'Free' },
   { label: '16:9' as const, value: '16:9' },

--- a/invokeai/frontend/web/src/features/regionalPrompts/components/RPLayerListItem.tsx
+++ b/invokeai/frontend/web/src/features/regionalPrompts/components/RPLayerListItem.tsx
@@ -75,7 +75,7 @@ export const RPLayerListItem = memo(({ layerId }: Props) => {
           <RPLayerSettingsPopover layerId={layerId} />
           <RPLayerMenu layerId={layerId} />
         </Flex>
-        <AddPromptButtons layerId={layerId} />
+        {!hasPositivePrompt && !hasNegativePrompt && !hasIPAdapters && <AddPromptButtons layerId={layerId} />}
         {hasPositivePrompt && <RPLayerPositivePrompt layerId={layerId} />}
         {hasNegativePrompt && <RPLayerNegativePrompt layerId={layerId} />}
         {hasIPAdapters && <RPLayerIPAdapterList layerId={layerId} />}

--- a/invokeai/frontend/web/src/features/regionalPrompts/components/StageComponent.tsx
+++ b/invokeai/frontend/web/src/features/regionalPrompts/components/StageComponent.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useMouseEvents } from 'features/regionalPrompts/hooks/mouseEventHooks';
 import {
   $cursorPosition,
+  $isMouseOver,
   $lastMouseDownPos,
   $tool,
   isVectorMaskLayer,
@@ -14,7 +15,7 @@ import {
   layerTranslated,
   selectRegionalPromptsSlice,
 } from 'features/regionalPrompts/store/regionalPromptsSlice';
-import { renderers } from 'features/regionalPrompts/util/renderers';
+import { debouncedRenderers, renderers } from 'features/regionalPrompts/util/renderers';
 import Konva from 'konva';
 import type { IRect } from 'konva/lib/types';
 import type { MutableRefObject } from 'react';
@@ -49,16 +50,20 @@ const useStageRenderer = (
   const { onMouseDown, onMouseUp, onMouseMove, onMouseEnter, onMouseLeave, onMouseWheel } = useMouseEvents();
   const cursorPosition = useStore($cursorPosition);
   const lastMouseDownPos = useStore($lastMouseDownPos);
+  const isMouseOver = useStore($isMouseOver);
   const selectedLayerIdColor = useAppSelector(selectSelectedLayerColor);
 
-  const renderLayers = useMemo(() => (asPreview ? renderers.layersDebounced : renderers.layers), [asPreview]);
-  const renderToolPreview = useMemo(
-    () => (asPreview ? renderers.toolPreviewDebounced : renderers.toolPreview),
+  const renderLayers = useMemo(
+    () => (asPreview ? debouncedRenderers.renderLayers : renderers.renderLayers),
     [asPreview]
   );
-  const renderBbox = useMemo(() => (asPreview ? renderers.bboxDebounced : renderers.bbox), [asPreview]);
+  const renderToolPreview = useMemo(
+    () => (asPreview ? debouncedRenderers.renderToolPreview : renderers.renderToolPreview),
+    [asPreview]
+  );
+  const renderBbox = useMemo(() => (asPreview ? debouncedRenderers.renderBbox : renderers.renderBbox), [asPreview]);
   const renderBackground = useMemo(
-    () => (asPreview ? renderers.backgroundDebounced : renderers.background),
+    () => (asPreview ? debouncedRenderers.renderBackground : renderers.renderBackground),
     [asPreview]
   );
 
@@ -158,6 +163,7 @@ const useStageRenderer = (
       state.globalMaskLayerOpacity,
       cursorPosition,
       lastMouseDownPos,
+      isMouseOver,
       state.brushSize
     );
   }, [
@@ -168,6 +174,7 @@ const useStageRenderer = (
     state.globalMaskLayerOpacity,
     cursorPosition,
     lastMouseDownPos,
+    isMouseOver,
     state.brushSize,
     renderToolPreview,
   ]);

--- a/invokeai/frontend/web/src/features/regionalPrompts/hooks/mouseEventHooks.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/hooks/mouseEventHooks.ts
@@ -44,6 +44,8 @@ const syncCursorPos = (stage: Konva.Stage): Vector2d | null => {
   return pos;
 };
 
+const BRUSH_SPACING = 20;
+
 export const useMouseEvents = () => {
   const dispatch = useAppDispatch();
   const selectedLayerId = useAppSelector((s) => s.regionalPrompts.present.selectedLayerId);
@@ -67,7 +69,6 @@ export const useMouseEvents = () => {
       if (!selectedLayerId) {
         return;
       }
-      // const tool = getTool();
       if (tool === 'brush' || tool === 'eraser') {
         dispatch(
           maskLayerLineAdded({
@@ -121,7 +122,8 @@ export const useMouseEvents = () => {
       }
       if (getIsFocused(stage) && $isMouseOver.get() && $isMouseDown.get() && (tool === 'brush' || tool === 'eraser')) {
         if (lastCursorPosRef.current) {
-          if (Math.hypot(lastCursorPosRef.current[0] - pos.x, lastCursorPosRef.current[1] - pos.y) < 20) {
+          // Dispatching redux events impacts perf substantially - using brush spacing keeps dispatches to a reasonable number
+          if (Math.hypot(lastCursorPosRef.current[0] - pos.x, lastCursorPosRef.current[1] - pos.y) < BRUSH_SPACING) {
             return;
           }
         }

--- a/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
@@ -16,7 +16,7 @@ type DrawingTool = 'brush' | 'eraser';
 
 export type Tool = DrawingTool | 'move' | 'rect';
 
-type VectorMaskLine = {
+export type VectorMaskLine = {
   id: string;
   type: 'vector_mask_line';
   tool: DrawingTool;
@@ -24,7 +24,7 @@ type VectorMaskLine = {
   points: number[];
 };
 
-type VectorMaskRect = {
+export type VectorMaskRect = {
   id: string;
   type: 'vector_mask_rect';
   x: number;

--- a/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/store/regionalPromptsSlice.ts
@@ -109,7 +109,7 @@ export const regionalPromptsSlice = createSlice({
             y: 0,
             autoNegative: 'invert',
             needsPixelBbox: false,
-            positivePrompt: null,
+            positivePrompt: '',
             negativePrompt: null,
             ipAdapterIds: [],
           };

--- a/invokeai/frontend/web/src/features/regionalPrompts/util/getLayerBlobs.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/util/getLayerBlobs.ts
@@ -20,7 +20,7 @@ export const getRegionalPromptLayerBlobs = async (
   const reduxLayers = state.regionalPrompts.present.layers;
   const container = document.createElement('div');
   const stage = new Konva.Stage({ container, width: state.generation.width, height: state.generation.height });
-  renderers.layers(stage, reduxLayers, 1, 'brush');
+  renderers.renderLayers(stage, reduxLayers, 1, 'brush');
 
   const konvaLayers = stage.find<Konva.Layer>(`.${VECTOR_MASK_LAYER_NAME}`);
   const blobs: Record<string, Blob> = {};

--- a/invokeai/frontend/web/src/features/regionalPrompts/util/renderers.ts
+++ b/invokeai/frontend/web/src/features/regionalPrompts/util/renderers.ts
@@ -588,7 +588,7 @@ const renderBackground = (stage: Konva.Stage, width: number, height: number) => 
  * @param stage The konva stage
  * @param layerIds An array of redux layer ids, in their z-index order
  */
-export const arrangeLayers = (stage: Konva.Stage, layerIds: string[]): void => {
+const arrangeLayers = (stage: Konva.Stage, layerIds: string[]): void => {
   let nextZIndex = 0;
   // Background is the first layer
   stage.findOne<Konva.Layer>(`#${BACKGROUND_LAYER_ID}`)?.zIndex(nextZIndex++);

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSizeCanvas.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSizeCanvas.tsx
@@ -2,6 +2,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { aspectRatioChanged, setBoundingBoxDimensions } from 'features/canvas/store/canvasSlice';
 import ParamBoundingBoxHeight from 'features/parameters/components/Canvas/BoundingBox/ParamBoundingBoxHeight';
 import ParamBoundingBoxWidth from 'features/parameters/components/Canvas/BoundingBox/ParamBoundingBoxWidth';
+import { AspectRatioIconPreview } from 'features/parameters/components/ImageSize/AspectRatioIconPreview';
 import { ImageSize } from 'features/parameters/components/ImageSize/ImageSize';
 import type { AspectRatioState } from 'features/parameters/components/ImageSize/types';
 import { selectOptimalDimension } from 'features/parameters/store/generationSlice';
@@ -41,6 +42,7 @@ export const ImageSizeCanvas = memo(() => {
       aspectRatioState={aspectRatioState}
       heightComponent={<ParamBoundingBoxHeight />}
       widthComponent={<ParamBoundingBoxWidth />}
+      previewComponent={<AspectRatioIconPreview />}
       onChangeAspectRatioState={onChangeAspectRatioState}
       onChangeWidth={onChangeWidth}
       onChangeHeight={onChangeHeight}

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSizeLinear.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/ImageSettingsAccordion/ImageSizeLinear.tsx
@@ -1,13 +1,17 @@
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { ParamHeight } from 'features/parameters/components/Core/ParamHeight';
 import { ParamWidth } from 'features/parameters/components/Core/ParamWidth';
+import { AspectRatioCanvasPreview } from 'features/parameters/components/ImageSize/AspectRatioCanvasPreview';
+import { AspectRatioIconPreview } from 'features/parameters/components/ImageSize/AspectRatioIconPreview';
 import { ImageSize } from 'features/parameters/components/ImageSize/ImageSize';
 import type { AspectRatioState } from 'features/parameters/components/ImageSize/types';
 import { aspectRatioChanged, heightChanged, widthChanged } from 'features/parameters/store/generationSlice';
+import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
 import { memo, useCallback } from 'react';
 
 export const ImageSizeLinear = memo(() => {
   const dispatch = useAppDispatch();
+  const tab = useAppSelector(activeTabNameSelector);
   const width = useAppSelector((s) => s.generation.width);
   const height = useAppSelector((s) => s.generation.height);
   const aspectRatioState = useAppSelector((s) => s.generation.aspectRatio);
@@ -40,6 +44,7 @@ export const ImageSizeLinear = memo(() => {
       aspectRatioState={aspectRatioState}
       heightComponent={<ParamHeight />}
       widthComponent={<ParamWidth />}
+      previewComponent={tab === 'txt2img' ? <AspectRatioCanvasPreview /> : <AspectRatioIconPreview />}
       onChangeAspectRatioState={onChangeAspectRatioState}
       onChangeWidth={onChangeWidth}
       onChangeHeight={onChangeHeight}


### PR DESCRIPTION
## Summary

- Restore non-RCC aspect ratio preview for non-t2i tabs
- Layers default to having a positive prompt
- Hide the 3 buttons when layer has any prompt
- Internal cleanup
- Fix layer arrangement - the bg layer was on top of everything. This coincidentally created the cool transparency effect you were seeing @hipsterusername , but it's not compatible with multiple control layers. We can implement the same effect in a different way though.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a
## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
