### PR TITLE
feat(nodes): add validation for invoke method return types

### DIFF
--- a/invokeai/app/invocations/baseinvocation.py
+++ b/invokeai/app/invocations/baseinvocation.py
@@ -495,16 +495,12 @@ def invocation(
         invoke_return_annotation = signature(cls.invoke).return_annotation
 
         try:
+            # TODO(psyche): If `invoke()` is not defined, `return_annotation` ends up as the string "BaseInvocationOutput"
+            # instead of the class `BaseInvocationOutput`. This may be a pydantic bug: https://github.com/pydantic/pydantic/issues/7978
             if isinstance(invoke_return_annotation, str):
                 invoke_return_annotation = getattr(sys.modules[cls.__module__], invoke_return_annotation)
 
             assert invoke_return_annotation is not BaseInvocationOutput
-            # TODO(psyche): If `invoke()` is not defined, `return_annotation` ends up as the string
-            # "BaseInvocationOutput". This may be a pydantic bug: https://github.com/pydantic/pydantic/issues/7978
-            # I cannot reproduce this in a simple test case, so I'm not sure how to fix it.
-            #
-            # This check should be in a try block, not a conditional, because `issubclass` errors if the first arg is
-            # not a class (e.g. the string "BaseInvocationOutput").
             assert issubclass(invoke_return_annotation, BaseInvocationOutput)
         except Exception:
             raise ValueError(

--- a/invokeai/app/invocations/baseinvocation.py
+++ b/invokeai/app/invocations/baseinvocation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import sys
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -492,7 +493,11 @@ def invocation(
 
         # And validate that `invoke()` returns a subclass of `BaseInvocationOutput
         invoke_return_annotation = signature(cls.invoke).return_annotation
+
         try:
+            if isinstance(invoke_return_annotation, str):
+                invoke_return_annotation = getattr(sys.modules[cls.__module__], invoke_return_annotation)
+
             assert invoke_return_annotation is not BaseInvocationOutput
             # TODO(psyche): If `invoke()` is not defined, `return_annotation` ends up as the string
             # "BaseInvocationOutput". This may be a pydantic bug: https://github.com/pydantic/pydantic/issues/7978

--- a/tests/test_node_graph.py
+++ b/tests/test_node_graph.py
@@ -34,6 +34,7 @@ from tests.test_nodes import (
     PolymorphicStringTestInvocation,
     PromptCollectionTestInvocation,
     PromptTestInvocation,
+    PromptTestInvocationOutput,
     TextToImageTestInvocation,
 )
 
@@ -509,7 +510,7 @@ def test_invocation_decorator():
 
     @invocation(invocation_type, title=title, tags=tags, category=category, version=version)
     class TestInvocation(BaseInvocation):
-        def invoke(self):
+        def invoke(self) -> PromptTestInvocationOutput:
             pass
 
     schema = TestInvocation.model_json_schema()
@@ -527,7 +528,7 @@ def test_invocation_version_must_be_semver():
 
     @invocation("test_invocation_version_valid", version=valid_version)
     class ValidVersionInvocation(BaseInvocation):
-        def invoke(self):
+        def invoke(self) -> PromptTestInvocationOutput:
             pass
 
     with pytest.raises(InvalidVersionError):

--- a/tests/test_node_graph.py
+++ b/tests/test_node_graph.py
@@ -715,3 +715,20 @@ def test_graph_can_generate_schema():
     # Not throwing on this line is sufficient
     # NOTE: if this test fails, it's PROBABLY because a new invocation type is breaking schema generation
     models_json_schema([(Graph, "serialization")])
+
+
+def test_nodes_must_implement_invoke_method():
+    with pytest.raises(ValueError, match='must implement the "invoke" method'):
+
+        @invocation("test_no_invoke_method", version="1.0.0")
+        class NoInvokeMethodInvocation(BaseInvocation):
+            pass
+
+
+def test_nodes_must_return_invocation_output():
+    with pytest.raises(ValueError, match="must have a return annotation of a subclass of BaseInvocationOutput"):
+
+        @invocation("test_no_output", version="1.0.0")
+        class NoOutputInvocation(BaseInvocation):
+            def invoke(self) -> str:
+                return "foo"


### PR DESCRIPTION
## Summary

Adds some checks for invocations' implementations of the `invoke` method, raising an error when the method isn't defined correctly.

## Related Issues / Discussions

See discussion here https://discord.com/channels/1020123559063990373/1233408559065206865

## QA Instructions

@dunkeroni I expect this commit to prevent invoke from launching, erroring on the problematic node you are working on.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
