### PR TITLE
fix(nodes): denoise latents accepts and validates CFG lists as input

### DIFF
--- a/invokeai/app/invocations/latent.py
+++ b/invokeai/app/invocations/latent.py
@@ -25,7 +25,7 @@ from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 from diffusers.schedulers import DPMSolverSDEScheduler
 from diffusers.schedulers import SchedulerMixin as Scheduler
 from PIL import Image, ImageFilter
-from pydantic import field_validator
+from pydantic import ValidationInfo, field_validator
 from torchvision.transforms.functional import resize as tv_resize
 from transformers import CLIPVisionModelWithProjection
 
@@ -341,7 +341,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
     )
     steps: int = InputField(default=10, gt=0, description=FieldDescriptions.steps)
     cfg_scale: Union[float, List[float]] = InputField(
-        default=7.5, ge=1, description=FieldDescriptions.cfg_scale, title="CFG Scale"
+        default=7.5, description=FieldDescriptions.cfg_scale, title="CFG Scale"
     )
     denoising_start: float = InputField(
         default=0.0,
@@ -397,12 +397,14 @@ class DenoiseLatentsInvocation(BaseInvocation):
     )
 
     @field_validator("cfg_scale")
-    def ge_one(cls, v: Union[List[float], float]) -> Union[List[float], float]:
+    def ge_one(cls, v: Union[List[float], float], info: ValidationInfo) -> Union[List[float], float]:
         """validate that all cfg_scale values are >= 1"""
         if isinstance(v, list):
             for i in v:
                 if i < 1:
                     raise ValueError("cfg_scale must be greater than 1")
+            if len(v) != info.data["steps"]:
+                raise ValueError("cfg_scale (list) must have the same length as the number of steps")
         else:
             if v < 1:
                 raise ValueError("cfg_scale must be greater than 1")


### PR DESCRIPTION
## Summary
Quick bug I ran into while trying to test the CFG schedulers paper.  
Denoise Latents Invocation already allowed a list[float] input for cfg_scale, but it could not actually use it. The ge=1 would fail to compare int and list.

We already had an extra validator defined to check elements >=1 for both list and float input types. I have added an additional check for len(cfg_scale) == steps when it is a list, which would otherwise cause an index error if they did not match.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
