### PR TITLE
feat: updater

### DIFF
--- a/installer/templates/invoke.ps1.in
+++ b/installer/templates/invoke.ps1.in
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+Launch script for InvokeAI on Windows.
+
+.DESCRIPTION
+This script activates a virtual environment and provides a menu for user operations.
+It assumes the .venv is in the same directory as this script.
+
+.NOTES
+Coauthored by Lincoln Stein, Eugene Brodsky, and Joshua Kimsey
+Copyright 2023, The InvokeAI Development Team
+#>
+
+# Stop on all errors
+$ErrorActionPreference = "Stop"
+
+# Ensure we're in the correct folder in case user's CWD is somewhere else
+$scriptdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location $scriptdir
+
+# Activate the virtual environment
+& .venv\Scripts\Activate.ps1
+
+$env:INVOKEAI_ROOT = $scriptdir
+
+function invokeai_update {
+    # Reset the updates dir
+    if (Test-Path invokeai-update) {
+        Remove-Item invokeai-update -Recurse -Force
+    }
+    # The helper downloads the installer to the invokeai-update directory
+    & invokeai-update-helper invokeai-update
+    # Use the install dir as a proxy for the update helper having retrieved the installer
+    if (Test-Path invokeai-update) {
+        # Must deactivate first to avoid issues with the installer
+        & .venv\Scripts\Deactivate.ps1
+        # Run the installer
+        & .\invokeai-update\InvokeAI-Installer\install.ps1 --root $scriptdir
+        # Clean up
+        Remove-Item invokeai-update -Recurse -Force
+        # Always exit after an update - user must re-run the script to get new options
+        exit 0
+    }
+}
+
+function do_choice {
+    param ($choice)
+    switch ($choice) {
+        1 {
+            Clear-Host
+            Write-Host "Generate images with a browser-based interface"
+            & invokeai-web @script:PARAMS
+        }
+        2 {
+            Clear-Host
+            Write-Host "Open the developer console"
+            & powershell -NoExit -Command "$MyInvocation.MyCommand.Definition"
+        }
+        3 {
+            Clear-Host
+            Write-Host "Check for updates"
+            invokeai_update
+        }
+        4 {
+            Clear-Host
+            Write-Host "Command-line help"
+            & invokeai-web --help
+        }
+        default {
+            Clear-Host
+            Write-Host "Exiting..."
+            exit
+        }
+    }
+    Clear-Host
+}
+
+function do_line_input {
+    Clear-Host
+    Write-Host "What would you like to do?"
+    Write-Host "1: Generate images using the browser-based interface"
+    Write-Host "2: Open the developer console"
+    Write-Host "3: Check for updates"
+    Write-Host "4: Command-line help"
+    Write-Host "Q: Quit`n"
+    Write-Host "To update, download and run the installer from https://github.com/invoke-ai/InvokeAI/releases/latest.`n"
+    $choice = Read-Host "Please enter 1-4, Q: [1]"
+    if (!$choice) { $choice = '1' }
+    do_choice $choice
+    Clear-Host
+}
+
+if ($MyInvocation.InvocationName -ne 'powershell') {
+    do {
+        do_line_input
+    } while ($true)
+} else { # in developer console
+    python --version
+    Write-Host "Press CTRL+D to exit"
+    $env:PS1 = "(InvokeAI) \u@\h \w> "
+}

--- a/installer/templates/invoke.ps1.in
+++ b/installer/templates/invoke.ps1.in
@@ -11,8 +11,6 @@ Coauthored by Lincoln Stein, Eugene Brodsky, and Joshua Kimsey
 Copyright 2023, The InvokeAI Development Team
 #>
 
-[console]::TreatControlCAsInput = $true
-
 # Ensure we're in the correct folder in case user's CWD is somewhere else
 $scriptdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 Set-Location $scriptdir
@@ -42,29 +40,36 @@ function invokeai_update {
     }
 }
 
+
+# We need to wrap all options in a try/finally to catch ^C, else it ends the launcher script.
 function do_choice {
     param ($choice)
     switch ($choice) {
         1 {
             Clear-Host
             Write-Host "Generate images with a browser-based interface"
-            invokeai-web @script:PARAMS
+            try { invokeai-web @script:PARAMS }
+            finally { do_line_input }
         }
         2 {
             Clear-Host
             Write-Host "Open the developer console`n"
             Write-Host "You are now in the system shell with Invoke's python venv activated. Type ``exit`` to quit.`n"
-            powershell -NoExit -Command "& .venv\Scripts\Activate.ps1; python --version;"
+            try { powershell -NoExit -Command "& .venv\Scripts\Activate.ps1; python --version;" }
+            finally { do_line_input }
         }
         3 {
             Clear-Host
             Write-Host "Check for updates"
-            invokeai_update
+            try { invokeai_update }
+            finally { do_line_input }
         }
         4 {
             Clear-Host
             Write-Host "Command-line help"
-            invokeai-web --help
+            try { invokeai-web --help }
+            finally { do_line_input }
+            
         }
         default {
             Clear-Host
@@ -73,11 +78,11 @@ function do_choice {
             exit
         }
     }
-    # Clear-Host
+    Clear-Host
 }
 
 function do_line_input {
-    # Clear-Host
+    Clear-Host
     Write-Host "What would you like to do?"
     Write-Host "1: Generate images using the browser-based interface"
     Write-Host "2: Open the developer console"
@@ -88,7 +93,7 @@ function do_line_input {
     $choice = Read-Host "Please enter 1-4, Q: [1]"
     if (!$choice) { $choice = '1' }
     do_choice $choice
-    # Clear-Host
+    Clear-Host
 }
 
 do {

--- a/installer/templates/invoke.ps1.in
+++ b/installer/templates/invoke.ps1.in
@@ -11,8 +11,7 @@ Coauthored by Lincoln Stein, Eugene Brodsky, and Joshua Kimsey
 Copyright 2023, The InvokeAI Development Team
 #>
 
-# Stop on all errors
-$ErrorActionPreference = "Stop"
+[console]::TreatControlCAsInput = $true
 
 # Ensure we're in the correct folder in case user's CWD is somewhere else
 $scriptdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
@@ -33,9 +32,9 @@ function invokeai_update {
     # Use the install dir as a proxy for the update helper having retrieved the installer
     if (Test-Path invokeai-update) {
         # Must deactivate first to avoid issues with the installer
-        & .venv\Scripts\Deactivate.ps1
+        deactivate
         # Run the installer
-        & .\invokeai-update\InvokeAI-Installer\install.ps1 --root $scriptdir
+        & .\invokeai-update\InvokeAI-Installer\install.bat --root $scriptdir
         # Clean up
         Remove-Item invokeai-update -Recurse -Force
         # Always exit after an update - user must re-run the script to get new options
@@ -49,12 +48,13 @@ function do_choice {
         1 {
             Clear-Host
             Write-Host "Generate images with a browser-based interface"
-            & invokeai-web @script:PARAMS
+            invokeai-web @script:PARAMS
         }
         2 {
             Clear-Host
-            Write-Host "Open the developer console"
-            & powershell -NoExit -Command "$MyInvocation.MyCommand.Definition"
+            Write-Host "Open the developer console`n"
+            Write-Host "You are now in the system shell with Invoke's python venv activated. Type ``exit`` to quit.`n"
+            powershell -NoExit -Command "& .venv\Scripts\Activate.ps1; python --version;"
         }
         3 {
             Clear-Host
@@ -64,19 +64,20 @@ function do_choice {
         4 {
             Clear-Host
             Write-Host "Command-line help"
-            & invokeai-web --help
+            invokeai-web --help
         }
         default {
             Clear-Host
             Write-Host "Exiting..."
+            deactivate
             exit
         }
     }
-    Clear-Host
+    # Clear-Host
 }
 
 function do_line_input {
-    Clear-Host
+    # Clear-Host
     Write-Host "What would you like to do?"
     Write-Host "1: Generate images using the browser-based interface"
     Write-Host "2: Open the developer console"
@@ -87,15 +88,9 @@ function do_line_input {
     $choice = Read-Host "Please enter 1-4, Q: [1]"
     if (!$choice) { $choice = '1' }
     do_choice $choice
-    Clear-Host
+    # Clear-Host
 }
 
-if ($MyInvocation.InvocationName -ne 'powershell') {
-    do {
-        do_line_input
-    } while ($true)
-} else { # in developer console
-    python --version
-    Write-Host "Press CTRL+D to exit"
-    $env:PS1 = "(InvokeAI) \u@\h \w> "
-}
+do {
+    do_line_input
+} while ($true)

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -11,7 +11,6 @@
 # 2. the .venv is also located in the runtime directory and is named exactly that
 #
 # If both of the above are not true, this script will likely not work as intended.
-# Activate the virtual environment and run `invoke.py` directly.
 ####
 
 set -eu
@@ -32,6 +31,26 @@ if [ "$(uname -s)" == "Darwin" ]; then
     export PYTORCH_ENABLE_MPS_FALLBACK=1
 fi
 
+invokeai_update() {
+    # Reset the updates dir
+    if [ -d invokeai-update ]; then
+        rm -rf invokeai-update
+    fi
+    # The helper downloads the installer to the invokeai-update directory, if the user says they want to update
+    invokeai-update-helper invokeai-update
+    # Use the install dir as a proxy for the update helper having retrieved the installer
+    if [ -d invokeai-update ]; then
+        # Must deactivate first to avoid issues with the installer
+        deactivate >/dev/null 2>&1
+        # Run the installer
+        bash ./invokeai-update/InvokeAI-Installer/install.sh --root "$(readlink -f $INVOKEAI_ROOT)"
+        # Clean up
+        rm -rf invokeai-update
+        # Always exit after an update - user must re-run `invoke.sh` to get new options
+        exit 0
+    fi
+}
+
 # Primary function for the case statement to determine user input
 do_choice() {
     case $1 in
@@ -47,6 +66,11 @@ do_choice() {
         bash --init-file "$file_name"
         ;;
     3)
+        clear
+        printf "Check for updates\n"
+        invokeai_update
+        ;;
+    4)
         clear
         printf "Command-line help\n"
         invokeai-web --help
@@ -66,7 +90,8 @@ do_line_input() {
     printf "What would you like to do?\n"
     printf "1: Generate images using the browser-based interface\n"
     printf "2: Open the developer console\n"
-    printf "3: Command-line help\n"
+    printf "3: Check for updates\n"
+    printf "4: Command-line help\n"
     printf "Q: Quit\n\n"
     printf "To update, download and run the installer from https://github.com/invoke-ai/InvokeAI/releases/latest.\n\n"
     read -p "Please enter 1-4, Q: [1] " yn

--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -48,11 +48,6 @@ do_choice() {
         ;;
     3)
         clear
-        printf "Running the db maintenance script\n"
-        invokeai-db-maintenance --root ${INVOKEAI_ROOT}
-        ;;
-    4)
-        clear
         printf "Command-line help\n"
         invokeai-web --help
         ;;
@@ -71,8 +66,7 @@ do_line_input() {
     printf "What would you like to do?\n"
     printf "1: Generate images using the browser-based interface\n"
     printf "2: Open the developer console\n"
-    printf "3: Run the InvokeAI image database maintenance script\n"
-    printf "4: Command-line help\n"
+    printf "3: Command-line help\n"
     printf "Q: Quit\n\n"
     printf "To update, download and run the installer from https://github.com/invoke-ai/InvokeAI/releases/latest.\n\n"
     read -p "Please enter 1-4, Q: [1] " yn

--- a/invokeai/frontend/install/update_helper.py
+++ b/invokeai/frontend/install/update_helper.py
@@ -1,0 +1,73 @@
+"""
+- Checks GitHub releases for updates, displaying any updates
+- If the user chooses to update, downloads the latest installer and unzips it to the dir provide as an arg
+"""
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+import requests
+from packaging.version import Version
+
+from invokeai.version.invokeai_version import __version__ as invokeai_version
+
+
+def check_for_updates(install_temp_dir: str) -> None:
+    current_version = Version(invokeai_version)
+    print(f"Current version: v{current_version}")
+    print("Checking for updates... ", end="")  # no trailing newline
+
+    response = requests.get("https://api.github.com/repos/invoke-ai/InvokeAI/releases")
+    response.raise_for_status()
+    req_json = response.json()
+
+    latest_release = [r for r in req_json if not r["prerelease"]][0]
+    latest_release_version = Version(latest_release["tag_name"])
+    is_release_available = current_version < latest_release_version
+
+    latest_prerelease = [r for r in req_json if r["prerelease"]][0]
+    latest_prerelease_version = Version(latest_prerelease["tag_name"])
+    is_prerelease_available = current_version < latest_prerelease_version
+
+    if not is_release_available and not is_prerelease_available:
+        print("up to date!")
+    else:
+        print("updates available:")
+        if is_release_available:
+            print(f"- New release: v{latest_release_version}")
+        if is_prerelease_available:
+            print(f"- New pre-release: v{latest_prerelease_version}")
+
+    prompt_msg = "\nDo you want to run the updater? You may select a version to update to or reinstall the current version. (y/n) [y]: "
+    response = input(prompt_msg).lower()
+
+    if response == "" or response == "y":
+        # Get the installer asset from the latest release - the asset name is InvokeAI-installer-*.zip
+        # TODO: It's possible that the prerelease installer is different from the release installer, but in an effort
+        # to keep this simple, we will always use the release installer...
+        installer_asset = next(
+            (a for a in latest_release["assets"] if re.match(r"InvokeAI-installer.*zip", a["name"], re.IGNORECASE))
+        )
+        download_url = installer_asset["browser_download_url"]
+        # Download & unzip the installer (it's only a few KB)
+        install_temp_path = Path(install_temp_dir, "installer.zip")
+        install_temp_path.parent.mkdir(exist_ok=True)
+        response = requests.get(download_url, stream=True)
+        response.raise_for_status()
+        with open(install_temp_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        shutil.unpack_archive(install_temp_path, install_temp_path.parent)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("install_temp_dir", type=str, help="Path to write the release URL to")
+    args = parser.parse_args()
+    check_for_updates(args.install_temp_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,10 @@ dependencies = [
   "easing-functions",
   "einops",
   "facexlib",
-  "matplotlib",       # needed for plotting of Penner easing functions
+  "matplotlib",                            # needed for plotting of Penner easing functions
   "npyscreen",
   "omegaconf",
+  "packaging",                             # used by launcher to update
   "picklescan",
   "pillow",
   "prompt-toolkit",
@@ -126,6 +127,7 @@ dependencies = [
 
 [project.scripts]
 "invokeai-web" = "invokeai.app.run_app:run_app"
+"invokeai-update-helper" = "invokeai.frontend.install.update_helper:main"
 "invokeai-import-images" = "invokeai.frontend.install.import_images:main"
 "invokeai-db-maintenance" = "invokeai.backend.util.db_maintenance:main"
 


### PR DESCRIPTION
## Summary

Similar to #6215, add update logic that fetches and runs the latest installer.

The main difference is that most of the logic in here is in a python script:
- Check for new releases/prereleases
- Advises user of current version and latest
- Asks user if they want to update - if so, download and unzip the latest installer

The python script then ends and the `invoke` script picks up. All it needs to do is check if the install script exists, and if so, run it and exit.

This works as expected for the macOS/linux `invoke.sh` script.

I ported the logic to powershell and it _mostly_ works, but there is some wonkiness when `invokeai-web` and the update helper exit. Powershell doesn't handle errors and exit codes (like when you Ctrl+C) for these non-.NET scripts nicely.

Depending on the combination of `$ErrorActionPreference` and whether or not you redirect stderr to stdout, you either catch every raised python error (including handled ones, bc they end up in stderr...) or none, and have to use a `finally` block to handle the signal from the python script. You cannot just catch the Ctrl+C and pass, letting the `invoke` script continue. If this sounds confusing, that's because it is.

Anyways, I'll revisit the powershell script later, maybe just write it in the batch file instead. Won't be hard, I just really wanted the powershell script to work bc it's so much more intelligible than batch.

## Related Issues / Discussions

#6215

## QA Instructions

Testing this is a bit convoluted. Two options:

1. Use a built installer
  - Build an installer from this branch (e.g. `make installer-zip`). 
  - Copy the wheel and the installer zip to the destination host.
  - Run the install script with `--wheel InvokeAI-4.2.0a3-py3-none-any.whl` to install from the wheel.
  - You should then have access to `invokeai-web` and `invokeai-update-helper` in your PATH, and the invoke launcher should work and update

2. Use an editable install
  - Do a normal install from any version to set up the root dir scripts
  - Check out this branch on the destination host
  - Activate your normal install's venv
  - Manually install (e.g. `pip install -e .`) into the normal install's venv
  - Copy and paste the launcher scripts from the branch to the install root (e.g. copy `invoke.sh.in` to `invoke.sh`)
  - You should then have access to `invokeai-web` and `invokeai-update-helper` in your PATH, and the invoke launcher should work and update
  
Ok, so then to make this more annoying, once you successfully use the updater to install, you will necessarily end up with a venv that no longer has the update functionality. So to test again, you need to repeat those steps to re-install from this branch, with update functionality...

## Merge Plan

This needs testing on multiple platforms (once the windows portion is working), and some coordination for releasing.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
