### PR TITLE
feat: improve the switch states of the control layers / viewer area

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -143,7 +143,6 @@
         "alpha": "Alpha",
         "selected": "Selected",
         "viewer": "Viewer",
-        "controlLayers": "Control Layers",
         "tab": "Tab"
     },
     "controlnet": {
@@ -1535,7 +1534,7 @@
         "moveForward": "Move Forward",
         "moveBackward": "Move Backward",
         "brushSize": "Brush Size",
-        "controlLayers": "Control Layers (BETA)",
+        "controlLayers": "Control Layers",
         "globalMaskOpacity": "Global Mask Opacity",
         "autoNegative": "Auto Negative",
         "toggleVisibility": "Toggle Layer Visibility",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -143,6 +143,7 @@
         "alpha": "Alpha",
         "selected": "Selected",
         "viewer": "Viewer",
+        "controlLayers": "Control Layers",
         "tab": "Tab"
     },
     "controlnet": {

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/EditorButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/EditorButton.tsx
@@ -1,19 +1,21 @@
+import { IconButton } from '@chakra-ui/react';
 import { Button } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import type { InvokeTabName } from 'features/ui/store/tabMap';
 import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PiArrowsDownUpBold } from 'react-icons/pi';
 
 import { useImageViewer } from './useImageViewer';
 
-const TAB_NAME_TO_TKEY: Record<InvokeTabName, string> = {
-  generation: 'ui.tabs.generationTab',
-  canvas: 'ui.tabs.canvasTab',
-  workflows: 'ui.tabs.workflowsTab',
-  models: 'ui.tabs.modelsTab',
-  queue: 'ui.tabs.queueTab',
-};
+// const TAB_NAME_TO_TKEY: Record<InvokeTabName, string> = {
+//   generation: 'ui.tabs.generationTab',
+//   canvas: 'ui.tabs.canvasTab',
+//   workflows: 'ui.tabs.workflowsTab',
+//   models: 'ui.tabs.modelsTab',
+//   queue: 'ui.tabs.queueTab',
+// };
 
 const TAB_NAME_TO_TKEY_SHORT: Record<InvokeTabName, string> = {
   generation: 'ui.tabs.generation',
@@ -27,11 +29,19 @@ export const EditorButton = () => {
   const { t } = useTranslation();
   const { onClose } = useImageViewer();
   const activeTabName = useAppSelector(activeTabNameSelector);
-  const tooltip = useMemo(() => t('gallery.switchTo', { tab: t(TAB_NAME_TO_TKEY[activeTabName]) }), [t, activeTabName]);
+
+  const tooltip = useMemo(
+    () =>
+      t('gallery.switchTo', {
+        tab: activeTabName === 'generation' ? t('common.controlLayers') : t(TAB_NAME_TO_TKEY_SHORT[activeTabName]),
+      }),
+    [t, activeTabName]
+  );
 
   return (
-    <Button aria-label={tooltip} tooltip={tooltip} onClick={onClose} variant="ghost">
-      {t(TAB_NAME_TO_TKEY_SHORT[activeTabName])}
+    <Button aria-label={tooltip} tooltip={tooltip} onClick={onClose} variant="outline" sx={{ display: 'flex', gap: 2 }}>
+      <IconButton aria-label={tooltip} variant="ghost" size="sm" icon={<PiArrowsDownUpBold />} />
+      {activeTabName === 'generation' ? t('common.controlLayers') : t(TAB_NAME_TO_TKEY_SHORT[activeTabName])}
     </Button>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/EditorButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/EditorButton.tsx
@@ -1,4 +1,3 @@
-import { IconButton } from '@chakra-ui/react';
 import { Button } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import type { InvokeTabName } from 'features/ui/store/tabMap';
@@ -9,16 +8,8 @@ import { PiArrowsDownUpBold } from 'react-icons/pi';
 
 import { useImageViewer } from './useImageViewer';
 
-// const TAB_NAME_TO_TKEY: Record<InvokeTabName, string> = {
-//   generation: 'ui.tabs.generationTab',
-//   canvas: 'ui.tabs.canvasTab',
-//   workflows: 'ui.tabs.workflowsTab',
-//   models: 'ui.tabs.modelsTab',
-//   queue: 'ui.tabs.queueTab',
-// };
-
 const TAB_NAME_TO_TKEY_SHORT: Record<InvokeTabName, string> = {
-  generation: 'ui.tabs.generation',
+  generation: 'controlLayers.controlLayers',
   canvas: 'ui.tabs.canvas',
   workflows: 'ui.tabs.workflows',
   models: 'ui.tabs.models',
@@ -29,19 +20,20 @@ export const EditorButton = () => {
   const { t } = useTranslation();
   const { onClose } = useImageViewer();
   const activeTabName = useAppSelector(activeTabNameSelector);
-
   const tooltip = useMemo(
-    () =>
-      t('gallery.switchTo', {
-        tab: activeTabName === 'generation' ? t('common.controlLayers') : t(TAB_NAME_TO_TKEY_SHORT[activeTabName]),
-      }),
+    () => t('gallery.switchTo', { tab: t(TAB_NAME_TO_TKEY_SHORT[activeTabName]) }),
     [t, activeTabName]
   );
 
   return (
-    <Button aria-label={tooltip} tooltip={tooltip} onClick={onClose} variant="outline" sx={{ display: 'flex', gap: 2 }}>
-      <IconButton aria-label={tooltip} variant="ghost" size="sm" icon={<PiArrowsDownUpBold />} />
-      {activeTabName === 'generation' ? t('common.controlLayers') : t(TAB_NAME_TO_TKEY_SHORT[activeTabName])}
+    <Button
+      aria-label={tooltip}
+      tooltip={tooltip}
+      onClick={onClose}
+      variant="outline"
+      leftIcon={<PiArrowsDownUpBold />}
+    >
+      {t(TAB_NAME_TO_TKEY_SHORT[activeTabName])}
     </Button>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerButton.tsx
@@ -1,16 +1,33 @@
+import { IconButton } from '@chakra-ui/react';
 import { Button } from '@invoke-ai/ui-library';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PiArrowsDownUpBold } from 'react-icons/pi';
 
 import { useImageViewer } from './useImageViewer';
 
 export const ViewerButton = () => {
   const { t } = useTranslation();
   const { onOpen } = useImageViewer();
-  const tooltip = useMemo(() => t('gallery.switchTo', { tab: t('common.viewer') }), [t]);
+
+  const tooltip = useMemo(
+    () =>
+      t('gallery.switchTo', {
+        tab: t('common.viewer'),
+      }),
+    [t]
+  );
 
   return (
-    <Button aria-label={tooltip} tooltip={tooltip} onClick={onOpen} variant="ghost" pointerEvents="auto">
+    <Button
+      aria-label={tooltip}
+      tooltip={tooltip}
+      onClick={onOpen}
+      variant="outline"
+      pointerEvents="auto"
+      sx={{ display: 'flex', gap: 2 }}
+    >
+      <IconButton aria-label={tooltip} variant="ghost" size="sm" icon={<PiArrowsDownUpBold />} />
       {t('common.viewer')}
     </Button>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerButton.tsx
@@ -1,4 +1,3 @@
-import { IconButton } from '@chakra-ui/react';
 import { Button } from '@invoke-ai/ui-library';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,14 +8,7 @@ import { useImageViewer } from './useImageViewer';
 export const ViewerButton = () => {
   const { t } = useTranslation();
   const { onOpen } = useImageViewer();
-
-  const tooltip = useMemo(
-    () =>
-      t('gallery.switchTo', {
-        tab: t('common.viewer'),
-      }),
-    [t]
-  );
+  const tooltip = useMemo(() => t('gallery.switchTo', { tab: t('common.viewer') }), [t]);
 
   return (
     <Button
@@ -25,9 +17,8 @@ export const ViewerButton = () => {
       onClick={onOpen}
       variant="outline"
       pointerEvents="auto"
-      sx={{ display: 'flex', gap: 2 }}
+      leftIcon={<PiArrowsDownUpBold />}
     >
-      <IconButton aria-label={tooltip} variant="ghost" size="sm" icon={<PiArrowsDownUpBold />} />
       {t('common.viewer')}
     </Button>
   );


### PR DESCRIPTION
## Summary

https://github.com/invoke-ai/InvokeAI/assets/54517381/562fda42-38a2-4739-a2e2-f33534c86ee4

Edit: Actually simplified it further .. Right now it's always the viewer. So it doesn't need context active naming at the moment. So for now we go back to how it was but with a switch button visual.
