### PR TITLE
Optimize RAM to VRAM transfer

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/model_cache_base.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache_base.py
@@ -46,6 +46,7 @@ class CacheRecord(Generic[T]):
 
     key: str
     model: T
+    state_dict: Optional[Dict[str, torch.Tensor]]  # this is a copy that stays in CPU
     size: int
     loaded: bool = False
     _locks: int = 0


### PR DESCRIPTION
## Summary

This PR speeds up the model manager’s system for moving models back and forth between RAM and VRAM . Instead of calling `model.to()` to accomplish the transfer, the model manager now stores a copy of the model’s state dict in RAM. When the model needs to be moved into VRAM for inference, the manager makes a VRAM copy of the state dict and assigns it to the model using `load_state_dict()`. When inference is done, the model is cleared from VRAM by calling `load_state_dict()` with the CPU copy of the state dict.

Benchmarking an SDXL model shows an improvement from 3 seconds to 0.81 seconds for a model load/unload cycle. Most of the improvement comes from the unload step, as shown in the table below:

```

model          from    to      old(s) new(s)                                                                    
-----          ----    --      -----  -----                                                                     
unet           cpu     cuda:0  0.69   0.52                                                                      
text_encoder   cpu     cuda:0  0.15   0.09                                                                      
text_encoder_2 cpu     cuda:0  0.16   0.14                                                                      
vae            cpu     cuda:0  0.02   0.02                                                                      
          LOAD TO CUDA TOTAL   1.02   0.77                                                                      
                                                                                                                
unet           cuda:0  cpu     1.45   0.03                                                                      
vae            cuda:0  cpu     0.09   0.00                                                                      
text_encoder   cuda:0  cpu     0.07   0.00                                                                      
text_encoder_2 cuda:0  cpu     0.40   0.01                                                                      
        UNLOAD FROM CUDA TOTAL 2.01   0.04
```

Thanks to @RyanJDick for suggesting this load/unload scheme.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Change models a number of times. 

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
