### PR TITLE
Update INSTALL_REQUIREMENTS.md - 'linux only' under AMD for SDXL.

### DIFF
--- a/docs/installation/INSTALL_REQUIREMENTS.md
+++ b/docs/installation/INSTALL_REQUIREMENTS.md
@@ -37,13 +37,13 @@ Invoke runs best with a dedicated GPU, but will fall back to running on CPU, alb
     === "Nvidia"
 
         ```
-        Any GPU with at least 8GB VRAM. Linux only.
+        Any GPU with at least 8GB VRAM.
         ```
 
     === "AMD"
 
         ```
-        Any GPU with at least 16GB VRAM.
+        Any GPU with at least 16GB VRAM. Linux only.
         ```
 
     === "Mac"


### PR DESCRIPTION
Moved 'Linux only.' back from under NVIDIA to under AMD for the SDXL hardware requirements.

## Summary

Documentation change - at some point 'Linux only.' got put under NVIDIA's requirements for SDXL. It's actually meant to be under AMD, just like with the SD 1.5 requirements.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

go go go

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
