### PR TITLE
feat(ui): protect against t2i adapters with incompatible image dimensions

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -934,7 +934,8 @@
             "noModelSelected": "No model selected",
             "noPrompts": "No prompts generated",
             "noNodesInGraph": "No nodes in graph",
-            "systemDisconnected": "System disconnected"
+            "systemDisconnected": "System disconnected",
+            "t2iAdapterMismatchedDimensions": "T2I Adapters require image dimensions to be multiples of 64"
         },
         "maskBlur": "Mask Blur",
         "negativePromptPlaceholder": "Negative Prompt",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -935,7 +935,19 @@
             "noPrompts": "No prompts generated",
             "noNodesInGraph": "No nodes in graph",
             "systemDisconnected": "System disconnected",
-            "t2iAdapterMismatchedDimensions": "T2I Adapters require image dimensions to be multiples of 64"
+            "layer": {
+                "initialImageNoImageSelected": "no initial image selected",
+                "controlAdapterNoModelSelected": "no Control Adapter model selected",
+                "controlAdapterIncompatibleBaseModel": "incompatible Control Adapter base model",
+                "controlAdapterNoImageSelected": "no Control Adapter image selected",
+                "controlAdapterImageNotProcessed": "Control Adapter image not processed",
+                "t2iAdapterIncompatibleDimensions": "T2I Adapter requires image dimension to be multiples of 64",
+                "ipAdapterNoModelSelected": "no IP adapter selected",
+                "ipAdapterIncompatibleBaseModel": "incompatible IP Adapter base model",
+                "ipAdapterNoImageSelected": "no IP Adapter image selected",
+                "rgNoPromptsOrIPAdapters": "no text prompts or IP Adapters",
+                "rgNoRegion": "no region selected"
+            }
         },
         "maskBlur": "Mask Blur",
         "negativePromptPlaceholder": "Negative Prompt",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -261,7 +261,6 @@
         "queue": "Queue",
         "queueFront": "Add to Front of Queue",
         "queueBack": "Add to Queue",
-        "queueCountPrediction": "{{promptsCount}} prompts \u00d7 {{iterations}} iterations -> {{count}} generations",
         "queueEmpty": "Queue Empty",
         "enqueueing": "Queueing Batch",
         "resume": "Resume",
@@ -314,7 +313,13 @@
         "batchFailedToQueue": "Failed to Queue Batch",
         "graphQueued": "Graph queued",
         "graphFailedToQueue": "Failed to queue graph",
-        "openQueue": "Open Queue"
+        "openQueue": "Open Queue",
+        "prompts_one": "Prompt",
+        "prompts_other": "Prompts",
+        "iterations_one": "Iteration",
+        "iterations_other": "Iterations",
+        "generations_one": "Generation",
+        "generations_other": "Generations"
     },
     "invocationCache": {
         "invocationCache": "Invocation Cache",
@@ -958,8 +963,6 @@
         "positivePromptPlaceholder": "Positive Prompt",
         "globalPositivePromptPlaceholder": "Global Positive Prompt",
         "iterations": "Iterations",
-        "iterationsWithCount_one": "{{count}} Iteration",
-        "iterationsWithCount_other": "{{count}} Iterations",
         "scale": "Scale",
         "scaleBeforeProcessing": "Scale Before Processing",
         "scaledHeight": "Scaled H",

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -29,6 +29,7 @@ const selector = createMemoizedSelector(
   ],
   (controlAdapters, generation, system, nodes, dynamicPrompts, controlLayers, activeTabName) => {
     const { model } = generation;
+    const { size } = controlLayers.present;
     const { positivePrompt } = controlLayers.present;
 
     const { isConnected } = system;
@@ -142,6 +143,9 @@ const selector = createMemoizedSelector(
                   number: i + 1,
                 })
               );
+            }
+            if (ca.type === 't2i_adapter' && (size.width % 64 !== 0 || size.height % 64 !== 0)) {
+              reasons.push(i18n.t('parameters.invoke.t2iAdapterMismatchedDimensions'));
             }
           });
       } else {

--- a/invokeai/frontend/web/src/features/controlLayers/components/ControlAndIPAdapter/ControlAdapterModelCombobox.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/ControlAndIPAdapter/ControlAdapterModelCombobox.tsx
@@ -42,6 +42,7 @@ export const ControlAdapterModelCombobox = memo(({ modelKey, onChange: onChangeM
     selectedModel,
     getIsDisabled,
     isLoading,
+    groupByType: true,
   });
 
   return (

--- a/invokeai/frontend/web/src/features/queue/components/InvokeQueueBackButton.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/InvokeQueueBackButton.tsx
@@ -16,25 +16,26 @@ export const InvokeQueueBackButton = memo(() => {
   return (
     <Flex pos="relative" flexGrow={1} minW="240px">
       <QueueIterationsNumberInput />
-      <Button
-        onClick={queueBack}
-        isLoading={isLoading || isLoadingDynamicPrompts}
-        loadingText={invoke}
-        isDisabled={isDisabled}
-        rightIcon={<RiSparkling2Fill />}
-        tooltip={<QueueButtonTooltip />}
-        variant="solid"
-        zIndex={1}
-        colorScheme="invokeYellow"
-        size="lg"
-        w="calc(100% - 60px)"
-        flexShrink={0}
-        justifyContent="space-between"
-        spinnerPlacement="end"
-      >
-        <span>{invoke}</span>
-        <Spacer />
-      </Button>
+      <QueueButtonTooltip>
+        <Button
+          onClick={queueBack}
+          isLoading={isLoading || isLoadingDynamicPrompts}
+          loadingText={invoke}
+          isDisabled={isDisabled}
+          rightIcon={<RiSparkling2Fill />}
+          variant="solid"
+          zIndex={1}
+          colorScheme="invokeYellow"
+          size="lg"
+          w="calc(100% - 60px)"
+          flexShrink={0}
+          justifyContent="space-between"
+          spinnerPlacement="end"
+        >
+          <span>{invoke}</span>
+          <Spacer />
+        </Button>
+      </QueueButtonTooltip>
     </Flex>
   );
 });

--- a/invokeai/frontend/web/src/features/queue/components/QueueButtonTooltip.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/QueueButtonTooltip.tsx
@@ -1,10 +1,11 @@
-import { Divider, Flex, ListItem, Text, UnorderedList } from '@invoke-ai/ui-library';
+import { Divider, Flex, ListItem, Text, Tooltip, UnorderedList } from '@invoke-ai/ui-library';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
 import { useIsReadyToEnqueue } from 'common/hooks/useIsReadyToEnqueue';
 import { selectControlLayersSlice } from 'features/controlLayers/store/controlLayersSlice';
 import { selectDynamicPromptsSlice } from 'features/dynamicPrompts/store/dynamicPromptsSlice';
 import { getShouldProcessPrompt } from 'features/dynamicPrompts/util/getShouldProcessPrompt';
+import type { PropsWithChildren } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useEnqueueBatchMutation } from 'services/api/endpoints/queue';
@@ -21,7 +22,15 @@ type Props = {
   prepend?: boolean;
 };
 
-export const QueueButtonTooltip = memo(({ prepend = false }: Props) => {
+export const QueueButtonTooltip = (props: PropsWithChildren<Props>) => {
+  return (
+    <Tooltip label={<TooltipContent prepend={props.prepend} />} maxW={512}>
+      {props.children}
+    </Tooltip>
+  );
+};
+
+const TooltipContent = memo(({ prepend = false }: Props) => {
   const { t } = useTranslation();
   const { isReady, reasons } = useIsReadyToEnqueue();
   const isLoadingDynamicPrompts = useAppSelector((s) => s.dynamicPrompts.isLoading);
@@ -64,8 +73,15 @@ export const QueueButtonTooltip = memo(({ prepend = false }: Props) => {
           <Divider opacity={0.2} borderColor="base.900" />
           <UnorderedList>
             {reasons.map((reason, i) => (
-              <ListItem key={`${reason}.${i}`}>
-                <Text>{reason}</Text>
+              <ListItem key={`${reason.content}.${i}`}>
+                <span>
+                  {reason.prefix && (
+                    <Text as="span" fontWeight="semibold">
+                      {reason.prefix}:{' '}
+                    </Text>
+                  )}
+                  <Text as="span">{reason.content}</Text>
+                </span>
               </ListItem>
             ))}
           </UnorderedList>
@@ -82,4 +98,4 @@ export const QueueButtonTooltip = memo(({ prepend = false }: Props) => {
   );
 });
 
-QueueButtonTooltip.displayName = 'QueueButtonTooltip';
+TooltipContent.displayName = 'QueueButtonTooltipContent';

--- a/invokeai/frontend/web/src/features/queue/components/QueueButtonTooltip.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/QueueButtonTooltip.tsx
@@ -35,12 +35,19 @@ const TooltipContent = memo(({ prepend = false }: Props) => {
   const { isReady, reasons } = useIsReadyToEnqueue();
   const isLoadingDynamicPrompts = useAppSelector((s) => s.dynamicPrompts.isLoading);
   const promptsCount = useAppSelector(selectPromptsCount);
-  const iterations = useAppSelector((s) => s.generation.iterations);
+  const iterationsCount = useAppSelector((s) => s.generation.iterations);
   const autoAddBoardId = useAppSelector((s) => s.gallery.autoAddBoardId);
   const autoAddBoardName = useBoardName(autoAddBoardId);
   const [_, { isLoading }] = useEnqueueBatchMutation({
     fixedCacheKey: 'enqueueBatch',
   });
+  const queueCountPredictionLabel = useMemo(() => {
+    const generationCount = Math.min(promptsCount * iterationsCount, 10000);
+    const prompts = t('queue.prompts', { count: promptsCount });
+    const iterations = t('queue.iterations', { count: iterationsCount });
+    const generations = t('queue.generations', { count: generationCount });
+    return `${promptsCount} ${prompts} \u00d7 ${iterationsCount} ${iterations} -> ${generationCount} ${generations}`.toLowerCase();
+  }, [iterationsCount, promptsCount, t]);
 
   const label = useMemo(() => {
     if (isLoading) {
@@ -61,13 +68,7 @@ const TooltipContent = memo(({ prepend = false }: Props) => {
   return (
     <Flex flexDir="column" gap={1}>
       <Text fontWeight="semibold">{label}</Text>
-      <Text>
-        {t('queue.queueCountPrediction', {
-          promptsCount,
-          iterations,
-          count: Math.min(promptsCount * iterations, 10000),
-        })}
-      </Text>
+      <Text>{queueCountPredictionLabel}</Text>
       {reasons.length > 0 && (
         <>
           <Divider opacity={0.2} borderColor="base.900" />

--- a/invokeai/frontend/web/src/features/queue/components/QueueFrontButton.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/QueueFrontButton.tsx
@@ -10,15 +10,16 @@ const QueueFrontButton = () => {
   const { t } = useTranslation();
   const { queueFront, isLoading, isDisabled } = useQueueFront();
   return (
-    <IconButton
-      aria-label={t('queue.queueFront')}
-      isDisabled={isDisabled}
-      isLoading={isLoading}
-      onClick={queueFront}
-      tooltip={<QueueButtonTooltip prepend />}
-      icon={<AiFillThunderbolt />}
-      size="lg"
-    />
+    <QueueButtonTooltip prepend>
+      <IconButton
+        aria-label={t('queue.queueFront')}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        onClick={queueFront}
+        icon={<AiFillThunderbolt />}
+        size="lg"
+      />
+    </QueueButtonTooltip>
   );
 };
 

--- a/invokeai/frontend/web/src/features/ui/components/FloatingParametersPanelButtons.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/FloatingParametersPanelButtons.tsx
@@ -63,16 +63,17 @@ const FloatingSidePanelButtons = (props: Props) => {
             sx={floatingButtonStyles}
             icon={<PiSlidersHorizontalBold size="16px" />}
           />
-          <IconButton
-            aria-label={t('queue.queueBack')}
-            onClick={queueBack}
-            isLoading={isLoading}
-            isDisabled={isDisabled}
-            icon={queueButtonIcon}
-            colorScheme="invokeYellow"
-            tooltip={<QueueButtonTooltip />}
-            sx={floatingButtonStyles}
-          />
+          <QueueButtonTooltip>
+            <IconButton
+              aria-label={t('queue.queueBack')}
+              onClick={queueBack}
+              isLoading={isLoading}
+              isDisabled={isDisabled}
+              icon={queueButtonIcon}
+              colorScheme="invokeYellow"
+              sx={floatingButtonStyles}
+            />
+          </QueueButtonTooltip>
           <CancelCurrentQueueItemIconButton sx={floatingButtonStyles} />
         </ButtonGroup>
         <ClearAllQueueIconButton sx={floatingButtonStyles} onOpen={disclosure.onOpen} />


### PR DESCRIPTION
## Summary

T2I Adapter requires images be multiples of 64. It's not clear if this is fixable or worth the effort to fix.

Pre-4.2.0, there was a little hack that set the image dimensions to the nearest multiple of 64 when selecting a T2I adapter. This was lost in the CL implementation. I don't like this solution - the user can change the image dimensions at any time and then they'll get a mysterious error when invoking.

To address the issue, an additional pre-Invoke check is added. You cannot click Invoke if you have a T2I layer and the image dimensions are not a multiple of 64.

![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/3dcbdec4-e30e-4392-82ff-3c8f5a8d6459)

Another issue apparent in the discord thread is that there is no way to differentiate between T2I adapter models and ControlNet models in the drop-down if the model names don't include "controlnet" or "t2i adapter" in them. It wasn't clear that the model in use was a T2I adapter model.

To address this, the model select now groups both by base model and model type:

![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/10ee776a-80ba-477c-9f56-d7d032e13938)

While fixing up the pre-invoke check messages, I reworked them for Control Layers. It's a bit stricter now - you cannot invoke if an enabled RG layer has no mask, for example. The messages are more descriptive, too.

![image](https://github.com/invoke-ai/InvokeAI/assets/4822129/8bf08763-1728-4bc6-8086-15e6f38a4904)

These changes are all CL-only - they do not apply to UC.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1238333845648969789

Closes #5370

## QA Instructions

Have a play with the pre-invoke checks, I believe that's the only change that may warrant some discussion. 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
