### PR TITLE
fix(ui): allow image dims multiple of 32 with SDXL and T2I adapter

### DIFF
--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -133,9 +133,12 @@ const createSelector = (templates: Templates) =>
                 } else if (l.controlAdapter.processorConfig && !l.controlAdapter.processedImage) {
                   problems.push(i18n.t('parameters.invoke.layer.controlAdapterImageNotProcessed'));
                 }
-                // T2I Adapters require images have dimensions that are multiples of 64
-                if (l.controlAdapter.type === 't2i_adapter' && (size.width % 64 !== 0 || size.height % 64 !== 0)) {
-                  problems.push(i18n.t('parameters.invoke.layer.t2iAdapterIncompatibleDimensions'));
+                // T2I Adapters require images have dimensions that are multiples of 64 (SD1.5) or 32 (SDXL)
+                if (l.controlAdapter.type === 't2i_adapter') {
+                  const multiple = model?.base === 'sdxl' ? 32 : 64;
+                  if (size.width % multiple !== 0 || size.height % multiple !== 0) {
+                    problems.push(i18n.t('parameters.invoke.layer.t2iAdapterIncompatibleDimensions'));
+                  }
                 }
               }
 


### PR DESCRIPTION
## Summary

When using T2I Adapter with SDXL base model, images with dimensions that are multiples of 32 are allowed. 

## Related Issues / Discussions

See https://github.com/invoke-ai/InvokeAI/pull/6342#issuecomment-2109912452 for discussion.

## QA Instructions

You should be prevented from Invoking if:
- SD1.5 model selected + T2I Adapter added + image dimensions are not a multiple of 64
- SDXL model selected + T2I Adapter added + image dimensions are not a multiple of 32

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
