### PR TITLE
feat(ui): SDXL clip skip

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addSDXLLoRAs.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addSDXLLoRAs.ts
@@ -11,6 +11,8 @@ export const addSDXLLoRas = (
   denoise: Invocation<'denoise_latents'>,
   modelLoader: Invocation<'sdxl_model_loader'>,
   seamless: Invocation<'seamless'> | null,
+  clipSkip: Invocation<'clip_skip'>,
+  clipSkip2: Invocation<'clip_skip'>,
   posCond: Invocation<'sdxl_compel_prompt'>,
   negCond: Invocation<'sdxl_compel_prompt'>
 ): void => {
@@ -37,8 +39,8 @@ export const addSDXLLoRas = (
   g.addEdge(loraCollector, 'collection', loraCollectionLoader, 'loras');
   // Use seamless as UNet input if it exists, otherwise use the model loader
   g.addEdge(seamless ?? modelLoader, 'unet', loraCollectionLoader, 'unet');
-  g.addEdge(modelLoader, 'clip', loraCollectionLoader, 'clip');
-  g.addEdge(modelLoader, 'clip2', loraCollectionLoader, 'clip2');
+  g.addEdge(clipSkip, 'clip', loraCollectionLoader, 'clip');
+  g.addEdge(clipSkip2, 'clip', loraCollectionLoader, 'clip2');
   // Reroute UNet & CLIP connections through the LoRA collection loader
   g.deleteEdgesTo(denoise, ['unet']);
   g.deleteEdgesTo(posCond, ['clip', 'clip2']);

--- a/invokeai/frontend/web/src/features/parameters/components/Advanced/ParamClipSkip.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Advanced/ParamClipSkip.tsx
@@ -39,10 +39,6 @@ const ParamClipSkip = () => {
     return CLIP_SKIP_MAP[model.base].markers;
   }, [model]);
 
-  if (model?.base === 'sdxl') {
-    return null;
-  }
-
   return (
     <FormControl>
       <InformationalPopover feature="clipSkip">

--- a/invokeai/frontend/web/src/features/parameters/types/constants.ts
+++ b/invokeai/frontend/web/src/features/parameters/types/constants.ts
@@ -39,8 +39,8 @@ export const CLIP_SKIP_MAP = {
     markers: [0, 1, 2, 3, 5, 10, 15, 20, 24],
   },
   sdxl: {
-    maxClip: 24,
-    markers: [0, 1, 2, 3, 5, 10, 15, 20, 24],
+    maxClip: 11,
+    markers: [0, 1, 2, 5, 11],
   },
   'sdxl-refiner': {
     maxClip: 24,


### PR DESCRIPTION
## Summary

Uses the same CLIP Skip value for both CLIP1 and CLIP2.

Adjusted SDXL CLIP Skip min/max/markers to be within the valid range (0 to 11).

## Related Issues / Discussions

Closes #4583

## QA Instructions

- Try it out, with and without LoRAs (which have a minor graph change to support SDXL CLIP Skip). Shouldn't break anything.
- This does not change the default CLIP skip value. Don't think we should make a change like that.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
