### PR TITLE
feat(ui): workflows undo/redo

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -774,6 +774,7 @@
         "cannotConnectOutputToOutput": "Cannot connect output to output",
         "cannotConnectToSelf": "Cannot connect to self",
         "cannotDuplicateConnection": "Cannot create duplicate connections",
+        "cannotMixAndMatchCollectionItemTypes": "Cannot mix and match collection item types",
         "nodePack": "Node pack",
         "collection": "Collection",
         "collectionFieldType": "{{name}} Collection",

--- a/invokeai/frontend/web/src/app/store/middleware/devtools/actionSanitizer.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/devtools/actionSanitizer.ts
@@ -1,7 +1,6 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import { deepClone } from 'common/util/deepClone';
 import { isAnyGraphBuilt } from 'features/nodes/store/actions';
-import { nodeTemplatesBuilt } from 'features/nodes/store/nodesSlice';
 import { appInfoApi } from 'services/api/endpoints/appInfo';
 import type { Graph } from 'services/api/types';
 import { socketGeneratorProgress } from 'services/events/actions';
@@ -22,13 +21,6 @@ export const actionSanitizer = <A extends UnknownAction>(action: A): A => {
     return {
       ...action,
       payload: '<OpenAPI schema omitted>',
-    };
-  }
-
-  if (nodeTemplatesBuilt.match(action)) {
-    return {
-      ...action,
-      payload: '<Node templates omitted>',
     };
   }
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/boardAndImagesDeleted.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/boardAndImagesDeleted.ts
@@ -21,7 +21,7 @@ export const addDeleteBoardAndImagesFulfilledListener = (startAppListening: AppS
 
       const { canvas, nodes, controlAdapters, controlLayers } = getState();
       deleted_images.forEach((image_name) => {
-        const imageUsage = getImageUsage(canvas, nodes, controlAdapters, controlLayers.present, image_name);
+        const imageUsage = getImageUsage(canvas, nodes.present, controlAdapters, controlLayers.present, image_name);
 
         if (imageUsage.isCanvasImage && !wasCanvasReset) {
           dispatch(resetCanvas());

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedNodes.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedNodes.ts
@@ -11,9 +11,9 @@ export const addEnqueueRequestedNodes = (startAppListening: AppStartListening) =
       enqueueRequested.match(action) && action.payload.tabName === 'workflows',
     effect: async (action, { getState, dispatch }) => {
       const state = getState();
-      const { nodes, edges } = state.nodes;
+      const { nodes, edges } = state.nodes.present;
       const workflow = state.workflow;
-      const graph = buildNodesGraph(state.nodes);
+      const graph = buildNodesGraph(state.nodes.present);
       const builtWorkflow = buildWorkflowWithValidation({
         nodes,
         edges,

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/getOpenAPISchema.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/getOpenAPISchema.ts
@@ -1,7 +1,7 @@
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import { parseify } from 'common/util/serialize';
-import { nodeTemplatesBuilt } from 'features/nodes/store/nodesSlice';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { parseSchema } from 'features/nodes/util/schema/parseSchema';
 import { size } from 'lodash-es';
 import { appInfoApi } from 'services/api/endpoints/appInfo';
@@ -9,7 +9,7 @@ import { appInfoApi } from 'services/api/endpoints/appInfo';
 export const addGetOpenAPISchemaListener = (startAppListening: AppStartListening) => {
   startAppListening({
     matcher: appInfoApi.endpoints.getOpenAPISchema.matchFulfilled,
-    effect: (action, { dispatch, getState }) => {
+    effect: (action, { getState }) => {
       const log = logger('system');
       const schemaJSON = action.payload;
 
@@ -20,7 +20,7 @@ export const addGetOpenAPISchemaListener = (startAppListening: AppStartListening
 
       log.debug({ nodeTemplates: parseify(nodeTemplates) }, `Built ${size(nodeTemplates)} node templates`);
 
-      dispatch(nodeTemplatesBuilt(nodeTemplates));
+      $templates.set(nodeTemplates);
     },
   });
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDeleted.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDeleted.ts
@@ -29,7 +29,7 @@ import type { ImageDTO } from 'services/api/types';
 import { imagesSelectors } from 'services/api/util';
 
 const deleteNodesImages = (state: RootState, dispatch: AppDispatch, imageDTO: ImageDTO) => {
-  state.nodes.nodes.forEach((node) => {
+  state.nodes.present.nodes.forEach((node) => {
     if (!isInvocationNode(node)) {
       return;
     }

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketGeneratorProgress.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketGeneratorProgress.ts
@@ -1,5 +1,8 @@
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
+import { deepClone } from 'common/util/deepClone';
+import { $nodeExecutionStates } from 'features/nodes/hooks/useExecutionState';
+import { zNodeStatus } from 'features/nodes/types/invocation';
 import { socketGeneratorProgress } from 'services/events/actions';
 
 const log = logger('socketio');
@@ -9,6 +12,13 @@ export const addGeneratorProgressEventListener = (startAppListening: AppStartLis
     actionCreator: socketGeneratorProgress,
     effect: (action) => {
       log.trace(action.payload, `Generator progress`);
+      const { source_node_id, step, total_steps, progress_image } = action.payload.data;
+      const nes = deepClone($nodeExecutionStates.get()[source_node_id]);
+      if (nes) {
+        nes.status = zNodeStatus.enum.IN_PROGRESS;
+        nes.progress = (step + 1) / total_steps;
+        nes.progressImage = progress_image ?? null;
+      }
     },
   });
 };

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketInvocationError.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketInvocationError.ts
@@ -1,5 +1,8 @@
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
+import { deepClone } from 'common/util/deepClone';
+import { $nodeExecutionStates, upsertExecutionState } from 'features/nodes/hooks/useExecutionState';
+import { zNodeStatus } from 'features/nodes/types/invocation';
 import { socketInvocationError } from 'services/events/actions';
 
 const log = logger('socketio');
@@ -9,6 +12,15 @@ export const addInvocationErrorEventListener = (startAppListening: AppStartListe
     actionCreator: socketInvocationError,
     effect: (action) => {
       log.error(action.payload, `Invocation error (${action.payload.data.node.type})`);
+      const { source_node_id } = action.payload.data;
+      const nes = deepClone($nodeExecutionStates.get()[source_node_id]);
+      if (nes) {
+        nes.status = zNodeStatus.enum.FAILED;
+        nes.error = action.payload.data.error;
+        nes.progress = null;
+        nes.progressImage = null;
+        upsertExecutionState(nes.nodeId, nes);
+      }
     },
   });
 };

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketInvocationStarted.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketInvocationStarted.ts
@@ -1,5 +1,8 @@
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
+import { deepClone } from 'common/util/deepClone';
+import { $nodeExecutionStates, upsertExecutionState } from 'features/nodes/hooks/useExecutionState';
+import { zNodeStatus } from 'features/nodes/types/invocation';
 import { socketInvocationStarted } from 'services/events/actions';
 
 const log = logger('socketio');
@@ -9,6 +12,12 @@ export const addInvocationStartedEventListener = (startAppListening: AppStartLis
     actionCreator: socketInvocationStarted,
     effect: (action) => {
       log.debug(action.payload, `Invocation started (${action.payload.data.node.type})`);
+      const { source_node_id } = action.payload.data;
+      const nes = deepClone($nodeExecutionStates.get()[source_node_id]);
+      if (nes) {
+        nes.status = zNodeStatus.enum.IN_PROGRESS;
+        upsertExecutionState(nes.nodeId, nes);
+      }
     },
   });
 };

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/updateAllNodesRequested.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/updateAllNodesRequested.ts
@@ -25,7 +25,7 @@ export const addUpdateAllNodesRequestedListener = (startAppListening: AppStartLi
           unableToUpdateCount++;
           return;
         }
-        if (!getNeedsUpdate(node, template)) {
+        if (!getNeedsUpdate(node.data, template)) {
           // No need to increment the count here, since we're not actually updating
           return;
         }

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/updateAllNodesRequested.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/updateAllNodesRequested.ts
@@ -1,7 +1,7 @@
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import { updateAllNodesRequested } from 'features/nodes/store/actions';
-import { nodeReplaced } from 'features/nodes/store/nodesSlice';
+import { $templates, nodeReplaced } from 'features/nodes/store/nodesSlice';
 import { NodeUpdateError } from 'features/nodes/types/error';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { getNeedsUpdate, updateNode } from 'features/nodes/util/node/nodeUpdate';
@@ -14,7 +14,8 @@ export const addUpdateAllNodesRequestedListener = (startAppListening: AppStartLi
     actionCreator: updateAllNodesRequested,
     effect: (action, { dispatch, getState }) => {
       const log = logger('nodes');
-      const { nodes, templates } = getState().nodes.present;
+      const { nodes } = getState().nodes.present;
+      const templates = $templates.get();
 
       let unableToUpdateCount = 0;
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/updateAllNodesRequested.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/updateAllNodesRequested.ts
@@ -14,7 +14,7 @@ export const addUpdateAllNodesRequestedListener = (startAppListening: AppStartLi
     actionCreator: updateAllNodesRequested,
     effect: (action, { dispatch, getState }) => {
       const log = logger('nodes');
-      const { nodes, templates } = getState().nodes;
+      const { nodes, templates } = getState().nodes.present;
 
       let unableToUpdateCount = 0;
 

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/workflowLoadRequested.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/workflowLoadRequested.ts
@@ -2,6 +2,7 @@ import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import { parseify } from 'common/util/serialize';
 import { workflowLoaded, workflowLoadRequested } from 'features/nodes/store/actions';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { $flow } from 'features/nodes/store/reactFlowInstance';
 import { WorkflowMigrationError, WorkflowVersionError } from 'features/nodes/types/error';
 import { validateWorkflow } from 'features/nodes/util/workflow/validateWorkflow';
@@ -14,10 +15,10 @@ import { fromZodError } from 'zod-validation-error';
 export const addWorkflowLoadRequestedListener = (startAppListening: AppStartListening) => {
   startAppListening({
     actionCreator: workflowLoadRequested,
-    effect: (action, { dispatch, getState }) => {
+    effect: (action, { dispatch }) => {
       const log = logger('nodes');
       const { workflow, asCopy } = action.payload;
-      const nodeTemplates = getState().nodes.present.templates;
+      const nodeTemplates = $templates.get();
 
       try {
         const { workflow: validatedWorkflow, warnings } = validateWorkflow(workflow, nodeTemplates);

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/workflowLoadRequested.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/workflowLoadRequested.ts
@@ -17,7 +17,7 @@ export const addWorkflowLoadRequestedListener = (startAppListening: AppStartList
     effect: (action, { dispatch, getState }) => {
       const log = logger('nodes');
       const { workflow, asCopy } = action.payload;
-      const nodeTemplates = getState().nodes.templates;
+      const nodeTemplates = getState().nodes.present.templates;
 
       try {
         const { workflow: validatedWorkflow, warnings } = validateWorkflow(workflow, nodeTemplates);

--- a/invokeai/frontend/web/src/app/store/store.ts
+++ b/invokeai/frontend/web/src/app/store/store.ts
@@ -21,7 +21,7 @@ import { galleryPersistConfig, gallerySlice } from 'features/gallery/store/galle
 import { hrfPersistConfig, hrfSlice } from 'features/hrf/store/hrfSlice';
 import { loraPersistConfig, loraSlice } from 'features/lora/store/loraSlice';
 import { modelManagerV2PersistConfig, modelManagerV2Slice } from 'features/modelManagerV2/store/modelManagerV2Slice';
-import { nodesPersistConfig, nodesSlice } from 'features/nodes/store/nodesSlice';
+import { nodesPersistConfig, nodesSlice, nodesUndoableConfig } from 'features/nodes/store/nodesSlice';
 import { workflowPersistConfig, workflowSlice } from 'features/nodes/store/workflowSlice';
 import { generationPersistConfig, generationSlice } from 'features/parameters/store/generationSlice';
 import { postprocessingPersistConfig, postprocessingSlice } from 'features/parameters/store/postprocessingSlice';
@@ -50,7 +50,7 @@ const allReducers = {
   [canvasSlice.name]: canvasSlice.reducer,
   [gallerySlice.name]: gallerySlice.reducer,
   [generationSlice.name]: generationSlice.reducer,
-  [nodesSlice.name]: nodesSlice.reducer,
+  [nodesSlice.name]: undoable(nodesSlice.reducer, nodesUndoableConfig),
   [postprocessingSlice.name]: postprocessingSlice.reducer,
   [systemSlice.name]: systemSlice.reducer,
   [configSlice.name]: configSlice.reducer,

--- a/invokeai/frontend/web/src/app/store/store.ts
+++ b/invokeai/frontend/web/src/app/store/store.ts
@@ -22,6 +22,7 @@ import { hrfPersistConfig, hrfSlice } from 'features/hrf/store/hrfSlice';
 import { loraPersistConfig, loraSlice } from 'features/lora/store/loraSlice';
 import { modelManagerV2PersistConfig, modelManagerV2Slice } from 'features/modelManagerV2/store/modelManagerV2Slice';
 import { nodesPersistConfig, nodesSlice, nodesUndoableConfig } from 'features/nodes/store/nodesSlice';
+import { workflowSettingsPersistConfig, workflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
 import { workflowPersistConfig, workflowSlice } from 'features/nodes/store/workflowSlice';
 import { generationPersistConfig, generationSlice } from 'features/parameters/store/generationSlice';
 import { postprocessingPersistConfig, postprocessingSlice } from 'features/parameters/store/postprocessingSlice';
@@ -66,6 +67,7 @@ const allReducers = {
   [workflowSlice.name]: workflowSlice.reducer,
   [hrfSlice.name]: hrfSlice.reducer,
   [controlLayersSlice.name]: undoable(controlLayersSlice.reducer, controlLayersUndoableConfig),
+  [workflowSettingsSlice.name]: workflowSettingsSlice.reducer,
   [api.reducerPath]: api.reducer,
 };
 
@@ -111,6 +113,7 @@ const persistConfigs: { [key in keyof typeof allReducers]?: PersistConfig } = {
   [modelManagerV2PersistConfig.name]: modelManagerV2PersistConfig,
   [hrfPersistConfig.name]: hrfPersistConfig,
   [controlLayersPersistConfig.name]: controlLayersPersistConfig,
+  [workflowSettingsPersistConfig.name]: workflowSettingsPersistConfig,
 };
 
 const unserialize: UnserializeFunction = (data, key) => {

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -10,6 +10,7 @@ import type { Layer } from 'features/controlLayers/store/types';
 import { selectDynamicPromptsSlice } from 'features/dynamicPrompts/store/dynamicPromptsSlice';
 import { getShouldProcessPrompt } from 'features/dynamicPrompts/util/getShouldProcessPrompt';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { selectGenerationSlice } from 'features/parameters/store/generationSlice';
 import { selectSystemSlice } from 'features/system/store/systemSlice';
@@ -31,11 +32,12 @@ const selector = createMemoizedSelector(
     selectGenerationSlice,
     selectSystemSlice,
     selectNodesSlice,
+    selectWorkflowSettingsSlice,
     selectDynamicPromptsSlice,
     selectControlLayersSlice,
     activeTabNameSelector,
   ],
-  (controlAdapters, generation, system, nodes, dynamicPrompts, controlLayers, activeTabName) => {
+  (controlAdapters, generation, system, nodes, workflowSettings, dynamicPrompts, controlLayers, activeTabName) => {
     const { model } = generation;
     const { size } = controlLayers.present;
     const { positivePrompt } = controlLayers.present;
@@ -50,7 +52,7 @@ const selector = createMemoizedSelector(
     }
 
     if (activeTabName === 'workflows') {
-      if (nodes.shouldValidateGraph) {
+      if (workflowSettings.shouldValidateGraph) {
         if (!nodes.nodes.length) {
           reasons.push({ content: i18n.t('parameters.invoke.noNodesInGraph') });
         }

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppSelector } from 'app/store/storeHooks';
 import {
@@ -9,14 +10,16 @@ import { selectControlLayersSlice } from 'features/controlLayers/store/controlLa
 import type { Layer } from 'features/controlLayers/store/types';
 import { selectDynamicPromptsSlice } from 'features/dynamicPrompts/store/dynamicPromptsSlice';
 import { getShouldProcessPrompt } from 'features/dynamicPrompts/util/getShouldProcessPrompt';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
+import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { selectGenerationSlice } from 'features/parameters/store/generationSlice';
 import { selectSystemSlice } from 'features/system/store/systemSlice';
 import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
 import i18n from 'i18next';
 import { forEach, upperFirst } from 'lodash-es';
+import { useMemo } from 'react';
 import { getConnectedEdges } from 'reactflow';
 
 const LAYER_TYPE_TO_TKEY: Record<Layer['type'], string> = {
@@ -26,200 +29,205 @@ const LAYER_TYPE_TO_TKEY: Record<Layer['type'], string> = {
   regional_guidance_layer: 'controlLayers.regionalGuidance',
 };
 
-const selector = createMemoizedSelector(
-  [
-    selectControlAdaptersSlice,
-    selectGenerationSlice,
-    selectSystemSlice,
-    selectNodesSlice,
-    selectWorkflowSettingsSlice,
-    selectDynamicPromptsSlice,
-    selectControlLayersSlice,
-    activeTabNameSelector,
-  ],
-  (controlAdapters, generation, system, nodes, workflowSettings, dynamicPrompts, controlLayers, activeTabName) => {
-    const { model } = generation;
-    const { size } = controlLayers.present;
-    const { positivePrompt } = controlLayers.present;
+const createSelector = (templates: Record<string, InvocationTemplate>) =>
+  createMemoizedSelector(
+    [
+      selectControlAdaptersSlice,
+      selectGenerationSlice,
+      selectSystemSlice,
+      selectNodesSlice,
+      selectWorkflowSettingsSlice,
+      selectDynamicPromptsSlice,
+      selectControlLayersSlice,
+      activeTabNameSelector,
+    ],
+    (controlAdapters, generation, system, nodes, workflowSettings, dynamicPrompts, controlLayers, activeTabName) => {
+      const { model } = generation;
+      const { size } = controlLayers.present;
+      const { positivePrompt } = controlLayers.present;
 
-    const { isConnected } = system;
+      const { isConnected } = system;
 
-    const reasons: { prefix?: string; content: string }[] = [];
+      const reasons: { prefix?: string; content: string }[] = [];
 
-    // Cannot generate if not connected
-    if (!isConnected) {
-      reasons.push({ content: i18n.t('parameters.invoke.systemDisconnected') });
-    }
+      // Cannot generate if not connected
+      if (!isConnected) {
+        reasons.push({ content: i18n.t('parameters.invoke.systemDisconnected') });
+      }
 
-    if (activeTabName === 'workflows') {
-      if (workflowSettings.shouldValidateGraph) {
-        if (!nodes.nodes.length) {
-          reasons.push({ content: i18n.t('parameters.invoke.noNodesInGraph') });
+      if (activeTabName === 'workflows') {
+        if (workflowSettings.shouldValidateGraph) {
+          if (!nodes.nodes.length) {
+            reasons.push({ content: i18n.t('parameters.invoke.noNodesInGraph') });
+          }
+
+          nodes.nodes.forEach((node) => {
+            if (!isInvocationNode(node)) {
+              return;
+            }
+
+            const nodeTemplate = templates[node.data.type];
+
+            if (!nodeTemplate) {
+              // Node type not found
+              reasons.push({ content: i18n.t('parameters.invoke.missingNodeTemplate') });
+              return;
+            }
+
+            const connectedEdges = getConnectedEdges([node], nodes.edges);
+
+            forEach(node.data.inputs, (field) => {
+              const fieldTemplate = nodeTemplate.inputs[field.name];
+              const hasConnection = connectedEdges.some(
+                (edge) => edge.target === node.id && edge.targetHandle === field.name
+              );
+
+              if (!fieldTemplate) {
+                reasons.push({ content: i18n.t('parameters.invoke.missingFieldTemplate') });
+                return;
+              }
+
+              if (fieldTemplate.required && field.value === undefined && !hasConnection) {
+                reasons.push({
+                  content: i18n.t('parameters.invoke.missingInputForField', {
+                    nodeLabel: node.data.label || nodeTemplate.title,
+                    fieldLabel: field.label || fieldTemplate.title,
+                  }),
+                });
+                return;
+              }
+            });
+          });
+        }
+      } else {
+        if (dynamicPrompts.prompts.length === 0 && getShouldProcessPrompt(positivePrompt)) {
+          reasons.push({ content: i18n.t('parameters.invoke.noPrompts') });
         }
 
-        nodes.nodes.forEach((node) => {
-          if (!isInvocationNode(node)) {
-            return;
-          }
+        if (!model) {
+          reasons.push({ content: i18n.t('parameters.invoke.noModelSelected') });
+        }
 
-          const nodeTemplate = nodes.templates[node.data.type];
-
-          if (!nodeTemplate) {
-            // Node type not found
-            reasons.push({ content: i18n.t('parameters.invoke.missingNodeTemplate') });
-            return;
-          }
-
-          const connectedEdges = getConnectedEdges([node], nodes.edges);
-
-          forEach(node.data.inputs, (field) => {
-            const fieldTemplate = nodeTemplate.inputs[field.name];
-            const hasConnection = connectedEdges.some(
-              (edge) => edge.target === node.id && edge.targetHandle === field.name
-            );
-
-            if (!fieldTemplate) {
-              reasons.push({ content: i18n.t('parameters.invoke.missingFieldTemplate') });
-              return;
-            }
-
-            if (fieldTemplate.required && field.value === undefined && !hasConnection) {
-              reasons.push({
-                content: i18n.t('parameters.invoke.missingInputForField', {
-                  nodeLabel: node.data.label || nodeTemplate.title,
-                  fieldLabel: field.label || fieldTemplate.title,
-                }),
-              });
-              return;
-            }
-          });
-        });
-      }
-    } else {
-      if (dynamicPrompts.prompts.length === 0 && getShouldProcessPrompt(positivePrompt)) {
-        reasons.push({ content: i18n.t('parameters.invoke.noPrompts') });
-      }
-
-      if (!model) {
-        reasons.push({ content: i18n.t('parameters.invoke.noModelSelected') });
-      }
-
-      if (activeTabName === 'generation') {
-        // Handling for generation tab
-        controlLayers.present.layers
-          .filter((l) => l.isEnabled)
-          .forEach((l, i) => {
-            const layerLiteral = i18n.t('controlLayers.layers_one');
-            const layerNumber = i + 1;
-            const layerType = i18n.t(LAYER_TYPE_TO_TKEY[l.type]);
-            const prefix = `${layerLiteral} #${layerNumber} (${layerType})`;
-            const problems: string[] = [];
-            if (l.type === 'control_adapter_layer') {
-              // Must have model
-              if (!l.controlAdapter.model) {
-                problems.push(i18n.t('parameters.invoke.layer.controlAdapterNoModelSelected'));
-              }
-              // Model base must match
-              if (l.controlAdapter.model?.base !== model?.base) {
-                problems.push(i18n.t('parameters.invoke.layer.controlAdapterIncompatibleBaseModel'));
-              }
-              // Must have a control image OR, if it has a processor, it must have a processed image
-              if (!l.controlAdapter.image) {
-                problems.push(i18n.t('parameters.invoke.layer.controlAdapterNoImageSelected'));
-              } else if (l.controlAdapter.processorConfig && !l.controlAdapter.processedImage) {
-                problems.push(i18n.t('parameters.invoke.layer.controlAdapterImageNotProcessed'));
-              }
-              // T2I Adapters require images have dimensions that are multiples of 64
-              if (l.controlAdapter.type === 't2i_adapter' && (size.width % 64 !== 0 || size.height % 64 !== 0)) {
-                problems.push(i18n.t('parameters.invoke.layer.t2iAdapterIncompatibleDimensions'));
-              }
-            }
-
-            if (l.type === 'ip_adapter_layer') {
-              // Must have model
-              if (!l.ipAdapter.model) {
-                problems.push(i18n.t('parameters.invoke.layer.ipAdapterNoModelSelected'));
-              }
-              // Model base must match
-              if (l.ipAdapter.model?.base !== model?.base) {
-                problems.push(i18n.t('parameters.invoke.layer.ipAdapterIncompatibleBaseModel'));
-              }
-              // Must have an image
-              if (!l.ipAdapter.image) {
-                problems.push(i18n.t('parameters.invoke.layer.ipAdapterNoImageSelected'));
-              }
-            }
-
-            if (l.type === 'initial_image_layer') {
-              // Must have an image
-              if (!l.image) {
-                problems.push(i18n.t('parameters.invoke.layer.initialImageNoImageSelected'));
-              }
-            }
-
-            if (l.type === 'regional_guidance_layer') {
-              // Must have a region
-              if (l.maskObjects.length === 0) {
-                problems.push(i18n.t('parameters.invoke.layer.rgNoRegion'));
-              }
-              // Must have at least 1 prompt or IP Adapter
-              if (l.positivePrompt === null && l.negativePrompt === null && l.ipAdapters.length === 0) {
-                problems.push(i18n.t('parameters.invoke.layer.rgNoPromptsOrIPAdapters'));
-              }
-              l.ipAdapters.forEach((ipAdapter) => {
+        if (activeTabName === 'generation') {
+          // Handling for generation tab
+          controlLayers.present.layers
+            .filter((l) => l.isEnabled)
+            .forEach((l, i) => {
+              const layerLiteral = i18n.t('controlLayers.layers_one');
+              const layerNumber = i + 1;
+              const layerType = i18n.t(LAYER_TYPE_TO_TKEY[l.type]);
+              const prefix = `${layerLiteral} #${layerNumber} (${layerType})`;
+              const problems: string[] = [];
+              if (l.type === 'control_adapter_layer') {
                 // Must have model
-                if (!ipAdapter.model) {
+                if (!l.controlAdapter.model) {
+                  problems.push(i18n.t('parameters.invoke.layer.controlAdapterNoModelSelected'));
+                }
+                // Model base must match
+                if (l.controlAdapter.model?.base !== model?.base) {
+                  problems.push(i18n.t('parameters.invoke.layer.controlAdapterIncompatibleBaseModel'));
+                }
+                // Must have a control image OR, if it has a processor, it must have a processed image
+                if (!l.controlAdapter.image) {
+                  problems.push(i18n.t('parameters.invoke.layer.controlAdapterNoImageSelected'));
+                } else if (l.controlAdapter.processorConfig && !l.controlAdapter.processedImage) {
+                  problems.push(i18n.t('parameters.invoke.layer.controlAdapterImageNotProcessed'));
+                }
+                // T2I Adapters require images have dimensions that are multiples of 64
+                if (l.controlAdapter.type === 't2i_adapter' && (size.width % 64 !== 0 || size.height % 64 !== 0)) {
+                  problems.push(i18n.t('parameters.invoke.layer.t2iAdapterIncompatibleDimensions'));
+                }
+              }
+
+              if (l.type === 'ip_adapter_layer') {
+                // Must have model
+                if (!l.ipAdapter.model) {
                   problems.push(i18n.t('parameters.invoke.layer.ipAdapterNoModelSelected'));
                 }
                 // Model base must match
-                if (ipAdapter.model?.base !== model?.base) {
+                if (l.ipAdapter.model?.base !== model?.base) {
                   problems.push(i18n.t('parameters.invoke.layer.ipAdapterIncompatibleBaseModel'));
                 }
                 // Must have an image
-                if (!ipAdapter.image) {
+                if (!l.ipAdapter.image) {
                   problems.push(i18n.t('parameters.invoke.layer.ipAdapterNoImageSelected'));
                 }
-              });
-            }
+              }
 
-            if (problems.length) {
-              const content = upperFirst(problems.join(', '));
-              reasons.push({ prefix, content });
-            }
-          });
-      } else {
-        // Handling for all other tabs
-        selectControlAdapterAll(controlAdapters)
-          .filter((ca) => ca.isEnabled)
-          .forEach((ca, i) => {
-            if (!ca.isEnabled) {
-              return;
-            }
+              if (l.type === 'initial_image_layer') {
+                // Must have an image
+                if (!l.image) {
+                  problems.push(i18n.t('parameters.invoke.layer.initialImageNoImageSelected'));
+                }
+              }
 
-            if (!ca.model) {
-              reasons.push({ content: i18n.t('parameters.invoke.noModelForControlAdapter', { number: i + 1 }) });
-            } else if (ca.model.base !== model?.base) {
-              // This should never happen, just a sanity check
-              reasons.push({
-                content: i18n.t('parameters.invoke.incompatibleBaseModelForControlAdapter', { number: i + 1 }),
-              });
-            }
+              if (l.type === 'regional_guidance_layer') {
+                // Must have a region
+                if (l.maskObjects.length === 0) {
+                  problems.push(i18n.t('parameters.invoke.layer.rgNoRegion'));
+                }
+                // Must have at least 1 prompt or IP Adapter
+                if (l.positivePrompt === null && l.negativePrompt === null && l.ipAdapters.length === 0) {
+                  problems.push(i18n.t('parameters.invoke.layer.rgNoPromptsOrIPAdapters'));
+                }
+                l.ipAdapters.forEach((ipAdapter) => {
+                  // Must have model
+                  if (!ipAdapter.model) {
+                    problems.push(i18n.t('parameters.invoke.layer.ipAdapterNoModelSelected'));
+                  }
+                  // Model base must match
+                  if (ipAdapter.model?.base !== model?.base) {
+                    problems.push(i18n.t('parameters.invoke.layer.ipAdapterIncompatibleBaseModel'));
+                  }
+                  // Must have an image
+                  if (!ipAdapter.image) {
+                    problems.push(i18n.t('parameters.invoke.layer.ipAdapterNoImageSelected'));
+                  }
+                });
+              }
 
-            if (
-              !ca.controlImage ||
-              (isControlNetOrT2IAdapter(ca) && !ca.processedControlImage && ca.processorType !== 'none')
-            ) {
-              reasons.push({ content: i18n.t('parameters.invoke.noControlImageForControlAdapter', { number: i + 1 }) });
-            }
-          });
+              if (problems.length) {
+                const content = upperFirst(problems.join(', '));
+                reasons.push({ prefix, content });
+              }
+            });
+        } else {
+          // Handling for all other tabs
+          selectControlAdapterAll(controlAdapters)
+            .filter((ca) => ca.isEnabled)
+            .forEach((ca, i) => {
+              if (!ca.isEnabled) {
+                return;
+              }
+
+              if (!ca.model) {
+                reasons.push({ content: i18n.t('parameters.invoke.noModelForControlAdapter', { number: i + 1 }) });
+              } else if (ca.model.base !== model?.base) {
+                // This should never happen, just a sanity check
+                reasons.push({
+                  content: i18n.t('parameters.invoke.incompatibleBaseModelForControlAdapter', { number: i + 1 }),
+                });
+              }
+
+              if (
+                !ca.controlImage ||
+                (isControlNetOrT2IAdapter(ca) && !ca.processedControlImage && ca.processorType !== 'none')
+              ) {
+                reasons.push({
+                  content: i18n.t('parameters.invoke.noControlImageForControlAdapter', { number: i + 1 }),
+                });
+              }
+            });
+        }
       }
-    }
 
-    return { isReady: !reasons.length, reasons };
-  }
-);
+      return { isReady: !reasons.length, reasons };
+    }
+  );
 
 export const useIsReadyToEnqueue = () => {
+  const templates = useStore($templates);
+  const selector = useMemo(() => createSelector(templates), [templates]);
   const value = useAppSelector(selector);
   return value;
 };

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -11,8 +11,8 @@ import type { Layer } from 'features/controlLayers/store/types';
 import { selectDynamicPromptsSlice } from 'features/dynamicPrompts/store/dynamicPromptsSlice';
 import { getShouldProcessPrompt } from 'features/dynamicPrompts/util/getShouldProcessPrompt';
 import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import type { Templates } from 'features/nodes/store/types';
 import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
-import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { selectGenerationSlice } from 'features/parameters/store/generationSlice';
 import { selectSystemSlice } from 'features/system/store/systemSlice';
@@ -29,7 +29,7 @@ const LAYER_TYPE_TO_TKEY: Record<Layer['type'], string> = {
   regional_guidance_layer: 'controlLayers.regionalGuidance',
 };
 
-const createSelector = (templates: Record<string, InvocationTemplate>) =>
+const createSelector = (templates: Templates) =>
   createMemoizedSelector(
     [
       selectControlAdaptersSlice,

--- a/invokeai/frontend/web/src/features/dnd/hooks/useScaledCenteredModifer.ts
+++ b/invokeai/frontend/web/src/features/dnd/hooks/useScaledCenteredModifer.ts
@@ -1,23 +1,21 @@
 import type { Modifier } from '@dnd-kit/core';
 import { getEventCoordinates } from '@dnd-kit/utilities';
-import { createSelector } from '@reduxjs/toolkit';
+import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { $viewport } from 'features/nodes/store/nodesSlice';
 import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
 import { useCallback } from 'react';
-
-const selectZoom = createSelector([selectNodesSlice, activeTabNameSelector], (nodes, activeTabName) =>
-  activeTabName === 'workflows' ? nodes.viewport.zoom : 1
-);
 
 /**
  * Applies scaling to the drag transform (if on node editor tab) and centers it on cursor.
  */
 export const useScaledModifer = () => {
-  const zoom = useAppSelector(selectZoom);
+  const activeTabName = useAppSelector(activeTabNameSelector);
+  const workflowsViewport = useStore($viewport);
   const modifier: Modifier = useCallback(
     ({ activatorEvent, draggingNodeRect, transform }) => {
       if (draggingNodeRect && activatorEvent) {
+        const zoom = activeTabName === 'workflows' ? workflowsViewport.zoom : 1;
         const activatorCoordinates = getEventCoordinates(activatorEvent);
 
         if (!activatorCoordinates) {
@@ -42,7 +40,7 @@ export const useScaledModifer = () => {
 
       return transform;
     },
-    [zoom]
+    [activeTabName, workflowsViewport.zoom]
   );
 
   return modifier;

--- a/invokeai/frontend/web/src/features/nodes/components/flow/AddNodePopover/AddNodePopover.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/AddNodePopover/AddNodePopover.tsx
@@ -148,7 +148,7 @@ const AddNodePopover = () => {
         const template = templates[node.data.type];
         assert(template, 'Template not found');
         const { nodes, edges } = store.getState().nodes.present;
-        const connection = getFirstValidConnection(nodes, edges, pendingConnection, node, template);
+        const connection = getFirstValidConnection(templates, nodes, edges, pendingConnection, node, template);
         if (connection) {
           dispatch(connectionMade(connection));
         }

--- a/invokeai/frontend/web/src/features/nodes/components/flow/AddNodePopover/AddNodePopover.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/AddNodePopover/AddNodePopover.tsx
@@ -55,8 +55,8 @@ const AddNodePopover = () => {
   const selectRef = useRef<SelectInstance<ComboboxOption> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const fieldFilter = useAppSelector((s) => s.nodes.connectionStartFieldType);
-  const handleFilter = useAppSelector((s) => s.nodes.connectionStartParams?.handleType);
+  const fieldFilter = useAppSelector((s) => s.nodes.present.connectionStartFieldType);
+  const handleFilter = useAppSelector((s) => s.nodes.present.connectionStartParams?.handleType);
 
   const selector = createMemoizedSelector(selectNodesSlice, (nodes) => {
     // If we have a connection in progress, we need to filter the node choices
@@ -105,7 +105,7 @@ const AddNodePopover = () => {
   });
 
   const { options } = useAppSelector(selector);
-  const isOpen = useAppSelector((s) => s.nodes.isAddNodePopoverOpen);
+  const isOpen = useAppSelector((s) => s.nodes.present.isAddNodePopoverOpen);
 
   const addNode = useCallback(
     (nodeType: string) => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/AddNodePopover/AddNodePopover.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/AddNodePopover/AddNodePopover.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppStore } from 'app/store/storeHooks';
 import type { SelectInstance } from 'chakra-react-select';
 import { useBuildNode } from 'features/nodes/hooks/useBuildNode';
 import {
+  $cursorPos,
   $isAddNodePopoverOpen,
   $pendingConnection,
   $templates,
@@ -117,8 +118,8 @@ const AddNodePopover = () => {
 
   const addNode = useCallback(
     (nodeType: string): AnyNode | null => {
-      const invocation = buildInvocation(nodeType);
-      if (!invocation) {
+      const node = buildInvocation(nodeType);
+      if (!node) {
         const errorMessage = t('nodes.unknownNode', {
           nodeType: nodeType,
         });
@@ -128,9 +129,9 @@ const AddNodePopover = () => {
         });
         return null;
       }
-
-      dispatch(nodeAdded(invocation));
-      return invocation;
+      const cursorPos = $cursorPos.get();
+      dispatch(nodeAdded({ node, cursorPos }));
+      return node;
     },
     [dispatch, buildInvocation, toaster, t]
   );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useConnection } from 'features/nodes/hooks/useConnection';
 import { useCopyPaste } from 'features/nodes/hooks/useCopyPaste';
+import { useSyncExecutionState } from 'features/nodes/hooks/useExecutionState';
 import { useIsValidConnection } from 'features/nodes/hooks/useIsValidConnection';
 import { useWorkflowWatcher } from 'features/nodes/hooks/useWorkflowWatcher';
 import {
@@ -81,6 +82,7 @@ export const Flow = memo(() => {
   const isValidConnection = useIsValidConnection();
   const cancelConnection = useReactFlowStore(selectCancelConnection);
   useWorkflowWatcher();
+  useSyncExecutionState();
   const [borderRadius] = useToken('radii', ['base']);
 
   const flowStyles = useMemo<CSSProperties>(

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -8,7 +8,6 @@ import {
   $cursorPos,
   connectionMade,
   edgeAdded,
-  edgeChangeStarted,
   edgeDeleted,
   edgesChanged,
   edgesDeleted,
@@ -170,7 +169,6 @@ export const Flow = memo(() => {
       edgeUpdateMouseEvent.current = e;
       // always delete the edge when starting an updated
       dispatch(edgeDeleted(edge.id));
-      dispatch(edgeChangeStarted());
     },
     [dispatch]
   );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -75,8 +75,8 @@ export const Flow = memo(() => {
   const nodes = useAppSelector((s) => s.nodes.present.nodes);
   const edges = useAppSelector((s) => s.nodes.present.edges);
   const viewport = useAppSelector((s) => s.nodes.present.viewport);
-  const shouldSnapToGrid = useAppSelector((s) => s.nodes.present.shouldSnapToGrid);
-  const selectionMode = useAppSelector((s) => s.nodes.present.selectionMode);
+  const shouldSnapToGrid = useAppSelector((s) => s.workflowSettings.shouldSnapToGrid);
+  const selectionMode = useAppSelector((s) => s.workflowSettings.selectionMode);
   const flowWrapper = useRef<HTMLDivElement>(null);
   const cursorPosition = useRef<XYPosition | null>(null);
   const isValidConnection = useIsValidConnection();

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -283,6 +283,7 @@ export const Flow = memo(() => {
       onPaneClick={handlePaneClick}
       deleteKeyCode={DELETE_KEYS}
       selectionMode={selectionMode}
+      elevateEdgesOnSelect
     >
       <Background />
     </ReactFlow>

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -1,5 +1,4 @@
 import { useGlobalMenuClose, useToken } from '@invoke-ai/ui-library';
-import { useStore } from '@nanostores/react';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useConnection } from 'features/nodes/hooks/useConnection';
 import { useCopyPaste } from 'features/nodes/hooks/useCopyPaste';
@@ -7,7 +6,6 @@ import { useIsValidConnection } from 'features/nodes/hooks/useIsValidConnection'
 import { useWorkflowWatcher } from 'features/nodes/hooks/useWorkflowWatcher';
 import {
   $cursorPos,
-  $pendingConnection,
   connectionMade,
   edgeAdded,
   edgeChangeStarted,
@@ -99,36 +97,6 @@ export const Flow = memo(() => {
     },
     [dispatch]
   );
-
-  // const onConnectStart: OnConnectStart = useCallback(
-  //   (event, params) => {
-  //     dispatch(connectionStarted(params));
-  //   },
-  //   [dispatch]
-  // );
-
-  // const onConnect: OnConnect = useCallback(
-  //   (connection) => {
-  //     dispatch(connectionMade(connection));
-  //   },
-  //   [dispatch]
-  // );
-
-  // const onConnectEnd: OnConnectEnd = useCallback(() => {
-  //   const cursorPosition = $cursorPos.get();
-  //   if (!cursorPosition) {
-  //     return;
-  //   }
-  //   dispatch(
-  //     connectionEnded({
-  //       cursorPosition,
-  //       mouseOverNodeId: $mouseOverNode.get(),
-  //     })
-  //   );
-  // }, [dispatch]);
-
-  const pendingConnection = useStore($pendingConnection);
-  console.log(pendingConnection)
 
   const onEdgesDelete: OnEdgesDelete = useCallback(
     (edges) => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -7,6 +7,8 @@ import { useIsValidConnection } from 'features/nodes/hooks/useIsValidConnection'
 import { useWorkflowWatcher } from 'features/nodes/hooks/useWorkflowWatcher';
 import {
   $cursorPos,
+  $isAddNodePopoverOpen,
+  $pendingConnection,
   $viewport,
   connectionMade,
   edgeAdded,
@@ -33,8 +35,9 @@ import type {
   OnNodesDelete,
   ProOptions,
   ReactFlowProps,
+  ReactFlowState,
 } from 'reactflow';
-import { Background, ReactFlow } from 'reactflow';
+import { Background, ReactFlow, useStore as useReactFlowStore } from 'reactflow';
 
 import CustomConnectionLine from './connectionLines/CustomConnectionLine';
 import InvocationCollapsedEdge from './edges/InvocationCollapsedEdge';
@@ -61,6 +64,8 @@ const proOptions: ProOptions = { hideAttribution: true };
 
 const snapGrid: [number, number] = [25, 25];
 
+const selectCancelConnection = (state: ReactFlowState) => state.cancelConnection;
+
 export const Flow = memo(() => {
   const dispatch = useAppDispatch();
   const nodes = useAppSelector((s) => s.nodes.present.nodes);
@@ -73,6 +78,7 @@ export const Flow = memo(() => {
   const { onConnectStart, onConnect, onConnectEnd } = useConnection();
   const flowWrapper = useRef<HTMLDivElement>(null);
   const isValidConnection = useIsValidConnection();
+  const cancelConnection = useReactFlowStore(selectCancelConnection);
   useWorkflowWatcher();
   const [borderRadius] = useToken('radii', ['base']);
 
@@ -233,6 +239,13 @@ export const Flow = memo(() => {
     }
   }, [dispatch, mayRedo]);
   useHotkeys(['meta+shift+z', 'ctrl+shift+z'], onRedoHotkey);
+
+  const onEscapeHotkey = useCallback(() => {
+    $pendingConnection.set(null);
+    $isAddNodePopoverOpen.set(false);
+    cancelConnection();
+  }, [cancelConnection]);
+  useHotkeys('esc', onEscapeHotkey);
 
   return (
     <ReactFlow

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -14,11 +14,13 @@ import {
   edgesDeleted,
   nodesChanged,
   nodesDeleted,
+  redo,
   selectedAll,
   selectedEdgesChanged,
   selectedNodesChanged,
   selectionCopied,
   selectionPasted,
+  undo,
   viewportChanged,
 } from 'features/nodes/store/nodesSlice';
 import { $flow } from 'features/nodes/store/reactFlowInstance';
@@ -70,11 +72,11 @@ const snapGrid: [number, number] = [25, 25];
 
 export const Flow = memo(() => {
   const dispatch = useAppDispatch();
-  const nodes = useAppSelector((s) => s.nodes.nodes);
-  const edges = useAppSelector((s) => s.nodes.edges);
-  const viewport = useAppSelector((s) => s.nodes.viewport);
-  const shouldSnapToGrid = useAppSelector((s) => s.nodes.shouldSnapToGrid);
-  const selectionMode = useAppSelector((s) => s.nodes.selectionMode);
+  const nodes = useAppSelector((s) => s.nodes.present.nodes);
+  const edges = useAppSelector((s) => s.nodes.present.edges);
+  const viewport = useAppSelector((s) => s.nodes.present.viewport);
+  const shouldSnapToGrid = useAppSelector((s) => s.nodes.present.shouldSnapToGrid);
+  const selectionMode = useAppSelector((s) => s.nodes.present.selectionMode);
   const flowWrapper = useRef<HTMLDivElement>(null);
   const cursorPosition = useRef<XYPosition | null>(null);
   const isValidConnection = useIsValidConnection();
@@ -250,6 +252,22 @@ export const Flow = memo(() => {
     e.preventDefault();
     dispatch(selectionPasted({ cursorPosition: cursorPosition.current }));
   });
+
+  useHotkeys(
+    ['meta+z', 'ctrl+z'],
+    () => {
+      dispatch(undo());
+    },
+    [dispatch]
+  );
+
+  useHotkeys(
+    ['meta+shift+z', 'ctrl+shift+z'],
+    () => {
+      dispatch(redo());
+    },
+    [dispatch]
+  );
 
   return (
     <ReactFlow

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -1,4 +1,5 @@
 import { useGlobalMenuClose, useToken } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useConnection } from 'features/nodes/hooks/useConnection';
 import { useCopyPaste } from 'features/nodes/hooks/useCopyPaste';
@@ -6,6 +7,7 @@ import { useIsValidConnection } from 'features/nodes/hooks/useIsValidConnection'
 import { useWorkflowWatcher } from 'features/nodes/hooks/useWorkflowWatcher';
 import {
   $cursorPos,
+  $viewport,
   connectionMade,
   edgeAdded,
   edgeDeleted,
@@ -16,7 +18,6 @@ import {
   redo,
   selectedAll,
   undo,
-  viewportChanged,
 } from 'features/nodes/store/nodesSlice';
 import { $flow } from 'features/nodes/store/reactFlowInstance';
 import type { CSSProperties, MouseEvent } from 'react';
@@ -64,7 +65,7 @@ export const Flow = memo(() => {
   const dispatch = useAppDispatch();
   const nodes = useAppSelector((s) => s.nodes.present.nodes);
   const edges = useAppSelector((s) => s.nodes.present.edges);
-  const viewport = useAppSelector((s) => s.nodes.present.viewport);
+  const viewport = useStore($viewport);
   const shouldSnapToGrid = useAppSelector((s) => s.workflowSettings.shouldSnapToGrid);
   const selectionMode = useAppSelector((s) => s.workflowSettings.selectionMode);
   const { onConnectStart, onConnect, onConnectEnd } = useConnection();
@@ -108,12 +109,9 @@ export const Flow = memo(() => {
     [dispatch]
   );
 
-  const handleMoveEnd: OnMoveEnd = useCallback(
-    (e, viewport) => {
-      dispatch(viewportChanged(viewport));
-    },
-    [dispatch]
-  );
+  const handleMoveEnd: OnMoveEnd = useCallback((e, viewport) => {
+    $viewport.set(viewport);
+  }, []);
 
   const { onCloseGlobal } = useGlobalMenuClose();
   const handlePaneClick = useCallback(() => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -66,6 +66,8 @@ export const Flow = memo(() => {
   const nodes = useAppSelector((s) => s.nodes.present.nodes);
   const edges = useAppSelector((s) => s.nodes.present.edges);
   const viewport = useStore($viewport);
+  const mayUndo = useAppSelector((s) => s.nodes.past.length > 0);
+  const mayRedo = useAppSelector((s) => s.nodes.future.length > 0);
   const shouldSnapToGrid = useAppSelector((s) => s.workflowSettings.shouldSnapToGrid);
   const selectionMode = useAppSelector((s) => s.workflowSettings.selectionMode);
   const { onConnectStart, onConnect, onConnectEnd } = useConnection();
@@ -192,13 +194,13 @@ export const Flow = memo(() => {
   const { copySelection, pasteSelection } = useCopyPaste();
 
   useHotkeys(['Ctrl+c', 'Meta+c'], (e) => {
-    e.preventDefault();
-    copySelection();
+      e.preventDefault();
+      copySelection();
   });
 
   useHotkeys(['Ctrl+a', 'Meta+a'], (e) => {
-    e.preventDefault();
-    dispatch(selectedAll());
+      e.preventDefault();
+      dispatch(selectedAll());
   });
 
   useHotkeys(['Ctrl+v', 'Meta+v'], (e) => {
@@ -221,6 +223,20 @@ export const Flow = memo(() => {
     },
     [dispatch]
   );
+
+  const onUndoHotkey = useCallback(() => {
+    if (mayUndo) {
+      dispatch(undo());
+    }
+  }, [dispatch, mayUndo]);
+  useHotkeys(['meta+z', 'ctrl+z'], onUndoHotkey);
+
+  const onRedoHotkey = useCallback(() => {
+    if (mayRedo) {
+      dispatch(redo());
+    }
+  }, [dispatch, mayRedo]);
+  useHotkeys(['meta+shift+z', 'ctrl+shift+z'], onRedoHotkey);
 
   return (
     <ReactFlow

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -193,36 +193,32 @@ export const Flow = memo(() => {
 
   const { copySelection, pasteSelection } = useCopyPaste();
 
-  useHotkeys(['Ctrl+c', 'Meta+c'], (e) => {
+  const onCopyHotkey = useCallback(
+    (e: KeyboardEvent) => {
       e.preventDefault();
       copySelection();
-  });
+    },
+    [copySelection]
+  );
+  useHotkeys(['Ctrl+c', 'Meta+c'], onCopyHotkey);
 
-  useHotkeys(['Ctrl+a', 'Meta+a'], (e) => {
+  const onSelectAllHotkey = useCallback(
+    (e: KeyboardEvent) => {
       e.preventDefault();
       dispatch(selectedAll());
-  });
-
-  useHotkeys(['Ctrl+v', 'Meta+v'], (e) => {
-    e.preventDefault();
-    pasteSelection();
-  });
-
-  useHotkeys(
-    ['meta+z', 'ctrl+z'],
-    () => {
-      dispatch(undo());
     },
     [dispatch]
   );
+  useHotkeys(['Ctrl+a', 'Meta+a'], onSelectAllHotkey);
 
-  useHotkeys(
-    ['meta+shift+z', 'ctrl+shift+z'],
-    () => {
-      dispatch(redo());
+  const onPasteHotkey = useCallback(
+    (e: KeyboardEvent) => {
+      e.preventDefault();
+      pasteSelection();
     },
-    [dispatch]
+    [pasteSelection]
   );
+  useHotkeys(['Ctrl+v', 'Meta+v'], onPasteHotkey);
 
   const onUndoHotkey = useCallback(() => {
     if (mayUndo) {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -1,14 +1,14 @@
 import { useGlobalMenuClose, useToken } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { useConnection } from 'features/nodes/hooks/useConnection';
 import { useCopyPaste } from 'features/nodes/hooks/useCopyPaste';
 import { useIsValidConnection } from 'features/nodes/hooks/useIsValidConnection';
-import { $mouseOverNode } from 'features/nodes/hooks/useMouseOverNode';
 import { useWorkflowWatcher } from 'features/nodes/hooks/useWorkflowWatcher';
 import {
   $cursorPos,
-  connectionEnded,
+  $pendingConnection,
   connectionMade,
-  connectionStarted,
   edgeAdded,
   edgeChangeStarted,
   edgeDeleted,
@@ -28,9 +28,6 @@ import type { CSSProperties, MouseEvent } from 'react';
 import { memo, useCallback, useMemo, useRef } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import type {
-  OnConnect,
-  OnConnectEnd,
-  OnConnectStart,
   OnEdgesChange,
   OnEdgesDelete,
   OnEdgeUpdateFunc,
@@ -76,6 +73,7 @@ export const Flow = memo(() => {
   const viewport = useAppSelector((s) => s.nodes.present.viewport);
   const shouldSnapToGrid = useAppSelector((s) => s.workflowSettings.shouldSnapToGrid);
   const selectionMode = useAppSelector((s) => s.workflowSettings.selectionMode);
+  const { onConnectStart, onConnect, onConnectEnd } = useConnection();
   const flowWrapper = useRef<HTMLDivElement>(null);
   const isValidConnection = useIsValidConnection();
   useWorkflowWatcher();
@@ -102,32 +100,35 @@ export const Flow = memo(() => {
     [dispatch]
   );
 
-  const onConnectStart: OnConnectStart = useCallback(
-    (event, params) => {
-      dispatch(connectionStarted(params));
-    },
-    [dispatch]
-  );
+  // const onConnectStart: OnConnectStart = useCallback(
+  //   (event, params) => {
+  //     dispatch(connectionStarted(params));
+  //   },
+  //   [dispatch]
+  // );
 
-  const onConnect: OnConnect = useCallback(
-    (connection) => {
-      dispatch(connectionMade(connection));
-    },
-    [dispatch]
-  );
+  // const onConnect: OnConnect = useCallback(
+  //   (connection) => {
+  //     dispatch(connectionMade(connection));
+  //   },
+  //   [dispatch]
+  // );
 
-  const onConnectEnd: OnConnectEnd = useCallback(() => {
-    const cursorPosition = $cursorPos.get();
-    if (!cursorPosition) {
-      return;
-    }
-    dispatch(
-      connectionEnded({
-        cursorPosition,
-        mouseOverNodeId: $mouseOverNode.get(),
-      })
-    );
-  }, [dispatch]);
+  // const onConnectEnd: OnConnectEnd = useCallback(() => {
+  //   const cursorPosition = $cursorPos.get();
+  //   if (!cursorPosition) {
+  //     return;
+  //   }
+  //   dispatch(
+  //     connectionEnded({
+  //       cursorPosition,
+  //       mouseOverNodeId: $mouseOverNode.get(),
+  //     })
+  //   );
+  // }, [dispatch]);
+
+  const pendingConnection = useStore($pendingConnection);
+  console.log(pendingConnection)
 
   const onEdgesDelete: OnEdgesDelete = useCallback(
     (edges) => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -15,8 +15,6 @@ import {
   nodesDeleted,
   redo,
   selectedAll,
-  selectedEdgesChanged,
-  selectedNodesChanged,
   undo,
   viewportChanged,
 } from 'features/nodes/store/nodesSlice';
@@ -32,7 +30,6 @@ import type {
   OnMoveEnd,
   OnNodesChange,
   OnNodesDelete,
-  OnSelectionChangeFunc,
   ProOptions,
   ReactFlowProps,
 } from 'reactflow';
@@ -107,14 +104,6 @@ export const Flow = memo(() => {
   const onNodesDelete: OnNodesDelete = useCallback(
     (nodes) => {
       dispatch(nodesDeleted(nodes));
-    },
-    [dispatch]
-  );
-
-  const handleSelectionChange: OnSelectionChangeFunc = useCallback(
-    ({ nodes, edges }) => {
-      dispatch(selectedNodesChanged(nodes ? nodes.map((n) => n.id) : []));
-      dispatch(selectedEdgesChanged(edges ? edges.map((e) => e.id) : []));
     },
     [dispatch]
   );
@@ -258,7 +247,6 @@ export const Flow = memo(() => {
       onConnectEnd={onConnectEnd}
       onMoveEnd={handleMoveEnd}
       connectionLineComponent={CustomConnectionLine}
-      onSelectionChange={handleSelectionChange}
       isValidConnection={isValidConnection}
       minZoom={0.1}
       snapToGrid={shouldSnapToGrid}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/connectionLines/CustomConnectionLine.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/connectionLines/CustomConnectionLine.tsx
@@ -3,17 +3,20 @@ import { useAppSelector } from 'app/store/storeHooks';
 import { colorTokenToCssVar } from 'common/util/colorTokenToCssVar';
 import { getFieldColor } from 'features/nodes/components/flow/edges/util/getEdgeColor';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
 import type { CSSProperties } from 'react';
 import { memo } from 'react';
 import type { ConnectionLineComponentProps } from 'reactflow';
 import { getBezierPath } from 'reactflow';
 
-const selectStroke = createSelector(selectNodesSlice, (nodes) =>
-  nodes.shouldColorEdges ? getFieldColor(nodes.connectionStartFieldType) : colorTokenToCssVar('base.500')
+const selectStroke = createSelector([selectNodesSlice, selectWorkflowSettingsSlice], (nodes, workflowSettings) =>
+  workflowSettings.shouldColorEdges ? getFieldColor(nodes.connectionStartFieldType) : colorTokenToCssVar('base.500')
 );
 
-const selectClassName = createSelector(selectNodesSlice, (nodes) =>
-  nodes.shouldAnimateEdges ? 'react-flow__custom_connection-path animated' : 'react-flow__custom_connection-path'
+const selectClassName = createSelector(selectWorkflowSettingsSlice, (workflowSettings) =>
+  workflowSettings.shouldAnimateEdges
+    ? 'react-flow__custom_connection-path animated'
+    : 'react-flow__custom_connection-path'
 );
 
 const pathStyles: CSSProperties = { opacity: 0.8 };

--- a/invokeai/frontend/web/src/features/nodes/components/flow/connectionLines/CustomConnectionLine.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/connectionLines/CustomConnectionLine.tsx
@@ -1,29 +1,33 @@
-import { createSelector } from '@reduxjs/toolkit';
+import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
 import { colorTokenToCssVar } from 'common/util/colorTokenToCssVar';
 import { getFieldColor } from 'features/nodes/components/flow/edges/util/getEdgeColor';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
+import { $pendingConnection } from 'features/nodes/store/nodesSlice';
 import type { CSSProperties } from 'react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import type { ConnectionLineComponentProps } from 'reactflow';
 import { getBezierPath } from 'reactflow';
-
-const selectStroke = createSelector([selectNodesSlice, selectWorkflowSettingsSlice], (nodes, workflowSettings) =>
-  workflowSettings.shouldColorEdges ? getFieldColor(nodes.connectionStartFieldType) : colorTokenToCssVar('base.500')
-);
-
-const selectClassName = createSelector(selectWorkflowSettingsSlice, (workflowSettings) =>
-  workflowSettings.shouldAnimateEdges
-    ? 'react-flow__custom_connection-path animated'
-    : 'react-flow__custom_connection-path'
-);
 
 const pathStyles: CSSProperties = { opacity: 0.8 };
 
 const CustomConnectionLine = ({ fromX, fromY, fromPosition, toX, toY, toPosition }: ConnectionLineComponentProps) => {
-  const stroke = useAppSelector(selectStroke);
-  const className = useAppSelector(selectClassName);
+  const pendingConnection = useStore($pendingConnection);
+  const shouldColorEdges = useAppSelector((state) => state.workflowSettings.shouldColorEdges);
+  const shouldAnimateEdges = useAppSelector((state) => state.workflowSettings.shouldAnimateEdges);
+  const stroke = useMemo(() => {
+    if (shouldColorEdges && pendingConnection) {
+      return getFieldColor(pendingConnection.fieldTemplate.type);
+    } else {
+      return colorTokenToCssVar('base.500');
+    }
+  }, [pendingConnection, shouldColorEdges]);
+  const className = useMemo(() => {
+    if (shouldAnimateEdges) {
+      return 'react-flow__custom_connection-path animated';
+    } else {
+      return 'react-flow__custom_connection-path';
+    }
+  }, [shouldAnimateEdges]);
 
   const pathParams = {
     sourceX: fromX,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationCollapsedEdge.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationCollapsedEdge.tsx
@@ -1,6 +1,8 @@
 import { Badge, Flex } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
 import { useChakraThemeTokens } from 'common/hooks/useChakraThemeTokens';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { memo, useMemo } from 'react';
 import type { EdgeProps } from 'reactflow';
 import { BaseEdge, EdgeLabelRenderer, getBezierPath } from 'reactflow';
@@ -22,9 +24,10 @@ const InvocationCollapsedEdge = ({
   sourceHandleId,
   targetHandleId,
 }: EdgeProps<{ count: number }>) => {
+  const templates = useStore($templates);
   const selector = useMemo(
-    () => makeEdgeSelector(source, sourceHandleId, target, targetHandleId, selected),
-    [selected, source, sourceHandleId, target, targetHandleId]
+    () => makeEdgeSelector(templates, source, sourceHandleId, target, targetHandleId, selected),
+    [templates, selected, source, sourceHandleId, target, targetHandleId]
   );
 
   const { isSelected, shouldAnimate } = useAppSelector(selector);

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationDefaultEdge.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationDefaultEdge.tsx
@@ -27,7 +27,7 @@ const InvocationDefaultEdge = ({
   );
 
   const { isSelected, shouldAnimate, stroke, label } = useAppSelector(selector);
-  const shouldShowEdgeLabels = useAppSelector((s) => s.nodes.shouldShowEdgeLabels);
+  const shouldShowEdgeLabels = useAppSelector((s) => s.nodes.present.shouldShowEdgeLabels);
 
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationDefaultEdge.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationDefaultEdge.tsx
@@ -27,7 +27,7 @@ const InvocationDefaultEdge = ({
   );
 
   const { isSelected, shouldAnimate, stroke, label } = useAppSelector(selector);
-  const shouldShowEdgeLabels = useAppSelector((s) => s.nodes.present.shouldShowEdgeLabels);
+  const shouldShowEdgeLabels = useAppSelector((s) => s.workflowSettings.shouldShowEdgeLabels);
 
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationDefaultEdge.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/InvocationDefaultEdge.tsx
@@ -1,5 +1,7 @@
 import { Flex, Text } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 import type { EdgeProps } from 'reactflow';
@@ -21,9 +23,10 @@ const InvocationDefaultEdge = ({
   sourceHandleId,
   targetHandleId,
 }: EdgeProps) => {
+  const templates = useStore($templates);
   const selector = useMemo(
-    () => makeEdgeSelector(source, sourceHandleId, target, targetHandleId, selected),
-    [source, sourceHandleId, target, targetHandleId, selected]
+    () => makeEdgeSelector(templates, source, sourceHandleId, target, targetHandleId, selected),
+    [templates, source, sourceHandleId, target, targetHandleId, selected]
   );
 
   const { isSelected, shouldAnimate, stroke, label } = useAppSelector(selector);

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/util/makeEdgeSelector.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/util/makeEdgeSelector.ts
@@ -1,8 +1,8 @@
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { colorTokenToCssVar } from 'common/util/colorTokenToCssVar';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import type { Templates } from 'features/nodes/store/types';
 import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
-import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 
 import { getFieldColor } from './getEdgeColor';
@@ -15,7 +15,7 @@ const defaultReturnValue = {
 };
 
 export const makeEdgeSelector = (
-  templates: Record<string, InvocationTemplate>,
+  templates: Templates,
   source: string,
   sourceHandleId: string | null | undefined,
   target: string,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/util/makeEdgeSelector.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/util/makeEdgeSelector.ts
@@ -2,6 +2,7 @@ import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { colorTokenToCssVar } from 'common/util/colorTokenToCssVar';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { selectFieldOutputTemplate, selectNodeTemplate } from 'features/nodes/store/selectors';
+import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 
 import { getFieldColor } from './getEdgeColor';
@@ -22,7 +23,8 @@ export const makeEdgeSelector = (
 ) =>
   createMemoizedSelector(
     selectNodesSlice,
-    (nodes): { isSelected: boolean; shouldAnimate: boolean; stroke: string; label: string } => {
+    selectWorkflowSettingsSlice,
+    (nodes, workflowSettings): { isSelected: boolean; shouldAnimate: boolean; stroke: string; label: string } => {
       const sourceNode = nodes.nodes.find((node) => node.id === source);
       const targetNode = nodes.nodes.find((node) => node.id === target);
 
@@ -36,7 +38,7 @@ export const makeEdgeSelector = (
       const outputFieldTemplate = selectFieldOutputTemplate(nodes, sourceNode.id, sourceHandleId);
       const sourceType = isInvocationToInvocationEdge ? outputFieldTemplate?.type : undefined;
 
-      const stroke = sourceType && nodes.shouldColorEdges ? getFieldColor(sourceType) : colorTokenToCssVar('base.500');
+      const stroke = sourceType && workflowSettings.shouldColorEdges ? getFieldColor(sourceType) : colorTokenToCssVar('base.500');
 
       const sourceNodeTemplate = selectNodeTemplate(nodes, sourceNode.id);
       const targetNodeTemplate = selectNodeTemplate(nodes, targetNode.id);
@@ -45,7 +47,7 @@ export const makeEdgeSelector = (
 
       return {
         isSelected,
-        shouldAnimate: nodes.shouldAnimateEdges && isSelected,
+        shouldAnimate: workflowSettings.shouldAnimateEdges && isSelected,
         stroke,
         label,
       };

--- a/invokeai/frontend/web/src/features/nodes/components/flow/edges/util/makeEdgeSelector.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/edges/util/makeEdgeSelector.ts
@@ -1,8 +1,8 @@
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { colorTokenToCssVar } from 'common/util/colorTokenToCssVar';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectFieldOutputTemplate, selectNodeTemplate } from 'features/nodes/store/selectors';
 import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettingsSlice';
+import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 
 import { getFieldColor } from './getEdgeColor';
@@ -15,6 +15,7 @@ const defaultReturnValue = {
 };
 
 export const makeEdgeSelector = (
+  templates: Record<string, InvocationTemplate>,
   source: string,
   sourceHandleId: string | null | undefined,
   target: string,
@@ -35,13 +36,14 @@ export const makeEdgeSelector = (
         return defaultReturnValue;
       }
 
-      const outputFieldTemplate = selectFieldOutputTemplate(nodes, sourceNode.id, sourceHandleId);
+      const sourceNodeTemplate = templates[sourceNode.data.type];
+      const targetNodeTemplate = templates[targetNode.data.type];
+
+      const outputFieldTemplate = sourceNodeTemplate?.outputs[sourceHandleId];
       const sourceType = isInvocationToInvocationEdge ? outputFieldTemplate?.type : undefined;
 
-      const stroke = sourceType && workflowSettings.shouldColorEdges ? getFieldColor(sourceType) : colorTokenToCssVar('base.500');
-
-      const sourceNodeTemplate = selectNodeTemplate(nodes, sourceNode.id);
-      const targetNodeTemplate = selectNodeTemplate(nodes, targetNode.id);
+      const stroke =
+        sourceType && workflowSettings.shouldColorEdges ? getFieldColor(sourceType) : colorTokenToCssVar('base.500');
 
       const label = `${sourceNodeTemplate?.title || sourceNode.data?.label} -> ${targetNodeTemplate?.title || targetNode.data?.label}`;
 

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeStatusIndicator.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeStatusIndicator.tsx
@@ -1,12 +1,10 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { Badge, CircularProgress, Flex, Icon, Image, Text, Tooltip } from '@invoke-ai/ui-library';
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { useExecutionState } from 'features/nodes/hooks/useExecutionState';
 import { DRAG_HANDLE_CLASSNAME } from 'features/nodes/types/constants';
 import type { NodeExecutionState } from 'features/nodes/types/invocation';
 import { zNodeStatus } from 'features/nodes/types/invocation';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiCheckBold, PiDotsThreeOutlineFill, PiWarningBold } from 'react-icons/pi';
 
@@ -24,12 +22,7 @@ const circleStyles: SystemStyleObject = {
 };
 
 const InvocationNodeStatusIndicator = ({ nodeId }: Props) => {
-  const selectNodeExecutionState = useMemo(
-    () => createMemoizedSelector(selectNodesSlice, (nodes) => nodes.nodeExecutionStates[nodeId]),
-    [nodeId]
-  );
-
-  const nodeExecutionState = useAppSelector(selectNodeExecutionState);
+  const nodeExecutionState = useExecutionState(nodeId);
 
   if (!nodeExecutionState) {
     return null;

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeWrapper.tsx
@@ -1,7 +1,6 @@
-import { createSelector } from '@reduxjs/toolkit';
-import { useAppSelector } from 'app/store/storeHooks';
+import { useStore } from '@nanostores/react';
 import InvocationNode from 'features/nodes/components/flow/nodes/Invocation/InvocationNode';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import type { InvocationNodeData } from 'features/nodes/types/invocation';
 import { memo, useMemo } from 'react';
 import type { NodeProps } from 'reactflow';
@@ -11,13 +10,8 @@ import InvocationNodeUnknownFallback from './InvocationNodeUnknownFallback';
 const InvocationNodeWrapper = (props: NodeProps<InvocationNodeData>) => {
   const { data, selected } = props;
   const { id: nodeId, type, isOpen, label } = data;
-
-  const hasTemplateSelector = useMemo(
-    () => createSelector(selectNodesSlice, (nodes) => Boolean(nodes.templates[type])),
-    [type]
-  );
-
-  const hasTemplate = useAppSelector(hasTemplateSelector);
+  const templates = useStore($templates);
+  const hasTemplate = useMemo(() => Boolean(templates[type]), [templates, type]);
 
   if (!hasTemplate) {
     return (

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/InvocationNodeWrapper.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react';
+import { useAppSelector } from 'app/store/storeHooks';
 import InvocationNode from 'features/nodes/components/flow/nodes/Invocation/InvocationNode';
 import { $templates } from 'features/nodes/store/nodesSlice';
 import type { InvocationNodeData } from 'features/nodes/types/invocation';
@@ -12,6 +13,11 @@ const InvocationNodeWrapper = (props: NodeProps<InvocationNodeData>) => {
   const { id: nodeId, type, isOpen, label } = data;
   const templates = useStore($templates);
   const hasTemplate = useMemo(() => Boolean(templates[type]), [templates, type]);
+  const nodeExists = useAppSelector((s) => Boolean(s.nodes.present.nodes.find((n) => n.id === nodeId)));
+
+  if (!nodeExists) {
+    return null;
+  }
 
   if (!hasTemplate) {
     return (

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/EditableFieldTitle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/EditableFieldTitle.tsx
@@ -37,7 +37,8 @@ const EditableFieldTitle = forwardRef((props: Props, ref) => {
   const [localTitle, setLocalTitle] = useState(label || fieldTemplateTitle || t('nodes.unknownField'));
 
   const handleSubmit = useCallback(
-    async (newTitle: string) => {
+    async (newTitleRaw: string) => {
+      const newTitle = newTitleRaw.trim();
       if (newTitle && (newTitle === label || newTitle === fieldTemplateTitle)) {
         return;
       }
@@ -57,22 +58,22 @@ const EditableFieldTitle = forwardRef((props: Props, ref) => {
   }, [label, fieldTemplateTitle, t]);
 
   return (
-    <Tooltip
-      label={withTooltip ? <FieldTooltipContent nodeId={nodeId} fieldName={fieldName} kind="inputs" /> : undefined}
-      openDelay={HANDLE_TOOLTIP_OPEN_DELAY}
+    <Editable
+      value={localTitle}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      as={Flex}
+      ref={ref}
+      position="relative"
+      overflow="hidden"
+      alignItems="center"
+      justifyContent="flex-start"
+      gap={1}
+      w="full"
     >
-      <Editable
-        value={localTitle}
-        onChange={handleChange}
-        onSubmit={handleSubmit}
-        as={Flex}
-        ref={ref}
-        position="relative"
-        overflow="hidden"
-        alignItems="center"
-        justifyContent="flex-start"
-        gap={1}
-        w="full"
+      <Tooltip
+        label={withTooltip ? <FieldTooltipContent nodeId={nodeId} fieldName={fieldName} kind="inputs" /> : undefined}
+        openDelay={HANDLE_TOOLTIP_OPEN_DELAY}
       >
         <EditablePreview
           fontWeight="semibold"
@@ -80,10 +81,10 @@ const EditableFieldTitle = forwardRef((props: Props, ref) => {
           noOfLines={1}
           color={isMissingInput ? 'error.300' : 'base.300'}
         />
-        <EditableInput className="nodrag" sx={editableInputStyles} />
-        <EditableControls />
-      </Editable>
-    </Tooltip>
+      </Tooltip>
+      <EditableInput className="nodrag" sx={editableInputStyles} />
+      <EditableControls />
+    </Editable>
   );
 });
 
@@ -127,7 +128,15 @@ const EditableControls = memo(() => {
   }
 
   return (
-    <Flex onClick={handleClick} position="absolute" w="full" h="full" top={0} insetInlineStart={0} cursor="text" />
+    <Flex
+      onClick={handleClick}
+      position="absolute"
+      w="min-content"
+      h="full"
+      top={0}
+      insetInlineStart={0}
+      cursor="text"
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputField.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputField.tsx
@@ -69,7 +69,7 @@ const InputField = ({ nodeId, fieldName }: Props) => {
     );
   }
 
-  if (fieldTemplate.input === 'connection') {
+  if (fieldTemplate.input === 'connection' || isConnected) {
     return (
       <InputFieldWrapper shouldDim={shouldDim}>
         <FormControl isInvalid={isMissingInput} isDisabled={isConnected} px={2}>

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputField.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputField.tsx
@@ -95,7 +95,15 @@ const InputField = ({ nodeId, fieldName }: Props) => {
 
   return (
     <InputFieldWrapper shouldDim={shouldDim}>
-      <FormControl isInvalid={isMissingInput} isDisabled={isConnected} orientation="vertical" px={2}>
+      <FormControl
+        isInvalid={isMissingInput}
+        isDisabled={isConnected}
+        // Without pointerEvents prop, disabled inputs don't trigger reactflow events. For example, when making a
+        // connection, the mouse up to end the connection won't fire, leaving the connection in-progress.
+        pointerEvents={isConnected ? 'none' : 'auto'}
+        orientation="vertical"
+        px={2}
+      >
         <Flex flexDir="column" w="full" gap={1} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
           <Flex>
             <EditableFieldTitle

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeWrapper.tsx
@@ -39,7 +39,7 @@ const NodeWrapper = (props: NodeWrapperProps) => {
 
   const dispatch = useAppDispatch();
 
-  const opacity = useAppSelector((s) => s.nodes.present.nodeOpacity);
+  const opacity = useAppSelector((s) => s.workflowSettings.nodeOpacity);
   const { onCloseGlobal } = useGlobalMenuClose();
 
   const handleClick = useCallback(

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeWrapper.tsx
@@ -39,7 +39,7 @@ const NodeWrapper = (props: NodeWrapperProps) => {
 
   const dispatch = useAppDispatch();
 
-  const opacity = useAppSelector((s) => s.nodes.nodeOpacity);
+  const opacity = useAppSelector((s) => s.nodes.present.nodeOpacity);
   const { onCloseGlobal } = useGlobalMenuClose();
 
   const handleClick = useCallback(

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeWrapper.tsx
@@ -1,14 +1,14 @@
 import type { ChakraProps } from '@invoke-ai/ui-library';
 import { Box, useGlobalMenuClose, useToken } from '@invoke-ai/ui-library';
-import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import NodeSelectionOverlay from 'common/components/NodeSelectionOverlay';
+import { useExecutionState } from 'features/nodes/hooks/useExecutionState';
 import { useMouseOverNode } from 'features/nodes/hooks/useMouseOverNode';
-import { nodeExclusivelySelected, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { nodeExclusivelySelected } from 'features/nodes/store/nodesSlice';
 import { DRAG_HANDLE_CLASSNAME, NODE_WIDTH } from 'features/nodes/types/constants';
 import { zNodeStatus } from 'features/nodes/types/invocation';
 import type { MouseEvent, PropsWithChildren } from 'react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 
 type NodeWrapperProps = PropsWithChildren & {
   nodeId: string;
@@ -20,16 +20,8 @@ const NodeWrapper = (props: NodeWrapperProps) => {
   const { nodeId, width, children, selected } = props;
   const { isMouseOverNode, handleMouseOut, handleMouseOver } = useMouseOverNode(nodeId);
 
-  const selectIsInProgress = useMemo(
-    () =>
-      createSelector(
-        selectNodesSlice,
-        (nodes) => nodes.nodeExecutionStates[nodeId]?.status === zNodeStatus.enum.IN_PROGRESS
-      ),
-    [nodeId]
-  );
-
-  const isInProgress = useAppSelector(selectIsInProgress);
+  const executionState = useExecutionState(nodeId);
+  const isInProgress = executionState?.status === zNodeStatus.enum.IN_PROGRESS;
 
   const [nodeInProgress, shadowsXl, shadowsBase] = useToken('shadows', [
     'nodeInProgress',

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/NodeOpacitySlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/NodeOpacitySlider.tsx
@@ -1,12 +1,12 @@
 import { CompositeSlider, Flex } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import { nodeOpacityChanged } from 'features/nodes/store/nodesSlice';
+import { nodeOpacityChanged } from 'features/nodes/store/workflowSettingsSlice';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const NodeOpacitySlider = () => {
   const dispatch = useAppDispatch();
-  const nodeOpacity = useAppSelector((s) => s.nodes.present.nodeOpacity);
+  const nodeOpacity = useAppSelector((s) => s.workflowSettings.nodeOpacity);
   const { t } = useTranslation();
 
   const handleChange = useCallback(

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/NodeOpacitySlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/NodeOpacitySlider.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 const NodeOpacitySlider = () => {
   const dispatch = useAppDispatch();
-  const nodeOpacity = useAppSelector((s) => s.nodes.nodeOpacity);
+  const nodeOpacity = useAppSelector((s) => s.nodes.present.nodeOpacity);
   const { t } = useTranslation();
 
   const handleChange = useCallback(

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/ViewportControls.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/ViewportControls.tsx
@@ -19,9 +19,9 @@ const ViewportControls = () => {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const dispatch = useAppDispatch();
   // const shouldShowFieldTypeLegend = useAppSelector(
-  //   (s) => s.nodes.shouldShowFieldTypeLegend
+  //   (s) => s.nodes.present.shouldShowFieldTypeLegend
   // );
-  const shouldShowMinimapPanel = useAppSelector((s) => s.nodes.shouldShowMinimapPanel);
+  const shouldShowMinimapPanel = useAppSelector((s) => s.nodes.present.shouldShowMinimapPanel);
 
   const handleClickedZoomIn = useCallback(() => {
     zoomIn();

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/ViewportControls.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/BottomLeftPanel/ViewportControls.tsx
@@ -1,9 +1,6 @@
 import { ButtonGroup, IconButton } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import {
-  // shouldShowFieldTypeLegendChanged,
-  shouldShowMinimapPanelChanged,
-} from 'features/nodes/store/nodesSlice';
+import { shouldShowMinimapPanelChanged } from 'features/nodes/store/workflowSettingsSlice';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,7 +18,7 @@ const ViewportControls = () => {
   // const shouldShowFieldTypeLegend = useAppSelector(
   //   (s) => s.nodes.present.shouldShowFieldTypeLegend
   // );
-  const shouldShowMinimapPanel = useAppSelector((s) => s.nodes.present.shouldShowMinimapPanel);
+  const shouldShowMinimapPanel = useAppSelector((s) => s.workflowSettings.shouldShowMinimapPanel);
 
   const handleClickedZoomIn = useCallback(() => {
     zoomIn();

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/MinimapPanel/MinimapPanel.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/MinimapPanel/MinimapPanel.tsx
@@ -16,7 +16,7 @@ const minimapStyles: SystemStyleObject = {
 };
 
 const MinimapPanel = () => {
-  const shouldShowMinimapPanel = useAppSelector((s) => s.nodes.shouldShowMinimapPanel);
+  const shouldShowMinimapPanel = useAppSelector((s) => s.nodes.present.shouldShowMinimapPanel);
 
   return (
     <Flex gap={2} position="absolute" bottom={0} insetInlineEnd={0}>

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/MinimapPanel/MinimapPanel.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/MinimapPanel/MinimapPanel.tsx
@@ -16,7 +16,7 @@ const minimapStyles: SystemStyleObject = {
 };
 
 const MinimapPanel = () => {
-  const shouldShowMinimapPanel = useAppSelector((s) => s.nodes.present.shouldShowMinimapPanel);
+  const shouldShowMinimapPanel = useAppSelector((s) => s.workflowSettings.shouldShowMinimapPanel);
 
   return (
     <Flex gap={2} position="absolute" bottom={0} insetInlineEnd={0}>

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/AddNodeButton.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/AddNodeButton.tsx
@@ -1,23 +1,18 @@
 import { IconButton } from '@invoke-ai/ui-library';
-import { useAppDispatch } from 'app/store/storeHooks';
-import { addNodePopoverOpened } from 'features/nodes/store/nodesSlice';
-import { memo, useCallback } from 'react';
+import { openAddNodePopover } from 'features/nodes/store/nodesSlice';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiPlusBold } from 'react-icons/pi';
 
 const AddNodeButton = () => {
-  const dispatch = useAppDispatch();
   const { t } = useTranslation();
-  const handleOpenAddNodePopover = useCallback(() => {
-    dispatch(addNodePopoverOpened());
-  }, [dispatch]);
 
   return (
     <IconButton
       tooltip={t('nodes.addNodeToolTip')}
       aria-label={t('nodes.addNode')}
       icon={<PiPlusBold />}
-      onClick={handleOpenAddNodePopover}
+      onClick={openAddNodePopover}
       pointerEvents="auto"
     />
   );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopRightPanel/WorkflowEditorSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopRightPanel/WorkflowEditorSettings.tsx
@@ -21,13 +21,13 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import ReloadNodeTemplatesButton from 'features/nodes/components/flow/panels/TopRightPanel/ReloadSchemaButton';
 import {
   selectionModeChanged,
-  selectNodesSlice,
+  selectWorkflowSettingsSlice,
   shouldAnimateEdgesChanged,
   shouldColorEdgesChanged,
   shouldShowEdgeLabelsChanged,
   shouldSnapToGridChanged,
   shouldValidateGraphChanged,
-} from 'features/nodes/store/nodesSlice';
+} from 'features/nodes/store/workflowSettingsSlice';
 import type { ChangeEvent, ReactNode } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +35,7 @@ import { SelectionMode } from 'reactflow';
 
 const formLabelProps: FormLabelProps = { flexGrow: 1 };
 
-const selector = createMemoizedSelector(selectNodesSlice, (nodes) => {
+const selector = createMemoizedSelector(selectWorkflowSettingsSlice, (workflowSettings) => {
   const {
     shouldAnimateEdges,
     shouldValidateGraph,
@@ -43,7 +43,7 @@ const selector = createMemoizedSelector(selectNodesSlice, (nodes) => {
     shouldColorEdges,
     shouldShowEdgeLabels,
     selectionMode,
-  } = nodes;
+  } = workflowSettings;
   return {
     shouldAnimateEdges,
     shouldValidateGraph,

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorDataTab.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorDataTab.tsx
@@ -3,27 +3,21 @@ import { useAppSelector } from 'app/store/storeHooks';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import DataViewer from 'features/gallery/components/ImageMetadataViewer/DataViewer';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectLastSelectedNode } from 'features/nodes/store/selectors';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-const selector = createMemoizedSelector(selectNodesSlice, (nodes) => {
-  const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
 
-  const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
-
-  return {
-    data: lastSelectedNode?.data,
-  };
-});
+const selector = createMemoizedSelector(selectNodesSlice, (nodes) => selectLastSelectedNode(nodes));
 
 const InspectorDataTab = () => {
   const { t } = useTranslation();
-  const { data } = useAppSelector(selector);
+  const lastSelectedNode = useAppSelector(selector);
 
-  if (!data) {
+  if (!lastSelectedNode) {
     return <IAINoContentFallback label={t('nodes.noNodeSelected')} icon={null} />;
   }
 
-  return <DataViewer data={data} label="Node Data" />;
+  return <DataViewer data={lastSelectedNode.data} label="Node Data" />;
 };
 
 export default memo(InspectorDataTab);

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorDetailsTab.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorDetailsTab.tsx
@@ -1,36 +1,39 @@
 import { Box, Flex, FormControl, FormLabel, HStack, Text } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppSelector } from 'app/store/storeHooks';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
 import NotesTextarea from 'features/nodes/components/flow/nodes/Invocation/NotesTextarea';
 import { useNodeNeedsUpdate } from 'features/nodes/hooks/useNodeNeedsUpdate';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { isInvocationNode } from 'features/nodes/types/invocation';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import EditableNodeTitle from './details/EditableNodeTitle';
 
-const selector = createMemoizedSelector(selectNodesSlice, (nodes) => {
-  const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
-
-  const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
-
-  const lastSelectedNodeTemplate = lastSelectedNode ? nodes.templates[lastSelectedNode.data.type] : undefined;
-
-  if (!isInvocationNode(lastSelectedNode) || !lastSelectedNodeTemplate) {
-    return;
-  }
-
-  return {
-    nodeId: lastSelectedNode.data.id,
-    nodeVersion: lastSelectedNode.data.version,
-    templateTitle: lastSelectedNodeTemplate.title,
-  };
-});
-
 const InspectorDetailsTab = () => {
+  const templates = useStore($templates);
+  const selector = useMemo(
+    () =>
+      createMemoizedSelector(selectNodesSlice, (nodes) => {
+        const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
+        const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
+        const lastSelectedNodeTemplate = lastSelectedNode ? templates[lastSelectedNode.data.type] : undefined;
+
+        if (!isInvocationNode(lastSelectedNode) || !lastSelectedNodeTemplate) {
+          return;
+        }
+
+        return {
+          nodeId: lastSelectedNode.data.id,
+          nodeVersion: lastSelectedNode.data.version,
+          templateTitle: lastSelectedNodeTemplate.title,
+        };
+      }),
+    [templates]
+  );
   const data = useAppSelector(selector);
   const { t } = useTranslation();
 

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorDetailsTab.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorDetailsTab.tsx
@@ -7,6 +7,7 @@ import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableCon
 import NotesTextarea from 'features/nodes/components/flow/nodes/Invocation/NotesTextarea';
 import { useNodeNeedsUpdate } from 'features/nodes/hooks/useNodeNeedsUpdate';
 import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectLastSelectedNode } from 'features/nodes/store/selectors';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,8 +19,7 @@ const InspectorDetailsTab = () => {
   const selector = useMemo(
     () =>
       createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
-        const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
+        const lastSelectedNode = selectLastSelectedNode(nodes);
         const lastSelectedNodeTemplate = lastSelectedNode ? templates[lastSelectedNode.data.type] : undefined;
 
         if (!isInvocationNode(lastSelectedNode) || !lastSelectedNodeTemplate) {

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorOutputsTab.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorOutputsTab.tsx
@@ -6,6 +6,7 @@ import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
 import DataViewer from 'features/gallery/components/ImageMetadataViewer/DataViewer';
 import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectLastSelectedNode } from 'features/nodes/store/selectors';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,11 +20,10 @@ const InspectorOutputsTab = () => {
   const selector = useMemo(
     () =>
       createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
-        const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
+        const lastSelectedNode = selectLastSelectedNode(nodes);
         const lastSelectedNodeTemplate = lastSelectedNode ? templates[lastSelectedNode.data.type] : undefined;
 
-        const nes = nodes.nodeExecutionStates[lastSelectedNodeId ?? '__UNKNOWN_NODE__'];
+        const nes = nodes.nodeExecutionStates[lastSelectedNode?.id ?? '__UNKNOWN_NODE__'];
 
         if (!isInvocationNode(lastSelectedNode) || !nes || !lastSelectedNodeTemplate) {
           return;

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorTemplateTab.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorTemplateTab.tsx
@@ -1,25 +1,26 @@
+import { useStore } from '@nanostores/react';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppSelector } from 'app/store/storeHooks';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import DataViewer from 'features/gallery/components/ImageMetadataViewer/DataViewer';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { memo } from 'react';
+import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const selector = createMemoizedSelector(selectNodesSlice, (nodes) => {
-  const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
-
-  const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
-
-  const lastSelectedNodeTemplate = lastSelectedNode ? nodes.templates[lastSelectedNode.data.type] : undefined;
-
-  return {
-    template: lastSelectedNodeTemplate,
-  };
-});
-
 const NodeTemplateInspector = () => {
-  const { template } = useAppSelector(selector);
+  const templates = useStore($templates);
+  const selector = useMemo(
+    () =>
+      createMemoizedSelector(selectNodesSlice, (nodes) => {
+        const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
+        const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
+        const lastSelectedNodeTemplate = lastSelectedNode ? templates[lastSelectedNode.data.type] : undefined;
+
+        return lastSelectedNodeTemplate;
+      }),
+    [templates]
+  );
+  const template = useAppSelector(selector);
   const { t } = useTranslation();
 
   if (!template) {

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorTemplateTab.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/inspector/InspectorTemplateTab.tsx
@@ -4,6 +4,7 @@ import { useAppSelector } from 'app/store/storeHooks';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import DataViewer from 'features/gallery/components/ImageMetadataViewer/DataViewer';
 import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectLastSelectedNode } from 'features/nodes/store/selectors';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -12,8 +13,7 @@ const NodeTemplateInspector = () => {
   const selector = useMemo(
     () =>
       createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const lastSelectedNodeId = nodes.selectedNodes[nodes.selectedNodes.length - 1];
-        const lastSelectedNode = nodes.nodes.find((node) => node.id === lastSelectedNodeId);
+        const lastSelectedNode = selectLastSelectedNode(nodes);
         const lastSelectedNodeTemplate = lastSelectedNode ? templates[lastSelectedNode.data.type] : undefined;
 
         return lastSelectedNodeTemplate;

--- a/invokeai/frontend/web/src/features/nodes/hooks/useAnyOrDirectInputFieldNames.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useAnyOrDirectInputFieldNames.ts
@@ -1,31 +1,19 @@
-import { EMPTY_ARRAY } from 'app/store/constants';
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import { getSortedFilteredFieldNames } from 'features/nodes/util/node/getSortedFilteredFieldNames';
 import { TEMPLATE_BUILDER_MAP } from 'features/nodes/util/schema/buildFieldInputTemplate';
 import { keys, map } from 'lodash-es';
 import { useMemo } from 'react';
 
 export const useAnyOrDirectInputFieldNames = (nodeId: string): string[] => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const template = selectNodeTemplate(nodes, nodeId);
-        if (!template) {
-          return EMPTY_ARRAY;
-        }
-        const fields = map(template.inputs).filter(
-          (field) =>
-            (['any', 'direct'].includes(field.input) || field.type.isCollectionOrScalar) &&
-            keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
-        );
-        return getSortedFilteredFieldNames(fields);
-      }),
-    [nodeId]
-  );
+  const template = useNodeTemplate(nodeId);
+  const fieldNames = useMemo(() => {
+    const fields = map(template.inputs).filter(
+      (field) =>
+        (['any', 'direct'].includes(field.input) || field.type.isCollectionOrScalar) &&
+        keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
+    );
+    return getSortedFilteredFieldNames(fields);
+  }, [template]);
 
-  const fieldNames = useAppSelector(selector);
   return fieldNames;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useAnyOrDirectInputFieldNames.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useAnyOrDirectInputFieldNames.ts
@@ -1,4 +1,7 @@
+import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
+import { useAppSelector } from 'app/store/storeHooks';
 import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
+import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { getSortedFilteredFieldNames } from 'features/nodes/util/node/getSortedFilteredFieldNames';
 import { TEMPLATE_BUILDER_MAP } from 'features/nodes/util/schema/buildFieldInputTemplate';
 import { keys, map } from 'lodash-es';
@@ -6,14 +9,31 @@ import { useMemo } from 'react';
 
 export const useAnyOrDirectInputFieldNames = (nodeId: string): string[] => {
   const template = useNodeTemplate(nodeId);
+  const selectConnectedFieldNames = useMemo(
+    () =>
+      createMemoizedSelector(selectNodesSlice, (nodesSlice) =>
+        nodesSlice.edges
+          .filter((e) => e.target === nodeId)
+          .map((e) => e.targetHandle)
+          .filter(Boolean)
+      ),
+    [nodeId]
+  );
+  const connectedFieldNames = useAppSelector(selectConnectedFieldNames);
+
   const fieldNames = useMemo(() => {
-    const fields = map(template.inputs).filter(
-      (field) =>
+    const fields = map(template.inputs).filter((field) => {
+      if (connectedFieldNames.includes(field.name)) {
+        return false;
+      }
+
+      return (
         (['any', 'direct'].includes(field.input) || field.type.isCollectionOrScalar) &&
         keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
-    );
+      );
+    });
     return getSortedFilteredFieldNames(fields);
-  }, [template]);
+  }, [connectedFieldNames, template.inputs]);
 
   return fieldNames;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useBuildNode.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useBuildNode.ts
@@ -8,7 +8,7 @@ import { useCallback } from 'react';
 import { useReactFlow } from 'reactflow';
 
 export const useBuildNode = () => {
-  const nodeTemplates = useAppSelector((s) => s.nodes.templates);
+  const nodeTemplates = useAppSelector((s) => s.nodes.present.templates);
 
   const flow = useReactFlow();
 

--- a/invokeai/frontend/web/src/features/nodes/hooks/useBuildNode.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useBuildNode.ts
@@ -1,4 +1,5 @@
-import { useAppSelector } from 'app/store/storeHooks';
+import { useStore } from '@nanostores/react';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { NODE_WIDTH } from 'features/nodes/types/constants';
 import type { AnyNode, InvocationTemplate } from 'features/nodes/types/invocation';
 import { buildCurrentImageNode } from 'features/nodes/util/node/buildCurrentImageNode';
@@ -8,8 +9,7 @@ import { useCallback } from 'react';
 import { useReactFlow } from 'reactflow';
 
 export const useBuildNode = () => {
-  const nodeTemplates = useAppSelector((s) => s.nodes.present.templates);
-
+  const templates = useStore($templates);
   const flow = useReactFlow();
 
   return useCallback(
@@ -41,10 +41,10 @@ export const useBuildNode = () => {
 
       // TODO: Keep track of invocation types so we do not need to cast this
       // We know it is safe because the caller of this function gets the `type` arg from the list of invocation templates.
-      const template = nodeTemplates[type] as InvocationTemplate;
+      const template = templates[type] as InvocationTemplate;
 
       return buildInvocationNode(position, template);
     },
-    [nodeTemplates, flow]
+    [templates, flow]
   );
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
@@ -70,7 +70,14 @@ export const useConnection = () => {
       }
       const candidateTemplate = templates[candidateNode.data.type];
       assert(candidateTemplate, `Template not found for node type: ${candidateNode.data.type}`);
-      const connection = getFirstValidConnection(templates, nodes, edges, pendingConnection, candidateNode, candidateTemplate);
+      const connection = getFirstValidConnection(
+        templates,
+        nodes,
+        edges,
+        pendingConnection,
+        candidateNode,
+        candidateTemplate
+      );
       if (connection) {
         dispatch(connectionMade(connection));
       }

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
@@ -1,0 +1,68 @@
+import { useStore } from '@nanostores/react';
+import { useAppStore } from 'app/store/storeHooks';
+import { $mouseOverNode } from 'features/nodes/hooks/useMouseOverNode';
+import { $pendingConnection, $templates, connectionMade } from 'features/nodes/store/nodesSlice';
+import { getFirstValidConnection } from 'features/nodes/store/util/findConnectionToValidHandle';
+import { isInvocationNode } from 'features/nodes/types/invocation';
+import { useCallback, useMemo } from 'react';
+import type { OnConnect, OnConnectEnd, OnConnectStart } from 'reactflow';
+import { assert } from 'tsafe';
+
+export const useConnection = () => {
+  const store = useAppStore();
+  const templates = useStore($templates);
+
+  const onConnectStart = useCallback<OnConnectStart>(
+    (event, params) => {
+      const nodes = store.getState().nodes.present.nodes;
+      const { nodeId, handleId, handleType } = params;
+      assert(nodeId && handleId && handleType, `Invalid connection start params: ${JSON.stringify(params)}`);
+      const node = nodes.find((n) => n.id === nodeId);
+      assert(isInvocationNode(node), `Invalid node during connection: ${JSON.stringify(node)}`);
+      const template = templates[node.data.type];
+      assert(template, `Template not found for node type: ${node.data.type}`);
+      const fieldTemplate = handleType === 'source' ? template.outputs[handleId] : template.inputs[handleId];
+      assert(fieldTemplate, `Field template not found for field: ${node.data.type}.${handleId}`);
+      $pendingConnection.set({
+        node,
+        template,
+        fieldTemplate,
+      });
+    },
+    [store, templates]
+  );
+  const onConnect = useCallback<OnConnect>(
+    (connection) => {
+      const { dispatch } = store;
+      dispatch(connectionMade(connection));
+      $pendingConnection.set(null);
+    },
+    [store]
+  );
+  const onConnectEnd = useCallback<OnConnectEnd>(() => {
+    const { dispatch } = store;
+    const pendingConnection = $pendingConnection.get();
+    if (!pendingConnection) {
+      return;
+    }
+    const mouseOverNodeId = $mouseOverNode.get();
+    const { nodes, edges } = store.getState().nodes.present;
+    if (mouseOverNodeId) {
+      const candidateNode = nodes.filter(isInvocationNode).find((n) => n.id === mouseOverNodeId);
+      if (!candidateNode) {
+        // The mouse is over a non-invocation node - bail
+        return;
+      }
+      const candidateTemplate = templates[candidateNode.data.type];
+      assert(candidateTemplate, `Template not found for node type: ${candidateNode.data.type}`);
+      const connection = getFirstValidConnection(nodes, edges, pendingConnection, candidateNode, candidateTemplate);
+      if (connection) {
+        dispatch(connectionMade(connection));
+      }
+    }
+    $pendingConnection.set(null);
+  }, [store, templates]);
+
+  const api = useMemo(() => ({ onConnectStart, onConnect, onConnectEnd }), [onConnectStart, onConnect, onConnectEnd]);
+  return api;
+};

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react';
 import { useAppStore } from 'app/store/storeHooks';
 import { $mouseOverNode } from 'features/nodes/hooks/useMouseOverNode';
-import { $pendingConnection, $templates, connectionMade } from 'features/nodes/store/nodesSlice';
+import { $isAddNodePopoverOpen, $pendingConnection, $templates, connectionMade } from 'features/nodes/store/nodesSlice';
 import { getFirstValidConnection } from 'features/nodes/store/util/findConnectionToValidHandle';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { useCallback, useMemo } from 'react';
@@ -59,8 +59,11 @@ export const useConnection = () => {
       if (connection) {
         dispatch(connectionMade(connection));
       }
+      $pendingConnection.set(null);
+    } else {
+      // The mouse is not over a node - we should open the add node popover
+      $isAddNodePopoverOpen.set(true);
     }
-    $pendingConnection.set(null);
   }, [store, templates]);
 
   const api = useMemo(() => ({ onConnectStart, onConnect, onConnectEnd }), [onConnectStart, onConnect, onConnectEnd]);

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
@@ -70,7 +70,7 @@ export const useConnection = () => {
       }
       const candidateTemplate = templates[candidateNode.data.type];
       assert(candidateTemplate, `Template not found for node type: ${candidateNode.data.type}`);
-      const connection = getFirstValidConnection(nodes, edges, pendingConnection, candidateNode, candidateTemplate);
+      const connection = getFirstValidConnection(templates, nodes, edges, pendingConnection, candidateNode, candidateTemplate);
       if (connection) {
         dispatch(connectionMade(connection));
       }

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnectionInputFieldNames.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnectionInputFieldNames.ts
@@ -1,34 +1,20 @@
-import { EMPTY_ARRAY } from 'app/store/constants';
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import { getSortedFilteredFieldNames } from 'features/nodes/util/node/getSortedFilteredFieldNames';
 import { TEMPLATE_BUILDER_MAP } from 'features/nodes/util/schema/buildFieldInputTemplate';
 import { keys, map } from 'lodash-es';
 import { useMemo } from 'react';
 
 export const useConnectionInputFieldNames = (nodeId: string): string[] => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const template = selectNodeTemplate(nodes, nodeId);
-        if (!template) {
-          return EMPTY_ARRAY;
-        }
+  const template = useNodeTemplate(nodeId);
+  const fieldNames = useMemo(() => {
+    // get the visible fields
+    const fields = map(template.inputs).filter(
+      (field) =>
+        (field.input === 'connection' && !field.type.isCollectionOrScalar) ||
+        !keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
+    );
 
-        // get the visible fields
-        const fields = map(template.inputs).filter(
-          (field) =>
-            (field.input === 'connection' && !field.type.isCollectionOrScalar) ||
-            !keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
-        );
-
-        return getSortedFilteredFieldNames(fields);
-      }),
-    [nodeId]
-  );
-
-  const fieldNames = useAppSelector(selector);
+    return getSortedFilteredFieldNames(fields);
+  }, [template]);
   return fieldNames;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnectionInputFieldNames.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnectionInputFieldNames.ts
@@ -1,4 +1,7 @@
+import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
+import { useAppSelector } from 'app/store/storeHooks';
 import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
+import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { getSortedFilteredFieldNames } from 'features/nodes/util/node/getSortedFilteredFieldNames';
 import { TEMPLATE_BUILDER_MAP } from 'features/nodes/util/schema/buildFieldInputTemplate';
 import { keys, map } from 'lodash-es';
@@ -6,15 +9,31 @@ import { useMemo } from 'react';
 
 export const useConnectionInputFieldNames = (nodeId: string): string[] => {
   const template = useNodeTemplate(nodeId);
+  const selectConnectedFieldNames = useMemo(
+    () =>
+      createMemoizedSelector(selectNodesSlice, (nodesSlice) =>
+        nodesSlice.edges
+          .filter((e) => e.target === nodeId)
+          .map((e) => e.targetHandle)
+          .filter(Boolean)
+      ),
+    [nodeId]
+  );
+  const connectedFieldNames = useAppSelector(selectConnectedFieldNames);
+
   const fieldNames = useMemo(() => {
     // get the visible fields
-    const fields = map(template.inputs).filter(
-      (field) =>
+    const fields = map(template.inputs).filter((field) => {
+      if (connectedFieldNames.includes(field.name)) {
+        return true;
+      }
+      return (
         (field.input === 'connection' && !field.type.isCollectionOrScalar) ||
         !keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
-    );
+      );
+    });
 
     return getSortedFilteredFieldNames(fields);
-  }, [template]);
+  }, [connectedFieldNames, template.inputs]);
   return fieldNames;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnectionState.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnectionState.ts
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
-import { $pendingConnection, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { $pendingConnection, $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { makeConnectionErrorSelector } from 'features/nodes/store/util/makeIsConnectionValidSelector';
 import { useMemo } from 'react';
 
@@ -15,6 +15,7 @@ type UseConnectionStateProps = {
 
 export const useConnectionState = ({ nodeId, fieldName, kind }: UseConnectionStateProps) => {
   const pendingConnection = useStore($pendingConnection);
+  const templates = useStore($templates);
   const fieldType = useFieldType(nodeId, fieldName, kind);
 
   const selectIsConnected = useMemo(
@@ -35,13 +36,14 @@ export const useConnectionState = ({ nodeId, fieldName, kind }: UseConnectionSta
   const selectConnectionError = useMemo(
     () =>
       makeConnectionErrorSelector(
+        templates,
         pendingConnection,
         nodeId,
         fieldName,
         kind === 'inputs' ? 'target' : 'source',
         fieldType
       ),
-    [pendingConnection, nodeId, fieldName, kind, fieldType]
+    [templates, pendingConnection, nodeId, fieldName, kind, fieldType]
   );
 
   const isConnected = useAppSelector(selectIsConnected);

--- a/invokeai/frontend/web/src/features/nodes/hooks/useCopyPaste.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useCopyPaste.ts
@@ -1,6 +1,12 @@
 import { getStore } from 'app/store/nanostores/store';
 import { deepClone } from 'common/util/deepClone';
-import { $copiedEdges,$copiedNodes,$cursorPos, selectionPasted, selectNodesSlice   } from 'features/nodes/store/nodesSlice';
+import {
+  $copiedEdges,
+  $copiedNodes,
+  $cursorPos,
+  selectionPasted,
+  selectNodesSlice,
+} from 'features/nodes/store/nodesSlice';
 import { findUnoccupiedPosition } from 'features/nodes/store/util/findUnoccupiedPosition';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/invokeai/frontend/web/src/features/nodes/hooks/useCopyPaste.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useCopyPaste.ts
@@ -1,0 +1,63 @@
+import { getStore } from 'app/store/nanostores/store';
+import { deepClone } from 'common/util/deepClone';
+import { $copiedEdges,$copiedNodes,$cursorPos, selectionPasted, selectNodesSlice   } from 'features/nodes/store/nodesSlice';
+import { findUnoccupiedPosition } from 'features/nodes/store/util/findUnoccupiedPosition';
+import { v4 as uuidv4 } from 'uuid';
+
+const copySelection = () => {
+  // Use the imperative API here so we don't have to pass the whole slice around
+  const { getState } = getStore();
+  const { nodes, edges } = selectNodesSlice(getState());
+  const selectedNodes = nodes.filter((node) => node.selected);
+  const selectedEdges = edges.filter((edge) => edge.selected);
+  $copiedNodes.set(selectedNodes);
+  $copiedEdges.set(selectedEdges);
+};
+
+const pasteSelection = () => {
+  const { getState, dispatch } = getStore();
+  const currentNodes = selectNodesSlice(getState()).nodes;
+  const cursorPos = $cursorPos.get();
+
+  const copiedNodes = deepClone($copiedNodes.get());
+  const copiedEdges = deepClone($copiedEdges.get());
+
+  // Calculate an offset to reposition nodes to surround the cursor position, maintaining relative positioning
+  const xCoords = copiedNodes.map((node) => node.position.x);
+  const yCoords = copiedNodes.map((node) => node.position.y);
+  const minX = Math.min(...xCoords);
+  const minY = Math.min(...yCoords);
+  const offsetX = cursorPos ? cursorPos.x - minX : 50;
+  const offsetY = cursorPos ? cursorPos.y - minY : 50;
+
+  copiedNodes.forEach((node) => {
+    const { x, y } = findUnoccupiedPosition(currentNodes, node.position.x + offsetX, node.position.y + offsetY);
+    node.position.x = x;
+    node.position.y = y;
+    // Pasted nodes are selected
+    node.selected = true;
+    // Also give em a fresh id
+    const id = uuidv4();
+    // Update the edges to point to the new node id
+    for (const edge of copiedEdges) {
+      if (edge.source === node.id) {
+        edge.source = id;
+        edge.id = edge.id.replace(node.data.id, id);
+      }
+      if (edge.target === node.id) {
+        edge.target = id;
+        edge.id = edge.id.replace(node.data.id, id);
+      }
+    }
+    node.id = id;
+    node.data.id = id;
+  });
+
+  dispatch(selectionPasted({ nodes: copiedNodes, edges: copiedEdges }));
+};
+
+const api = { copySelection, pasteSelection };
+
+export const useCopyPaste = () => {
+  return api;
+};

--- a/invokeai/frontend/web/src/features/nodes/hooks/useExecutionState.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useExecutionState.ts
@@ -1,0 +1,56 @@
+import { useStore } from '@nanostores/react';
+import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
+import { useAppSelector } from 'app/store/storeHooks';
+import { deepClone } from 'common/util/deepClone';
+import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import type { NodeExecutionStates } from 'features/nodes/store/types';
+import type { NodeExecutionState } from 'features/nodes/types/invocation';
+import { zNodeStatus } from 'features/nodes/types/invocation';
+import { map } from 'nanostores';
+import { useEffect, useMemo } from 'react';
+
+export const $nodeExecutionStates = map<NodeExecutionStates>({});
+
+const initialNodeExecutionState: Omit<NodeExecutionState, 'nodeId'> = {
+  status: zNodeStatus.enum.PENDING,
+  error: null,
+  progress: null,
+  progressImage: null,
+  outputs: [],
+};
+
+export const useExecutionState = (nodeId?: string) => {
+  const executionStates = useStore($nodeExecutionStates, nodeId ? { keys: [nodeId] } : undefined);
+  const executionState = useMemo(() => (nodeId ? executionStates[nodeId] : undefined), [executionStates, nodeId]);
+  return executionState;
+};
+
+const removeNodeExecutionState = (nodeId: string) => {
+  $nodeExecutionStates.setKey(nodeId, undefined);
+};
+
+export const upsertExecutionState = (nodeId: string, updates?: Partial<NodeExecutionState>) => {
+  const state = $nodeExecutionStates.get()[nodeId];
+  if (!state) {
+    $nodeExecutionStates.setKey(nodeId, { ...deepClone(initialNodeExecutionState), nodeId, ...updates });
+  } else {
+    $nodeExecutionStates.setKey(nodeId, { ...state, ...updates });
+  }
+};
+
+const selectNodeIds = createMemoizedSelector(selectNodesSlice, (nodesSlice) => nodesSlice.nodes.map((node) => node.id));
+
+export const useSyncExecutionState = () => {
+  const nodeIds = useAppSelector(selectNodeIds);
+  useEffect(() => {
+    const nodeExecutionStates = $nodeExecutionStates.get();
+    const nodeIdsToAdd = nodeIds.filter((id) => !nodeExecutionStates[id]);
+    const nodeIdsToRemove = Object.keys(nodeExecutionStates).filter((id) => !nodeIds.includes(id));
+    for (const id of nodeIdsToAdd) {
+      upsertExecutionState(id);
+    }
+    for (const id of nodeIdsToRemove) {
+      removeNodeExecutionState(id);
+    }
+  }, [nodeIds]);
+};

--- a/invokeai/frontend/web/src/features/nodes/hooks/useFieldInputTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useFieldInputTemplate.ts
@@ -1,20 +1,9 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectFieldInputTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import type { FieldInputTemplate } from 'features/nodes/types/field';
 import { useMemo } from 'react';
 
 export const useFieldInputTemplate = (nodeId: string, fieldName: string): FieldInputTemplate | null => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        return selectFieldInputTemplate(nodes, nodeId, fieldName);
-      }),
-    [fieldName, nodeId]
-  );
-
-  const fieldTemplate = useAppSelector(selector);
-
+  const template = useNodeTemplate(nodeId);
+  const fieldTemplate = useMemo(() => template.inputs[fieldName] ?? null, [fieldName, template.inputs]);
   return fieldTemplate;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useFieldOutputTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useFieldOutputTemplate.ts
@@ -1,20 +1,9 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectFieldOutputTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import type { FieldOutputTemplate } from 'features/nodes/types/field';
 import { useMemo } from 'react';
 
 export const useFieldOutputTemplate = (nodeId: string, fieldName: string): FieldOutputTemplate | null => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        return selectFieldOutputTemplate(nodes, nodeId, fieldName);
-      }),
-    [fieldName, nodeId]
-  );
-
-  const fieldTemplate = useAppSelector(selector);
-
+  const template = useNodeTemplate(nodeId);
+  const fieldTemplate = useMemo(() => template.outputs[fieldName] ?? null, [fieldName, template.outputs]);
   return fieldTemplate;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useFieldTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useFieldTemplate.ts
@@ -1,27 +1,36 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
+import { useStore } from '@nanostores/react';
+import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectFieldInputTemplate, selectFieldOutputTemplate } from 'features/nodes/store/selectors';
+import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectInvocationNodeType } from 'features/nodes/store/selectors';
 import type { FieldInputTemplate, FieldOutputTemplate } from 'features/nodes/types/field';
 import { useMemo } from 'react';
+import { assert } from 'tsafe';
 
 export const useFieldTemplate = (
   nodeId: string,
   fieldName: string,
   kind: 'inputs' | 'outputs'
-): FieldInputTemplate | FieldOutputTemplate | null => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        if (kind === 'inputs') {
-          return selectFieldInputTemplate(nodes, nodeId, fieldName);
-        }
-        return selectFieldOutputTemplate(nodes, nodeId, fieldName);
-      }),
-    [fieldName, kind, nodeId]
+): FieldInputTemplate | FieldOutputTemplate => {
+  const templates = useStore($templates);
+  const selectNodeType = useMemo(
+    () => createSelector(selectNodesSlice, (nodes) => selectInvocationNodeType(nodes, nodeId)),
+    [nodeId]
   );
-
-  const fieldTemplate = useAppSelector(selector);
+  const nodeType = useAppSelector(selectNodeType);
+  const fieldTemplate = useMemo(() => {
+    const template = templates[nodeType];
+    assert(template, `Template for node type ${nodeType} not found`);
+    if (kind === 'inputs') {
+      const fieldTemplate = template.inputs[fieldName];
+      assert(fieldTemplate, `Field template for field ${fieldName} not found`);
+      return fieldTemplate;
+    } else {
+      const fieldTemplate = template.outputs[fieldName];
+      assert(fieldTemplate, `Field template for field ${fieldName} not found`);
+      return fieldTemplate;
+    }
+  }, [fieldName, kind, nodeType, templates]);
 
   return fieldTemplate;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useFieldTemplateTitle.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useFieldTemplateTitle.ts
@@ -1,22 +1,8 @@
-import { createSelector } from '@reduxjs/toolkit';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectFieldInputTemplate, selectFieldOutputTemplate } from 'features/nodes/store/selectors';
+import { useFieldTemplate } from 'features/nodes/hooks/useFieldTemplate';
 import { useMemo } from 'react';
 
 export const useFieldTemplateTitle = (nodeId: string, fieldName: string, kind: 'inputs' | 'outputs'): string | null => {
-  const selector = useMemo(
-    () =>
-      createSelector(selectNodesSlice, (nodes) => {
-        if (kind === 'inputs') {
-          return selectFieldInputTemplate(nodes, nodeId, fieldName)?.title ?? null;
-        }
-        return selectFieldOutputTemplate(nodes, nodeId, fieldName)?.title ?? null;
-      }),
-    [fieldName, kind, nodeId]
-  );
-
-  const fieldTemplateTitle = useAppSelector(selector);
-
+  const fieldTemplate = useFieldTemplate(nodeId, fieldName, kind);
+  const fieldTemplateTitle = useMemo(() => fieldTemplate.title, [fieldTemplate]);
   return fieldTemplateTitle;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useFieldType.ts.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useFieldType.ts.ts
@@ -1,23 +1,9 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectFieldInputTemplate, selectFieldOutputTemplate } from 'features/nodes/store/selectors';
+import { useFieldTemplate } from 'features/nodes/hooks/useFieldTemplate';
 import type { FieldType } from 'features/nodes/types/field';
 import { useMemo } from 'react';
 
-export const useFieldType = (nodeId: string, fieldName: string, kind: 'inputs' | 'outputs'): FieldType | null => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        if (kind === 'inputs') {
-          return selectFieldInputTemplate(nodes, nodeId, fieldName)?.type ?? null;
-        }
-        return selectFieldOutputTemplate(nodes, nodeId, fieldName)?.type ?? null;
-      }),
-    [fieldName, kind, nodeId]
-  );
-
-  const fieldType = useAppSelector(selector);
-
+export const useFieldType = (nodeId: string, fieldName: string, kind: 'inputs' | 'outputs'): FieldType => {
+  const fieldTemplate = useFieldTemplate(nodeId, fieldName, kind);
+  const fieldType = useMemo(() => fieldTemplate.type, [fieldTemplate]);
   return fieldType;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useGetNodesNeedUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useGetNodesNeedUpdate.ts
@@ -16,7 +16,7 @@ export const useGetNodesNeedUpdate = () => {
           if (!template) {
             return false;
           }
-          return getNeedsUpdate(node, template);
+          return getNeedsUpdate(node.data, template);
         })
       ),
     [templates]

--- a/invokeai/frontend/web/src/features/nodes/hooks/useGetNodesNeedUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useGetNodesNeedUpdate.ts
@@ -1,20 +1,26 @@
+import { useStore } from '@nanostores/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { getNeedsUpdate } from 'features/nodes/util/node/nodeUpdate';
-
-const selector = createSelector(selectNodesSlice, (nodes) =>
-  nodes.nodes.filter(isInvocationNode).some((node) => {
-    const template = nodes.templates[node.data.type];
-    if (!template) {
-      return false;
-    }
-    return getNeedsUpdate(node, template);
-  })
-);
+import { useMemo } from 'react';
 
 export const useGetNodesNeedUpdate = () => {
-  const getNeedsUpdate = useAppSelector(selector);
-  return getNeedsUpdate;
+  const templates = useStore($templates);
+  const selector = useMemo(
+    () =>
+      createSelector(selectNodesSlice, (nodes) =>
+        nodes.nodes.filter(isInvocationNode).some((node) => {
+          const template = templates[node.data.type];
+          if (!template) {
+            return false;
+          }
+          return getNeedsUpdate(node, template);
+        })
+      ),
+    [templates]
+  );
+  const needsUpdate = useAppSelector(selector);
+  return needsUpdate;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useHasImageOutput.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useHasImageOutput.ts
@@ -1,26 +1,20 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import { some } from 'lodash-es';
 import { useMemo } from 'react';
 
 export const useHasImageOutput = (nodeId: string): boolean => {
-  const selector = useMemo(
+  const template = useNodeTemplate(nodeId);
+  const hasImageOutput = useMemo(
     () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const template = selectNodeTemplate(nodes, nodeId);
-        return some(
-          template?.outputs,
-          (output) =>
-            output.type.name === 'ImageField' &&
-            // the image primitive node (node type "image") does not actually save the image, do not show the image-saving checkboxes
-            template?.type !== 'image'
-        );
-      }),
-    [nodeId]
+      some(
+        template?.outputs,
+        (output) =>
+          output.type.name === 'ImageField' &&
+          // the image primitive node (node type "image") does not actually save the image, do not show the image-saving checkboxes
+          template?.type !== 'image'
+      ),
+    [template]
   );
 
-  const hasImageOutput = useAppSelector(selector);
   return hasImageOutput;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
@@ -13,7 +13,7 @@ import type { Connection, Node } from 'reactflow';
 
 export const useIsValidConnection = () => {
   const store = useAppStore();
-  const shouldValidateGraph = useAppSelector((s) => s.nodes.present.shouldValidateGraph);
+  const shouldValidateGraph = useAppSelector((s) => s.workflowSettings.shouldValidateGraph);
   const isValidConnection = useCallback(
     ({ source, sourceHandle, target, targetHandle }: Connection): boolean => {
       // Connection must have valid targets

--- a/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
@@ -3,8 +3,10 @@ import { useStore } from '@nanostores/react';
 import { useAppSelector, useAppStore } from 'app/store/storeHooks';
 import { $templates } from 'features/nodes/store/nodesSlice';
 import { getIsGraphAcyclic } from 'features/nodes/store/util/getIsGraphAcyclic';
+import { getCollectItemType } from 'features/nodes/store/util/makeIsConnectionValidSelector';
 import { validateSourceAndTargetTypes } from 'features/nodes/store/util/validateSourceAndTargetTypes';
 import type { InvocationNodeData } from 'features/nodes/types/invocation';
+import { isEqual } from 'lodash-es';
 import { useCallback } from 'react';
 import type { Connection, Node } from 'reactflow';
 
@@ -58,6 +60,14 @@ export const useIsValidConnection = () => {
       ) {
         // We already have a connection from this source to this target
         return false;
+      }
+
+      if (targetNode.data.type === 'collect' && targetFieldTemplate.name === 'item') {
+        // Collect nodes shouldn't mix and match field types
+        const collectItemType = getCollectItemType(templates, nodes, edges, targetNode.id);
+        if (collectItemType) {
+          return isEqual(sourceFieldTemplate.type, collectItemType);
+        }
       }
 
       // Connection is invalid if target already has a connection

--- a/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
@@ -1,5 +1,7 @@
 // TODO: enable this at some point
+import { useStore } from '@nanostores/react';
 import { useAppSelector, useAppStore } from 'app/store/storeHooks';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { getIsGraphAcyclic } from 'features/nodes/store/util/getIsGraphAcyclic';
 import { validateSourceAndTargetTypes } from 'features/nodes/store/util/validateSourceAndTargetTypes';
 import type { InvocationNodeData } from 'features/nodes/types/invocation';
@@ -13,6 +15,7 @@ import type { Connection, Node } from 'reactflow';
 
 export const useIsValidConnection = () => {
   const store = useAppStore();
+  const templates = useStore($templates);
   const shouldValidateGraph = useAppSelector((s) => s.workflowSettings.shouldValidateGraph);
   const isValidConnection = useCallback(
     ({ source, sourceHandle, target, targetHandle }: Connection): boolean => {
@@ -27,7 +30,7 @@ export const useIsValidConnection = () => {
       }
 
       const state = store.getState();
-      const { nodes, edges, templates } = state.nodes.present;
+      const { nodes, edges } = state.nodes.present;
 
       // Find the source and target nodes
       const sourceNode = nodes.find((node) => node.id === source) as Node<InvocationNodeData>;
@@ -76,7 +79,7 @@ export const useIsValidConnection = () => {
       // Graphs much be acyclic (no loops!)
       return getIsGraphAcyclic(source, target, nodes, edges);
     },
-    [shouldValidateGraph, store]
+    [shouldValidateGraph, templates, store]
   );
 
   return isValidConnection;

--- a/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
@@ -13,7 +13,7 @@ import type { Connection, Node } from 'reactflow';
 
 export const useIsValidConnection = () => {
   const store = useAppStore();
-  const shouldValidateGraph = useAppSelector((s) => s.nodes.shouldValidateGraph);
+  const shouldValidateGraph = useAppSelector((s) => s.nodes.present.shouldValidateGraph);
   const isValidConnection = useCallback(
     ({ source, sourceHandle, target, targetHandle }: Connection): boolean => {
       // Connection must have valid targets
@@ -27,7 +27,7 @@ export const useIsValidConnection = () => {
       }
 
       const state = store.getState();
-      const { nodes, edges, templates } = state.nodes;
+      const { nodes, edges, templates } = state.nodes.present;
 
       // Find the source and target nodes
       const sourceNode = nodes.find((node) => node.id === source) as Node<InvocationNodeData>;

--- a/invokeai/frontend/web/src/features/nodes/hooks/useNodeClassification.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useNodeClassification.ts
@@ -1,19 +1,9 @@
-import { createSelector } from '@reduxjs/toolkit';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import type { Classification } from 'features/nodes/types/common';
 import { useMemo } from 'react';
 
-export const useNodeClassification = (nodeId: string): Classification | null => {
-  const selector = useMemo(
-    () =>
-      createSelector(selectNodesSlice, (nodes) => {
-        return selectNodeTemplate(nodes, nodeId)?.classification ?? null;
-      }),
-    [nodeId]
-  );
-
-  const title = useAppSelector(selector);
-  return title;
+export const useNodeClassification = (nodeId: string): Classification => {
+  const template = useNodeTemplate(nodeId);
+  const classification = useMemo(() => template.classification, [template]);
+  return classification;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useNodeData.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useNodeData.ts
@@ -5,7 +5,7 @@ import { selectNodeData } from 'features/nodes/store/selectors';
 import type { InvocationNodeData } from 'features/nodes/types/invocation';
 import { useMemo } from 'react';
 
-export const useNodeData = (nodeId: string): InvocationNodeData | null => {
+export const useNodeData = (nodeId: string): InvocationNodeData => {
   const selector = useMemo(
     () =>
       createMemoizedSelector(selectNodesSlice, (nodes) => {

--- a/invokeai/frontend/web/src/features/nodes/hooks/useNodeNeedsUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useNodeNeedsUpdate.ts
@@ -1,25 +1,11 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectInvocationNode, selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeData } from 'features/nodes/hooks/useNodeData';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import { getNeedsUpdate } from 'features/nodes/util/node/nodeUpdate';
 import { useMemo } from 'react';
 
 export const useNodeNeedsUpdate = (nodeId: string) => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const node = selectInvocationNode(nodes, nodeId);
-        const template = selectNodeTemplate(nodes, nodeId);
-        if (!node || !template) {
-          return false;
-        }
-        return getNeedsUpdate(node, template);
-      }),
-    [nodeId]
-  );
-
-  const needsUpdate = useAppSelector(selector);
-
+  const data = useNodeData(nodeId);
+  const template = useNodeTemplate(nodeId);
+  const needsUpdate = useMemo(() => getNeedsUpdate(data, template), [data, template]);
   return needsUpdate;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useNodeTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useNodeTemplate.ts
@@ -1,20 +1,23 @@
+import { useStore } from '@nanostores/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { $templates, selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import { selectInvocationNodeType } from 'features/nodes/store/selectors';
 import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import { useMemo } from 'react';
+import { assert } from 'tsafe';
 
-export const useNodeTemplate = (nodeId: string): InvocationTemplate | null => {
-  const selector = useMemo(
-    () =>
-      createSelector(selectNodesSlice, (nodes) => {
-        return selectNodeTemplate(nodes, nodeId);
-      }),
+export const useNodeTemplate = (nodeId: string): InvocationTemplate => {
+  const templates = useStore($templates);
+  const selectNodeType = useMemo(
+    () => createSelector(selectNodesSlice, (nodes) => selectInvocationNodeType(nodes, nodeId)),
     [nodeId]
   );
-
-  const nodeTemplate = useAppSelector(selector);
-
-  return nodeTemplate;
+  const nodeType = useAppSelector(selectNodeType);
+  const template = useMemo(() => {
+    const t = templates[nodeType];
+    assert(t, `Template for node type ${nodeType} not found`);
+    return t;
+  }, [nodeType, templates]);
+  return template;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useNodeTemplateTitle.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useNodeTemplateTitle.ts
@@ -1,18 +1,8 @@
-import { createSelector } from '@reduxjs/toolkit';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import { useMemo } from 'react';
 
 export const useNodeTemplateTitle = (nodeId: string): string | null => {
-  const selector = useMemo(
-    () =>
-      createSelector(selectNodesSlice, (nodes) => {
-        return selectNodeTemplate(nodes, nodeId)?.title ?? null;
-      }),
-    [nodeId]
-  );
-
-  const title = useAppSelector(selector);
+  const template = useNodeTemplate(nodeId);
+  const title = useMemo(() => template.title, [template.title]);
   return title;
 };

--- a/invokeai/frontend/web/src/features/nodes/hooks/useOutputFieldNames.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useOutputFieldNames.ts
@@ -1,26 +1,10 @@
-import { EMPTY_ARRAY } from 'app/store/constants';
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
-import { selectNodeTemplate } from 'features/nodes/store/selectors';
+import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
 import { getSortedFilteredFieldNames } from 'features/nodes/util/node/getSortedFilteredFieldNames';
 import { map } from 'lodash-es';
 import { useMemo } from 'react';
 
-export const useOutputFieldNames = (nodeId: string) => {
-  const selector = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodes) => {
-        const template = selectNodeTemplate(nodes, nodeId);
-        if (!template) {
-          return EMPTY_ARRAY;
-        }
-
-        return getSortedFilteredFieldNames(map(template.outputs));
-      }),
-    [nodeId]
-  );
-
-  const fieldNames = useAppSelector(selector);
+export const useOutputFieldNames = (nodeId: string): string[] => {
+  const template = useNodeTemplate(nodeId);
+  const fieldNames = useMemo(() => getSortedFilteredFieldNames(map(template.outputs)), [template.outputs]);
   return fieldNames;
 };

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -760,6 +760,14 @@ export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
 export const $pendingConnection = atom<PendingConnection | null>(null);
 export const $isModifyingEdge = atom(false);
+export const $isAddNodePopoverOpen = atom(false);
+export const closeAddNodePopover = () => {
+  $isAddNodePopoverOpen.set(false);
+  $pendingConnection.set(null);
+};
+export const openAddNodePopover = () => {
+  $isAddNodePopoverOpen.set(true);
+};
 
 export const selectNodesSlice = (state: RootState) => state.nodes.present;
 

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -57,15 +57,7 @@ import type {
   Viewport,
   XYPosition,
 } from 'reactflow';
-import {
-  addEdge,
-  applyEdgeChanges,
-  applyNodeChanges,
-  getConnectedEdges,
-  getIncomers,
-  getOutgoers,
-  SelectionMode,
-} from 'reactflow';
+import { addEdge, applyEdgeChanges, applyNodeChanges, getConnectedEdges, getIncomers, getOutgoers } from 'reactflow';
 import type { UndoableOptions } from 'redux-undo';
 import {
   socketGeneratorProgress,
@@ -99,21 +91,13 @@ const initialNodesState: NodesState = {
   connectionMade: false,
   modifyingEdge: false,
   addNewNodePosition: null,
-  shouldShowMinimapPanel: true,
-  shouldValidateGraph: true,
-  shouldAnimateEdges: true,
-  shouldSnapToGrid: false,
-  shouldColorEdges: true,
-  shouldShowEdgeLabels: false,
   isAddNodePopoverOpen: false,
-  nodeOpacity: 1,
   selectedNodes: [],
   selectedEdges: [],
   nodeExecutionStates: {},
   viewport: { x: 0, y: 0, zoom: 1 },
   nodesToCopy: [],
   edgesToCopy: [],
-  selectionMode: SelectionMode.Partial,
 };
 
 type FieldValueAction<T extends FieldValue> = PayloadAction<{
@@ -538,30 +522,9 @@ export const nodesSlice = createSlice({
       }
       node.data.notes = value;
     },
-    shouldShowMinimapPanelChanged: (state, action: PayloadAction<boolean>) => {
-      state.shouldShowMinimapPanel = action.payload;
-    },
     nodeEditorReset: (state) => {
       state.nodes = [];
       state.edges = [];
-    },
-    shouldValidateGraphChanged: (state, action: PayloadAction<boolean>) => {
-      state.shouldValidateGraph = action.payload;
-    },
-    shouldAnimateEdgesChanged: (state, action: PayloadAction<boolean>) => {
-      state.shouldAnimateEdges = action.payload;
-    },
-    shouldShowEdgeLabelsChanged: (state, action: PayloadAction<boolean>) => {
-      state.shouldShowEdgeLabels = action.payload;
-    },
-    shouldSnapToGridChanged: (state, action: PayloadAction<boolean>) => {
-      state.shouldSnapToGrid = action.payload;
-    },
-    shouldColorEdgesChanged: (state, action: PayloadAction<boolean>) => {
-      state.shouldColorEdges = action.payload;
-    },
-    nodeOpacityChanged: (state, action: PayloadAction<number>) => {
-      state.nodeOpacity = action.payload;
     },
     viewportChanged: (state, action: PayloadAction<Viewport>) => {
       state.viewport = action.payload;
@@ -700,9 +663,6 @@ export const nodesSlice = createSlice({
       state.connectionStartParams = null;
       state.connectionStartFieldType = null;
     },
-    selectionModeChanged: (state, action: PayloadAction<boolean>) => {
-      state.selectionMode = action.payload ? SelectionMode.Full : SelectionMode.Partial;
-    },
     nodeTemplatesBuilt: (state, action: PayloadAction<Record<string, InvocationTemplate>>) => {
       state.templates = action.payload;
     },
@@ -819,7 +779,6 @@ export const {
   nodeIsOpenChanged,
   nodeLabelChanged,
   nodeNotesChanged,
-  nodeOpacityChanged,
   nodesChanged,
   nodesDeleted,
   nodeUseCacheChanged,
@@ -828,17 +787,10 @@ export const {
   selectedEdgesChanged,
   selectedNodesChanged,
   selectionCopied,
-  selectionModeChanged,
   selectionPasted,
-  shouldAnimateEdgesChanged,
-  shouldColorEdgesChanged,
-  shouldShowMinimapPanelChanged,
-  shouldSnapToGridChanged,
-  shouldValidateGraphChanged,
   viewportChanged,
   edgeAdded,
   nodeTemplatesBuilt,
-  shouldShowEdgeLabelsChanged,
   undo,
   redo,
 } = nodesSlice.actions;

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -43,12 +43,7 @@ import {
   zT2IAdapterModelFieldValue,
   zVAEModelFieldValue,
 } from 'features/nodes/types/field';
-import type {
-  AnyNode,
-  InvocationNodeEdge,
-  InvocationTemplate,
-  NodeExecutionState,
-} from 'features/nodes/types/invocation';
+import type { AnyNode, InvocationNodeEdge, NodeExecutionState } from 'features/nodes/types/invocation';
 import { isInvocationNode, isNotesNode, zNodeStatus } from 'features/nodes/types/invocation';
 import { forEach } from 'lodash-es';
 import { atom } from 'nanostores';
@@ -74,7 +69,7 @@ import {
 } from 'services/events/actions';
 import type { z } from 'zod';
 
-import type { NodesState } from './types';
+import type { NodesState, Templates } from './types';
 import { findConnectionToValidHandle } from './util/findConnectionToValidHandle';
 import { findUnoccupiedPosition } from './util/findUnoccupiedPosition';
 
@@ -766,7 +761,7 @@ export const isAnyNodeOrEdgeMutation = isAnyOf(
 );
 
 export const $cursorPos = atom<XYPosition | null>(null);
-export const $templates = atom<Record<string, InvocationTemplate>>({});
+export const $templates = atom<Templates>({});
 export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
 

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -592,7 +592,7 @@ export const $templates = atom<Templates>({});
 export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
 export const $pendingConnection = atom<PendingConnection | null>(null);
-export const $isModifyingEdge = atom(false);
+export const $isUpdatingEdge = atom(false);
 export const $viewport = atom<Viewport>({ x: 0, y: 0, zoom: 1 });
 export const $isAddNodePopoverOpen = atom(false);
 export const closeAddNodePopover = () => {

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -602,9 +602,6 @@ export const nodesSlice = createSlice({
       state.connectionStartParams = null;
       state.connectionStartFieldType = null;
     },
-    nodeTemplatesBuilt: (state, action: PayloadAction<Record<string, InvocationTemplate>>) => {
-      state.templates = action.payload;
-    },
     undo: (state) => state,
     redo: (state) => state,
   },
@@ -728,7 +725,6 @@ export const {
   selectionPasted,
   viewportChanged,
   edgeAdded,
-  nodeTemplatesBuilt,
   undo,
   redo,
 } = nodesSlice.actions;
@@ -770,6 +766,7 @@ export const isAnyNodeOrEdgeMutation = isAnyOf(
 );
 
 export const $cursorPos = atom<XYPosition | null>(null);
+export const $templates = atom<Record<string, InvocationTemplate>>({});
 export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
 

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -69,7 +69,7 @@ import {
 } from 'services/events/actions';
 import type { z } from 'zod';
 
-import type { NodesState, Templates } from './types';
+import type { NodesState, PendingConnection, Templates } from './types';
 import { findConnectionToValidHandle } from './util/findConnectionToValidHandle';
 import { findUnoccupiedPosition } from './util/findUnoccupiedPosition';
 
@@ -215,13 +215,7 @@ export const nodesSlice = createSlice({
       state.connectionStartFieldType = field?.type ?? null;
     },
     connectionMade: (state, action: PayloadAction<Connection>) => {
-      const fieldType = state.connectionStartFieldType;
-      if (!fieldType) {
-        return;
-      }
       state.edges = addEdge({ ...action.payload, type: 'default' }, state.edges);
-
-      state.connectionMade = true;
     },
     connectionEnded: (
       state,
@@ -764,6 +758,8 @@ export const $cursorPos = atom<XYPosition | null>(null);
 export const $templates = atom<Templates>({});
 export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
+export const $pendingConnection = atom<PendingConnection | null>(null);
+export const $isModifyingEdge = atom(false);
 
 export const selectNodesSlice = (state: RootState) => state.nodes.present;
 

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -75,7 +75,6 @@ const initialNodesState: NodesState = {
   nodes: [],
   edges: [],
   nodeExecutionStates: {},
-  viewport: { x: 0, y: 0, zoom: 1 },
 };
 
 type FieldValueAction<T extends FieldValue> = PayloadAction<{
@@ -410,9 +409,6 @@ export const nodesSlice = createSlice({
       state.nodes = [];
       state.edges = [];
     },
-    viewportChanged: (state, action: PayloadAction<Viewport>) => {
-      state.viewport = action.payload;
-    },
     selectedAll: (state) => {
       state.nodes = applyNodeChanges(
         state.nodes.map((n) => ({ id: n.id, type: 'select', selected: true })),
@@ -586,7 +582,6 @@ export const {
   notesNodeValueChanged,
   selectedAll,
   selectionPasted,
-  viewportChanged,
   edgeAdded,
   undo,
   redo,
@@ -598,6 +593,7 @@ export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
 export const $pendingConnection = atom<PendingConnection | null>(null);
 export const $isModifyingEdge = atom(false);
+export const $viewport = atom<Viewport>({ x: 0, y: 0, zoom: 1 });
 export const $isAddNodePopoverOpen = atom(false);
 export const closeAddNodePopover = () => {
   $isAddNodePopoverOpen.set(false);
@@ -638,7 +634,7 @@ const isSelectionAction = (action: UnknownAction) => {
   return false;
 };
 
-const individualGroupByMatcher = isAnyOf(nodesChanged, viewportChanged);
+const individualGroupByMatcher = isAnyOf(nodesChanged);
 
 export const nodesUndoableConfig: UndoableOptions<NodesState, UnknownAction> = {
   limit: 64,

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -651,6 +651,10 @@ export const nodesUndoableConfig: UndoableOptions<NodesState, UnknownAction> = {
     return null;
   },
   filter: (action, _state, _history) => {
+    // Ignore all actions from other slices
+    if (!action.type.startsWith(nodesSlice.name)) {
+      return false;
+    }
     if (nodesChanged.match(action)) {
       if (action.payload.every((change) => change.type === 'dimensions')) {
         return false;

--- a/invokeai/frontend/web/src/features/nodes/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/selectors.ts
@@ -1,6 +1,6 @@
 import type { NodesState } from 'features/nodes/store/types';
 import type { FieldInputInstance, FieldInputTemplate, FieldOutputTemplate } from 'features/nodes/types/field';
-import type { InvocationNode, InvocationNodeData, InvocationTemplate } from 'features/nodes/types/invocation';
+import type { InvocationNode, InvocationNodeData } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 
 export const selectInvocationNode = (nodesSlice: NodesState, nodeId: string): InvocationNode | null => {
@@ -13,14 +13,6 @@ export const selectInvocationNode = (nodesSlice: NodesState, nodeId: string): In
 
 export const selectNodeData = (nodesSlice: NodesState, nodeId: string): InvocationNodeData | null => {
   return selectInvocationNode(nodesSlice, nodeId)?.data ?? null;
-};
-
-export const selectNodeTemplate = (nodesSlice: NodesState, nodeId: string): InvocationTemplate | null => {
-  const node = selectInvocationNode(nodesSlice, nodeId);
-  if (!node) {
-    return null;
-  }
-  return nodesSlice.templates[node.data.type] ?? null;
 };
 
 export const selectFieldInputInstance = (

--- a/invokeai/frontend/web/src/features/nodes/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/selectors.ts
@@ -4,7 +4,7 @@ import type { InvocationNode, InvocationNodeData } from 'features/nodes/types/in
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { assert } from 'tsafe';
 
-export const selectInvocationNode = (nodesSlice: NodesState, nodeId: string): InvocationNode => {
+const selectInvocationNode = (nodesSlice: NodesState, nodeId: string): InvocationNode => {
   const node = nodesSlice.nodes.find((node) => node.id === nodeId);
   assert(isInvocationNode(node), `Node ${nodeId} is not an invocation node`);
   return node;

--- a/invokeai/frontend/web/src/features/nodes/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/selectors.ts
@@ -1,18 +1,23 @@
 import type { NodesState } from 'features/nodes/store/types';
-import type { FieldInputInstance, FieldInputTemplate, FieldOutputTemplate } from 'features/nodes/types/field';
+import type { FieldInputInstance } from 'features/nodes/types/field';
 import type { InvocationNode, InvocationNodeData } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
+import { assert } from 'tsafe';
 
-export const selectInvocationNode = (nodesSlice: NodesState, nodeId: string): InvocationNode | null => {
+export const selectInvocationNode = (nodesSlice: NodesState, nodeId: string): InvocationNode => {
   const node = nodesSlice.nodes.find((node) => node.id === nodeId);
-  if (!isInvocationNode(node)) {
-    return null;
-  }
+  assert(isInvocationNode(node), `Node ${nodeId} is not an invocation node`);
   return node;
 };
 
-export const selectNodeData = (nodesSlice: NodesState, nodeId: string): InvocationNodeData | null => {
-  return selectInvocationNode(nodesSlice, nodeId)?.data ?? null;
+export const selectInvocationNodeType = (nodesSlice: NodesState, nodeId: string): string => {
+  const node = selectInvocationNode(nodesSlice, nodeId);
+  return node.data.type;
+};
+
+export const selectNodeData = (nodesSlice: NodesState, nodeId: string): InvocationNodeData => {
+  const node = selectInvocationNode(nodesSlice, nodeId);
+  return node.data;
 };
 
 export const selectFieldInputInstance = (
@@ -22,22 +27,4 @@ export const selectFieldInputInstance = (
 ): FieldInputInstance | null => {
   const data = selectNodeData(nodesSlice, nodeId);
   return data?.inputs[fieldName] ?? null;
-};
-
-export const selectFieldInputTemplate = (
-  nodesSlice: NodesState,
-  nodeId: string,
-  fieldName: string
-): FieldInputTemplate | null => {
-  const template = selectNodeTemplate(nodesSlice, nodeId);
-  return template?.inputs[fieldName] ?? null;
-};
-
-export const selectFieldOutputTemplate = (
-  nodesSlice: NodesState,
-  nodeId: string,
-  fieldName: string
-): FieldOutputTemplate | null => {
-  const template = selectNodeTemplate(nodesSlice, nodeId);
-  return template?.outputs[fieldName] ?? null;
 };

--- a/invokeai/frontend/web/src/features/nodes/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/selectors.ts
@@ -28,3 +28,11 @@ export const selectFieldInputInstance = (
   const data = selectNodeData(nodesSlice, nodeId);
   return data?.inputs[fieldName] ?? null;
 };
+
+export const selectLastSelectedNode = (nodesSlice: NodesState) => {
+  const selectedNodes = nodesSlice.nodes.filter((n) => n.selected);
+  if (selectedNodes.length === 1) {
+    return selectedNodes[0];
+  }
+  return null;
+};

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -12,7 +12,6 @@ import type {
   NodeExecutionState,
 } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
-import type { Viewport } from 'reactflow';
 
 export type Templates = Record<string, InvocationTemplate>;
 
@@ -27,7 +26,6 @@ export type NodesState = {
   nodes: AnyNode[];
   edges: InvocationNodeEdge[];
   nodeExecutionStates: Record<string, NodeExecutionState>;
-  viewport: Viewport;
 };
 
 export type WorkflowMode = 'edit' | 'view';

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -1,6 +1,13 @@
-import type { FieldIdentifier, FieldType, StatefulFieldValue } from 'features/nodes/types/field';
+import type {
+  FieldIdentifier,
+  FieldInputTemplate,
+  FieldOutputTemplate,
+  FieldType,
+  StatefulFieldValue,
+} from 'features/nodes/types/field';
 import type {
   AnyNode,
+  InvocationNode,
   InvocationNodeEdge,
   InvocationTemplate,
   NodeExecutionState,
@@ -9,6 +16,12 @@ import type { WorkflowV3 } from 'features/nodes/types/workflow';
 import type { OnConnectStartParams, Viewport, XYPosition } from 'reactflow';
 
 export type Templates = Record<string, InvocationTemplate>;
+
+export type PendingConnection = {
+  node: InvocationNode;
+  template: InvocationTemplate;
+  fieldTemplate: FieldInputTemplate | FieldOutputTemplate;
+};
 
 export type NodesState = {
   _version: 1;

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -14,6 +14,7 @@ import type {
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
 
 export type Templates = Record<string, InvocationTemplate>;
+export type NodeExecutionStates = Record<string, NodeExecutionState | undefined>;
 
 export type PendingConnection = {
   node: InvocationNode;
@@ -25,7 +26,6 @@ export type NodesState = {
   _version: 1;
   nodes: AnyNode[];
   edges: InvocationNodeEdge[];
-  nodeExecutionStates: Record<string, NodeExecutionState>;
 };
 
 export type WorkflowMode = 'edit' | 'view';

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -2,7 +2,6 @@ import type {
   FieldIdentifier,
   FieldInputTemplate,
   FieldOutputTemplate,
-  FieldType,
   StatefulFieldValue,
 } from 'features/nodes/types/field';
 import type {
@@ -13,7 +12,7 @@ import type {
   NodeExecutionState,
 } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
-import type { OnConnectStartParams, Viewport, XYPosition } from 'reactflow';
+import type { Viewport } from 'reactflow';
 
 export type Templates = Record<string, InvocationTemplate>;
 
@@ -27,16 +26,10 @@ export type NodesState = {
   _version: 1;
   nodes: AnyNode[];
   edges: InvocationNodeEdge[];
-  connectionStartParams: OnConnectStartParams | null;
-  connectionStartFieldType: FieldType | null;
-  connectionMade: boolean;
-  modifyingEdge: boolean;
   selectedNodes: string[];
   selectedEdges: string[];
   nodeExecutionStates: Record<string, NodeExecutionState>;
   viewport: Viewport;
-  isAddNodePopoverOpen: boolean;
-  addNewNodePosition: XYPosition | null;
 };
 
 export type WorkflowMode = 'edit' | 'view';

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -2,10 +2,13 @@ import type { FieldIdentifier, FieldType, StatefulFieldValue } from 'features/no
 import type {
   AnyNode,
   InvocationNodeEdge,
+  InvocationTemplate,
   NodeExecutionState,
 } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
 import type { OnConnectStartParams, Viewport, XYPosition } from 'reactflow';
+
+export type Templates = Record<string, InvocationTemplate>;
 
 export type NodesState = {
   _version: 1;

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -26,8 +26,6 @@ export type NodesState = {
   _version: 1;
   nodes: AnyNode[];
   edges: InvocationNodeEdge[];
-  selectedNodes: string[];
-  selectedEdges: string[];
   nodeExecutionStates: Record<string, NodeExecutionState>;
   viewport: Viewport;
 };

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -6,7 +6,7 @@ import type {
   NodeExecutionState,
 } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
-import type { OnConnectStartParams, SelectionMode, Viewport, XYPosition } from 'reactflow';
+import type { OnConnectStartParams, Viewport, XYPosition } from 'reactflow';
 
 export type NodesState = {
   _version: 1;
@@ -17,13 +17,6 @@ export type NodesState = {
   connectionStartFieldType: FieldType | null;
   connectionMade: boolean;
   modifyingEdge: boolean;
-  shouldShowMinimapPanel: boolean;
-  shouldValidateGraph: boolean;
-  shouldAnimateEdges: boolean;
-  nodeOpacity: number;
-  shouldSnapToGrid: boolean;
-  shouldColorEdges: boolean;
-  shouldShowEdgeLabels: boolean;
   selectedNodes: string[];
   selectedEdges: string[];
   nodeExecutionStates: Record<string, NodeExecutionState>;
@@ -32,7 +25,6 @@ export type NodesState = {
   edgesToCopy: InvocationNodeEdge[];
   isAddNodePopoverOpen: boolean;
   addNewNodePosition: XYPosition | null;
-  selectionMode: SelectionMode;
 };
 
 export type WorkflowMode = 'edit' | 'view';

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -21,8 +21,6 @@ export type NodesState = {
   selectedEdges: string[];
   nodeExecutionStates: Record<string, NodeExecutionState>;
   viewport: Viewport;
-  nodesToCopy: AnyNode[];
-  edgesToCopy: InvocationNodeEdge[];
   isAddNodePopoverOpen: boolean;
   addNewNodePosition: XYPosition | null;
 };

--- a/invokeai/frontend/web/src/features/nodes/store/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/types.ts
@@ -2,7 +2,6 @@ import type { FieldIdentifier, FieldType, StatefulFieldValue } from 'features/no
 import type {
   AnyNode,
   InvocationNodeEdge,
-  InvocationTemplate,
   NodeExecutionState,
 } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
@@ -12,7 +11,6 @@ export type NodesState = {
   _version: 1;
   nodes: AnyNode[];
   edges: InvocationNodeEdge[];
-  templates: Record<string, InvocationTemplate>;
   connectionStartParams: OnConnectStartParams | null;
   connectionStartFieldType: FieldType | null;
   connectionMade: boolean;

--- a/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
@@ -1,8 +1,10 @@
-import type { Templates } from 'features/nodes/store/types';
+import type { PendingConnection, Templates } from 'features/nodes/store/types';
 import type { FieldInputTemplate, FieldOutputTemplate, FieldType } from 'features/nodes/types/field';
-import type { AnyNode, InvocationNodeEdge } from 'features/nodes/types/invocation';
+import type { AnyNode, InvocationNode, InvocationNodeEdge, InvocationTemplate } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
+import { differenceWith, map } from 'lodash-es';
 import type { Connection, Edge, HandleType, Node } from 'reactflow';
+import { assert } from 'tsafe';
 
 import { getIsGraphAcyclic } from './getIsGraphAcyclic';
 import { validateSourceAndTargetTypes } from './validateSourceAndTargetTypes';
@@ -109,5 +111,100 @@ export const findConnectionToValidHandle = (
       };
     }
   }
+  return null;
+};
+
+export const getFirstValidConnection = (
+  nodes: AnyNode[],
+  edges: InvocationNodeEdge[],
+  pendingConnection: PendingConnection,
+  candidateNode: InvocationNode,
+  candidateTemplate: InvocationTemplate
+): Connection | null => {
+  if (pendingConnection.node.id === candidateNode.id) {
+    // Cannot connect to self
+    return null;
+  }
+
+  const pendingFieldKind = pendingConnection.fieldTemplate.fieldKind === 'input' ? 'target' : 'source';
+
+  if (pendingFieldKind === 'source') {
+    // Connecting from a source to a target
+    if (!getIsGraphAcyclic(pendingConnection.node.id, candidateNode.id, nodes, edges)) {
+      return null;
+    }
+    if (candidateNode.data.type === 'collect') {
+      // Special handling for collect node - the `item` field takes any number of connections
+      return {
+        source: pendingConnection.node.id,
+        sourceHandle: pendingConnection.fieldTemplate.name,
+        target: candidateNode.id,
+        targetHandle: 'item',
+      };
+    }
+    // Only one connection per target field is allowed - look for an unconnected target field
+    const candidateFields = map(candidateTemplate.inputs);
+    const candidateConnectedFields = edges
+      .filter((edge) => edge.target === candidateNode.id)
+      .map((edge) => {
+        // Edges must always have a targetHandle, safe to assert here
+        assert(edge.targetHandle);
+        return edge.targetHandle;
+      });
+    const candidateUnconnectedFields = differenceWith(
+      candidateFields,
+      candidateConnectedFields,
+      (field, connectedFieldName) => field.name === connectedFieldName
+    );
+    const candidateField = candidateUnconnectedFields.find((field) =>
+      validateSourceAndTargetTypes(pendingConnection.fieldTemplate.type, field.type)
+    );
+    if (candidateField) {
+      return {
+        source: pendingConnection.node.id,
+        sourceHandle: pendingConnection.fieldTemplate.name,
+        target: candidateNode.id,
+        targetHandle: candidateField.name,
+      };
+    }
+  } else {
+    // Connecting from a target to a source
+    // Ensure we there is not already an edge to the target
+    if (
+      edges.some(
+        (e) => e.target === pendingConnection.node.id && e.targetHandle === pendingConnection.fieldTemplate.name
+      )
+    ) {
+      return null;
+    }
+
+    if (!getIsGraphAcyclic(candidateNode.id, pendingConnection.node.id, nodes, edges)) {
+      return null;
+    }
+
+    if (candidateNode.data.type === 'collect') {
+      // Special handling for collect node - connect to the `collection` field
+      return {
+        source: candidateNode.id,
+        sourceHandle: 'collection',
+        target: pendingConnection.node.id,
+        targetHandle: pendingConnection.fieldTemplate.name,
+      };
+    }
+    // Sources/outputs can have any number of edges, we can take the first matching output field
+    const candidateFields = map(candidateTemplate.outputs);
+    const candidateField = candidateFields.find((field) =>
+      validateSourceAndTargetTypes(field.type, pendingConnection.fieldTemplate.type)
+    );
+    if (candidateField) {
+      return {
+        source: candidateNode.id,
+        sourceHandle: candidateField.name,
+        target: pendingConnection.node.id,
+        targetHandle: pendingConnection.fieldTemplate.name,
+      };
+    }
+  }
+
   return null;
 };

--- a/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
@@ -1,5 +1,6 @@
+import type { Templates } from 'features/nodes/store/types';
 import type { FieldInputTemplate, FieldOutputTemplate, FieldType } from 'features/nodes/types/field';
-import type { AnyNode, InvocationNodeEdge, InvocationTemplate } from 'features/nodes/types/invocation';
+import type { AnyNode, InvocationNodeEdge } from 'features/nodes/types/invocation';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import type { Connection, Edge, HandleType, Node } from 'reactflow';
 
@@ -43,7 +44,7 @@ export const findConnectionToValidHandle = (
   node: AnyNode,
   nodes: AnyNode[],
   edges: InvocationNodeEdge[],
-  templates: Record<string, InvocationTemplate>,
+  templates: Templates,
   handleCurrentNodeId: string,
   handleCurrentName: string,
   handleCurrentType: HandleType,

--- a/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
@@ -1,119 +1,12 @@
 import type { PendingConnection, Templates } from 'features/nodes/store/types';
 import { getCollectItemType } from 'features/nodes/store/util/makeIsConnectionValidSelector';
-import type { FieldInputTemplate, FieldOutputTemplate, FieldType } from 'features/nodes/types/field';
 import type { AnyNode, InvocationNode, InvocationNodeEdge, InvocationTemplate } from 'features/nodes/types/invocation';
-import { isInvocationNode } from 'features/nodes/types/invocation';
 import { differenceWith, isEqual, map } from 'lodash-es';
-import type { Connection, Edge, HandleType, Node } from 'reactflow';
+import type { Connection } from 'reactflow';
 import { assert } from 'tsafe';
 
 import { getIsGraphAcyclic } from './getIsGraphAcyclic';
 import { validateSourceAndTargetTypes } from './validateSourceAndTargetTypes';
-
-const isValidConnection = (
-  edges: Edge[],
-  handleCurrentType: HandleType,
-  handleCurrentFieldType: FieldType,
-  node: Node,
-  handle: FieldInputTemplate | FieldOutputTemplate
-) => {
-  let isValidConnection = true;
-  if (handleCurrentType === 'source') {
-    if (
-      edges.find((edge) => {
-        return edge.target === node.id && edge.targetHandle === handle.name;
-      })
-    ) {
-      isValidConnection = false;
-    }
-  } else {
-    if (
-      edges.find((edge) => {
-        return edge.source === node.id && edge.sourceHandle === handle.name;
-      })
-    ) {
-      isValidConnection = false;
-    }
-  }
-
-  if (!validateSourceAndTargetTypes(handleCurrentFieldType, handle.type)) {
-    isValidConnection = false;
-  }
-
-  return isValidConnection;
-};
-
-export const findConnectionToValidHandle = (
-  node: AnyNode,
-  nodes: AnyNode[],
-  edges: InvocationNodeEdge[],
-  templates: Templates,
-  handleCurrentNodeId: string,
-  handleCurrentName: string,
-  handleCurrentType: HandleType,
-  handleCurrentFieldType: FieldType
-): Connection | null => {
-  if (node.id === handleCurrentNodeId || !isInvocationNode(node)) {
-    return null;
-  }
-
-  const template = templates[node.data.type];
-
-  if (!template) {
-    return null;
-  }
-
-  const handles = handleCurrentType === 'source' ? template.inputs : template.outputs;
-
-  //Prioritize handles whos name matches the node we're coming from
-  const handle = handles[handleCurrentName];
-
-  if (handle) {
-    const sourceID = handleCurrentType === 'source' ? handleCurrentNodeId : node.id;
-    const targetID = handleCurrentType === 'source' ? node.id : handleCurrentNodeId;
-    const sourceHandle = handleCurrentType === 'source' ? handleCurrentName : handle.name;
-    const targetHandle = handleCurrentType === 'source' ? handle.name : handleCurrentName;
-
-    const isGraphAcyclic = getIsGraphAcyclic(sourceID, targetID, nodes, edges);
-
-    const valid = isValidConnection(edges, handleCurrentType, handleCurrentFieldType, node, handle);
-
-    if (isGraphAcyclic && valid) {
-      return {
-        source: sourceID,
-        sourceHandle: sourceHandle,
-        target: targetID,
-        targetHandle: targetHandle,
-      };
-    }
-  }
-
-  for (const handleName in handles) {
-    const handle = handles[handleName];
-    if (!handle) {
-      continue;
-    }
-
-    const sourceID = handleCurrentType === 'source' ? handleCurrentNodeId : node.id;
-    const targetID = handleCurrentType === 'source' ? node.id : handleCurrentNodeId;
-    const sourceHandle = handleCurrentType === 'source' ? handleCurrentName : handle.name;
-    const targetHandle = handleCurrentType === 'source' ? handle.name : handleCurrentName;
-
-    const isGraphAcyclic = getIsGraphAcyclic(sourceID, targetID, nodes, edges);
-
-    const valid = isValidConnection(edges, handleCurrentType, handleCurrentFieldType, node, handle);
-
-    if (isGraphAcyclic && valid) {
-      return {
-        source: sourceID,
-        sourceHandle: sourceHandle,
-        target: targetID,
-        targetHandle: targetHandle,
-      };
-    }
-  }
-  return null;
-};
 
 export const getFirstValidConnection = (
   templates: Templates,

--- a/invokeai/frontend/web/src/features/nodes/store/util/findUnoccupiedPosition.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/findUnoccupiedPosition.ts
@@ -4,8 +4,8 @@ export const findUnoccupiedPosition = (nodes: Node[], x: number, y: number) => {
   let newX = x;
   let newY = y;
   while (nodes.find((n) => n.position.x === newX && n.position.y === newY)) {
-    newX = newX + 50;
-    newY = newY + 50;
+    newX = Math.floor(newX + 50);
+    newY = Math.floor(newY + 50);
   }
   return { x: newX, y: newY };
 };

--- a/invokeai/frontend/web/src/features/nodes/store/util/makeIsConnectionValidSelector.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/makeIsConnectionValidSelector.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
+import type { PendingConnection } from 'features/nodes/store/types';
 import type { FieldType } from 'features/nodes/types/field';
 import i18n from 'i18next';
 import type { HandleType } from 'reactflow';
@@ -13,27 +14,27 @@ import { validateSourceAndTargetTypes } from './validateSourceAndTargetTypes';
  */
 
 export const makeConnectionErrorSelector = (
+  pendingConnection: PendingConnection | null,
   nodeId: string,
   fieldName: string,
   handleType: HandleType,
   fieldType?: FieldType | null
 ) => {
   return createSelector(selectNodesSlice, (nodesSlice) => {
+    const { nodes, edges } = nodesSlice;
+
     if (!fieldType) {
       return i18n.t('nodes.noFieldType');
     }
 
-    const { connectionStartFieldType, connectionStartParams, nodes, edges } = nodesSlice;
-
-    if (!connectionStartParams || !connectionStartFieldType) {
+    if (!pendingConnection) {
       return i18n.t('nodes.noConnectionInProgress');
     }
 
-    const {
-      handleType: connectionHandleType,
-      nodeId: connectionNodeId,
-      handleId: connectionFieldName,
-    } = connectionStartParams;
+    const connectionNodeId = pendingConnection.node.id;
+    const connectionFieldName = pendingConnection.fieldTemplate.name;
+    const connectionHandleType = pendingConnection.fieldTemplate.fieldKind === 'input' ? 'target' : 'source';
+    const connectionStartFieldType = pendingConnection.fieldTemplate.type;
 
     if (!connectionHandleType || !connectionNodeId || !connectionFieldName) {
       return i18n.t('nodes.noConnectionData');

--- a/invokeai/frontend/web/src/features/nodes/store/workflowSettingsSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/workflowSettingsSlice.ts
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { PersistConfig, RootState } from 'app/store/store';
 import { SelectionMode } from 'reactflow';
 
-export type WorkflowSettingsState = {
+type WorkflowSettingsState = {
   _version: 1;
   shouldShowMinimapPanel: boolean;
   shouldValidateGraph: boolean;

--- a/invokeai/frontend/web/src/features/nodes/store/workflowSettingsSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/workflowSettingsSlice.ts
@@ -1,0 +1,87 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+import type { PersistConfig, RootState } from 'app/store/store';
+import { SelectionMode } from 'reactflow';
+
+export type WorkflowSettingsState = {
+  _version: 1;
+  shouldShowMinimapPanel: boolean;
+  shouldValidateGraph: boolean;
+  shouldAnimateEdges: boolean;
+  nodeOpacity: number;
+  shouldSnapToGrid: boolean;
+  shouldColorEdges: boolean;
+  shouldShowEdgeLabels: boolean;
+  selectionMode: SelectionMode;
+};
+
+const initialState: WorkflowSettingsState = {
+  _version: 1,
+  shouldShowMinimapPanel: true,
+  shouldValidateGraph: true,
+  shouldAnimateEdges: true,
+  shouldSnapToGrid: false,
+  shouldColorEdges: true,
+  shouldShowEdgeLabels: false,
+  nodeOpacity: 1,
+  selectionMode: SelectionMode.Partial,
+};
+
+export const workflowSettingsSlice = createSlice({
+  name: 'workflowSettings',
+  initialState,
+  reducers: {
+    shouldShowMinimapPanelChanged: (state, action: PayloadAction<boolean>) => {
+      state.shouldShowMinimapPanel = action.payload;
+    },
+    shouldValidateGraphChanged: (state, action: PayloadAction<boolean>) => {
+      state.shouldValidateGraph = action.payload;
+    },
+    shouldAnimateEdgesChanged: (state, action: PayloadAction<boolean>) => {
+      state.shouldAnimateEdges = action.payload;
+    },
+    shouldShowEdgeLabelsChanged: (state, action: PayloadAction<boolean>) => {
+      state.shouldShowEdgeLabels = action.payload;
+    },
+    shouldSnapToGridChanged: (state, action: PayloadAction<boolean>) => {
+      state.shouldSnapToGrid = action.payload;
+    },
+    shouldColorEdgesChanged: (state, action: PayloadAction<boolean>) => {
+      state.shouldColorEdges = action.payload;
+    },
+    nodeOpacityChanged: (state, action: PayloadAction<number>) => {
+      state.nodeOpacity = action.payload;
+    },
+    selectionModeChanged: (state, action: PayloadAction<boolean>) => {
+      state.selectionMode = action.payload ? SelectionMode.Full : SelectionMode.Partial;
+    },
+  },
+});
+
+export const {
+  shouldAnimateEdgesChanged,
+  shouldColorEdgesChanged,
+  shouldShowMinimapPanelChanged,
+  shouldShowEdgeLabelsChanged,
+  shouldSnapToGridChanged,
+  shouldValidateGraphChanged,
+  nodeOpacityChanged,
+  selectionModeChanged,
+} = workflowSettingsSlice.actions;
+
+export const selectWorkflowSettingsSlice = (state: RootState) => state.workflowSettings;
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+const migrateWorkflowSettingsState = (state: any): any => {
+  if (!('_version' in state)) {
+    state._version = 1;
+  }
+  return state;
+};
+
+export const workflowSettingsPersistConfig: PersistConfig<WorkflowSettingsState> = {
+  name: workflowSettingsSlice.name,
+  initialState,
+  migrate: migrateWorkflowSettingsState,
+  persistDenylist: [],
+};

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
@@ -1,17 +1,17 @@
 import { deepClone } from 'common/util/deepClone';
 import { satisfies } from 'compare-versions';
 import { NodeUpdateError } from 'features/nodes/types/error';
-import type { InvocationNode, InvocationTemplate } from 'features/nodes/types/invocation';
+import type { InvocationNode, InvocationNodeData, InvocationTemplate } from 'features/nodes/types/invocation';
 import { zParsedSemver } from 'features/nodes/types/semver';
 import { defaultsDeep, keys, pick } from 'lodash-es';
 
 import { buildInvocationNode } from './buildInvocationNode';
 
-export const getNeedsUpdate = (node: InvocationNode, template: InvocationTemplate): boolean => {
-  if (node.data.type !== template.type) {
+export const getNeedsUpdate = (data: InvocationNodeData, template: InvocationTemplate): boolean => {
+  if (data.type !== template.type) {
     return true;
   }
-  return node.data.version !== template.version;
+  return data.version !== template.version;
 };
 
 /**
@@ -20,7 +20,7 @@ export const getNeedsUpdate = (node: InvocationNode, template: InvocationTemplat
  * @param template The invocation template to check against.
  */
 const getMayUpdateNode = (node: InvocationNode, template: InvocationTemplate): boolean => {
-  const needsUpdate = getNeedsUpdate(node, template);
+  const needsUpdate = getNeedsUpdate(node.data, template);
   if (!needsUpdate || node.data.type !== template.type) {
     return false;
   }

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.test.ts
@@ -1,0 +1,814 @@
+import { parseSchema } from 'features/nodes/util/schema/parseSchema';
+import { omit, pick } from 'lodash-es';
+import type { OpenAPIV3_1 } from 'openapi-types';
+import { describe, expect, it } from 'vitest';
+
+describe('parseSchema', () => {
+  it('should parse the schema', () => {
+    const templates = parseSchema(schema);
+    expect(templates).toEqual(expected);
+  });
+  it('should omit denied nodes', () => {
+    const templates = parseSchema(schema, undefined, ['add']);
+    expect(templates).toEqual(omit(expected, 'add'));
+  });
+  it('should include only allowed nodes', () => {
+    const templates = parseSchema(schema, ['add']);
+    expect(templates).toEqual(pick(expected, 'add'));
+  });
+});
+
+const expected = {
+  add: {
+    title: 'Add Integers',
+    type: 'add',
+    version: '1.0.1',
+    tags: ['math', 'add'],
+    description: 'Adds two numbers',
+    outputType: 'integer_output',
+    inputs: {
+      a: {
+        name: 'a',
+        title: 'A',
+        required: false,
+        description: 'The first number',
+        fieldKind: 'input',
+        input: 'any',
+        ui_hidden: false,
+        type: {
+          name: 'IntegerField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        default: 0,
+      },
+      b: {
+        name: 'b',
+        title: 'B',
+        required: false,
+        description: 'The second number',
+        fieldKind: 'input',
+        input: 'any',
+        ui_hidden: false,
+        type: {
+          name: 'IntegerField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        default: 0,
+      },
+    },
+    outputs: {
+      value: {
+        fieldKind: 'output',
+        name: 'value',
+        title: 'Value',
+        description: 'The output integer',
+        type: {
+          name: 'IntegerField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        ui_hidden: false,
+      },
+    },
+    useCache: true,
+    nodePack: 'invokeai',
+    classification: 'stable',
+  },
+  scheduler: {
+    title: 'Scheduler',
+    type: 'scheduler',
+    version: '1.0.0',
+    tags: ['scheduler'],
+    description: 'Selects a scheduler.',
+    outputType: 'scheduler_output',
+    inputs: {
+      scheduler: {
+        name: 'scheduler',
+        title: 'Scheduler',
+        required: false,
+        description: 'Scheduler to use during inference',
+        fieldKind: 'input',
+        input: 'any',
+        ui_hidden: false,
+        ui_type: 'SchedulerField',
+        type: {
+          name: 'SchedulerField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        default: 'euler',
+      },
+    },
+    outputs: {
+      scheduler: {
+        fieldKind: 'output',
+        name: 'scheduler',
+        title: 'Scheduler',
+        description: 'Scheduler to use during inference',
+        type: {
+          name: 'SchedulerField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        ui_hidden: false,
+        ui_type: 'SchedulerField',
+      },
+    },
+    useCache: true,
+    nodePack: 'invokeai',
+    classification: 'stable',
+  },
+  main_model_loader: {
+    title: 'Main Model',
+    type: 'main_model_loader',
+    version: '1.0.2',
+    tags: ['model'],
+    description: 'Loads a main model, outputting its submodels.',
+    outputType: 'model_loader_output',
+    inputs: {
+      model: {
+        name: 'model',
+        title: 'Model',
+        required: true,
+        description: 'Main model (UNet, VAE, CLIP) to load',
+        fieldKind: 'input',
+        input: 'direct',
+        ui_hidden: false,
+        ui_type: 'MainModelField',
+        type: {
+          name: 'MainModelField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+      },
+    },
+    outputs: {
+      vae: {
+        fieldKind: 'output',
+        name: 'vae',
+        title: 'VAE',
+        description: 'VAE',
+        type: {
+          name: 'VAEField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        ui_hidden: false,
+      },
+      clip: {
+        fieldKind: 'output',
+        name: 'clip',
+        title: 'CLIP',
+        description: 'CLIP (tokenizer, text encoder, LoRAs) and skipped layer count',
+        type: {
+          name: 'CLIPField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        ui_hidden: false,
+      },
+      unet: {
+        fieldKind: 'output',
+        name: 'unet',
+        title: 'UNet',
+        description: 'UNet (scheduler, LoRAs)',
+        type: {
+          name: 'UNetField',
+          isCollection: false,
+          isCollectionOrScalar: false,
+        },
+        ui_hidden: false,
+      },
+    },
+    useCache: true,
+    nodePack: 'invokeai',
+    classification: 'stable',
+  },
+};
+
+const schema = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Invoke - Community Edition',
+    description: 'An API for invoking AI image operations',
+    version: '1.0.0',
+  },
+  components: {
+    schemas: {
+      AddInvocation: {
+        properties: {
+          id: {
+            type: 'string',
+            title: 'Id',
+            description: 'The id of this instance of an invocation. Must be unique among all instances of invocations.',
+            field_kind: 'node_attribute',
+          },
+          is_intermediate: {
+            type: 'boolean',
+            title: 'Is Intermediate',
+            description: 'Whether or not this is an intermediate invocation.',
+            default: false,
+            field_kind: 'node_attribute',
+            ui_type: 'IsIntermediate',
+          },
+          use_cache: {
+            type: 'boolean',
+            title: 'Use Cache',
+            description: 'Whether or not to use the cache',
+            default: true,
+            field_kind: 'node_attribute',
+          },
+          a: {
+            type: 'integer',
+            title: 'A',
+            description: 'The first number',
+            default: 0,
+            field_kind: 'input',
+            input: 'any',
+            orig_default: 0,
+            orig_required: false,
+            ui_hidden: false,
+          },
+          b: {
+            type: 'integer',
+            title: 'B',
+            description: 'The second number',
+            default: 0,
+            field_kind: 'input',
+            input: 'any',
+            orig_default: 0,
+            orig_required: false,
+            ui_hidden: false,
+          },
+          type: {
+            type: 'string',
+            enum: ['add'],
+            const: 'add',
+            title: 'type',
+            default: 'add',
+            field_kind: 'node_attribute',
+          },
+        },
+        type: 'object',
+        required: ['type', 'id'],
+        title: 'Add Integers',
+        description: 'Adds two numbers',
+        category: 'math',
+        classification: 'stable',
+        node_pack: 'invokeai',
+        tags: ['math', 'add'],
+        version: '1.0.1',
+        output: {
+          $ref: '#/components/schemas/IntegerOutput',
+        },
+        class: 'invocation',
+      },
+      IntegerOutput: {
+        description: 'Base class for nodes that output a single integer',
+        properties: {
+          value: {
+            description: 'The output integer',
+            field_kind: 'output',
+            title: 'Value',
+            type: 'integer',
+            ui_hidden: false,
+          },
+          type: {
+            const: 'integer_output',
+            default: 'integer_output',
+            enum: ['integer_output'],
+            field_kind: 'node_attribute',
+            title: 'type',
+            type: 'string',
+          },
+        },
+        required: ['value', 'type', 'type'],
+        title: 'IntegerOutput',
+        type: 'object',
+        class: 'output',
+      },
+      SchedulerInvocation: {
+        properties: {
+          id: {
+            type: 'string',
+            title: 'Id',
+            description: 'The id of this instance of an invocation. Must be unique among all instances of invocations.',
+            field_kind: 'node_attribute',
+          },
+          is_intermediate: {
+            type: 'boolean',
+            title: 'Is Intermediate',
+            description: 'Whether or not this is an intermediate invocation.',
+            default: false,
+            field_kind: 'node_attribute',
+            ui_type: 'IsIntermediate',
+          },
+          use_cache: {
+            type: 'boolean',
+            title: 'Use Cache',
+            description: 'Whether or not to use the cache',
+            default: true,
+            field_kind: 'node_attribute',
+          },
+          scheduler: {
+            type: 'string',
+            enum: [
+              'ddim',
+              'ddpm',
+              'deis',
+              'lms',
+              'lms_k',
+              'pndm',
+              'heun',
+              'heun_k',
+              'euler',
+              'euler_k',
+              'euler_a',
+              'kdpm_2',
+              'kdpm_2_a',
+              'dpmpp_2s',
+              'dpmpp_2s_k',
+              'dpmpp_2m',
+              'dpmpp_2m_k',
+              'dpmpp_2m_sde',
+              'dpmpp_2m_sde_k',
+              'dpmpp_sde',
+              'dpmpp_sde_k',
+              'unipc',
+              'lcm',
+              'tcd',
+            ],
+            title: 'Scheduler',
+            description: 'Scheduler to use during inference',
+            default: 'euler',
+            field_kind: 'input',
+            input: 'any',
+            orig_default: 'euler',
+            orig_required: false,
+            ui_hidden: false,
+            ui_type: 'SchedulerField',
+          },
+          type: {
+            type: 'string',
+            enum: ['scheduler'],
+            const: 'scheduler',
+            title: 'type',
+            default: 'scheduler',
+            field_kind: 'node_attribute',
+          },
+        },
+        type: 'object',
+        required: ['type', 'id'],
+        title: 'Scheduler',
+        description: 'Selects a scheduler.',
+        category: 'latents',
+        classification: 'stable',
+        node_pack: 'invokeai',
+        tags: ['scheduler'],
+        version: '1.0.0',
+        output: {
+          $ref: '#/components/schemas/SchedulerOutput',
+        },
+        class: 'invocation',
+      },
+      SchedulerOutput: {
+        properties: {
+          scheduler: {
+            description: 'Scheduler to use during inference',
+            enum: [
+              'ddim',
+              'ddpm',
+              'deis',
+              'lms',
+              'lms_k',
+              'pndm',
+              'heun',
+              'heun_k',
+              'euler',
+              'euler_k',
+              'euler_a',
+              'kdpm_2',
+              'kdpm_2_a',
+              'dpmpp_2s',
+              'dpmpp_2s_k',
+              'dpmpp_2m',
+              'dpmpp_2m_k',
+              'dpmpp_2m_sde',
+              'dpmpp_2m_sde_k',
+              'dpmpp_sde',
+              'dpmpp_sde_k',
+              'unipc',
+              'lcm',
+              'tcd',
+            ],
+            field_kind: 'output',
+            title: 'Scheduler',
+            type: 'string',
+            ui_hidden: false,
+            ui_type: 'SchedulerField',
+          },
+          type: {
+            const: 'scheduler_output',
+            default: 'scheduler_output',
+            enum: ['scheduler_output'],
+            field_kind: 'node_attribute',
+            title: 'type',
+            type: 'string',
+          },
+        },
+        required: ['scheduler', 'type', 'type'],
+        title: 'SchedulerOutput',
+        type: 'object',
+        class: 'output',
+      },
+      MainModelLoaderInvocation: {
+        properties: {
+          id: {
+            type: 'string',
+            title: 'Id',
+            description: 'The id of this instance of an invocation. Must be unique among all instances of invocations.',
+            field_kind: 'node_attribute',
+          },
+          is_intermediate: {
+            type: 'boolean',
+            title: 'Is Intermediate',
+            description: 'Whether or not this is an intermediate invocation.',
+            default: false,
+            field_kind: 'node_attribute',
+            ui_type: 'IsIntermediate',
+          },
+          use_cache: {
+            type: 'boolean',
+            title: 'Use Cache',
+            description: 'Whether or not to use the cache',
+            default: true,
+            field_kind: 'node_attribute',
+          },
+          model: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Main model (UNet, VAE, CLIP) to load',
+            field_kind: 'input',
+            input: 'direct',
+            orig_required: true,
+            ui_hidden: false,
+            ui_type: 'MainModelField',
+          },
+          type: {
+            type: 'string',
+            enum: ['main_model_loader'],
+            const: 'main_model_loader',
+            title: 'type',
+            default: 'main_model_loader',
+            field_kind: 'node_attribute',
+          },
+        },
+        type: 'object',
+        required: ['model', 'type', 'id'],
+        title: 'Main Model',
+        description: 'Loads a main model, outputting its submodels.',
+        category: 'model',
+        classification: 'stable',
+        node_pack: 'invokeai',
+        tags: ['model'],
+        version: '1.0.2',
+        output: {
+          $ref: '#/components/schemas/ModelLoaderOutput',
+        },
+        class: 'invocation',
+      },
+      ModelIdentifierField: {
+        properties: {
+          key: {
+            description: "The model's unique key",
+            title: 'Key',
+            type: 'string',
+          },
+          hash: {
+            description: "The model's BLAKE3 hash",
+            title: 'Hash',
+            type: 'string',
+          },
+          name: {
+            description: "The model's name",
+            title: 'Name',
+            type: 'string',
+          },
+          base: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/BaseModelType',
+              },
+            ],
+            description: "The model's base model type",
+          },
+          type: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelType',
+              },
+            ],
+            description: "The model's type",
+          },
+          submodel_type: {
+            anyOf: [
+              {
+                $ref: '#/components/schemas/SubModelType',
+              },
+              {
+                type: 'null',
+              },
+            ],
+            default: null,
+            description: 'The submodel to load, if this is a main model',
+          },
+        },
+        required: ['key', 'hash', 'name', 'base', 'type'],
+        title: 'ModelIdentifierField',
+        type: 'object',
+      },
+      BaseModelType: {
+        description: 'Base model type.',
+        enum: ['any', 'sd-1', 'sd-2', 'sdxl', 'sdxl-refiner'],
+        title: 'BaseModelType',
+        type: 'string',
+      },
+      ModelType: {
+        description: 'Model type.',
+        enum: ['onnx', 'main', 'vae', 'lora', 'controlnet', 'embedding', 'ip_adapter', 'clip_vision', 't2i_adapter'],
+        title: 'ModelType',
+        type: 'string',
+      },
+      SubModelType: {
+        description: 'Submodel type.',
+        enum: [
+          'unet',
+          'text_encoder',
+          'text_encoder_2',
+          'tokenizer',
+          'tokenizer_2',
+          'vae',
+          'vae_decoder',
+          'vae_encoder',
+          'scheduler',
+          'safety_checker',
+        ],
+        title: 'SubModelType',
+        type: 'string',
+      },
+      ModelLoaderOutput: {
+        description: 'Model loader output',
+        properties: {
+          vae: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/VAEField',
+              },
+            ],
+            description: 'VAE',
+            field_kind: 'output',
+            title: 'VAE',
+            ui_hidden: false,
+          },
+          type: {
+            const: 'model_loader_output',
+            default: 'model_loader_output',
+            enum: ['model_loader_output'],
+            field_kind: 'node_attribute',
+            title: 'type',
+            type: 'string',
+          },
+          clip: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/CLIPField',
+              },
+            ],
+            description: 'CLIP (tokenizer, text encoder, LoRAs) and skipped layer count',
+            field_kind: 'output',
+            title: 'CLIP',
+            ui_hidden: false,
+          },
+          unet: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/UNetField',
+              },
+            ],
+            description: 'UNet (scheduler, LoRAs)',
+            field_kind: 'output',
+            title: 'UNet',
+            ui_hidden: false,
+          },
+        },
+        required: ['vae', 'type', 'clip', 'unet', 'type'],
+        title: 'ModelLoaderOutput',
+        type: 'object',
+        class: 'output',
+      },
+      VAEField: {
+        properties: {
+          vae: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Info to load vae submodel',
+          },
+          seamless_axes: {
+            description: 'Axes("x" and "y") to which apply seamless',
+            items: {
+              type: 'string',
+            },
+            title: 'Seamless Axes',
+            type: 'array',
+          },
+        },
+        required: ['vae'],
+        title: 'VAEField',
+        type: 'object',
+        class: 'output',
+      },
+    },
+    UNetField: {
+      properties: {
+        unet: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ModelIdentifierField',
+            },
+          ],
+          description: 'Info to load unet submodel',
+        },
+        scheduler: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ModelIdentifierField',
+            },
+          ],
+          description: 'Info to load scheduler submodel',
+        },
+        loras: {
+          description: 'LoRAs to apply on model loading',
+          items: {
+            $ref: '#/components/schemas/LoRAField',
+          },
+          title: 'Loras',
+          type: 'array',
+        },
+        seamless_axes: {
+          description: 'Axes("x" and "y") to which apply seamless',
+          items: {
+            type: 'string',
+          },
+          title: 'Seamless Axes',
+          type: 'array',
+        },
+        freeu_config: {
+          anyOf: [
+            {
+              $ref: '#/components/schemas/FreeUConfig',
+            },
+            {
+              type: 'null',
+            },
+          ],
+          default: null,
+          description: 'FreeU configuration',
+        },
+      },
+      required: ['unet', 'scheduler', 'loras'],
+      title: 'UNetField',
+      type: 'object',
+      class: 'output',
+    },
+    LoRAField: {
+      properties: {
+        lora: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ModelIdentifierField',
+            },
+          ],
+          description: 'Info to load lora model',
+        },
+        weight: {
+          description: 'Weight to apply to lora model',
+          title: 'Weight',
+          type: 'number',
+        },
+      },
+      required: ['lora', 'weight'],
+      title: 'LoRAField',
+      type: 'object',
+      class: 'output',
+    },
+    FreeUConfig: {
+      description:
+        'Configuration for the FreeU hyperparameters.\n- https://huggingface.co/docs/diffusers/main/en/using-diffusers/freeu\n- https://github.com/ChenyangSi/FreeU',
+      properties: {
+        s1: {
+          description:
+            'Scaling factor for stage 1 to attenuate the contributions of the skip features. This is done to mitigate the "oversmoothing effect" in the enhanced denoising process.',
+          maximum: 3.0,
+          minimum: -1.0,
+          title: 'S1',
+          type: 'number',
+        },
+        s2: {
+          description:
+            'Scaling factor for stage 2 to attenuate the contributions of the skip features. This is done to mitigate the "oversmoothing effect" in the enhanced denoising process.',
+          maximum: 3.0,
+          minimum: -1.0,
+          title: 'S2',
+          type: 'number',
+        },
+        b1: {
+          description: 'Scaling factor for stage 1 to amplify the contributions of backbone features.',
+          maximum: 3.0,
+          minimum: -1.0,
+          title: 'B1',
+          type: 'number',
+        },
+        b2: {
+          description: 'Scaling factor for stage 2 to amplify the contributions of backbone features.',
+          maximum: 3.0,
+          minimum: -1.0,
+          title: 'B2',
+          type: 'number',
+        },
+      },
+      required: ['s1', 's2', 'b1', 'b2'],
+      title: 'FreeUConfig',
+      type: 'object',
+      class: 'output',
+    },
+    VAEField: {
+      properties: {
+        vae: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ModelIdentifierField',
+            },
+          ],
+          description: 'Info to load vae submodel',
+        },
+        seamless_axes: {
+          description: 'Axes("x" and "y") to which apply seamless',
+          items: {
+            type: 'string',
+          },
+          title: 'Seamless Axes',
+          type: 'array',
+        },
+      },
+      required: ['vae'],
+      title: 'VAEField',
+      type: 'object',
+      class: 'output',
+    },
+    CLIPField: {
+      properties: {
+        tokenizer: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ModelIdentifierField',
+            },
+          ],
+          description: 'Info to load tokenizer submodel',
+        },
+        text_encoder: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ModelIdentifierField',
+            },
+          ],
+          description: 'Info to load text_encoder submodel',
+        },
+        skipped_layers: {
+          description: 'Number of skipped layers in text_encoder',
+          title: 'Skipped Layers',
+          type: 'integer',
+        },
+        loras: {
+          description: 'LoRAs to apply on model loading',
+          items: {
+            $ref: '#/components/schemas/LoRAField',
+          },
+          title: 'Loras',
+          type: 'array',
+        },
+      },
+      required: ['tokenizer', 'text_encoder', 'skipped_layers', 'loras'],
+      title: 'CLIPField',
+      type: 'object',
+      class: 'output',
+    },
+  },
+} as OpenAPIV3_1.Document;

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.test.ts
@@ -611,6 +611,119 @@ const schema = {
         type: 'object',
         class: 'output',
       },
+      UNetField: {
+        properties: {
+          unet: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Info to load unet submodel',
+          },
+          scheduler: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Info to load scheduler submodel',
+          },
+          loras: {
+            description: 'LoRAs to apply on model loading',
+            items: {
+              $ref: '#/components/schemas/LoRAField',
+            },
+            title: 'Loras',
+            type: 'array',
+          },
+          seamless_axes: {
+            description: 'Axes("x" and "y") to which apply seamless',
+            items: {
+              type: 'string',
+            },
+            title: 'Seamless Axes',
+            type: 'array',
+          },
+          freeu_config: {
+            anyOf: [
+              {
+                $ref: '#/components/schemas/FreeUConfig',
+              },
+              {
+                type: 'null',
+              },
+            ],
+            default: null,
+            description: 'FreeU configuration',
+          },
+        },
+        required: ['unet', 'scheduler', 'loras'],
+        title: 'UNetField',
+        type: 'object',
+        class: 'output',
+      },
+      LoRAField: {
+        properties: {
+          lora: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Info to load lora model',
+          },
+          weight: {
+            description: 'Weight to apply to lora model',
+            title: 'Weight',
+            type: 'number',
+          },
+        },
+        required: ['lora', 'weight'],
+        title: 'LoRAField',
+        type: 'object',
+        class: 'output',
+      },
+      FreeUConfig: {
+        description:
+          'Configuration for the FreeU hyperparameters.\n- https://huggingface.co/docs/diffusers/main/en/using-diffusers/freeu\n- https://github.com/ChenyangSi/FreeU',
+        properties: {
+          s1: {
+            description:
+              'Scaling factor for stage 1 to attenuate the contributions of the skip features. This is done to mitigate the "oversmoothing effect" in the enhanced denoising process.',
+            maximum: 3.0,
+            minimum: -1.0,
+            title: 'S1',
+            type: 'number',
+          },
+          s2: {
+            description:
+              'Scaling factor for stage 2 to attenuate the contributions of the skip features. This is done to mitigate the "oversmoothing effect" in the enhanced denoising process.',
+            maximum: 3.0,
+            minimum: -1.0,
+            title: 'S2',
+            type: 'number',
+          },
+          b1: {
+            description: 'Scaling factor for stage 1 to amplify the contributions of backbone features.',
+            maximum: 3.0,
+            minimum: -1.0,
+            title: 'B1',
+            type: 'number',
+          },
+          b2: {
+            description: 'Scaling factor for stage 2 to amplify the contributions of backbone features.',
+            maximum: 3.0,
+            minimum: -1.0,
+            title: 'B2',
+            type: 'number',
+          },
+        },
+        required: ['s1', 's2', 'b1', 'b2'],
+        title: 'FreeUConfig',
+        type: 'object',
+        class: 'output',
+      },
       VAEField: {
         properties: {
           vae: {
@@ -635,180 +748,43 @@ const schema = {
         type: 'object',
         class: 'output',
       },
-    },
-    UNetField: {
-      properties: {
-        unet: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ModelIdentifierField',
-            },
-          ],
-          description: 'Info to load unet submodel',
-        },
-        scheduler: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ModelIdentifierField',
-            },
-          ],
-          description: 'Info to load scheduler submodel',
-        },
-        loras: {
-          description: 'LoRAs to apply on model loading',
-          items: {
-            $ref: '#/components/schemas/LoRAField',
+      CLIPField: {
+        properties: {
+          tokenizer: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Info to load tokenizer submodel',
           },
-          title: 'Loras',
-          type: 'array',
-        },
-        seamless_axes: {
-          description: 'Axes("x" and "y") to which apply seamless',
-          items: {
-            type: 'string',
+          text_encoder: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/ModelIdentifierField',
+              },
+            ],
+            description: 'Info to load text_encoder submodel',
           },
-          title: 'Seamless Axes',
-          type: 'array',
-        },
-        freeu_config: {
-          anyOf: [
-            {
-              $ref: '#/components/schemas/FreeUConfig',
-            },
-            {
-              type: 'null',
-            },
-          ],
-          default: null,
-          description: 'FreeU configuration',
-        },
-      },
-      required: ['unet', 'scheduler', 'loras'],
-      title: 'UNetField',
-      type: 'object',
-      class: 'output',
-    },
-    LoRAField: {
-      properties: {
-        lora: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ModelIdentifierField',
-            },
-          ],
-          description: 'Info to load lora model',
-        },
-        weight: {
-          description: 'Weight to apply to lora model',
-          title: 'Weight',
-          type: 'number',
-        },
-      },
-      required: ['lora', 'weight'],
-      title: 'LoRAField',
-      type: 'object',
-      class: 'output',
-    },
-    FreeUConfig: {
-      description:
-        'Configuration for the FreeU hyperparameters.\n- https://huggingface.co/docs/diffusers/main/en/using-diffusers/freeu\n- https://github.com/ChenyangSi/FreeU',
-      properties: {
-        s1: {
-          description:
-            'Scaling factor for stage 1 to attenuate the contributions of the skip features. This is done to mitigate the "oversmoothing effect" in the enhanced denoising process.',
-          maximum: 3.0,
-          minimum: -1.0,
-          title: 'S1',
-          type: 'number',
-        },
-        s2: {
-          description:
-            'Scaling factor for stage 2 to attenuate the contributions of the skip features. This is done to mitigate the "oversmoothing effect" in the enhanced denoising process.',
-          maximum: 3.0,
-          minimum: -1.0,
-          title: 'S2',
-          type: 'number',
-        },
-        b1: {
-          description: 'Scaling factor for stage 1 to amplify the contributions of backbone features.',
-          maximum: 3.0,
-          minimum: -1.0,
-          title: 'B1',
-          type: 'number',
-        },
-        b2: {
-          description: 'Scaling factor for stage 2 to amplify the contributions of backbone features.',
-          maximum: 3.0,
-          minimum: -1.0,
-          title: 'B2',
-          type: 'number',
-        },
-      },
-      required: ['s1', 's2', 'b1', 'b2'],
-      title: 'FreeUConfig',
-      type: 'object',
-      class: 'output',
-    },
-    VAEField: {
-      properties: {
-        vae: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ModelIdentifierField',
-            },
-          ],
-          description: 'Info to load vae submodel',
-        },
-        seamless_axes: {
-          description: 'Axes("x" and "y") to which apply seamless',
-          items: {
-            type: 'string',
+          skipped_layers: {
+            description: 'Number of skipped layers in text_encoder',
+            title: 'Skipped Layers',
+            type: 'integer',
           },
-          title: 'Seamless Axes',
-          type: 'array',
-        },
-      },
-      required: ['vae'],
-      title: 'VAEField',
-      type: 'object',
-      class: 'output',
-    },
-    CLIPField: {
-      properties: {
-        tokenizer: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ModelIdentifierField',
+          loras: {
+            description: 'LoRAs to apply on model loading',
+            items: {
+              $ref: '#/components/schemas/LoRAField',
             },
-          ],
-          description: 'Info to load tokenizer submodel',
-        },
-        text_encoder: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ModelIdentifierField',
-            },
-          ],
-          description: 'Info to load text_encoder submodel',
-        },
-        skipped_layers: {
-          description: 'Number of skipped layers in text_encoder',
-          title: 'Skipped Layers',
-          type: 'integer',
-        },
-        loras: {
-          description: 'LoRAs to apply on model loading',
-          items: {
-            $ref: '#/components/schemas/LoRAField',
+            title: 'Loras',
+            type: 'array',
           },
-          title: 'Loras',
-          type: 'array',
         },
+        required: ['tokenizer', 'text_encoder', 'skipped_layers', 'loras'],
+        title: 'CLIPField',
+        type: 'object',
+        class: 'output',
       },
-      required: ['tokenizer', 'text_encoder', 'skipped_layers', 'loras'],
-      title: 'CLIPField',
-      type: 'object',
-      class: 'output',
     },
   },
 } as OpenAPIV3_1.Document;

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -1,5 +1,6 @@
 import { logger } from 'app/logging/logger';
 import { parseify } from 'common/util/serialize';
+import type { Templates } from 'features/nodes/store/types';
 import { FieldParseError } from 'features/nodes/types/error';
 import type { FieldInputTemplate, FieldOutputTemplate } from 'features/nodes/types/field';
 import type { InvocationTemplate } from 'features/nodes/types/invocation';
@@ -58,14 +59,14 @@ export const parseSchema = (
   openAPI: OpenAPIV3_1.Document,
   nodesAllowlistExtra: string[] | undefined = undefined,
   nodesDenylistExtra: string[] | undefined = undefined
-): Record<string, InvocationTemplate> => {
+): Templates => {
   const filteredSchemas = Object.values(openAPI.components?.schemas ?? {})
     .filter(isInvocationSchemaObject)
     .filter(isNotInDenylist)
     .filter((schema) => (nodesAllowlistExtra ? nodesAllowlistExtra.includes(schema.properties.type.default) : true))
     .filter((schema) => (nodesDenylistExtra ? !nodesDenylistExtra.includes(schema.properties.type.default) : true));
 
-  const invocations = filteredSchemas.reduce<Record<string, InvocationTemplate>>((invocationsAccumulator, schema) => {
+  const invocations = filteredSchemas.reduce<Templates>((invocationsAccumulator, schema) => {
     const type = schema.properties.type.default;
     const title = schema.title.replace('Invocation', '');
     const tags = schema.tags ?? [];

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
@@ -1,11 +1,10 @@
 import * as dagre from '@dagrejs/dagre';
 import { logger } from 'app/logging/logger';
-import { getStore } from 'app/store/nanostores/store';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { NODE_WIDTH } from 'features/nodes/types/constants';
 import type { FieldInputInstance } from 'features/nodes/types/field';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
 import { buildFieldInputInstance } from 'features/nodes/util/schema/buildFieldInputInstance';
-import { t } from 'i18next';
 import { forEach } from 'lodash-es';
 import type { NonNullableGraph } from 'services/api/types';
 import { v4 as uuidv4 } from 'uuid';
@@ -18,11 +17,7 @@ import { v4 as uuidv4 } from 'uuid';
  * @returns The workflow.
  */
 export const graphToWorkflow = (graph: NonNullableGraph, autoLayout = true): WorkflowV3 => {
-  const invocationTemplates = getStore().getState().nodes.present.templates;
-
-  if (!invocationTemplates) {
-    throw new Error(t('app.storeNotInitialized'));
-  }
+  const templates = $templates.get();
 
   // Initialize the workflow
   const workflow: WorkflowV3 = {
@@ -44,11 +39,11 @@ export const graphToWorkflow = (graph: NonNullableGraph, autoLayout = true): Wor
 
   // Convert nodes
   forEach(graph.nodes, (node) => {
-    const template = invocationTemplates[node.type];
+    const template = templates[node.type];
 
     // Skip missing node templates - this is a best-effort
     if (!template) {
-      logger('nodes').warn(`Node type ${node.type} not found in invocationTemplates`);
+      logger('nodes').warn(`Node type ${node.type} not found in templates`);
       return;
     }
 

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
@@ -18,7 +18,7 @@ import { v4 as uuidv4 } from 'uuid';
  * @returns The workflow.
  */
 export const graphToWorkflow = (graph: NonNullableGraph, autoLayout = true): WorkflowV3 => {
-  const invocationTemplates = getStore().getState().nodes.templates;
+  const invocationTemplates = getStore().getState().nodes.present.templates;
 
   if (!invocationTemplates) {
     throw new Error(t('app.storeNotInitialized'));

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/migrations.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/migrations.ts
@@ -1,5 +1,5 @@
-import { $store } from 'app/store/nanostores/store';
 import { deepClone } from 'common/util/deepClone';
+import { $templates } from 'features/nodes/store/nodesSlice';
 import { WorkflowMigrationError, WorkflowVersionError } from 'features/nodes/types/error';
 import type { FieldType } from 'features/nodes/types/field';
 import type { InvocationNodeData } from 'features/nodes/types/invocation';
@@ -33,11 +33,7 @@ const zWorkflowMetaVersion = z.object({
  * - Workflow schema version bumped to 2.0.0
  */
 const migrateV1toV2 = (workflowToMigrate: WorkflowV1): WorkflowV2 => {
-  const invocationTemplates = $store.get()?.getState().nodes.present.templates;
-
-  if (!invocationTemplates) {
-    throw new Error(t('app.storeNotInitialized'));
-  }
+  const templates = $templates.get();
 
   workflowToMigrate.nodes.forEach((node) => {
     if (node.type === 'invocation') {
@@ -57,7 +53,7 @@ const migrateV1toV2 = (workflowToMigrate: WorkflowV1): WorkflowV2 => {
         (output.type as unknown as FieldType) = newFieldType;
       });
       // Add node pack
-      const invocationTemplate = invocationTemplates[node.data.type];
+      const invocationTemplate = templates[node.data.type];
       const nodePack = invocationTemplate ? invocationTemplate.nodePack : t('common.unknown');
 
       (node.data as unknown as InvocationNodeData).nodePack = nodePack;

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/migrations.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/migrations.ts
@@ -33,7 +33,7 @@ const zWorkflowMetaVersion = z.object({
  * - Workflow schema version bumped to 2.0.0
  */
 const migrateV1toV2 = (workflowToMigrate: WorkflowV1): WorkflowV2 => {
-  const invocationTemplates = $store.get()?.getState().nodes.templates;
+  const invocationTemplates = $store.get()?.getState().nodes.present.templates;
 
   if (!invocationTemplates) {
     throw new Error(t('app.storeNotInitialized'));

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -1,6 +1,6 @@
 import type { JSONObject } from 'common/types';
 import { parseify } from 'common/util/serialize';
-import type { InvocationTemplate } from 'features/nodes/types/invocation';
+import type { Templates } from 'features/nodes/store/types';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
 import { isWorkflowInvocationNode } from 'features/nodes/types/workflow';
 import { getNeedsUpdate } from 'features/nodes/util/node/nodeUpdate';
@@ -33,7 +33,7 @@ type ValidateWorkflowResult = {
  */
 export const validateWorkflow = (
   workflow: unknown,
-  invocationTemplates: Record<string, InvocationTemplate>
+  invocationTemplates: Templates
 ): ValidateWorkflowResult => {
   // Parse the raw workflow data & migrate it to the latest version
   const _workflow = parseAndMigrateWorkflow(workflow);

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -68,7 +68,7 @@ export const validateWorkflow = (
       return;
     }
 
-    if (getNeedsUpdate(node, template)) {
+    if (getNeedsUpdate(node.data, template)) {
       // This node needs to be updated, based on comparison of its version to the template version
       const message = t('nodes.mismatchedVersion', {
         node: node.id,

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -31,10 +31,7 @@ type ValidateWorkflowResult = {
  * @throws {WorkflowVersionError} If the workflow version is not recognized.
  * @throws {z.ZodError} If there is a validation error.
  */
-export const validateWorkflow = (
-  workflow: unknown,
-  invocationTemplates: Templates
-): ValidateWorkflowResult => {
+export const validateWorkflow = (workflow: unknown, invocationTemplates: Templates): ValidateWorkflowResult => {
   // Parse the raw workflow data & migrate it to the latest version
   const _workflow = parseAndMigrateWorkflow(workflow);
 


### PR DESCRIPTION
## Summary

Adds undo/redo to workflows. This required splitting up the workflow editor state a bit so that undoable state is isolated from the rest of it.

In order to split things up, I needed to rewrite the auto-connection logic. In the end, that logic is much cleaner. I fixed a number of fiddly interactions and improved some things:
- Jank in the auto-add-node and auto-connect logic.
- Rewrote copy and paste logic. Should be identical now, except the position of pasted nodes may need some tweaking.
- Collect node inputs now narrow to accept connections only from fields of the same type as are already connected.
- Selecting an edge moves it to the front so that when you grab an existing edge, it prefers the currently selected edge.
- Editable field titles do not allow whitespace only labels.
- Disconnected fields "collapse" and move up to the top of the node, hiding their UI input component.

Note: The grouping of undoable actions needs some tuning. You might find that you need to undo multiple times to see any change. Each undo is doing _something_, but it may not result in any _visible_ change. Conversely, you might undo and find it undoes too much. I'll refine this as I use it more - it's tricky to find the edge cases.

## Related Issues / Discussions

Closes #4137

## QA Instructions

Play around with undo/redo, copy/paste, auto-connect and auto-node.

Due to interactions between reactflow and undo/redo, it may be hard to provide consistent reproductions when undo/redo don't do what you expect. Ideally you can take a screen recording, starting from a fresh load of the page, showing the problem.

## Merge Plan

This needs user testing before release. I don't plan on an OSS release until next week.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
