### PR TITLE
feat(ui): copy/paste input edges when copying node

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -231,6 +231,15 @@ export const Flow = memo(() => {
   );
   useHotkeys(['Ctrl+v', 'Meta+v'], onPasteHotkey);
 
+  const onPasteWithEdgesToNodesHotkey = useCallback(
+    (e: KeyboardEvent) => {
+      e.preventDefault();
+      pasteSelection(true);
+    },
+    [pasteSelection]
+  );
+  useHotkeys(['Ctrl+shift+v', 'Meta+shift+v'], onPasteWithEdgesToNodesHotkey);
+
   const onUndoHotkey = useCallback(() => {
     if (mayUndo) {
       dispatch(undo());

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -498,6 +498,7 @@ export const $cursorPos = atom<XYPosition | null>(null);
 export const $templates = atom<Templates>({});
 export const $copiedNodes = atom<AnyNode[]>([]);
 export const $copiedEdges = atom<InvocationNodeEdge[]>([]);
+export const $edgesToCopiedNodes = atom<InvocationNodeEdge[]>([]);
 export const $pendingConnection = atom<PendingConnection | null>(null);
 export const $isUpdatingEdge = atom(false);
 export const $viewport = atom<Viewport>({ x: 0, y: 0, zoom: 1 });


### PR DESCRIPTION
## Summary

[feat(ui): copy/paste input edges when copying node](https://github.com/invoke-ai/InvokeAI/commit/118a58e2f31bd3276194cdf4d77765b3c52b7c43)

- Copy edges to selected nodes on copy
- If pasted with `ctrl/meta-shift-v`, also paste the input edges

https://github.com/invoke-ai/InvokeAI/assets/4822129/f030f118-c731-4a14-8052-862ce7517fb6

## Related Issues / Discussions

Related: #5600

## QA Instructions

Copy and paste with the hotkeys 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
