### PR TITLE
feat(ui): prevent connections to direct-only inputs

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useIsValidConnection.ts
@@ -45,6 +45,10 @@ export const useIsValidConnection = () => {
         return false;
       }
 
+      if (targetFieldTemplate.input === 'direct') {
+        return false;
+      }
+
       if (!shouldValidateGraph) {
         // manual override!
         return true;

--- a/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/findConnectionToValidHandle.ts
@@ -38,7 +38,7 @@ export const getFirstValidConnection = (
       };
     }
     // Only one connection per target field is allowed - look for an unconnected target field
-    const candidateFields = map(candidateTemplate.inputs);
+    const candidateFields = map(candidateTemplate.inputs).filter((i) => i.input !== 'direct');
     const candidateConnectedFields = edges
       .filter((edge) => edge.target === candidateNode.id)
       .map((edge) => {


### PR DESCRIPTION
## Summary

Minor fix. The auto-connect logic would let you connect to direct-only inputs (i.e. inputs without handles). Now it doesn't.

## Related Issues / Discussions

n/a

## QA Instructions

You shouldn't be able to connect to a direct-only input. Not sure if there's a way for this to happen with core nodes only, but it can happen with some community nodes.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
