### PR TITLE
fix(ui): field ordering & display

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/EditableFieldTitle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/EditableFieldTitle.tsx
@@ -25,10 +25,11 @@ interface Props {
   kind: 'inputs' | 'outputs';
   isMissingInput?: boolean;
   withTooltip?: boolean;
+  shouldDim?: boolean;
 }
 
 const EditableFieldTitle = forwardRef((props: Props, ref) => {
-  const { nodeId, fieldName, kind, isMissingInput = false, withTooltip = false } = props;
+  const { nodeId, fieldName, kind, isMissingInput = false, withTooltip = false, shouldDim = false } = props;
   const label = useFieldLabel(nodeId, fieldName);
   const fieldTemplateTitle = useFieldTemplateTitle(nodeId, fieldName, kind);
   const { t } = useTranslation();
@@ -80,6 +81,7 @@ const EditableFieldTitle = forwardRef((props: Props, ref) => {
           sx={editablePreviewStyles}
           noOfLines={1}
           color={isMissingInput ? 'error.300' : 'base.300'}
+          opacity={shouldDim ? 0.5 : 1}
         />
       </Tooltip>
       <EditableInput className="nodrag" sx={editableInputStyles} />

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/EditableFieldTitle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/EditableFieldTitle.tsx
@@ -40,13 +40,11 @@ const EditableFieldTitle = forwardRef((props: Props, ref) => {
   const handleSubmit = useCallback(
     async (newTitleRaw: string) => {
       const newTitle = newTitleRaw.trim();
-      if (newTitle && (newTitle === label || newTitle === fieldTemplateTitle)) {
-        return;
-      }
-      setLocalTitle(newTitle || fieldTemplateTitle || t('nodes.unknownField'));
-      dispatch(fieldLabelChanged({ nodeId, fieldName, label: newTitle }));
+      const finalTitle = newTitle || fieldTemplateTitle || t('nodes.unknownField');
+      setLocalTitle(finalTitle);
+      dispatch(fieldLabelChanged({ nodeId, fieldName, label: finalTitle }));
     },
-    [label, fieldTemplateTitle, dispatch, nodeId, fieldName, t]
+    [fieldTemplateTitle, dispatch, nodeId, fieldName, t]
   );
 
   const handleChange = useCallback((newTitle: string) => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputField.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputField.tsx
@@ -79,6 +79,7 @@ const InputField = ({ nodeId, fieldName }: Props) => {
             kind="inputs"
             isMissingInput={isMissingInput}
             withTooltip
+            shouldDim
           />
         </FormControl>
 

--- a/invokeai/frontend/web/src/features/nodes/hooks/useAnyOrDirectInputFieldNames.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useAnyOrDirectInputFieldNames.ts
@@ -1,7 +1,5 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
+import { EMPTY_ARRAY } from 'app/store/constants';
 import { useNodeTemplate } from 'features/nodes/hooks/useNodeTemplate';
-import { selectNodesSlice } from 'features/nodes/store/nodesSlice';
 import { getSortedFilteredFieldNames } from 'features/nodes/util/node/getSortedFilteredFieldNames';
 import { TEMPLATE_BUILDER_MAP } from 'features/nodes/util/schema/buildFieldInputTemplate';
 import { keys, map } from 'lodash-es';
@@ -9,31 +7,20 @@ import { useMemo } from 'react';
 
 export const useAnyOrDirectInputFieldNames = (nodeId: string): string[] => {
   const template = useNodeTemplate(nodeId);
-  const selectConnectedFieldNames = useMemo(
-    () =>
-      createMemoizedSelector(selectNodesSlice, (nodesSlice) =>
-        nodesSlice.edges
-          .filter((e) => e.target === nodeId)
-          .map((e) => e.targetHandle)
-          .filter(Boolean)
-      ),
-    [nodeId]
-  );
-  const connectedFieldNames = useAppSelector(selectConnectedFieldNames);
 
   const fieldNames = useMemo(() => {
     const fields = map(template.inputs).filter((field) => {
-      if (connectedFieldNames.includes(field.name)) {
-        return false;
-      }
-
       return (
         (['any', 'direct'].includes(field.input) || field.type.isCollectionOrScalar) &&
         keys(TEMPLATE_BUILDER_MAP).includes(field.type.name)
       );
     });
-    return getSortedFilteredFieldNames(fields);
-  }, [connectedFieldNames, template.inputs]);
+    const _fieldNames = getSortedFilteredFieldNames(fields);
+    if (_fieldNames.length === 0) {
+      return EMPTY_ARRAY;
+    }
+    return _fieldNames;
+  }, [template.inputs]);
 
   return fieldNames;
 };


### PR DESCRIPTION
## Summary

As of the workflow internal state rework, fields were re-ordered when connecting/disconnecting them. With feedback that this [was jarring](https://discord.com/channels/1020123559063990373/1130288930319761428/1241022691834859621), I've changed the behaviour:

https://github.com/invoke-ai/InvokeAI/assets/4822129/72a32db6-7903-4d34-8112-3d680dd48976

Also sneaking in a fix for issue with field titles not updating correctly.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1130288930319761428/1241022691834859621

## QA Instructions

Try it out I suppose. There's some minor jank with the positioning of handles during a connection. This is an [upstream issue](https://github.com/xyflow/xyflow/issues/3983).

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
