### PR TITLE
fix(ui): workflow edges not saved

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -1,7 +1,6 @@
 import type { PayloadAction, UnknownAction } from '@reduxjs/toolkit';
 import { createSlice, isAnyOf } from '@reduxjs/toolkit';
 import type { PersistConfig, RootState } from 'app/store/store';
-import { deepClone } from 'common/util/deepClone';
 import { workflowLoaded } from 'features/nodes/store/actions';
 import { SHARED_NODE_PROPERTIES } from 'features/nodes/types/constants';
 import type {
@@ -105,7 +104,8 @@ export const nodesSlice = createSlice({
       state.edges = applyEdgeChanges(edgeChanges, state.edges);
     },
     edgesChanged: (state, action: PayloadAction<EdgeChange[]>) => {
-      const changes = deepClone(action.payload);
+      const changes: EdgeChange[] = [];
+      // We may need to massage the edge changes or otherwise handle them
       action.payload.forEach((change) => {
         if (change.type === 'remove' || change.type === 'select') {
           const edge = state.edges.find((e) => e.id === change.id);
@@ -124,6 +124,13 @@ export const nodesSlice = createSlice({
             }
           }
         }
+        if (change.type === 'add') {
+          if (!change.item.type) {
+            // We must add the edge type!
+            change.item.type = 'default';
+          }
+        }
+        changes.push(change);
       });
       state.edges = applyEdgeChanges(changes, state.edges);
     },

--- a/invokeai/frontend/web/src/features/nodes/types/workflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/workflow.ts
@@ -47,6 +47,7 @@ const zWorkflowEdgeDefault = zWorkflowEdgeBase.extend({
   type: z.literal('default'),
   sourceHandle: z.string().trim().min(1),
   targetHandle: z.string().trim().min(1),
+  hidden: z.boolean().optional(),
 });
 const zWorkflowEdgeCollapsed = zWorkflowEdgeBase.extend({
   type: z.literal('collapsed'),

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/buildWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/buildWorkflow.ts
@@ -66,6 +66,7 @@ export const buildWorkflowFast: BuildWorkflowFunction = ({ nodes, edges, workflo
         target: edge.target,
         sourceHandle: edge.sourceHandle,
         targetHandle: edge.targetHandle,
+        hidden: edge.hidden,
       });
     } else if (edge.type === 'collapsed') {
       newWorkflow.edges.push({


### PR DESCRIPTION
## Summary

- [fix(ui): ensure invocation edges have a type](https://github.com/invoke-ai/InvokeAI/commit/c88b6703eed22dbbdc84c6a2cda69d8998936843)

- [fix(ui): store hidden state of edges in workflows](https://github.com/invoke-ai/InvokeAI/commit/f70ee689e396ce0822d4343d49f1e99a57b4bcf7)
  
  This prevents a minor visual bug where collapsed edges between collapsed nodes didn't display correctly on first load of a workflow.


## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149513625321603162/1241849984140447886

## QA Instructions

- Save and then load a workflow, its edges should be saved.
- Collapse two connected nodes so their edges are in the collapsed state. Save and load the workflow, the collapsed edge state should be retained (e.g. grey line w/ a number over it if there were multiple edges).

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
