### PR TITLE
feat(ui): workflow resource check

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -897,7 +897,10 @@
         "zoomInNodes": "Zoom In",
         "zoomOutNodes": "Zoom Out",
         "betaDesc": "This invocation is in beta. Until it is stable, it may have breaking changes during app updates. We plan to support this invocation long-term.",
-        "prototypeDesc": "This invocation is a prototype. It may have breaking changes during app updates and may be removed at any time."
+        "prototypeDesc": "This invocation is a prototype. It may have breaking changes during app updates and may be removed at any time.",
+        "imageAccessError": "Unable to find image {{image_name}}, resetting to default",
+        "boardAccessError": "Unable to find board {{board_id}}, resetting to default",
+        "modelAccessError": "Unable to find model {{key}}, resetting to default"
     },
     "parameters": {
         "aspect": "Aspect",

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
@@ -1,0 +1,116 @@
+import { img_resize, main_model_loader } from 'features/nodes/store/util/testUtils';
+import type { WorkflowV3 } from 'features/nodes/types/workflow';
+import { validateWorkflow } from 'features/nodes/util/workflow/validateWorkflow';
+import { get } from 'lodash-es';
+import { describe, expect, it } from 'vitest';
+
+describe('validateWorkflow', () => {
+  const workflow: WorkflowV3 = {
+    name: '',
+    author: '',
+    description: '',
+    version: '',
+    contact: '',
+    tags: '',
+    notes: '',
+    exposedFields: [],
+    meta: { version: '3.0.0', category: 'user' },
+    nodes: [
+      {
+        id: '94b1d596-f2f2-4c1c-bd5b-a79c62d947ad',
+        type: 'invocation',
+        data: {
+          id: '94b1d596-f2f2-4c1c-bd5b-a79c62d947ad',
+          type: 'main_model_loader',
+          version: '1.0.2',
+          label: '',
+          notes: '',
+          isOpen: true,
+          isIntermediate: true,
+          useCache: true,
+          inputs: {
+            model: {
+              name: 'model',
+              label: '',
+              value: {
+                key: '2c85d9e7-12cd-4e59-bb94-96d4502e99d4',
+                hash: 'random:aadc6641321ba17a324788ef1691f3584b382f0e7fa4a90be169f2a4ac77435c',
+                name: 'Analog-Diffusion2',
+                base: 'sd-1',
+                type: 'main',
+              },
+            },
+          },
+        },
+        position: { x: 394.62314170481613, y: -424.6962537790139 },
+      },
+      {
+        id: 'afad11b4-bb5c-45d1-b956-6c8e2357ee11',
+        type: 'invocation',
+        data: {
+          id: 'afad11b4-bb5c-45d1-b956-6c8e2357ee11',
+          type: 'img_resize',
+          version: '1.2.2',
+          label: '',
+          notes: '',
+          isOpen: true,
+          isIntermediate: true,
+          useCache: true,
+          inputs: {
+            board: {
+              name: 'board',
+              label: '',
+              value: { board_id: '99a08f09-8232-4b74-94a2-f8e136d62f8c' },
+            },
+            metadata: { name: 'metadata', label: 'Metadata' },
+            image: {
+              name: 'image',
+              label: '',
+              value: { image_name: '96c124c8-f62f-4d4f-9788-72218469f298.png' },
+            },
+            width: { name: 'width', label: '', value: 512 },
+            height: { name: 'height', label: '', value: 512 },
+            resample_mode: { name: 'resample_mode', label: '', value: 'bicubic' },
+          },
+        },
+        position: { x: -46.428806920557236, y: -479.6641524207518 },
+      },
+    ],
+    edges: [],
+  };
+  const resolveTrue = async (): Promise<boolean> => new Promise((resolve) => resolve(true));
+  const resolveFalse = async (): Promise<boolean> => new Promise((resolve) => resolve(false));
+  it('should reset images that are inaccessible', async () => {
+    const validationResult = await validateWorkflow(
+      workflow,
+      { img_resize, main_model_loader },
+      resolveFalse,
+      resolveTrue,
+      resolveTrue
+    );
+    expect(validationResult.warnings.length).toBe(1);
+    expect(get(validationResult, 'workflow.nodes[1].data.inputs.image.value')).toBeUndefined();
+  });
+  it('should reset boards that are inaccessible', async () => {
+    const validationResult = await validateWorkflow(
+      workflow,
+      { img_resize, main_model_loader },
+      resolveTrue,
+      resolveFalse,
+      resolveTrue
+    );
+    expect(validationResult.warnings.length).toBe(1);
+    expect(get(validationResult, 'workflow.nodes[1].data.inputs.board.value')).toBeUndefined();
+  });
+  it('should reset models that are inaccessible', async () => {
+    const validationResult = await validateWorkflow(
+      workflow,
+      { img_resize, main_model_loader },
+      resolveTrue,
+      resolveTrue,
+      resolveFalse
+    );
+    expect(validationResult.warnings.length).toBe(1);
+    expect(get(validationResult, 'workflow.nodes[0].data.inputs.model.value')).toBeUndefined();
+  });
+});

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -112,6 +112,9 @@ export const validateWorkflow = async (
         });
         continue;
       }
+
+      // We need to confirm that all images, boards and models are accessible before loading,
+      // else the workflow could end up with stale data an an error state.
       if (fieldTemplate.type.name === 'ImageField' && isImageFieldInputInstance(input) && input.value) {
         const hasAccess = await checkImageAccess(input.value.image_name);
         if (!hasAccess) {

--- a/invokeai/frontend/web/src/services/api/hooks/accessChecks.ts
+++ b/invokeai/frontend/web/src/services/api/hooks/accessChecks.ts
@@ -1,0 +1,55 @@
+import { getStore } from 'app/store/nanostores/store';
+import { boardsApi } from 'services/api/endpoints/boards';
+import { imagesApi } from 'services/api/endpoints/images';
+import { modelsApi } from 'services/api/endpoints/models';
+
+/**
+ * Checks if the client has access to a model.
+ * @param key The model key.
+ * @returns A promise that resolves to true if the client has access, else false.
+ */
+export const checkModelAccess = async (key: string): Promise<boolean> => {
+  const { dispatch } = getStore();
+  try {
+    const req = dispatch(modelsApi.endpoints.getModelConfig.initiate(key));
+    req.unsubscribe();
+    const result = await req.unwrap();
+    return Boolean(result);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Checks if the client has access to an image.
+ * @param name The image name.
+ * @returns A promise that resolves to true if the client has access, else false.
+ */
+export const checkImageAccess = async (name: string): Promise<boolean> => {
+  const { dispatch } = getStore();
+  try {
+    const req = dispatch(imagesApi.endpoints.getImageDTO.initiate(name));
+    req.unsubscribe();
+    const result = await req.unwrap();
+    return Boolean(result);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Checks if the client has access to a board.
+ * @param id The board id.
+ * @returns A promise that resolves to true if the client has access, else false.
+ */
+export const checkBoardAccess = async (id: string): Promise<boolean> => {
+  const { dispatch } = getStore();
+  try {
+    const req = dispatch(boardsApi.endpoints.listAllBoards.initiate());
+    req.unsubscribe();
+    const result = await req.unwrap();
+    return result.some((b) => b.board_id === id);
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary

These fields are reset back to `undefined` if not accessible. A warning toast is showing, and in the JS console, the full warning message is logged.

## Related Issues / Discussions

n/a

## QA Instructions

There are tests for this functionality. To test manually:

- Create a board
- Create a workflow with an image resize node
- Set the board to the new board
- Set an image
- Check the data tab in the bottom left panel of the workflow editor and check that the value for the board and image are populated
- Save the workflow
- Delete the board and image
- Refresh the page
- Re-load the workflow
- Check the data tab in bottom left panel of the workflow editor and check that the value for the board and image are now undefined

Then do the same thing, but with the model loader. You'll need to delete the model between the reloads.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
