### PR TITLE
feat: update queue items session on complete

### DIFF
--- a/invokeai/app/api/routers/session_queue.py
+++ b/invokeai/app/api/routers/session_queue.py
@@ -203,6 +203,7 @@ async def get_batch_status(
     responses={
         200: {"model": SessionQueueItem},
     },
+    response_model_exclude_none=True,
 )
 async def get_queue_item(
     queue_id: str = Path(description="The queue id to perform this operation on"),

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -245,6 +245,9 @@ class DefaultSessionProcessor(SessionProcessorBase):
                         # The session is complete if the all invocations are complete or there was an error
                         if self._queue_item.session.is_complete() or cancel_event.is_set():
                             # Send complete event
+                            self._invoker.services.session_queue.set_queue_item_session(
+                                self._queue_item.item_id, self._queue_item.session
+                            )
                             self._invoker.services.events.emit_graph_execution_complete(
                                 queue_batch_id=self._queue_item.batch_id,
                                 queue_item_id=self._queue_item.item_id,
@@ -281,6 +284,9 @@ class DefaultSessionProcessor(SessionProcessorBase):
                     )
                     # Cancel the queue item
                     if self._queue_item is not None:
+                        self._invoker.services.session_queue.set_queue_item_session(
+                            self._queue_item.item_id, self._queue_item.session
+                        )
                         self._invoker.services.session_queue.cancel_queue_item(
                             self._queue_item.item_id, error=traceback.format_exc()
                         )

--- a/invokeai/app/services/session_queue/session_queue_base.py
+++ b/invokeai/app/services/session_queue/session_queue_base.py
@@ -16,6 +16,7 @@ from invokeai.app.services.session_queue.session_queue_common import (
     SessionQueueItemDTO,
     SessionQueueStatus,
 )
+from invokeai.app.services.shared.graph import GraphExecutionState
 from invokeai.app.services.shared.pagination import CursorPaginatedResults
 
 
@@ -102,4 +103,9 @@ class SessionQueueBase(ABC):
     @abstractmethod
     def get_queue_item(self, item_id: int) -> SessionQueueItem:
         """Gets a session queue item by ID"""
+        pass
+
+    @abstractmethod
+    def set_queue_item_session(self, item_id: int, session: GraphExecutionState) -> SessionQueueItem:
+        """Sets the session for a session queue item. Use this to update the session state."""
         pass

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketQueueItemStatusChanged.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketio/socketQueueItemStatusChanged.ts
@@ -43,20 +43,15 @@ export const addSocketQueueItemStatusChangedEventListener = (startAppListening: 
         queueApi.util.updateQueryData('getBatchStatus', { batch_id: batch_status.batch_id }, () => batch_status)
       );
 
-      // Update the queue item status (this is the full queue item, including the session)
-      dispatch(
-        queueApi.util.updateQueryData('getQueueItem', queue_item.item_id, (draft) => {
-          if (!draft) {
-            return;
-          }
-          Object.assign(draft, queue_item);
-        })
-      );
-
       // Invalidate caches for things we cannot update
       // TODO: technically, we could possibly update the current session queue item, but feels safer to just request it again
       dispatch(
-        queueApi.util.invalidateTags(['CurrentSessionQueueItem', 'NextSessionQueueItem', 'InvocationCacheStatus'])
+        queueApi.util.invalidateTags([
+          'CurrentSessionQueueItem',
+          'NextSessionQueueItem',
+          'InvocationCacheStatus',
+          { type: 'SessionQueueItem', id: queue_item.item_id },
+        ])
       );
 
       if (['in_progress'].includes(action.payload.data.queue_item.status)) {


### PR DESCRIPTION
## Summary

[feat(app): update queue item's session on session completion](https://github.com/invoke-ai/InvokeAI/commit/e9bbbabdfddc885a24e2e1bf0ee89a5557036472)

The session is never updated in the queue after it is first enqueued. As a result, the queue detail view in the frontend never never updates and the session itself doesn't show outputs, execution graph, etc.

We need a new method on the queue service to update a queue item's session, then call it before updating the queue item's status.

Queue item status may be updated via a session-type event _or_ queue-type event. Adding the updated session to all these events is a hairy - simpler to just update the session before we do anything that could trigger a queue item status change event:
- Before calling `emit_session_complete` in the processor (handles session error, completed and cancel events and the corresponding queue events)
- Before calling `cancel_queue_item` in the processor (handles another way queue items can be canceled, outside the session execution loop)

When serializing the session, both in the new service method and the `get_queue_item` endpoint, we need to use `exclude_none=True` to prevent unexpected validation errors.

## Related Issues / Discussions

Closes #5933
Supersedes #6408

## QA Instructions

- On `main`, generate an image & wait for it to finish
- Check the queue tab and expand the queue item detail view
- Observe that the execution graph, results and such are empty
- Check out this PR
- Do the same thing
- Observe that the queue item detail view shows the executed session
- Invoke a workflow that will error (e.g. integer primitive of 0 into a resize image node's width)
- Observe that the queue item detail view shows a partially executed session w/ error

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
