### PR TITLE
fix(ui): regional guidance layers not disabling correctly

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -147,7 +147,9 @@
         "viewing": "Viewing",
         "viewingDesc": "Review images in a large gallery view",
         "editing": "Editing",
-        "editingDesc": "Edit on the Control Layers canvas"
+        "editingDesc": "Edit on the Control Layers canvas",
+        "enabled": "Enabled",
+        "disabled": "Disabled"
     },
     "controlnet": {
         "controlAdapter_one": "Control Adapter",
@@ -1573,7 +1575,6 @@
         "controlLayers": "Control Layers",
         "globalMaskOpacity": "Global Mask Opacity",
         "autoNegative": "Auto Negative",
-        "toggleVisibility": "Toggle Layer Visibility",
         "deletePrompt": "Delete Prompt",
         "resetRegion": "Reset Region",
         "debugLayers": "Debug Layers",

--- a/invokeai/frontend/web/src/features/controlLayers/components/CALayer/CALayer.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CALayer/CALayer.tsx
@@ -4,7 +4,7 @@ import { CALayerControlAdapterWrapper } from 'features/controlLayers/components/
 import { LayerDeleteButton } from 'features/controlLayers/components/LayerCommon/LayerDeleteButton';
 import { LayerMenu } from 'features/controlLayers/components/LayerCommon/LayerMenu';
 import { LayerTitle } from 'features/controlLayers/components/LayerCommon/LayerTitle';
-import { LayerVisibilityToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
+import { LayerIsEnabledToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
 import { LayerWrapper } from 'features/controlLayers/components/LayerCommon/LayerWrapper';
 import { layerSelected, selectCALayerOrThrow } from 'features/controlLayers/store/controlLayersSlice';
 import { memo, useCallback } from 'react';
@@ -26,7 +26,7 @@ export const CALayer = memo(({ layerId }: Props) => {
   return (
     <LayerWrapper onClick={onClick} borderColor={isSelected ? 'base.400' : 'base.800'}>
       <Flex gap={3} alignItems="center" p={3} cursor="pointer" onDoubleClick={onToggle}>
-        <LayerVisibilityToggle layerId={layerId} />
+        <LayerIsEnabledToggle layerId={layerId} />
         <LayerTitle type="control_adapter_layer" />
         <Spacer />
         <CALayerOpacity layerId={layerId} />

--- a/invokeai/frontend/web/src/features/controlLayers/components/IILayer/IILayer.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IILayer/IILayer.tsx
@@ -5,7 +5,7 @@ import { InitialImagePreview } from 'features/controlLayers/components/IILayer/I
 import { LayerDeleteButton } from 'features/controlLayers/components/LayerCommon/LayerDeleteButton';
 import { LayerMenu } from 'features/controlLayers/components/LayerCommon/LayerMenu';
 import { LayerTitle } from 'features/controlLayers/components/LayerCommon/LayerTitle';
-import { LayerVisibilityToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
+import { LayerIsEnabledToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
 import { LayerWrapper } from 'features/controlLayers/components/LayerCommon/LayerWrapper';
 import {
   iiLayerDenoisingStrengthChanged,
@@ -66,7 +66,7 @@ export const IILayer = memo(({ layerId }: Props) => {
   return (
     <LayerWrapper onClick={onClick} borderColor={layer.isSelected ? 'base.400' : 'base.800'}>
       <Flex gap={3} alignItems="center" p={3} cursor="pointer" onDoubleClick={onToggle}>
-        <LayerVisibilityToggle layerId={layerId} />
+        <LayerIsEnabledToggle layerId={layerId} />
         <LayerTitle type="initial_image_layer" />
         <Spacer />
         <IILayerOpacity layerId={layerId} />

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPALayer/IPALayer.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPALayer/IPALayer.tsx
@@ -3,7 +3,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { IPALayerIPAdapterWrapper } from 'features/controlLayers/components/IPALayer/IPALayerIPAdapterWrapper';
 import { LayerDeleteButton } from 'features/controlLayers/components/LayerCommon/LayerDeleteButton';
 import { LayerTitle } from 'features/controlLayers/components/LayerCommon/LayerTitle';
-import { LayerVisibilityToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
+import { LayerIsEnabledToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
 import { LayerWrapper } from 'features/controlLayers/components/LayerCommon/LayerWrapper';
 import { layerSelected, selectIPALayerOrThrow } from 'features/controlLayers/store/controlLayersSlice';
 import { memo, useCallback } from 'react';
@@ -22,7 +22,7 @@ export const IPALayer = memo(({ layerId }: Props) => {
   return (
     <LayerWrapper onClick={onClick} borderColor={isSelected ? 'base.400' : 'base.800'}>
       <Flex gap={3} alignItems="center" p={3} cursor="pointer" onDoubleClick={onToggle}>
-        <LayerVisibilityToggle layerId={layerId} />
+        <LayerIsEnabledToggle layerId={layerId} />
         <LayerTitle type="ip_adapter_layer" />
         <Spacer />
         <LayerDeleteButton layerId={layerId} />

--- a/invokeai/frontend/web/src/features/controlLayers/components/LayerCommon/LayerVisibilityToggle.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/LayerCommon/LayerVisibilityToggle.tsx
@@ -1,8 +1,8 @@
 import { IconButton } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { stopPropagation } from 'common/util/stopPropagation';
-import { useLayerIsVisible } from 'features/controlLayers/hooks/layerStateHooks';
-import { layerVisibilityToggled } from 'features/controlLayers/store/controlLayersSlice';
+import { useLayerIsEnabled } from 'features/controlLayers/hooks/layerStateHooks';
+import { layerIsEnabledToggled } from 'features/controlLayers/store/controlLayersSlice';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiCheckBold } from 'react-icons/pi';
@@ -11,21 +11,21 @@ type Props = {
   layerId: string;
 };
 
-export const LayerVisibilityToggle = memo(({ layerId }: Props) => {
+export const LayerIsEnabledToggle = memo(({ layerId }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const isVisible = useLayerIsVisible(layerId);
+  const isEnabled = useLayerIsEnabled(layerId);
   const onClick = useCallback(() => {
-    dispatch(layerVisibilityToggled(layerId));
+    dispatch(layerIsEnabledToggled(layerId));
   }, [dispatch, layerId]);
 
   return (
     <IconButton
       size="sm"
-      aria-label={t('controlLayers.toggleVisibility')}
-      tooltip={t('controlLayers.toggleVisibility')}
+      aria-label={t(isEnabled ? 'common.enabled' : 'common.disabled')}
+      tooltip={t(isEnabled ? 'common.enabled' : 'common.disabled')}
       variant="outline"
-      icon={isVisible ? <PiCheckBold /> : undefined}
+      icon={isEnabled ? <PiCheckBold /> : undefined}
       onClick={onClick}
       colorScheme="base"
       onDoubleClick={stopPropagation} // double click expands the layer
@@ -33,4 +33,4 @@ export const LayerVisibilityToggle = memo(({ layerId }: Props) => {
   );
 });
 
-LayerVisibilityToggle.displayName = 'LayerVisibilityToggle';
+LayerIsEnabledToggle.displayName = 'LayerVisibilityToggle';

--- a/invokeai/frontend/web/src/features/controlLayers/components/RGLayer/RGLayer.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RGLayer/RGLayer.tsx
@@ -6,7 +6,7 @@ import { AddPromptButtons } from 'features/controlLayers/components/AddPromptBut
 import { LayerDeleteButton } from 'features/controlLayers/components/LayerCommon/LayerDeleteButton';
 import { LayerMenu } from 'features/controlLayers/components/LayerCommon/LayerMenu';
 import { LayerTitle } from 'features/controlLayers/components/LayerCommon/LayerTitle';
-import { LayerVisibilityToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
+import { LayerIsEnabledToggle } from 'features/controlLayers/components/LayerCommon/LayerVisibilityToggle';
 import { LayerWrapper } from 'features/controlLayers/components/LayerCommon/LayerWrapper';
 import {
   isRegionalGuidanceLayer,
@@ -55,7 +55,7 @@ export const RGLayer = memo(({ layerId }: Props) => {
   return (
     <LayerWrapper onClick={onClick} borderColor={isSelected ? color : 'base.800'}>
       <Flex gap={3} alignItems="center" p={3} cursor="pointer" onDoubleClick={onToggle}>
-        <LayerVisibilityToggle layerId={layerId} />
+        <LayerIsEnabledToggle layerId={layerId} />
         <LayerTitle type="regional_guidance_layer" />
         <Spacer />
         {autoNegative === 'invert' && (

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/layerStateHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/layerStateHooks.ts
@@ -39,7 +39,7 @@ export const useLayerNegativePrompt = (layerId: string) => {
   return prompt;
 };
 
-export const useLayerIsVisible = (layerId: string) => {
+export const useLayerIsEnabled = (layerId: string) => {
   const selectLayer = useMemo(
     () =>
       createSelector(selectControlLayersSlice, (controlLayers) => {

--- a/invokeai/frontend/web/src/features/controlLayers/store/controlLayersSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/controlLayersSlice.ts
@@ -139,7 +139,7 @@ export const controlLayersSlice = createSlice({
     layerSelected: (state, action: PayloadAction<string>) => {
       exclusivelySelectLayer(state, action.payload);
     },
-    layerVisibilityToggled: (state, action: PayloadAction<string>) => {
+    layerIsEnabledToggled: (state, action: PayloadAction<string>) => {
       const layer = state.layers.find((l) => l.id === action.payload);
       if (layer) {
         layer.isEnabled = !layer.isEnabled;
@@ -791,7 +791,7 @@ class LayerColors {
 export const {
   // Any Layer Type
   layerSelected,
-  layerVisibilityToggled,
+  layerIsEnabledToggled,
   layerTranslated,
   layerBboxChanged,
   layerReset,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addControlLayers.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addControlLayers.ts
@@ -487,26 +487,19 @@ const isValidIPAdapter = (ipa: IPAdapterConfigV2, base: BaseModelType): boolean 
 };
 
 const isValidLayer = (layer: Layer, base: BaseModelType) => {
+  if (!layer.isEnabled) {
+    return false;
+  }
   if (isControlAdapterLayer(layer)) {
-    if (!layer.isEnabled) {
-      return false;
-    }
     return isValidControlAdapter(layer.controlAdapter, base);
   }
   if (isIPAdapterLayer(layer)) {
-    if (!layer.isEnabled) {
-      return false;
-    }
     return isValidIPAdapter(layer.ipAdapter, base);
   }
   if (isInitialImageLayer(layer)) {
-    if (!layer.isEnabled) {
-      return false;
-    }
     if (!layer.image) {
       return false;
     }
-    return true;
   }
   if (isRegionalGuidanceLayer(layer)) {
     const hasTextPrompt = Boolean(layer.positivePrompt || layer.negativePrompt);


### PR DESCRIPTION
## Summary

- Regional guidance layers were missing a check for the `isEnabled` flag and were always applied, even when disabled.
- Changed messaging from "visibility" to "enabled", which is what the checkboxes do

## Related Issues / Discussions

Closes #6424

## QA Instructions

- Generate an image w/ a regional guidance layer and manual seed
- Disable the layer and generate again
- Should be a different image created
- Metadata should correctly show only the enabled layers

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
