### PR TITLE
fix(ui): `'undefined'` being used for metadata on uploaded images

### DIFF
--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -576,7 +576,9 @@ export const imagesApi = api.injectEndpoints({
       query: ({ file, image_category, is_intermediate, session_id, board_id, crop_visible, metadata }) => {
         const formData = new FormData();
         formData.append('file', file);
-        formData.append('metadata', JSON.stringify(metadata));
+        if (metadata) {
+          formData.append('metadata', JSON.stringify(metadata));
+        }
         return {
           url: buildImagesUrl('upload'),
           method: 'POST',


### PR DESCRIPTION
## Summary

TIL if you add `undefined` to a form data object, it gets stringified to `'undefined'`. Whoops!

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
