### PR TITLE
Update TI handling for compatibility with transformers 4.40.0

### DIFF
--- a/invokeai/backend/textual_inversion.py
+++ b/invokeai/backend/textual_inversion.py
@@ -107,7 +107,7 @@ class TextualInversionManager(BaseTextualInversionManager):
 
         # Do not exceed the max model input size. The -2 here is compensating for
         # compel.embeddings_provider.get_token_ids(), which first removes and then adds back the start and end tokens.
-        max_length = list(self.tokenizer.max_model_input_sizes.values())[0] - 2
+        max_length = self.tokenizer.model_max_length - 2
         if len(new_token_ids) > max_length:
             new_token_ids = new_token_ids[0:max_length]
 

--- a/invokeai/backend/textual_inversion.py
+++ b/invokeai/backend/textual_inversion.py
@@ -109,6 +109,9 @@ class TextualInversionManager(BaseTextualInversionManager):
         # compel.embeddings_provider.get_token_ids(), which first removes and then adds back the start and end tokens.
         max_length = self.tokenizer.model_max_length - 2
         if len(new_token_ids) > max_length:
+            # HACK: If TI token expansion causes us to exceed the max text encoder input length, we silently discard
+            # tokens. Token expansion should happen in a way that is compatible with compel's default handling of long
+            # prompts.
             new_token_ids = new_token_ids[0:max_length]
 
         return new_token_ids


### PR DESCRIPTION
## Summary

- Updated the documentation for `TextualInversionManager`
- Updated the `self.tokenizer.model_max_length` access to work with the latest transformers version. Thanks to @skunkworxdark for looking into this here: https://github.com/invoke-ai/InvokeAI/issues/6445#issuecomment-2133098342

## Related Issues / Discussions

Closes #6445 

## QA Instructions

I tested with `transformers==4.41.1`, and compared the results against a recent InvokeAI version before updating tranformers - no change, as expected.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
