### PR TITLE
[MM]Fix bug in offload_unlocked_models() call

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/model_locker.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_locker.py
@@ -60,5 +60,5 @@ class ModelLocker(ModelLockerBase):
 
         self._cache_entry.unlock()
         if not self._cache.lazy_offloading:
-            self._cache.offload_unlocked_models(self._cache_entry.size)
+            self._cache.offload_unlocked_models(0)
             self._cache.print_cuda_stats()


### PR DESCRIPTION
## Summary

When lazy offloading is false, the model locker's `unlock()` method was asking `offload_unlocked_models` to free up VRAM sufficient to load the model that is being unlocked. This was incorrect. The method should be called with a size of 0, which will have the effect of removing models until VRAM is less than or equal to `max_vram_cache`.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

Please see https://github.com/invoke-ai/InvokeAI/pull/6439#pullrequestreview-2081213194 for @RyanJDick 's discovery of this bug.

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
