### PR TITLE
Prefixed JSON filenames with the image UUID

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
@@ -33,7 +33,7 @@ const DataViewer = (props: Props) => {
     const blob = new Blob([dataString]);
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = `${ fileName || label }.json`;
+    a.download = `${fileName || label}.json`;
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
@@ -32,9 +32,8 @@ const DataViewer = (props: Props) => {
   const handleDownload = useCallback(() => {
     const blob = new Blob([dataString]);
     const a = document.createElement('a');
-    const imageName = fileName ? fileName.replace('.png', '') : null;
     a.href = URL.createObjectURL(blob);
-    a.download = imageName ? `${ imageName }_${ label }.json` : `${ label }.json`;
+    a.download = `${ fileName || label }.json`;
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
@@ -32,8 +32,9 @@ const DataViewer = (props: Props) => {
   const handleDownload = useCallback(() => {
     const blob = new Blob([dataString]);
     const a = document.createElement('a');
+    const imageName = fileName ? fileName.replace('.png', '') : null;
     a.href = URL.createObjectURL(blob);
-    a.download = `${fileName || label}.json`;
+    a.download = imageName ? `${ imageName }_${ label }.json` : `${ label }.json`;
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataGraphTabContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataGraphTabContent.tsx
@@ -28,7 +28,7 @@ const ImageMetadataGraphTabContent = ({ image }: Props) => {
     return <IAINoContentFallback label={t('nodes.noGraph')} />;
   }
 
-  return <DataViewer data={graph} label={t('nodes.graph')} />;
+  return <DataViewer fileName={image.image_name} data={graph} label={t('nodes.graph')} />;
 };
 
 export default memo(ImageMetadataGraphTabContent);

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataGraphTabContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataGraphTabContent.tsx
@@ -28,7 +28,9 @@ const ImageMetadataGraphTabContent = ({ image }: Props) => {
     return <IAINoContentFallback label={t('nodes.noGraph')} />;
   }
 
-  return <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('nodes.graph')}`} data={graph} label={t('nodes.graph')} />;
+  return (
+    <DataViewer fileName={`${image.image_name.replace('.png', '')}_graph`} data={graph} label={t('nodes.graph')} />
+  );
 };
 
 export default memo(ImageMetadataGraphTabContent);

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataGraphTabContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataGraphTabContent.tsx
@@ -28,7 +28,7 @@ const ImageMetadataGraphTabContent = ({ image }: Props) => {
     return <IAINoContentFallback label={t('nodes.noGraph')} />;
   }
 
-  return <DataViewer fileName={image.image_name} data={graph} label={t('nodes.graph')} />;
+  return <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('nodes.graph')}`} data={graph} label={t('nodes.graph')} />;
 };
 
 export default memo(ImageMetadataGraphTabContent);

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
@@ -68,14 +68,14 @@ const ImageMetadataViewer = ({ image }: ImageMetadataViewerProps) => {
           </TabPanel>
           <TabPanel>
             {metadata ? (
-              <DataViewer data={metadata} label={t('metadata.metadata')} />
+              <DataViewer fileName={image.image_name} data={metadata} label={t('metadata.metadata')} />
             ) : (
               <IAINoContentFallback label={t('metadata.noMetaData')} />
             )}
           </TabPanel>
           <TabPanel>
             {image ? (
-              <DataViewer data={image} label={t('metadata.imageDetails')} />
+              <DataViewer fileName={image.image_name} data={image} label={t('metadata.imageDetails')} />
             ) : (
               <IAINoContentFallback label={t('metadata.noImageDetails')} />
             )}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
@@ -68,14 +68,22 @@ const ImageMetadataViewer = ({ image }: ImageMetadataViewerProps) => {
           </TabPanel>
           <TabPanel>
             {metadata ? (
-              <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('metadata.metadata')}`} data={metadata} label={t('metadata.metadata')} />
+              <DataViewer
+                fileName={`${image.image_name.replace('.png', '')}_metadata`}
+                data={metadata}
+                label={t('metadata.metadata')}
+              />
             ) : (
               <IAINoContentFallback label={t('metadata.noMetaData')} />
             )}
           </TabPanel>
           <TabPanel>
             {image ? (
-              <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('metadata.imageDetails')}`} data={image} label={t('metadata.imageDetails')} />
+              <DataViewer
+                fileName={`${image.image_name.replace('.png', '')}_details`}
+                data={image}
+                label={t('metadata.imageDetails')}
+              />
             ) : (
               <IAINoContentFallback label={t('metadata.noImageDetails')} />
             )}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataViewer.tsx
@@ -68,14 +68,14 @@ const ImageMetadataViewer = ({ image }: ImageMetadataViewerProps) => {
           </TabPanel>
           <TabPanel>
             {metadata ? (
-              <DataViewer fileName={image.image_name} data={metadata} label={t('metadata.metadata')} />
+              <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('metadata.metadata')}`} data={metadata} label={t('metadata.metadata')} />
             ) : (
               <IAINoContentFallback label={t('metadata.noMetaData')} />
             )}
           </TabPanel>
           <TabPanel>
             {image ? (
-              <DataViewer fileName={image.image_name} data={image} label={t('metadata.imageDetails')} />
+              <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('metadata.imageDetails')}`} data={image} label={t('metadata.imageDetails')} />
             ) : (
               <IAINoContentFallback label={t('metadata.noImageDetails')} />
             )}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataWorkflowTabContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataWorkflowTabContent.tsx
@@ -28,7 +28,13 @@ const ImageMetadataWorkflowTabContent = ({ image }: Props) => {
     return <IAINoContentFallback label={t('nodes.noWorkflow')} />;
   }
 
-  return <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('metadata.workflow')}`} data={workflow} label={t('metadata.workflow')} />;
+  return (
+    <DataViewer
+      fileName={`${image.image_name.replace('.png', '')}_workflow`}
+      data={workflow}
+      label={t('metadata.workflow')}
+    />
+  );
 };
 
 export default memo(ImageMetadataWorkflowTabContent);

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataWorkflowTabContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataWorkflowTabContent.tsx
@@ -28,7 +28,7 @@ const ImageMetadataWorkflowTabContent = ({ image }: Props) => {
     return <IAINoContentFallback label={t('nodes.noWorkflow')} />;
   }
 
-  return <DataViewer data={workflow} label={t('metadata.workflow')} />;
+  return <DataViewer fileName={image.image_name} data={workflow} label={t('metadata.workflow')} />;
 };
 
 export default memo(ImageMetadataWorkflowTabContent);

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataWorkflowTabContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataWorkflowTabContent.tsx
@@ -28,7 +28,7 @@ const ImageMetadataWorkflowTabContent = ({ image }: Props) => {
     return <IAINoContentFallback label={t('nodes.noWorkflow')} />;
   }
 
-  return <DataViewer fileName={image.image_name} data={workflow} label={t('metadata.workflow')} />;
+  return <DataViewer fileName={`${image.image_name.replace('.png','')}_${t('metadata.workflow')}`} data={workflow} label={t('metadata.workflow')} />;
 };
 
 export default memo(ImageMetadataWorkflowTabContent);


### PR DESCRIPTION
## Summary

Added the image UUID as a prefix for the various JSON files generated from the image metadata interface

## Related Issues / Discussions

Closes #6469

## QA Instructions

Go to "info" for a generated image, switch to "Metadata", "Image Details", etc. and click the JSON download button. The downloaded file should now have the image UUID with an underscore and then the JSON label itself. If there is no UUID (no image_name), the fallback will just be the label.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
