### PR TITLE
add url for downloading huggingface models

### DIFF
--- a/invokeai/frontend/web/src/app/components/App.tsx
+++ b/invokeai/frontend/web/src/app/components/App.tsx
@@ -13,9 +13,11 @@ import ChangeBoardModal from 'features/changeBoardModal/components/ChangeBoardMo
 import DeleteImageModal from 'features/deleteImageModal/components/DeleteImageModal';
 import { DynamicPromptsModal } from 'features/dynamicPrompts/components/DynamicPromptsPreviewModal';
 import { useStarterModelsToast } from 'features/modelManagerV2/hooks/useStarterModelsToast';
+import { setDownloadHFModel } from 'features/modelManagerV2/store/modelManagerV2Slice';
 import { configChanged } from 'features/system/store/configSlice';
 import { languageSelector } from 'features/system/store/systemSelectors';
 import InvokeTabs from 'features/ui/components/InvokeTabs';
+import { setActiveTab } from 'features/ui/store/uiSlice';
 import { AnimatePresence } from 'framer-motion';
 import i18n from 'i18n';
 import { size } from 'lodash-es';
@@ -69,6 +71,17 @@ const App = ({ config = DEFAULT_CONFIG, selectedImage }: Props) => {
 
   useEffect(() => {
     dispatch(appStarted());
+  }, [dispatch]);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const hfModel = url.pathname.match(/\/install\/hf\/(.*)/);
+    if (hfModel) {
+      const newUrl = url.href.replace(/\/install.*/, '');
+      window.history.replaceState({}, '', newUrl);
+      dispatch(setActiveTab('models'));
+      dispatch(setDownloadHFModel(hfModel[1]));
+    }
   }, [dispatch]);
 
   useStarterModelsToast();

--- a/invokeai/frontend/web/src/app/hooks/useSocketIO.ts
+++ b/invokeai/frontend/web/src/app/hooks/useSocketIO.ts
@@ -42,7 +42,7 @@ export const useSocketIO = () => {
   const socketOptions = useMemo(() => {
     const options: Partial<ManagerOptions & SocketOptions> = {
       timeout: 60000,
-      path: baseUrl ? '/ws/socket.io' : `${window.location.pathname}ws/socket.io`,
+      path: '/ws/socket.io',
       autoConnect: false, // achtung! removing this breaks the dynamic middleware
       forceNew: true,
     };
@@ -53,7 +53,7 @@ export const useSocketIO = () => {
     }
 
     return { ...options, ...addlSocketOptions };
-  }, [authToken, addlSocketOptions, baseUrl]);
+  }, [authToken, addlSocketOptions]);
 
   useEffect(() => {
     if ($isSocketInitialized.get()) {

--- a/invokeai/frontend/web/src/features/modelManagerV2/store/modelManagerV2Slice.ts
+++ b/invokeai/frontend/web/src/features/modelManagerV2/store/modelManagerV2Slice.ts
@@ -12,6 +12,7 @@ type ModelManagerState = {
   searchTerm: string;
   filteredModelType: FilterableModelType | null;
   scanPath: string | undefined;
+  downloadHFModel: string | undefined;
 };
 
 const initialModelManagerState: ModelManagerState = {
@@ -21,6 +22,7 @@ const initialModelManagerState: ModelManagerState = {
   filteredModelType: null,
   searchTerm: '',
   scanPath: undefined,
+  downloadHFModel: undefined,
 };
 
 export const modelManagerV2Slice = createSlice({
@@ -37,17 +39,19 @@ export const modelManagerV2Slice = createSlice({
     setSearchTerm: (state, action: PayloadAction<string>) => {
       state.searchTerm = action.payload;
     },
-
     setFilteredModelType: (state, action: PayloadAction<FilterableModelType | null>) => {
       state.filteredModelType = action.payload;
     },
     setScanPath: (state, action: PayloadAction<string | undefined>) => {
       state.scanPath = action.payload;
     },
+    setDownloadHFModel: (state, action: PayloadAction<string | undefined>) => {
+      state.downloadHFModel = action.payload;
+    }
   },
 });
 
-export const { setSelectedModelKey, setSearchTerm, setFilteredModelType, setSelectedModelMode, setScanPath } =
+export const { setSelectedModelKey, setSearchTerm, setFilteredModelType, setSelectedModelMode, setScanPath, setDownloadHFModel } =
   modelManagerV2Slice.actions;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/invokeai/frontend/web/src/features/modelManagerV2/store/modelManagerV2Slice.ts
+++ b/invokeai/frontend/web/src/features/modelManagerV2/store/modelManagerV2Slice.ts
@@ -47,12 +47,18 @@ export const modelManagerV2Slice = createSlice({
     },
     setDownloadHFModel: (state, action: PayloadAction<string | undefined>) => {
       state.downloadHFModel = action.payload;
-    }
+    },
   },
 });
 
-export const { setSelectedModelKey, setSearchTerm, setFilteredModelType, setSelectedModelMode, setScanPath, setDownloadHFModel } =
-  modelManagerV2Slice.actions;
+export const {
+  setSelectedModelKey,
+  setSearchTerm,
+  setFilteredModelType,
+  setSelectedModelMode,
+  setScanPath,
+  setDownloadHFModel,
+} = modelManagerV2Slice.actions;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 const migrateModelManagerState = (state: any): any => {

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/HuggingFaceFolder/HuggingFaceForm.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/HuggingFaceFolder/HuggingFaceForm.tsx
@@ -1,17 +1,21 @@
 import { Button, Flex, FormControl, FormErrorMessage, FormHelperText, FormLabel, Input } from '@invoke-ai/ui-library';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useInstallModel } from 'features/modelManagerV2/hooks/useInstallModel';
+import { setDownloadHFModel } from 'features/modelManagerV2/store/modelManagerV2Slice';
 import type { ChangeEventHandler } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyGetHuggingFaceModelsQuery } from 'services/api/endpoints/models';
 
 import { HuggingFaceResults } from './HuggingFaceResults';
 
 export const HuggingFaceForm = () => {
+  const dispatch = useAppDispatch();
   const [huggingFaceRepo, setHuggingFaceRepo] = useState('');
   const [displayResults, setDisplayResults] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const { t } = useTranslation();
+  const downloadHFModel = useAppSelector((state) => state.modelmanagerV2.downloadHFModel);
 
   const [_getHuggingFaceModels, { isLoading, data }] = useLazyGetHuggingFaceModelsQuery();
   const [installModel] = useInstallModel();
@@ -39,6 +43,15 @@ export const HuggingFaceForm = () => {
     setHuggingFaceRepo(e.target.value);
     setErrorMessage('');
   }, []);
+
+  useEffect(() => {
+    if (downloadHFModel && huggingFaceRepo) {
+      getModels();
+      dispatch(setDownloadHFModel());
+    } else if (downloadHFModel) {
+      setHuggingFaceRepo(downloadHFModel);
+    }
+  }, [downloadHFModel, getModels, huggingFaceRepo, dispatch]);
 
   return (
     <Flex flexDir="column" height="100%" gap={3}>

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/InstallModels.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/InstallModels.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Heading, Tab, TabList, TabPanel, TabPanels, Tabs } from '@invoke-ai/ui-library';
+import { useAppSelector } from 'app/store/storeHooks';
 import { StarterModelsForm } from 'features/modelManagerV2/subpanels/AddModelPanel/StarterModels/StarterModelsForm';
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMainModels } from 'services/api/hooks/modelsByType';
 
@@ -12,17 +13,27 @@ import { ScanModelsForm } from './AddModelPanel/ScanFolder/ScanFolderForm';
 export const InstallModels = () => {
   const { t } = useTranslation();
   const [mainModels, { data }] = useMainModels();
-  const defaultIndex = useMemo(() => {
-    if (data && mainModels.length) {
-      return 0;
+  const downloadHFModel = useAppSelector((state) => state.modelmanagerV2.downloadHFModel);
+
+  const [selectedTabIndex, setSelectedTabIndex] = useState(data && mainModels.length ? 0 : 3);
+
+  useEffect(() => {
+    if (downloadHFModel) {
+      setSelectedTabIndex(1);
     }
-    return 3;
-  }, [data, mainModels.length]);
+  }, [downloadHFModel]);
 
   return (
     <Flex layerStyle="first" borderRadius="base" w="full" h="full" flexDir="column" gap={4}>
       <Heading fontSize="xl">{t('modelManager.addModel')}</Heading>
-      <Tabs variant="collapse" height="50%" display="flex" flexDir="column" defaultIndex={defaultIndex}>
+      <Tabs
+        variant="collapse"
+        height="50%"
+        display="flex"
+        flexDir="column"
+        index={selectedTabIndex}
+        onChange={setSelectedTabIndex}
+      >
         <TabList>
           <Tab>{t('modelManager.urlOrLocalPath')}</Tab>
           <Tab>{t('modelManager.huggingFace')}</Tab>

--- a/invokeai/frontend/web/src/i18n.ts
+++ b/invokeai/frontend/web/src/i18n.ts
@@ -32,7 +32,7 @@ if (import.meta.env.MODE === 'package') {
       fallbackLng: 'en',
       debug: false,
       backend: {
-        loadPath: `${window.location.href.replace(/\/$/, '')}/locales/{{lng}}.json`,
+        loadPath: `${window.location.origin}/locales/{{lng}}.json`,
       },
       interpolation: {
         escapeValue: false,

--- a/invokeai/frontend/web/src/services/api/endpoints/appInfo.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/appInfo.ts
@@ -70,7 +70,7 @@ export const appInfoApi = api.injectEndpoints({
     getOpenAPISchema: build.query<OpenAPIV3_1.Document, void>({
       query: () => {
         const openAPISchemaUrl = $openAPISchemaUrl.get();
-        const url = openAPISchemaUrl ? openAPISchemaUrl : `${window.location.href.replace(/\/$/, '')}/openapi.json`;
+        const url = openAPISchemaUrl ? openAPISchemaUrl : `${window.location.origin}/openapi.json`;
         return url;
       },
       providesTags: ['Schema'],

--- a/invokeai/frontend/web/src/services/api/index.ts
+++ b/invokeai/frontend/web/src/services/api/index.ts
@@ -61,7 +61,7 @@ const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryE
     (typeof args === 'string' && args.includes('openapi.json'));
 
   const fetchBaseQueryArgs: FetchBaseQueryArgs = {
-    baseUrl: baseUrl || window.location.href.replace(/\/$/, ''),
+    baseUrl: baseUrl || window.location.origin,
   };
 
   // When fetching the openapi.json, we need to remove circular references from the JSON.


### PR DESCRIPTION
## Summary
provides a url that people can go to for downloading huggingface models. example: http://localhost:5173/models/hf/InvokeAI/ip_adapter_sd15 will open the model manager and download the ip_adapter_sd15 model
<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions
can test by adding /models/hf/repoId to your url locally
<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
