### PR TITLE
Make the VAE tile size configurable for tiled VAE

### DIFF
--- a/invokeai/app/invocations/fields.py
+++ b/invokeai/app/invocations/fields.py
@@ -160,6 +160,8 @@ class FieldDescriptions:
     fp32 = "Whether or not to use full float32 precision"
     precision = "Precision to use"
     tiled = "Processing using overlapping tiles (reduce memory consumption)"
+    vae_tile_size = "The tile size for VAE tiling in pixels (image space). If set to 0, the default tile size for the "
+    "model will be used. Larger tile sizes generally produce better results at the cost of higher memory usage."
     detect_res = "Pixel resolution for detection"
     image_res = "Pixel resolution for output image"
     safe_mode = "Whether or not to use safe mode"

--- a/invokeai/backend/stable_diffusion/vae_tiling.py
+++ b/invokeai/backend/stable_diffusion/vae_tiling.py
@@ -1,0 +1,29 @@
+from contextlib import contextmanager
+
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+from diffusers.models.autoencoders.autoencoder_tiny import AutoencoderTiny
+
+
+@contextmanager
+def patch_vae_tiling_params(
+    vae: AutoencoderKL | AutoencoderTiny,
+    tile_sample_min_size: int,
+    tile_latent_min_size: int,
+    tile_overlap_factor: float,
+):
+    # Record initial config.
+    orig_tile_sample_min_size = vae.tile_sample_min_size
+    orig_tile_latent_min_size = vae.tile_latent_min_size
+    orig_tile_overlap_factor = vae.tile_overlap_factor
+
+    try:
+        # Apply target config.
+        vae.tile_sample_min_size = tile_sample_min_size
+        vae.tile_latent_min_size = tile_latent_min_size
+        vae.tile_overlap_factor = tile_overlap_factor
+        yield
+    finally:
+        # Restore initial config.
+        vae.tile_sample_min_size = orig_tile_sample_min_size
+        vae.tile_latent_min_size = orig_tile_latent_min_size
+        vae.tile_overlap_factor = orig_tile_overlap_factor

--- a/invokeai/backend/stable_diffusion/vae_tiling.py
+++ b/invokeai/backend/stable_diffusion/vae_tiling.py
@@ -11,6 +11,12 @@ def patch_vae_tiling_params(
     tile_latent_min_size: int,
     tile_overlap_factor: float,
 ):
+    """Patch the parameters that control the VAE tiling tile size and overlap.
+
+    These parameters are not explicitly exposed in the VAE's API, but they have a significant impact on the quality of
+    the outputs. As a general rule, bigger tiles produce better results, but this comes at the cost of higher memory
+    usage.
+    """
     # Record initial config.
     orig_tile_sample_min_size = vae.tile_sample_min_size
     orig_tile_latent_min_size = vae.tile_latent_min_size

--- a/tests/backend/stable_diffusion/test_vae_tiling.py
+++ b/tests/backend/stable_diffusion/test_vae_tiling.py
@@ -1,0 +1,13 @@
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+
+from invokeai.backend.stable_diffusion.vae_tiling import patch_vae_tiling_params
+
+
+def test_patch_vae_tiling_params():
+    """Smoke test the patch_vae_tiling_params(...) context manager. The main purpose of this unit test is to detect if
+    diffusers ever changes the attributes of the AutoencoderKL class that we expect to exist.
+    """
+    vae = AutoencoderKL()
+
+    with patch_vae_tiling_params(vae, 1, 2, 3):
+        pass


### PR DESCRIPTION
## Summary

- This PR exposes a `tile_size` field on `ImageToLatentsInvocation` and `LatentsToImageInvocation`.
  - Setting `tile_size = 0` preserves the default behaviour.
- This feature is primarily intended to support upscaling workflows that require VAE encoding/decoding high resolution images. In the future, we may want to expose the tile size as a global application config, but that's a separate conversation.
- As a general rule, larger tile sizes produce better results at the cost of higher memory usage.

### Example:

Original (5472x5472)
![orig](https://github.com/invoke-ai/InvokeAI/assets/14897797/af0a975d-11ed-4f3c-9e53-84f3da6c997e)

VAE roundtrip with 512x512 tiles (note the discoloration)
![vae_roundtrip_512x512](https://github.com/invoke-ai/InvokeAI/assets/14897797/d589ae3e-fe93-410a-904c-f61f0fc0f1f2)

VAE roundtrip with 1024x1024 tiles (some discoloration still present, but less severe than at 512x512)
![vae_roundtrip_1024x1024](https://github.com/invoke-ai/InvokeAI/assets/14897797/d0bb9752-3bfa-444f-88c9-39a3ca89c748)


## Related Issues / Discussions

Related: #6144 

## QA Instructions

- [x] Test image generation via the Linear tab
- [x] Test VAE roundtrip with tiling disabled
- [x] Test VAE roundtrip with tiling and tile_size = 0
- [x] Test VAE roundtrip with tiling and tile_size > 0

## Merge Plan

No special instructions.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
