### PR TITLE
fix(app): fix SQL query w/ enum for python 3.11

### DIFF
--- a/invokeai/app/services/image_records/image_records_sqlite.py
+++ b/invokeai/app/services/image_records/image_records_sqlite.py
@@ -213,11 +213,11 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
 
             if starred_first:
                 query_pagination = f"""--sql
-                ORDER BY images.starred DESC, images.created_at {order_dir} LIMIT ? OFFSET ?
+                ORDER BY images.starred DESC, images.created_at {order_dir.value} LIMIT ? OFFSET ?
                 """
             else:
                 query_pagination = f"""--sql
-                ORDER BY images.created_at {order_dir} LIMIT ? OFFSET ?
+                ORDER BY images.created_at {order_dir.value} LIMIT ? OFFSET ?
                 """
 
             # Final images query with pagination


### PR DESCRIPTION
## Summary

Python 3.11 has a wonderfully devious breaking change where _sometimes_ using enum classes that inherit from `str` or `int` do not work the same way as they do in 3.10 when used within string formatting/interpolation.

This breaks the new gallery sort queries. The fix is to use `order_dir.value` instead of `order_dir` in the query.

This was not an issue during development because the feature was developed w/ python 3.10.

## Related Issues / Discussions

Thanks to @JPPhoto for reporting and troubleshooting: https://discord.com/channels/1020123559063990373/1149513625321603162/1256211815982039173

## QA Instructions

JP's fancy python 3.11 system should work on this PR.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
