### PR TITLE
Fix access token lookup for model downloads

### DIFF
--- a/invokeai/app/services/download/download_default.py
+++ b/invokeai/app/services/download/download_default.py
@@ -185,7 +185,7 @@ class DownloadQueueService(DownloadQueueServiceBase):
             job = DownloadJob(
                 source=url,
                 dest=path,
-                access_token=access_token,
+                access_token=access_token or self._lookup_access_token(url),
             )
             mfdj.download_parts.add(job)
             self._download_part2parent[job.source] = mfdj


### PR DESCRIPTION
## Summary

PR #6132 inadvertently broke the system for submitting access tokens that match the source URL's regular expression. This PR fixes the issue.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

Nobody seems to have noticed this problem!

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Be sure to set up a civitai or huggingface access token in `invokeai.yaml`. E.g.:

```
remote_api_tokens:
- url_regex: huggingface\.co
  token: hf_xyxyxyxyxyxyx
- url_regex: civitai\.com
  token: abcabcabcabc
```

Then attempt to download a restricted model. It should succeed. If you remove or change the access token in the config, the download should fail.

<!--WHEN APPLICABLE: Describe how we can test the changes in this PR.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
