### PR TITLE
[WIP] Generation backend rewrite

### DIFF
--- a/invokeai/backend/stable_diffusion/denoise_context.py
+++ b/invokeai/backend/stable_diffusion/denoise_context.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import torch
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, Optional, Union, Dict, Tuple
+from diffusers import UNet2DConditionModel
+from diffusers.schedulers.scheduling_utils import SchedulerMixin, SchedulerOutput
+
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from invokeai.backend.stable_diffusion.diffusion.conditioning_data import TextConditioningData
+
+
+
+@dataclass
+class UNetKwargs:
+    sample: torch.Tensor
+    timestep: Union[torch.Tensor, float, int]
+    encoder_hidden_states: torch.Tensor
+
+    class_labels: Optional[torch.Tensor] = None
+    timestep_cond: Optional[torch.Tensor] = None
+    attention_mask: Optional[torch.Tensor] = None
+    cross_attention_kwargs: Optional[Dict[str, Any]] = None
+    added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None
+    down_block_additional_residuals: Optional[Tuple[torch.Tensor]] = None
+    mid_block_additional_residual: Optional[torch.Tensor] = None
+    down_intrablock_additional_residuals: Optional[Tuple[torch.Tensor]] = None
+    encoder_attention_mask: Optional[torch.Tensor] = None
+    #return_dict: bool = True
+
+
+@dataclass
+class DenoiseContext:
+    latents: torch.Tensor
+    scheduler_step_kwargs: dict[str, Any]
+    conditioning_data: TextConditioningData
+    noise: Optional[torch.Tensor]
+    seed: int
+    timesteps: torch.Tensor
+    init_timestep: torch.Tensor
+    
+    unet: UNet2DConditionModel
+    scheduler: SchedulerMixin
+
+    orig_latents: Optional[torch.Tensor] = None
+    step_index: Optional[int] = None
+    timestep: Optional[torch.Tensor] = None
+    unet_kwargs: Optional[UNetKwargs] = None
+    step_output: Optional[SchedulerOutput] = None
+
+    latent_model_input: Optional[torch.Tensor] = None
+    conditioning_mode: Optional[str] = None
+    negative_noise_pred: Optional[torch.Tensor] = None
+    positive_noise_pred: Optional[torch.Tensor] = None
+    noise_pred: Optional[torch.Tensor] = None
+
+    def __delattr__(self, name: str):
+        setattr(self, name, None)
+
+    @classmethod
+    def from_kwargs(cls, **kwargs) -> DenoiseContext:
+        names = set([f.name for f in dataclasses.fields(cls)])
+        return cls(**{
+            k: v for k, v in kwargs.items() 
+            if k in names
+        })

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -30,7 +30,7 @@ from invokeai.backend.util.attention import auto_detect_slice_size
 from invokeai.backend.util.devices import TorchDevice
 from invokeai.backend.util.hotfixes import ControlNetModel
 
-from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt, InpaintExt, T2IAdapterExt
+from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt, InpaintExt, T2IAdapterExt, ControlNetExt
 from .extensions_manager import ExtensionsManager
 
 
@@ -644,6 +644,21 @@ class StableDiffusionBackend:
                         weight=t2i_adapter.weight,
                         begin_step_percent=t2i_adapter.begin_step_percent,
                         end_step_percent=t2i_adapter.end_step_percent,
+                        priority=100,
+                    )
+                )
+
+        if control_data is not None:
+            for controlnet in control_data:
+                ext_controller.add_extension(
+                    ControlNetExt(
+                        model=controlnet.model,
+                        image_tensor=controlnet.image_tensor,
+                        weight=controlnet.weight,
+                        begin_step_percent=controlnet.begin_step_percent,
+                        end_step_percent=controlnet.end_step_percent,
+                        control_mode=controlnet.control_mode,
+                        resize_mode=controlnet.resize_mode,
                         priority=100,
                     )
                 )

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -29,17 +29,8 @@ from invokeai.backend.util.attention import auto_detect_slice_size
 from invokeai.backend.util.devices import TorchDevice
 from invokeai.backend.util.hotfixes import ControlNetModel
 
+from .extensions import PipelineIntermediateState, PreviewExt
 from .extensions_manager import ExtensionsManager
-
-
-@dataclass
-class PipelineIntermediateState:
-    step: int
-    order: int
-    total_steps: int
-    timestep: int
-    latents: torch.Tensor
-    predicted_original: Optional[torch.Tensor] = None
 
 
 @dataclass
@@ -641,6 +632,7 @@ class StableDiffusionBackend:
     ) -> torch.Tensor:
         ctx = DenoiseContext.from_kwargs(**locals(), unet=self.unet, scheduler=self.scheduler)
         ext_controller = ExtensionsManager()
+        ext_controller.add_extension(PreviewExt(callback, priority=99999))
         return self.latents_from_embeddings(ctx, ext_controller)
 
 

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -29,7 +29,7 @@ from invokeai.backend.util.attention import auto_detect_slice_size
 from invokeai.backend.util.devices import TorchDevice
 from invokeai.backend.util.hotfixes import ControlNetModel
 
-from .extensions import PipelineIntermediateState, PreviewExt
+from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt
 from .extensions_manager import ExtensionsManager
 
 
@@ -633,6 +633,10 @@ class StableDiffusionBackend:
         ctx = DenoiseContext.from_kwargs(**locals(), unet=self.unet, scheduler=self.scheduler)
         ext_controller = ExtensionsManager()
         ext_controller.add_extension(PreviewExt(callback, priority=99999))
+
+        if ctx.conditioning_data.guidance_rescale_multiplier > 0:
+            ext_controller.add_extension(RescaleCFGExt(ctx.conditioning_data.guidance_rescale_multiplier, priority=100))
+
         return self.latents_from_embeddings(ctx, ext_controller)
 
 

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -30,7 +30,7 @@ from invokeai.backend.util.attention import auto_detect_slice_size
 from invokeai.backend.util.devices import TorchDevice
 from invokeai.backend.util.hotfixes import ControlNetModel
 
-from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt, InpaintExt
+from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt, InpaintExt, T2IAdapterExt
 from .extensions_manager import ExtensionsManager
 
 
@@ -635,6 +635,18 @@ class StableDiffusionBackend:
         ext_controller = ExtensionsManager()
         if mask is not None or is_inpainting_model(ctx.unet):
             ext_controller.add_extension(InpaintExt(mask, masked_latents, is_gradient_mask, priority=200))
+
+        if t2i_adapter_data is not None:
+            for t2i_adapter in t2i_adapter_data:
+                ext_controller.add_extension(
+                    T2IAdapterExt(
+                        adapter_state=t2i_adapter.adapter_state,
+                        weight=t2i_adapter.weight,
+                        begin_step_percent=t2i_adapter.begin_step_percent,
+                        end_step_percent=t2i_adapter.end_step_percent,
+                        priority=100,
+                    )
+                )
 
         ext_controller.add_extension(PreviewExt(callback, priority=99999))
 

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -29,7 +29,7 @@ from invokeai.backend.util.attention import auto_detect_slice_size
 from invokeai.backend.util.devices import TorchDevice
 from invokeai.backend.util.hotfixes import ControlNetModel
 
-from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt
+from .extensions import PipelineIntermediateState, PreviewExt, RescaleCFGExt, InpaintExt
 from .extensions_manager import ExtensionsManager
 
 
@@ -632,6 +632,9 @@ class StableDiffusionBackend:
     ) -> torch.Tensor:
         ctx = DenoiseContext.from_kwargs(**locals(), unet=self.unet, scheduler=self.scheduler)
         ext_controller = ExtensionsManager()
+        if mask is not None or is_inpainting_model(ctx.unet):
+            ext_controller.add_extension(InpaintExt(mask, masked_latents, is_gradient_mask, priority=200))
+
         ext_controller.add_extension(PreviewExt(callback, priority=99999))
 
         if ctx.conditioning_data.guidance_rescale_multiplier > 0:

--- a/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
@@ -121,3 +121,96 @@ class TextConditioningData:
     def is_sdxl(self):
         assert isinstance(self.uncond_text, SDXLConditioningInfo) == isinstance(self.cond_text, SDXLConditioningInfo)
         return isinstance(self.cond_text, SDXLConditioningInfo)
+
+    def to_unet_kwargs(self, unet_kwargs, conditioning_mode):
+        if conditioning_mode == "both":
+            encoder_hidden_states, encoder_attention_mask = self._concat_conditionings_for_batch(
+                self.uncond_text.embeds, self.cond_text.embeds
+            )
+        elif conditioning_mode == "positive":
+            encoder_hidden_states = self.cond_text.embeds
+            encoder_attention_mask = None
+        else: # elif conditioning_mode == "negative":
+            encoder_hidden_states = self.uncond_text.embeds
+            encoder_attention_mask = None
+
+        unet_kwargs.encoder_hidden_states=encoder_hidden_states
+        unet_kwargs.encoder_attention_mask=encoder_attention_mask
+
+        if self.is_sdxl():
+            if conditioning_mode == "negative":
+                added_cond_kwargs = dict(
+                    text_embeds=self.cond_text.pooled_embeds,
+                    time_ids=self.cond_text.add_time_ids,
+                )
+            elif conditioning_mode == "positive":
+                added_cond_kwargs = dict(
+                    text_embeds=self.uncond_text.pooled_embeds,
+                    time_ids=self.uncond_text.add_time_ids,
+                )
+            else: # elif conditioning_mode == "both":
+                added_cond_kwargs = dict(
+                    text_embeds=torch.cat(
+                        [
+                            # TODO: how to pad? just by zeros? or even truncate?
+                            self.uncond_text.pooled_embeds,
+                            self.cond_text.pooled_embeds,
+                        ],
+                    ),
+                    time_ids=torch.cat(
+                        [
+                            self.uncond_text.add_time_ids,
+                            self.cond_text.add_time_ids,
+                        ],
+                    ),
+                )
+
+            unet_kwargs.added_cond_kwargs=added_cond_kwargs
+
+
+    def _concat_conditionings_for_batch(self, unconditioning, conditioning):
+        def _pad_conditioning(cond, target_len, encoder_attention_mask):
+            conditioning_attention_mask = torch.ones(
+                (cond.shape[0], cond.shape[1]), device=cond.device, dtype=cond.dtype
+            )
+
+            if cond.shape[1] < max_len:
+                conditioning_attention_mask = torch.cat(
+                    [
+                        conditioning_attention_mask,
+                        torch.zeros((cond.shape[0], max_len - cond.shape[1]), device=cond.device, dtype=cond.dtype),
+                    ],
+                    dim=1,
+                )
+
+                cond = torch.cat(
+                    [
+                        cond,
+                        torch.zeros(
+                            (cond.shape[0], max_len - cond.shape[1], cond.shape[2]),
+                            device=cond.device,
+                            dtype=cond.dtype,
+                        ),
+                    ],
+                    dim=1,
+                )
+
+            if encoder_attention_mask is None:
+                encoder_attention_mask = conditioning_attention_mask
+            else:
+                encoder_attention_mask = torch.cat(
+                    [
+                        encoder_attention_mask,
+                        conditioning_attention_mask,
+                    ]
+                )
+
+            return cond, encoder_attention_mask
+
+        encoder_attention_mask = None
+        if unconditioning.shape[1] != conditioning.shape[1]:
+            max_len = max(unconditioning.shape[1], conditioning.shape[1])
+            unconditioning, encoder_attention_mask = _pad_conditioning(unconditioning, max_len, encoder_attention_mask)
+            conditioning, encoder_attention_mask = _pad_conditioning(conditioning, max_len, encoder_attention_mask)
+
+        return torch.cat([unconditioning, conditioning]), encoder_attention_mask

--- a/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
+++ b/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
@@ -37,7 +37,17 @@ class CustomAttnProcessor2_0(AttnProcessor2_0):
                 for the i'th IP-Adapter.
         """
         super().__init__()
-        self._ip_adapter_attention_weights = ip_adapter_attention_weights
+        # TODO: remove with old backend code(and fix file name)
+        self._old_back = ip_adapter_attention_weights is not None
+        if self._old_back:
+            self._ip_adapter_attention_weights = ip_adapter_attention_weights
+        else:
+            self._ip_adapter_attention_weights = []
+
+    def add_ip_adapter(self, ip_adapter: IPAdapterAttentionWeights) -> int:
+        assert self._old_back == False
+        self._ip_adapter_attention_weights.append(ip_adapter)
+        return len(self._ip_adapter_attention_weights) - 1 # idx
 
     def __call__(
         self,

--- a/invokeai/backend/stable_diffusion/diffusion/regional_prompt_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/regional_prompt_data.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
 import torch
 import torch.nn.functional as F
 
-from invokeai.backend.stable_diffusion.diffusion.conditioning_data import (
-    TextConditioningRegions,
-)
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from invokeai.backend.stable_diffusion.diffusion.conditioning_data import (
+        TextConditioningRegions,
+    )
 
 
 class RegionalPromptData:

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -8,6 +8,7 @@ from .preview import PreviewExt, PipelineIntermediateState
 from .rescale import RescaleCFGExt
 from .t2i_adapter import T2IAdapterExt
 from .controlnet import ControlNetExt
+from .ip_adapter import IPAdapterExt
 
 __all__ = [
     "PipelineIntermediateState",
@@ -17,4 +18,5 @@ __all__ = [
     "RescaleCFGExt",
     "T2IAdapterExt",
     "ControlNetExt",
+    "IPAdapterExt",
 ]

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -3,12 +3,14 @@ Initialization file for the invokeai.backend.stable_diffusion.extensions package
 """
 
 from .base import ExtensionBase
+from .inpaint import InpaintExt
 from .preview import PreviewExt, PipelineIntermediateState
 from .rescale import RescaleCFGExt
 
 __all__ = [
     "PipelineIntermediateState",
     "ExtensionBase",
+    "InpaintExt",
     "PreviewExt",
     "RescaleCFGExt",
 ]

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -1,0 +1,9 @@
+"""
+Initialization file for the invokeai.backend.stable_diffusion.extensions package
+"""
+
+from .base import ExtensionBase
+
+__all__ = [
+    "ExtensionBase",
+]

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -3,7 +3,10 @@ Initialization file for the invokeai.backend.stable_diffusion.extensions package
 """
 
 from .base import ExtensionBase
+from .preview import PreviewExt, PipelineIntermediateState
 
 __all__ = [
+    "PipelineIntermediateState",
     "ExtensionBase",
+    "PreviewExt",
 ]

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -7,6 +7,7 @@ from .inpaint import InpaintExt
 from .preview import PreviewExt, PipelineIntermediateState
 from .rescale import RescaleCFGExt
 from .t2i_adapter import T2IAdapterExt
+from .controlnet import ControlNetExt
 
 __all__ = [
     "PipelineIntermediateState",
@@ -15,4 +16,5 @@ __all__ = [
     "PreviewExt",
     "RescaleCFGExt",
     "T2IAdapterExt",
+    "ControlNetExt",
 ]

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -4,9 +4,11 @@ Initialization file for the invokeai.backend.stable_diffusion.extensions package
 
 from .base import ExtensionBase
 from .preview import PreviewExt, PipelineIntermediateState
+from .rescale import RescaleCFGExt
 
 __all__ = [
     "PipelineIntermediateState",
     "ExtensionBase",
     "PreviewExt",
+    "RescaleCFGExt",
 ]

--- a/invokeai/backend/stable_diffusion/extensions/__init__.py
+++ b/invokeai/backend/stable_diffusion/extensions/__init__.py
@@ -6,6 +6,7 @@ from .base import ExtensionBase
 from .inpaint import InpaintExt
 from .preview import PreviewExt, PipelineIntermediateState
 from .rescale import RescaleCFGExt
+from .t2i_adapter import T2IAdapterExt
 
 __all__ = [
     "PipelineIntermediateState",
@@ -13,4 +14,5 @@ __all__ = [
     "InpaintExt",
     "PreviewExt",
     "RescaleCFGExt",
+    "T2IAdapterExt",
 ]

--- a/invokeai/backend/stable_diffusion/extensions/base.py
+++ b/invokeai/backend/stable_diffusion/extensions/base.py
@@ -1,0 +1,53 @@
+from typing import Optional, Callable, List
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from diffusers import UNet2DConditionModel
+
+@dataclass
+class InjectionInfo:
+    type: str
+    name: str
+    order: Optional[str]
+    function: Callable
+
+def modifier(name: str, order: str = "any"):
+    def _decorator(func):
+        func.__inj_info__ = dict(
+            type="modifier",
+            name=name,
+            order=order,
+        )
+        return func
+    return _decorator
+
+def override(name: str):
+    def _decorator(func):
+        func.__inj_info__ = dict(
+            type="override",
+            name=name,
+        )
+        return func
+    return _decorator
+
+class ExtensionBase(ABC):
+    def __init__(self, priority: int):
+        self.priority = priority
+        self.injections: List[InjectionInfo] = []
+        for func_name in dir(self):
+            func = getattr(self, func_name)
+            if not callable(func) or not hasattr(func, "__inj_info__"):
+                continue
+
+            self.injections.append(InjectionInfo(**func.__inj_info__, function=func))
+
+    def apply_attention_processor(self, attention_processor_cls: object):
+        pass
+
+    def restore_attention_processor(self):
+        pass
+
+    def patch_unet(self, unet: UNet2DConditionModel):
+        pass
+
+    def unpatch_unet(self, unet: UNet2DConditionModel):
+        pass

--- a/invokeai/backend/stable_diffusion/extensions/controlnet.py
+++ b/invokeai/backend/stable_diffusion/extensions/controlnet.py
@@ -1,0 +1,112 @@
+import math
+import torch
+from typing import Union, List
+from .base import ExtensionBase, modifier
+from ..denoise_context import DenoiseContext, UNetKwargs
+from invokeai.backend.util.hotfixes import ControlNetModel
+
+class ControlNetExt(ExtensionBase):
+    def __init__(
+        self,
+        model: ControlNetModel,
+        image_tensor: torch.Tensor,
+        weight: Union[float, List[float]],
+        begin_step_percent: float,
+        end_step_percent: float,
+        control_mode: str,
+        resize_mode: str,
+        priority: int,
+    ):
+        super().__init__(priority=priority)
+        self.model = model
+        self.image_tensor = image_tensor
+        self.weight = weight
+        self.begin_step_percent = begin_step_percent
+        self.end_step_percent = end_step_percent
+        self.control_mode = control_mode
+        self.resize_mode = resize_mode
+
+    def apply_attention_processor(self, attention_processor_cls):
+        self._original_processors = self.model.attn_processors
+        self.model.set_attn_processor(attention_processor_cls())
+
+    def restore_attention_processor(self):
+        self.model.set_attn_processor(self._original_processors)
+        del self._original_processors
+
+    @modifier("pre_unet_forward")
+    def pre_unet_step(self, ctx: DenoiseContext):
+        # skip if model not active in current step
+        total_steps = len(ctx.timesteps)
+        first_step = math.floor(self.begin_step_percent * total_steps)
+        last_step  = math.ceil(self.end_step_percent * total_steps)
+        if ctx.step_index < first_step or ctx.step_index > last_step:
+            return
+
+        # convert mode to internal flags
+        soft_injection = self.control_mode in ["more_prompt", "more_control"]
+        cfg_injection  = self.control_mode in ["more_control", "unbalanced"]
+
+        # no negative conditioning in cfg_injection mode
+        if cfg_injection:
+            if ctx.conditioning_mode == "negative":
+                return
+            down_samples, mid_sample = self._run(ctx, soft_injection, "positive")
+
+            if ctx.conditioning_mode == "both":
+                # add zeros as samples for negative conditioning
+                down_samples = [torch.cat([torch.zeros_like(d), d]) for d in down_samples]
+                mid_sample = torch.cat([torch.zeros_like(mid_sample), mid_sample])
+
+        else:
+            down_samples, mid_sample = self._run(ctx, soft_injection, ctx.conditioning_mode)
+
+
+        if ctx.unet_kwargs.down_block_additional_residuals is None and ctx.unet_kwargs.mid_block_additional_residual is None:
+            ctx.unet_kwargs.down_block_additional_residuals, ctx.unet_kwargs.mid_block_additional_residual = down_samples, mid_sample
+        else:
+            # add controlnet outputs together if have multiple controlnets
+            ctx.unet_kwargs.down_block_additional_residuals = [
+                samples_prev + samples_curr
+                for samples_prev, samples_curr in zip(ctx.unet_kwargs.down_block_additional_residuals, down_samples, strict=True)
+            ]
+            ctx.unet_kwargs.mid_block_additional_residual += mid_sample
+
+    def _run(self, ctx: DenoiseContext, soft_injection, conditioning_mode):
+        total_steps = len(ctx.timesteps)
+        model_input = ctx.latent_model_input
+        if conditioning_mode == "both":
+            model_input = torch.cat([model_input] * 2)
+
+        cn_unet_kwargs = UNetKwargs(
+            sample=model_input,
+            timestep=ctx.timestep,
+            encoder_hidden_states=None, # set later by conditoning
+
+            cross_attention_kwargs=dict(
+                percent_through=ctx.step_index / total_steps,
+            ),
+        )
+
+        ctx.conditioning_data.to_unet_kwargs(cn_unet_kwargs, conditioning_mode=conditioning_mode)
+
+        # get static weight, or weight corresponding to current step
+        weight = self.weight
+        if isinstance(weight, list):
+            weight = weight[ctx.step_index]
+
+        tmp_kwargs = vars(cn_unet_kwargs)
+        tmp_kwargs.pop("down_block_additional_residuals", None)
+        tmp_kwargs.pop("mid_block_additional_residual", None)
+        tmp_kwargs.pop("down_intrablock_additional_residuals", None)
+
+        # controlnet(s) inference
+        down_samples, mid_sample = self.model(
+            controlnet_cond=self.image_tensor,
+            conditioning_scale=weight,  # controlnet specific, NOT the guidance scale
+            guess_mode=soft_injection,  # this is still called guess_mode in diffusers ControlNetModel
+            return_dict=False,
+            **vars(cn_unet_kwargs),
+        )
+
+        return down_samples, mid_sample

--- a/invokeai/backend/stable_diffusion/extensions/inpaint.py
+++ b/invokeai/backend/stable_diffusion/extensions/inpaint.py
@@ -1,0 +1,118 @@
+import torch
+import einops
+from typing import Optional
+from .base import ExtensionBase, modifier
+from ..denoise_context import DenoiseContext
+from diffusers import UNet2DConditionModel
+
+
+class InpaintExt(ExtensionBase):
+    def __init__(
+        self,
+        mask: Optional[torch.Tensor],
+        masked_latents: Optional[torch.Tensor],
+        is_gradient_mask: bool,
+        priority: int,
+    ):
+        super().__init__(priority=priority)
+        self.mask = mask
+        self.masked_latents = masked_latents
+        self.is_gradient_mask = is_gradient_mask
+        self.noise = None
+
+    def _is_inpaint_model(self, unet: UNet2DConditionModel):
+        return unet.conv_in.in_channels == 9
+
+    def _apply_mask(self, ctx: DenoiseContext, latents: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        batch_size = latents.size(0)
+        mask = einops.repeat(self.mask, "b c h w -> (repeat b) c h w", repeat=batch_size)
+        if t.dim() == 0:
+            # some schedulers expect t to be one-dimensional.
+            # TODO: file diffusers bug about inconsistency?
+            t = einops.repeat(t, "-> batch", batch=batch_size)
+        # Noise shouldn't be re-randomized between steps here. The multistep schedulers
+        # get very confused about what is happening from step to step when we do that.
+        mask_latents = ctx.scheduler.add_noise(ctx.orig_latents, self.noise, t)
+        # TODO: Do we need to also apply scheduler.scale_model_input? Or is add_noise appropriately scaled already?
+        # mask_latents = self.scheduler.scale_model_input(mask_latents, t)
+        mask_latents = einops.repeat(mask_latents, "b c h w -> (repeat b) c h w", repeat=batch_size)
+        if self.is_gradient_mask:
+            threshhold = (t.item()) / ctx.scheduler.config.num_train_timesteps
+            mask_bool = mask > threshhold  # I don't know when mask got inverted, but it did
+            masked_input = torch.where(mask_bool, latents, mask_latents)
+        else:
+            masked_input = torch.lerp(mask_latents.to(dtype=latents.dtype), latents, mask.to(dtype=latents.dtype))
+        return masked_input
+
+
+    @modifier("pre_denoise_loop")
+    def init_tensors(self, ctx: DenoiseContext):
+        if self._is_inpaint_model(ctx.unet):
+            if self.mask is None:
+                self.mask = torch.ones_like(ctx.latents[:1, :1])
+            self.mask.to(device=ctx.latents.device, dtype=ctx.latents.dtype)
+
+            if self.masked_latents is None:
+                self.masked_latents = torch.zeros_like(ctx.latents[:1])
+            self.masked_latents.to(device=ctx.latents.device, dtype=ctx.latents.dtype)
+
+        else:
+            #self.orig_latents = ctx.orig_latents
+            self.noise = ctx.noise
+            if self.noise is None:
+                self.noise = torch.randn(
+                    ctx.orig_latents.shape,
+                    dtype=torch.float32,
+                    device="cpu",
+                    generator=torch.Generator(device="cpu").manual_seed(ctx.seed),
+                ).to(device=ctx.orig_latents.device, dtype=ctx.orig_latents.dtype)
+
+    # do first to make other extensions works with changed latents
+    @modifier("pre_step", order="first")
+    def apply_mask_to_latents(self, ctx: DenoiseContext):
+        if self._is_inpaint_model(ctx.unet) or self.mask is None:
+            return
+        ctx.latents = self._apply_mask(ctx, ctx.latents, ctx.timestep)
+
+    # do last so that other extensions works with normal latents
+    @modifier("pre_unet_forward", order="last")
+    def append_inpaint_layers(self, ctx: DenoiseContext):
+        if not self._is_inpaint_model(ctx.unet):
+            return
+
+        batch_size = ctx.unet_kwargs.sample.shape[0]
+        b_mask = torch.cat([self.mask] * batch_size)
+        b_masked_latents = torch.cat([self.masked_latents] * batch_size)
+        ctx.unet_kwargs.sample = torch.cat(
+            [ctx.unet_kwargs.sample, b_mask, b_masked_latents],
+            dim=1,
+        )
+
+    @modifier("post_step", order="first")
+    def apply_mask_to_preview(self, ctx: DenoiseContext):
+        if self._is_inpaint_model(ctx.unet) or self.mask is None:
+            return
+
+        timestep = ctx.scheduler.timesteps[-1]
+        if hasattr(ctx.step_output, "denoised"):
+            ctx.step_output.denoised = self._apply_mask(ctx, ctx.step_output.denoised, timestep)
+        elif hasattr(ctx.step_output, "pred_original_sample"):
+            ctx.step_output.pred_original_sample = self._apply_mask(ctx, ctx.step_output.pred_original_sample, timestep)
+        else:
+            ctx.step_output.pred_original_sample = self._apply_mask(ctx, ctx.step_output.prev_sample, timestep)
+
+    @modifier("post_denoise_loop") # last?
+    def restore_unmasked(self, ctx: DenoiseContext):
+        if self.mask is None:
+            return
+
+        # restore unmasked part after the last step is completed
+        # in-process masking happens before each step
+        if self.is_gradient_mask:
+            ctx.latents = torch.where(self.mask > 0, ctx.latents, ctx.orig_latents)
+        else:
+            ctx.latents = torch.lerp(
+                ctx.orig_latents,
+                ctx.latents.to(dtype=ctx.orig_latents.dtype),
+                self.mask.to(dtype=ctx.orig_latents.dtype),
+            )

--- a/invokeai/backend/stable_diffusion/extensions/ip_adapter.py
+++ b/invokeai/backend/stable_diffusion/extensions/ip_adapter.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import math
+import torch
+from typing import Any, List, Dict, Union
+from diffusers import UNet2DConditionModel
+
+from invokeai.backend.ip_adapter.ip_adapter import IPAdapter
+from invokeai.backend.stable_diffusion.diffusion.conditioning_data import IPAdapterConditioningInfo
+from invokeai.backend.stable_diffusion.diffusion.regional_ip_data import RegionalIPData
+from .base import ExtensionBase, modifier
+from ..denoise_context import DenoiseContext
+from invokeai.backend.stable_diffusion.diffusion.custom_atttention import (
+    CustomAttnProcessor2_0,
+    IPAdapterAttentionWeights,
+)
+
+
+class IPAdapterExt(ExtensionBase):
+    def __init__(
+        self,
+        model: IPAdapter,
+        conditioning: IPAdapterConditioningInfo,
+        mask: torch.Tensor,
+        target_blocks: List[str],
+        weight: Union[float, List[float]],
+        begin_step_percent: float,
+        end_step_percent: float,
+        priority: int,
+    ):
+        super().__init__(priority=priority)
+        self.model = model
+        self.conditioning = conditioning
+        self.mask = mask
+        self.target_blocks = target_blocks
+        self.weight = weight
+        self.begin_step_percent = begin_step_percent
+        self.end_step_percent = end_step_percent
+
+    def patch_unet(self, unet: UNet2DConditionModel):
+        for idx, name in enumerate(unet.attn_processors.keys()):
+            if name.endswith("attn1.processor"):
+                continue
+
+            ip_adapter_weights = self.model.attn_weights.get_attention_processor_weights(idx)
+            skip = True
+            for block in self.target_blocks:
+                if block in name:
+                    skip = False
+                    break
+
+            assert isinstance(unet.attn_processors[name], CustomAttnProcessor2_0)
+            unet.attn_processors[name].add_ip_adapter(
+                IPAdapterAttentionWeights(
+                    ip_adapter_weights=ip_adapter_weights,
+                    skip=skip,
+                )
+            )
+
+    def unpatch_unet(self, unet: UNet2DConditionModel):
+        # nop, as it unpatched with attention processor
+        pass
+
+    @modifier("pre_unet_forward")
+    def pre_unet_step(self, ctx: DenoiseContext):
+        # skip if model not active in current step
+        total_steps = len(ctx.timesteps)
+        first_step = math.floor(self.begin_step_percent * total_steps)
+        last_step = math.ceil(self.end_step_percent * total_steps)
+        if ctx.step_index < first_step or ctx.step_index > last_step:
+            return
+
+        weight = self.weight
+        if isinstance(weight, List):
+            weight = weight[ctx.step_index]
+
+        if ctx.conditioning_mode == "both":
+            embeds = torch.stack([self.conditioning.uncond_image_prompt_embeds, self.conditioning.cond_image_prompt_embeds])
+        elif ctx.conditioning_mode == "negative":
+            embeds = torch.stack([self.conditioning.uncond_image_prompt_embeds])
+        else: # elif ctx.conditioning_mode == "positive":
+            embeds = torch.stack([self.conditioning.cond_image_prompt_embeds])
+
+        if ctx.unet_kwargs.cross_attention_kwargs is None:
+            ctx.unet_kwargs.cross_attention_kwargs = dict()
+
+        regional_ip_data = ctx.unet_kwargs.cross_attention_kwargs.get("regional_ip_data", None)
+        if regional_ip_data is None:
+            regional_ip_data = RegionalIPData(
+                image_prompt_embeds=[],
+                scales=[],
+                masks=[],
+                dtype=ctx.latent_model_input.dtype,
+                device=ctx.latent_model_input.device,
+            )
+            ctx.unet_kwargs.cross_attention_kwargs.update(dict(
+                regional_ip_data=regional_ip_data,
+            ))
+
+
+        regional_ip_data.add(
+            embeds=embeds,
+            scale=weight,
+            mask=self.mask,
+        )

--- a/invokeai/backend/stable_diffusion/extensions/preview.py
+++ b/invokeai/backend/stable_diffusion/extensions/preview.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+import torch
+from typing import Callable, Optional
+from .base import ExtensionBase, modifier
+from ..denoise_context import DenoiseContext
+
+
+@dataclass
+class PipelineIntermediateState:
+    step: int
+    order: int
+    total_steps: int
+    timestep: int
+    latents: torch.Tensor
+    predicted_original: Optional[torch.Tensor] = None
+
+
+class PreviewExt(ExtensionBase):
+    def __init__(self, callback: Callable[[PipelineIntermediateState], None], priority: int):
+        super().__init__(priority=priority)
+        self.callback = callback
+
+    # do last so that all other changes shown
+    @modifier("pre_denoise_loop", order="last")
+    def initial_preview(self, ctx: DenoiseContext):
+        self.callback(
+            PipelineIntermediateState(
+                step=-1,
+                order=ctx.scheduler.order,
+                total_steps=len(ctx.timesteps),
+                timestep=int(ctx.scheduler.config.num_train_timesteps), # TODO: is there any code which uses it?
+                latents=ctx.latents,
+            )
+        )
+
+    # do last so that all other changes shown
+    @modifier("post_step", order="last")
+    def step_preview(self, ctx: DenoiseContext):
+        if hasattr(ctx.step_output, "denoised"):
+            predicted_original = ctx.step_output.denoised
+        elif hasattr(ctx.step_output, "pred_original_sample"):
+            predicted_original = ctx.step_output.pred_original_sample
+        else:
+            predicted_original = ctx.step_output.prev_sample
+
+
+        self.callback(
+            PipelineIntermediateState(
+                step=ctx.step_index,
+                order=ctx.scheduler.order,
+                total_steps=len(ctx.timesteps),
+                timestep=int(ctx.timestep), # TODO: is there any code which uses it?
+                latents=ctx.step_output.prev_sample,
+                predicted_original=predicted_original, # TODO: is there any reason for additional field?
+            )
+        )

--- a/invokeai/backend/stable_diffusion/extensions/rescale.py
+++ b/invokeai/backend/stable_diffusion/extensions/rescale.py
@@ -1,0 +1,28 @@
+import torch
+from .base import ExtensionBase, modifier
+from ..denoise_context import DenoiseContext
+
+
+class RescaleCFGExt(ExtensionBase):
+    def __init__(self, guidance_rescale_multiplier: float, priority: int):
+        super().__init__(priority=priority)
+        self.guidance_rescale_multiplier = guidance_rescale_multiplier
+
+    @staticmethod
+    def _rescale_cfg(total_noise_pred: torch.Tensor, pos_noise_pred: torch.Tensor, multiplier: float=0.7):
+        """Implementation of Algorithm 2 from https://arxiv.org/pdf/2305.08891.pdf."""
+        ro_pos = torch.std(pos_noise_pred, dim=(1, 2, 3), keepdim=True)
+        ro_cfg = torch.std(total_noise_pred, dim=(1, 2, 3), keepdim=True)
+
+        x_rescaled = total_noise_pred * (ro_pos / ro_cfg)
+        x_final = multiplier * x_rescaled + (1.0 - multiplier) * total_noise_pred
+        return x_final
+
+    @modifier("modify_noise_prediction")
+    def rescale_noise_pred(self, ctx: DenoiseContext):
+        if self.guidance_rescale_multiplier > 0:
+            ctx.noise_pred = self._rescale_cfg(
+                ctx.noise_pred,
+                ctx.positive_noise_pred,
+                self.guidance_rescale_multiplier,
+            )

--- a/invokeai/backend/stable_diffusion/extensions/t2i_adapter.py
+++ b/invokeai/backend/stable_diffusion/extensions/t2i_adapter.py
@@ -1,0 +1,46 @@
+import torch
+import math
+from typing import List, Union
+from .base import ExtensionBase, modifier
+from ..denoise_context import DenoiseContext
+
+
+class T2IAdapterExt(ExtensionBase):
+    adapter_state: List[torch.Tensor]
+    weight: Union[float, List[float]]
+    begin_step_percent: float
+    end_step_percent: float
+
+    def __init__(
+        self,
+        adapter_state: List[torch.Tensor],
+        weight: Union[float, List[float]],
+        begin_step_percent: float,
+        end_step_percent: float,
+        priority: int,
+    ):
+        super().__init__(priority=priority)
+        self.adapter_state = adapter_state
+        self.weight = weight
+        self.begin_step_percent = begin_step_percent
+        self.end_step_percent = end_step_percent
+
+    @modifier("pre_unet_forward")
+    def pre_unet_step(self, ctx: DenoiseContext):
+        # skip if model not active in current step
+        total_steps = len(ctx.timesteps)
+        first_step = math.floor(self.begin_step_percent * total_steps)
+        last_step  = math.ceil(self.end_step_percent * total_steps)
+        if ctx.step_index < first_step or ctx.step_index > last_step:
+            return
+
+        weight = self.weight
+        if isinstance(weight, list):
+            weight = weight[ctx.step_index]
+
+        # TODO: conditioning_mode?
+        if ctx.unet_kwargs.down_intrablock_additional_residuals is None:
+            ctx.unet_kwargs.down_intrablock_additional_residuals = [v * weight for v in self.adapter_state]
+        else:
+            for i, value in enumerate(self.adapter_state):
+                ctx.unet_kwargs.down_intrablock_additional_residuals[i] += value * weight

--- a/invokeai/backend/stable_diffusion/extensions_manager.py
+++ b/invokeai/backend/stable_diffusion/extensions_manager.py
@@ -1,0 +1,140 @@
+from abc import ABC
+from contextlib import contextmanager
+from typing import Callable
+from functools import partial
+
+from diffusers import UNet2DConditionModel
+from .denoise_context import DenoiseContext
+from .extensions import ExtensionBase
+
+class ExtModifiersApi(ABC):
+    def pre_denoise_loop(self, ctx: DenoiseContext):
+        pass
+
+    def post_denoise_loop(self, ctx: DenoiseContext):
+        pass
+
+    def pre_step(self, ctx: DenoiseContext):
+        pass
+
+    def post_step(self, ctx: DenoiseContext):
+        pass
+
+    def modify_noise_prediction(self, ctx: DenoiseContext):
+        pass
+
+    def pre_unet_forward(self, ctx: DenoiseContext):
+        pass
+
+class ExtOverridesApi(ABC):
+    def step(self, orig_func, ctx: DenoiseContext):
+        pass
+
+    def combine_noise(self, orig_func: Callable, ctx: DenoiseContext):
+        pass
+
+class ProxyCallsClass:
+    def __init__(self, handler):
+        self._handler = handler
+    def __getattr__(self, item):
+        return partial(self._handler, item)
+
+class ModifierInjectionPoint:
+    def __init__(self):
+        self.first = []
+        self.any = []
+        self.last = []
+
+    def add(self, func: Callable, order: str):
+        if order == "first":
+            self.first.append(func)
+        elif order == "last":
+            self.last.append(func)
+        else: # elif order == "any":
+            self.any.append(func)
+
+    def __call__(self, *args, **kwargs):
+        for func in self.first:
+            func(*args, **kwargs)
+        for func in self.any:
+            func(*args, **kwargs)
+        for func in reversed(self.last):
+            func(*args, **kwargs)
+
+
+class ExtensionsManager:
+    def __init__(self):
+        self.extensions = []
+
+        self._overrides = dict()
+        self._modifiers = dict()
+
+        self.modifiers: ExtModifiersApi = ProxyCallsClass(self.call_modifier)
+        self.overrides: ExtOverridesApi = ProxyCallsClass(self.call_override)
+
+
+    def add_extension(self, ext: ExtensionBase):
+        self.extensions.append(ext)
+        ordered_extensions = sorted(self.extensions, reverse=True, key=lambda ext: ext.priority)
+
+        self._overrides.clear()
+        self._modifiers.clear()
+
+        for ext in ordered_extensions:
+            for inj_info in ext.injections:
+                if inj_info.type == "modifier":
+                    if inj_info.name not in self._modifiers:
+                        self._modifiers[inj_info.name] = ModifierInjectionPoint()
+                    self._modifiers[inj_info.name].add(inj_info.function, inj_info.order)
+
+                else:
+                    if inj_info.name in self._overrides:
+                        raise Exception(f"Already overloaded - {inj_info.name}")
+                    self._overrides[inj_info.name] = inj_info.function
+
+    def call_modifier(self, name: str, ctx: DenoiseContext):
+        if name in self._modifiers:
+            self._modifiers[name](ctx)
+
+    def call_override(self, name: str, orig_func: Callable, ctx: DenoiseContext):
+        if name in self._overrides:
+            return self._overrides[name](orig_func, ctx)
+        else:
+            return orig_func(ctx, self)
+
+    @contextmanager
+    def patch_attention_processor(self, unet: UNet2DConditionModel, attn_processor_cls: object):
+        unet_orig_processors = unet.attn_processors
+        patched_extensions = []
+        try:
+            # just to be sure that attentions have not same processor instance
+            attn_procs = dict()
+            for idx, name in enumerate(unet.attn_processors.keys()):
+                attn_procs[name] = attn_processor_cls()
+            unet.set_attn_processor(attn_procs)
+
+            for ext in self.extensions:
+                ext.apply_attention_processor(attn_processor_cls)
+                patched_extensions.append(ext)
+
+            yield None
+
+        finally:
+            unet.set_attn_processor(unet_orig_processors)
+            for ext in patched_extensions:
+                ext.restore_attention_processor()
+
+    @contextmanager
+    def patch_unet(self, unet: UNet2DConditionModel):
+        _extensions = []
+        try:
+            ordered_extensions = sorted(self.extensions, reverse=True, key=lambda ext: ext.priority)
+            for ext in ordered_extensions:
+                ext.patch_unet(unet)
+                _extensions.append(ext)
+
+            yield None
+
+        finally:
+            for ext in _extensions:
+                ext.unpatch_unet(unet)


### PR DESCRIPTION
## Summary

Rewriting of generation backend. At this moment backend rewritten to new architecture, but from user perspective nothing should change as backend converts arguments silently. Later in major update we can apply changes further.
Recreated after conversation with @dunkeroni, from #6548 and his ideas.

What here done:
Simplified generation logic to most basic steps and added injection points(modifiers/overrides) to which users can attach and change generation logic.
Logic moved from backend to extensions:
- Generation latents preview
- Rescale CFG
- Handling inpainting/inpaint models
- Guidance models - ControlNet, T2I Adapter, IP Adapter

## Related Issues / Discussions

None

## QA Instructions

Currently old generation code not removed, so you can patch if in `latents_from_embeddings` and run old logic to check/compare.

## Merge Plan

Add tiled generation support.
Remove old backend code, which currently remains for testing.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_

@dunkeroni @RyanJDick