### PR TITLE
Fixed 404 error on latest release link (line 16):

### DIFF
--- a/installer/templates/invoke.bat.in
+++ b/installer/templates/invoke.bat.in
@@ -13,7 +13,7 @@ echo 2. Open the developer console
 echo 3. Command-line help
 echo Q - Quit
 echo.
-echo To update, download and run the installer from https://github.com/invoke-ai/InvokeAI/releases/latest.
+echo To update, download and run the installer from https://github.com/invoke-ai/InvokeAI/releases/latest
 echo.
 set /P choice="Please enter 1-4, Q: [1] "
 if not defined choice set choice=1


### PR DESCRIPTION
## Summary

This commit corrects a broken link on line 16 that was pointing to the latest release but causing a 404 error (page not found) when clicked. The issue was identified as a trailing dot at the end of the URL, which has now been removed. This ensures users can access the intended latest release page.
