### PR TITLE
Demote error log to warning for models treated as having size 0

### DIFF
--- a/invokeai/backend/model_manager/load/model_util.py
+++ b/invokeai/backend/model_manager/load/model_util.py
@@ -38,7 +38,7 @@ def calc_model_size_by_data(logger: logging.Logger, model: AnyModel) -> int:
     else:
         # TODO(ryand): Promote this from a log to an exception once we are confident that we are handling all of the
         # supported model types.
-        logger.error(
+        logger.warning(
             f"Failed to calculate model size for unexpected model type: {type(model)}. The model will be treated as "
             "having size 0."
         )


### PR DESCRIPTION
## Summary

Demote error log to warning for models treated as having size 0.

## Related Issues / Discussions

Closes #6587 

I looked into handling ESRGAN model sizes properly. They load a state_dict with a bit of an unusual nested-dict structure. Rather than figure out how to accurately calculate their size, we can just wait for https://github.com/invoke-ai/InvokeAI/pull/6556. ESRGAN model size handling should work properly when loaded through that pathway.

## QA Instructions

Loaded an ESRGAN model, and confirmed that the warning log is at the warning level.

## Merge Plan

No special instructions.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
