### PR TITLE
fix(ui): gallery followups

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/addArchivedOrDeletedBoardListener.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/addArchivedOrDeletedBoardListener.ts
@@ -31,18 +31,12 @@ export const addArchivedOrDeletedBoardListener = (startAppListening: AppStartLis
         return;
       }
 
-      let didReset = false;
-
-      if (!queryResult.data.find((board) => board.board_id === autoAddBoardId)) {
-        dispatch(autoAddBoardIdChanged('none'));
-        didReset = true;
-      }
       if (!queryResult.data.find((board) => board.board_id === selectedBoardId)) {
         dispatch(boardIdSelected({ boardId: 'none' }));
-        didReset = true;
-      }
-      if (didReset) {
         dispatch(galleryViewChanged('images'));
+      }
+      if (!queryResult.data.find((board) => board.board_id === autoAddBoardId)) {
+        dispatch(autoAddBoardIdChanged('none'));
       }
     },
   });
@@ -90,25 +84,17 @@ export const addArchivedOrDeletedBoardListener = (startAppListening: AppStartLis
         return;
       }
 
-      let didReset = false;
-
       // Handle the case where selected board is archived
       const selectedBoard = queryResult.data.find((b) => b.board_id === selectedBoardId);
       if (selectedBoard && selectedBoard.archived) {
         dispatch(boardIdSelected({ boardId: 'none' }));
-        didReset = true;
+        dispatch(galleryViewChanged('images'));
       }
 
       // Handle the case where auto-add board is archived
       const autoAddBoard = queryResult.data.find((b) => b.board_id === autoAddBoardId);
       if (autoAddBoard && autoAddBoard.archived) {
         dispatch(autoAddBoardIdChanged('none'));
-        didReset = true;
-      }
-
-      // When resetting the auto-add board or selected board, we should also reset the view to images
-      if (didReset) {
-        dispatch(galleryViewChanged('images'));
       }
     },
   });
@@ -123,25 +109,15 @@ export const addArchivedOrDeletedBoardListener = (startAppListening: AppStartLis
       const state = getState();
       const { selectedBoardId, autoAddBoardId } = state.gallery;
 
-      let didReset = false;
-
       // Handle the case where selected board isn't in the list of boards
-      const selectedBoard = boards.find((b) => b.board_id === selectedBoardId);
-      if (selectedBoard && selectedBoard.archived) {
+      if (!boards.find((b) => b.board_id === selectedBoardId)) {
         dispatch(boardIdSelected({ boardId: 'none' }));
-        didReset = true;
+        dispatch(galleryViewChanged('images'));
       }
 
       // Handle the case where auto-add board isn't in the list of boards
-      const autoAddBoard = boards.find((b) => b.board_id === autoAddBoardId);
-      if (autoAddBoard && autoAddBoard.archived) {
+      if (!boards.find((b) => b.board_id === autoAddBoardId)) {
         dispatch(autoAddBoardIdChanged('none'));
-        didReset = true;
-      }
-
-      // When resetting the auto-add board or selected board, we should also reset the view to images
-      if (didReset) {
-        dispatch(galleryViewChanged('images'));
       }
     },
   });

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardsList.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardsList.tsx
@@ -73,7 +73,7 @@ const BoardsList = () => {
               </Flex>
             </Flex>
           )}
-          <Flex direction="column" gap={1}>
+          <Flex direction="column" gap={1} pb={2}>
             <Flex
               position="sticky"
               w="full"

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -93,7 +93,6 @@ export const imagesApi = api.injectEndpoints({
         const boardId = imageDTO.board_id ?? 'none';
 
         return [
-          { type: 'Image', id: imageDTO.image_name },
           {
             type: 'ImageList',
             id: getListImagesUrl({
@@ -138,9 +137,6 @@ export const imagesApi = api.injectEndpoints({
               id: boardId,
             },
           ];
-          for (const imageDTO of imageDTOs) {
-            tags.push({ type: 'Image', id: imageDTO.image_name });
-          }
 
           return tags;
         }
@@ -508,7 +504,6 @@ export const imagesApi = api.injectEndpoints({
 export const {
   useGetIntermediatesCountQuery,
   useListImagesQuery,
-  useGetImageDTOQuery,
   useGetImageMetadataQuery,
   useGetImageWorkflowQuery,
   useLazyGetImageWorkflowQuery,
@@ -525,6 +520,10 @@ export const {
   useUnstarImagesMutation,
   useBulkDownloadImagesMutation,
 } = imagesApi;
+
+export const useGetImageDTOQuery = (...args: Parameters<typeof imagesApi.useGetImageDTOQuery>) => {
+  return imagesApi.useGetImageDTOQuery(...args);
+};
 
 /**
  * Imperative RTKQ helper to fetch an ImageDTO.


### PR DESCRIPTION
## Summary

- Prevent cutoff of last board in the list when scrolling down to the bottom.
- Fix handling of selected and auto-add boards when a board is archived or deleted.
- Do not invalidate an image's query cache when it was deleted. This was causing spurious `getImageDTO` requests and console errors like `[2024-07-12 10:46:50,049]::[InvokeAI]::ERROR --> Image record not found`.

## Related Issues / Discussions

- Closes #6598 

## QA Instructions

- Board list should display correctly.
- Should be able to generate/delete on archived boards (when they are visible in the list).
- Delete a big image on windows and confirm it deletes correctly.

## Merge Plan

Once we are sure the deletion issue is resolved we can do another release. May also want to get the intermediates count issue resolved first.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
