### PR TITLE
fix(ui): clear selection when deleting last image in board

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDeletionListeners.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDeletionListeners.ts
@@ -136,7 +136,12 @@ export const addImageDeletionListeners = (startAppListening: AppStartListening) 
           if (data) {
             const deletedImageIndex = data.items.findIndex((i) => i.image_name === imageDTO.image_name);
             const nextImage = data.items[deletedImageIndex + 1] ?? data.items[0] ?? null;
-            dispatch(imageSelected(nextImage));
+            if (nextImage?.image_name === imageDTO.image_name) {
+              // If the next image is the same as the deleted one, it means it was the last image, reset selection
+              dispatch(imageSelected(null));
+            } else {
+              dispatch(imageSelected(nextImage));
+            }
           }
         }
 
@@ -176,6 +181,8 @@ export const addImageDeletionListeners = (startAppListening: AppStartListening) 
           const queryArgs = selectListImagesQueryArgs(state);
           const { data } = imagesApi.endpoints.listImages.select(queryArgs)(state);
           if (data) {
+            // When we delete multiple images, we clear the selection. Then, the the next time we load images, we will
+            // select the first one. This is handled below in the listener for `imagesApi.endpoints.listImages.matchFulfilled`.
             dispatch(imageSelected(null));
           }
         }


### PR DESCRIPTION
## Summary

fix(ui): clear selection when deleting last image in board

## Related Issues / Discussions

Discord report: https://discord.com/channels/1020123559063990373/1149506274971631688/1261802456573280329

## QA Instructions

Individually delete images in a board until it is empty. When you delete the last image, the selection should be cleared (no image selected).

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
