### PR TITLE
Add node to read watermarks

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -543,13 +543,13 @@ class ImageWatermarkInvocation(BaseInvocation, WithMetadata, WithBoard):
 
 
 @invocation(
-    "read_watermark",
-    title="Read Invisible Watermark from Image",
+    "retrieve_watermark",
+    title="Retrieve Invisible Watermark",
     tags=["image", "watermark"],
     category="image",
     version="1.2.2",
 )
-class ReadWatermarkInvocation(BaseInvocation):
+class RetrieveWatermarkInvocation(BaseInvocation):
     """Read an invisible watermark from an image"""
 
     image: ImageField = InputField(description="The image to read the watermark from")

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -16,7 +16,7 @@ from invokeai.app.invocations.fields import (
     WithBoard,
     WithMetadata,
 )
-from invokeai.app.invocations.primitives import ImageOutput
+from invokeai.app.invocations.primitives import ImageOutput, StringOutput
 from invokeai.app.services.image_records.image_records_common import ImageCategory
 from invokeai.app.services.shared.invocation_context import InvocationContext
 from invokeai.backend.image_util.invisible_watermark import InvisibleWatermark
@@ -540,6 +540,25 @@ class ImageWatermarkInvocation(BaseInvocation, WithMetadata, WithBoard):
         image_dto = context.images.save(image=new_image)
 
         return ImageOutput.build(image_dto)
+
+
+@invocation(
+    "read_watermark",
+    title="Read Invisible Watermark from Image",
+    tags=["image", "watermark"],
+    category="image",
+    version="1.2.2",
+)
+class ReadWatermarkInvocation(BaseInvocation):
+    """Read an invisible watermark from an image"""
+
+    image: ImageField = InputField(description="The image to read the watermark from")
+    watermark_len: int = InputField(default=8, description="length of watermark, in characters")
+
+    def invoke(self, context: InvocationContext) -> StringOutput:
+        image = context.images.get_pil(self.image.image_name)
+        watermark_text = InvisibleWatermark.read_watermark(image, self.watermark_len * 8)
+        return StringOutput(value=watermark_text)
 
 
 @invocation(

--- a/invokeai/backend/image_util/invisible_watermark.py
+++ b/invokeai/backend/image_util/invisible_watermark.py
@@ -6,7 +6,7 @@ configuration variable, that allows the watermarking to be supressed.
 
 import cv2
 import numpy as np
-from imwatermark import WatermarkEncoder
+from imwatermark import WatermarkDecoder, WatermarkEncoder
 from PIL import Image
 
 import invokeai.backend.util.logging as logger
@@ -28,3 +28,10 @@ class InvisibleWatermark:
         encoder.set_watermark("bytes", watermark_text.encode("utf-8"))
         bgr_encoded = encoder.encode(bgr, "dwtDct")
         return Image.fromarray(cv2.cvtColor(bgr_encoded, cv2.COLOR_BGR2RGB)).convert("RGBA")
+
+    @classmethod
+    def read_watermark(cls, image: Image.Image, length: int = 64) -> str:
+        bgr = cv2.cvtColor(np.array(image.convert("RGB")), cv2.COLOR_RGB2BGR)
+        decoder = WatermarkDecoder("bytes", length)
+        watermark = decoder.decode(bgr, "dwtDct")
+        return watermark.decode("utf-8")


### PR DESCRIPTION
## Summary

This adds an invocation to read the invisible watermark created by the AddWatermark invocation.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions
![Screenshot from 2024-07-17 15-12-13](https://github.com/user-attachments/assets/b07f36be-1943-44a4-8bc4-b7729600f380)

1. Create a simple workflow which pipes an image from AddWatermark to RetrieveWatermark, as per example above
2. [Optional] Change the default watermark text from "InvokeAI" to something of your choice. If you do this, be sure to adjust the watermark string length in RetrieveWatermark appropriately.
3. Run the invocation. The output from RetrieveWatermark should match the AddWatermark string.

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
