### PR TITLE
Bump fastapi-events dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   "transformers==4.41.1",
 
   # Core application dependencies, pinned for reproducible builds.
-  "fastapi-events==0.11.0",
+  "fastapi-events==0.11.1",
   "fastapi==0.111.0",
   "huggingface-hub==0.23.1",
   "pydantic-settings==2.2.1",


### PR DESCRIPTION
## Summary

This is required to fix an issue in fastapi-events OpenTelemetry implementation. https://github.com/melvinkcx/fastapi-events/issues/63. PR fix is open but not yet merged: https://github.com/melvinkcx/fastapi-events/pull/64

## QA Instructions

- The diff in this version bump does not affect Invoke OSS: https://github.com/melvinkcx/fastapi-events/compare/v0.11.0...v0.11.1
- The changes in the proposed OpenTelemetry fix were tested in the Invoke hosted environment and do not affect the OSS installations either

## Merge Plan

Merge anytime

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
