### PR TITLE
fix: update uncategorized board totals when deleting and moving images

### DIFF
--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -417,6 +417,7 @@ export const imagesApi = api.injectEndpoints({
             type: 'BoardImagesTotal',
             id: imageDTO.board_id ?? 'none',
           },
+          { type: 'BoardImagesTotal', id: 'none' },
         ];
       },
     }),

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -104,6 +104,10 @@ export const imagesApi = api.injectEndpoints({
             type: 'Board',
             id: boardId,
           },
+          {
+            type: 'BoardImagesTotal',
+            id: boardId,
+          },
         ];
       },
     }),
@@ -134,6 +138,10 @@ export const imagesApi = api.injectEndpoints({
             },
             {
               type: 'Board',
+              id: boardId,
+            },
+            {
+              type: 'BoardImagesTotal',
               id: boardId,
             },
           ];
@@ -167,6 +175,10 @@ export const imagesApi = api.injectEndpoints({
           },
           {
             type: 'Board',
+            id: boardId,
+          },
+          {
+            type: 'BoardImagesTotal',
             id: boardId,
           },
         ];
@@ -300,6 +312,10 @@ export const imagesApi = api.injectEndpoints({
             type: 'Board',
             id: boardId,
           },
+          {
+            type: 'BoardImagesTotal',
+            id: boardId,
+          },
         ];
       },
     }),
@@ -362,6 +378,10 @@ export const imagesApi = api.injectEndpoints({
           },
           { type: 'Board', id: board_id },
           { type: 'Board', id: imageDTO.board_id ?? 'none' },
+          {
+            type: 'BoardImagesTotal',
+            id: imageDTO.board_id ?? 'none',
+          },
         ];
       },
     }),
@@ -393,6 +413,10 @@ export const imagesApi = api.injectEndpoints({
           },
           { type: 'Board', id: imageDTO.board_id ?? 'none' },
           { type: 'Board', id: 'none' },
+          {
+            type: 'BoardImagesTotal',
+            id: imageDTO.board_id ?? 'none',
+          },
         ];
       },
     }),
@@ -434,6 +458,10 @@ export const imagesApi = api.injectEndpoints({
           tags.push({ type: 'Image', id: imageDTO.image_name });
         }
         tags.push({ type: 'Board', id: board_id });
+        tags.push({
+          type: 'BoardImagesTotal',
+          id: board_id ?? 'none',
+        });
         return tags;
       },
     }),
@@ -480,6 +508,10 @@ export const imagesApi = api.injectEndpoints({
           }
           tags.push({ type: 'Image', id: image_name });
           tags.push({ type: 'Board', id: board_id });
+          tags.push({
+            type: 'BoardImagesTotal',
+            id: board_id ?? 'none',
+          });
         });
 
         return tags;


### PR DESCRIPTION
## Summary
- currently the total for uncategorized images is not updating when moving and deleting images, this will update that count when making those actions
<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
