### PR TITLE
fix(ui): model select overflowing when model  names are too long

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/MainModel/ParamMainModelSelect.tsx
@@ -51,7 +51,7 @@ const ParamMainModelSelect = () => {
         <FormLabel>{t('modelManager.model')}</FormLabel>
       </InformationalPopover>
       <Tooltip label={tooltipLabel}>
-        <Box w="full">
+        <Box w="full" minW={0}>
           <Combobox
             value={value}
             placeholder={placeholder}

--- a/invokeai/frontend/web/src/features/sdxl/components/SDXLRefiner/ParamSDXLRefinerModelSelect.tsx
+++ b/invokeai/frontend/web/src/features/sdxl/components/SDXLRefiner/ParamSDXLRefinerModelSelect.tsx
@@ -1,4 +1,4 @@
-import { Combobox, FormControl, FormLabel } from '@invoke-ai/ui-library';
+import { Box, Combobox, FormControl, FormLabel } from '@invoke-ai/ui-library';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
@@ -37,18 +37,20 @@ const ParamSDXLRefinerModelSelect = () => {
     optionsFilter,
   });
   return (
-    <FormControl isDisabled={!options.length} isInvalid={!options.length}>
+    <FormControl isDisabled={!options.length} isInvalid={!options.length} w="full">
       <InformationalPopover feature="refinerModel">
         <FormLabel>{t('sdxl.refinermodel')}</FormLabel>
       </InformationalPopover>
-      <Combobox
-        value={value}
-        placeholder={placeholder}
-        options={options}
-        onChange={onChange}
-        noOptionsMessage={noOptionsMessage}
-        isClearable
-      />
+      <Box w="full" minW={0}>
+        <Combobox
+          value={value}
+          placeholder={placeholder}
+          options={options}
+          onChange={onChange}
+          noOptionsMessage={noOptionsMessage}
+          isClearable
+        />
+      </Box>
     </FormControl>
   );
 };

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/RefinerSettingsAccordion/RefinerSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/RefinerSettingsAccordion/RefinerSettingsAccordion.tsx
@@ -62,7 +62,7 @@ const RefinerSettingsAccordionContent: React.FC = memo(() => {
 
   return (
     <FormControlGroup isDisabled={!isRefinerModelSelected}>
-      <Flex p={4} gap={4} flexDir="column">
+      <Flex p={4} gap={4} flexDir="column" minW={0}>
         <ParamSDXLRefinerModelSelect />
         <FormControlGroup formLabelProps={stepsScaleLabelProps} isDisabled={!isRefinerModelSelected}>
           <ParamSDXLRefinerScheduler />

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleSettingsAccordion.tsx
@@ -53,7 +53,7 @@ export const UpscaleSettingsAccordion = memo(() => {
         <Flex flexDir="column" gap={4}>
           <Flex gap={4}>
             <UpscaleInitialImage />
-            <Flex direction="column" w="full" alignItems="center" gap={2}>
+            <Flex direction="column" w="full" alignItems="center" gap={2} minW={0}>
               <ParamSpandrelModel />
               <UpscaleScaleSlider />
             </Flex>


### PR DESCRIPTION
## Summary

This issue has always existed but I didn't notice it until we added spandrel models. The `SwinIR` model's name is really long and it causes the model selects to overflow. The issue also occurs on the main and refiner model selects.

## Related Issues / Discussions

n/a

## QA Instructions

Before:
<img width="501" alt="Screenshot 2024-07-24 at 8 27 17 am" src="https://github.com/user-attachments/assets/badbbc36-f02a-427f-9c36-85dddd39fefa">
<img width="529" alt="Screenshot 2024-07-24 at 8 27 08 am" src="https://github.com/user-attachments/assets/18c9a821-2223-4a59-912a-0f2f3ea791bc">

After:
<img width="509" alt="Screenshot 2024-07-24 at 8 27 42 am" src="https://github.com/user-attachments/assets/0eeab2d5-2c13-416a-920f-5d21e6f13d19">
<img width="495" alt="Screenshot 2024-07-24 at 8 27 36 am" src="https://github.com/user-attachments/assets/a6ce7c41-fcaf-447a-bbde-86b4a5749c10">



## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
