### PR TITLE
fix(ui): few cases where board totals don't updated when moving

### DIFF
--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -382,6 +382,10 @@ export const imagesApi = api.injectEndpoints({
             type: 'BoardImagesTotal',
             id: imageDTO.board_id ?? 'none',
           },
+          {
+            type: 'BoardImagesTotal',
+            id: board_id,
+          },
         ];
       },
     }),
@@ -454,6 +458,10 @@ export const imagesApi = api.injectEndpoints({
             }),
           });
           tags.push({ type: 'Board', id: imageDTOs[0].board_id ?? 'none' });
+          tags.push({
+            type: 'BoardImagesTotal',
+            id: imageDTOs[0].board_id ?? 'none',
+          });
         }
         for (const imageDTO of imageDTOs) {
           tags.push({ type: 'Image', id: imageDTO.image_name });
@@ -497,6 +505,10 @@ export const imagesApi = api.injectEndpoints({
               board_id: 'none',
               categories: getCategories(imageDTOs[0]),
             }),
+          });
+          tags.push({
+            type: 'BoardImagesTotal',
+            id: 'none',
           });
         }
 


### PR DESCRIPTION
## Summary

Followup from #6646, couple spots we missed

## Related Issues / Discussions

Alerted to issue by https://discord.com/channels/1020123559063990373/1149510134058471514/1265487718893228092 and tested `main`, found these spots we had missed

## QA Instructions

- Move a single image from uncategorized to a board
- Move a single image from a board to uncategorized
- Move multiple images from uncategorized to a board
- Move multiple images from a board to uncategorized

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
