### PR TITLE
fix(ui): copied edges must have new ids set

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/hooks/useCopyPaste.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useCopyPaste.ts
@@ -59,15 +59,17 @@ const pasteSelection = (withEdgesToCopiedNodes?: boolean) => {
     for (const edge of copiedEdges) {
       if (edge.source === node.id) {
         edge.source = id;
-        edge.id = edge.id.replace(node.data.id, id);
-      }
-      if (edge.target === node.id) {
+      } else if (edge.target === node.id) {
         edge.target = id;
-        edge.id = edge.id.replace(node.data.id, id);
       }
     }
     node.id = id;
     node.data.id = id;
+  });
+
+  copiedEdges.forEach((edge) => {
+    // Copied edges need a fresh id too
+    edge.id = uuidv4();
   });
 
   const nodeChanges: NodeChange[] = [];


### PR DESCRIPTION
## Summary

Problems this was causing:
- Deleting an edge was a copy of another edge deletes both edges
- Deleting a node that was a copy-with-edges of another node deletes its edges and it's original edges, leaving what I will call "ghost noodles" behind

## Related Issues / Discussions

I think @JPPhoto had reported this recently but I can't find where that was.

## QA Instructions

- Load a workflow
- Copy a node that has a few inputs
- Ctrl + Shift + V to paste the node and its edges
- Delete one of the new edges - before this would delete the OG edge too, after it should not
- Delete the copied node - before this would delete the OG input edges & cause ghost noodles, after should not

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
