### PR TITLE
Update docker image to use pnpm version 8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM node:20-slim AS web-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack use pnpm@8.x
 RUN corepack enable
 
 WORKDIR /build


### PR DESCRIPTION
## Summary

Our frontend now requires pnpm version 8 to be used during installs. This small PR updates our dockerfile to build images using the correct pnpm version.

## QA Instructions

Run `docker build . -f ./docker/Dockerfile` with docker properly setup on your environment and confirm the image builds sucessfully.

## Merge Plan

This can be merged when approved