### PR TITLE
[WIP] Modular backend - overrides

### DIFF
--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -854,7 +854,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
                 # ext: freeu, seamless, ip adapter, lora
                 ext_manager.patch_unet(unet, cached_weights),
             ):
-                sd_backend = StableDiffusionBackend(unet, scheduler)
+                sd_backend = StableDiffusionBackend()
                 denoise_ctx.unet = unet
                 result_latents = sd_backend.latents_from_embeddings(denoise_ctx, ext_manager)
 

--- a/invokeai/backend/stable_diffusion/extension_override_type.py
+++ b/invokeai/backend/stable_diffusion/extension_override_type.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class ExtensionOverrideType(Enum):
+    STEP = "step"
+    UNET_FORWARD = "unet_forward"  # predict_noise, run_model, ...?
+    COMBINE_NOISE_PREDS = "combine_noise_preds"

--- a/invokeai/backend/stable_diffusion/extensions/base.py
+++ b/invokeai/backend/stable_diffusion/extensions/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import torch
 from diffusers import UNet2DConditionModel
@@ -10,6 +10,7 @@ from diffusers import UNet2DConditionModel
 if TYPE_CHECKING:
     from invokeai.backend.stable_diffusion.denoise_context import DenoiseContext
     from invokeai.backend.stable_diffusion.extension_callback_type import ExtensionCallbackType
+    from invokeai.backend.stable_diffusion.extension_override_type import ExtensionOverrideType
 
 
 @dataclass
@@ -35,21 +36,53 @@ def callback(callback_type: ExtensionCallbackType, order: int = 0):
     return _decorator
 
 
+@dataclass
+class OverrideMetadata:
+    override_type: ExtensionOverrideType
+
+
+@dataclass
+class OverrideFunctionWithMetadata:
+    metadata: OverrideMetadata
+    function: Callable[..., Any]
+
+
+def override(override_type: ExtensionOverrideType):
+    def _decorator(function):
+        function._ext_metadata = OverrideMetadata(
+            override_type=override_type,
+        )
+        return function
+
+    return _decorator
+
+
 class ExtensionBase:
     def __init__(self):
         self._callbacks: Dict[ExtensionCallbackType, List[CallbackFunctionWithMetadata]] = {}
+        self._overrides: Dict[ExtensionOverrideType, OverrideFunctionWithMetadata] = {}
 
         # Register all of the callback methods for this instance.
         for func_name in dir(self):
             func = getattr(self, func_name)
             metadata = getattr(func, "_ext_metadata", None)
-            if metadata is not None and isinstance(metadata, CallbackMetadata):
-                if metadata.callback_type not in self._callbacks:
-                    self._callbacks[metadata.callback_type] = []
-                self._callbacks[metadata.callback_type].append(CallbackFunctionWithMetadata(metadata, func))
+            if metadata is not None:
+                if isinstance(metadata, CallbackMetadata):
+                    if metadata.callback_type not in self._callbacks:
+                        self._callbacks[metadata.callback_type] = []
+                    self._callbacks[metadata.callback_type].append(CallbackFunctionWithMetadata(metadata, func))
+                elif isinstance(metadata, OverrideMetadata):
+                    if metadata.override_type in self._overrides:
+                        raise RuntimeError(
+                            f"Override {metadata.override_type} defined multiple times in {type(self).__qualname__}"
+                        )
+                    self._overrides[metadata.override_type] = OverrideFunctionWithMetadata(metadata, func)
 
     def get_callbacks(self):
         return self._callbacks
+
+    def get_overrides(self):
+        return self._overrides
 
     @contextmanager
     def patch_extension(self, ctx: DenoiseContext):

--- a/invokeai/backend/stable_diffusion/extensions/preview.py
+++ b/invokeai/backend/stable_diffusion/extensions/preview.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 
 from invokeai.backend.stable_diffusion.extension_callback_type import ExtensionCallbackType
-from invokeai.backend.stable_diffusion.extensions.base import ExtensionBase, callback
+from invokeai.backend.stable_diffusion.extension_override_type import ExtensionOverrideType
+from invokeai.backend.stable_diffusion.extensions.base import ExtensionBase, callback, override
 
 if TYPE_CHECKING:
     from invokeai.backend.stable_diffusion.denoise_context import DenoiseContext
+    from invokeai.backend.stable_diffusion.extensions_manager import ExtensionsManager
 
 
 # TODO: change event to accept image instead of latents
@@ -41,6 +43,31 @@ class PreviewExt(ExtensionBase):
             )
         )
 
+    # TODO: remove when inpaint PR merged
+    @override(ExtensionOverrideType.STEP)
+    def step(self, orig_func: Callable[..., Any], ctx: DenoiseContext, ext_manager: ExtensionsManager):
+        step_output = orig_func(ctx, ext_manager)
+        if hasattr(step_output, "denoised"):
+            predicted_original = step_output.denoised
+        elif hasattr(step_output, "pred_original_sample"):
+            predicted_original = step_output.pred_original_sample
+        else:
+            predicted_original = step_output.prev_sample
+
+        self.callback(
+            PipelineIntermediateState(
+                step=ctx.step_index,
+                order=ctx.scheduler.order,
+                total_steps=len(ctx.inputs.timesteps),
+                timestep=int(ctx.timestep),  # TODO: is there any code which uses it?
+                latents=step_output.prev_sample,
+                predicted_original=predicted_original,  # TODO: is there any reason for additional field?
+            )
+        )
+
+        return step_output
+
+    """
     # do last so that all other changes shown
     @callback(ExtensionCallbackType.POST_STEP, order=1000)
     def step_preview(self, ctx: DenoiseContext):
@@ -61,3 +88,4 @@ class PreviewExt(ExtensionBase):
                 predicted_original=predicted_original,  # TODO: is there any reason for additional field?
             )
         )
+    """


### PR DESCRIPTION
## Summary

Initial implementation of overrides in modular backend, should be used in inpaint and tiled extensions(also in preview extension after preview event rewrite).
Created PR now just to have ability to discuss.
To be precise - need to decide about override name for unet call and how better to implement arguments in overrides.

## Related Issues / Discussions

#6606
https://invokeai.notion.site/Modular-Stable-Diffusion-Backend-Design-Document-e8952daab5d5472faecdc4a72d377b0d

## QA Instructions

Run with set `USE_MODULAR_DENOISE` environment.

## Merge Plan

Firstly merge #6643 and rewrite to use unet call override.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
