### PR TITLE
fix(ui): deleting a board or hiding archived should reset selected & auto-add boards

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/addArchivedOrDeletedBoardListener.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/addArchivedOrDeletedBoardListener.ts
@@ -71,7 +71,7 @@ export const addArchivedOrDeletedBoardListener = (startAppListening: AppStartLis
       const shouldShowArchivedBoards = action.payload;
 
       // We only need to take action if we have just hidden archived boards.
-      if (!shouldShowArchivedBoards) {
+      if (shouldShowArchivedBoards) {
         return;
       }
 
@@ -86,14 +86,16 @@ export const addArchivedOrDeletedBoardListener = (startAppListening: AppStartLis
 
       // Handle the case where selected board is archived
       const selectedBoard = queryResult.data.find((b) => b.board_id === selectedBoardId);
-      if (selectedBoard && selectedBoard.archived) {
+      if (!selectedBoard || selectedBoard.archived) {
+        // If we can't find the selected board or it's archived, we should reset the selected board to uncategorized
         dispatch(boardIdSelected({ boardId: 'none' }));
         dispatch(galleryViewChanged('images'));
       }
 
       // Handle the case where auto-add board is archived
       const autoAddBoard = queryResult.data.find((b) => b.board_id === autoAddBoardId);
-      if (autoAddBoard && autoAddBoard.archived) {
+      if (!autoAddBoard || autoAddBoard.archived) {
+        // If we can't find the auto-add board or it's archived, we should reset the selected board to uncategorized
         dispatch(autoAddBoardIdChanged('none'));
       }
     },


### PR DESCRIPTION
## Summary

[fix(ui): fix logic to reset selected/auto-add boards when toggling show archived boards](https://github.com/invoke-ai/InvokeAI/commit/9027c96470ac42d039d721ca3aff12ba55f93b7a)

The logic was incorrect in two ways:
1. We only ran the logic if we _enable_ showing archived boards. It should be run we we _disable_ showing archived boards.
2. If we couldn't find the selected board in the query cache, we didn't do the reset. This is wrong - if the board isn't in the query cache, we _should_ do the reset. This inverted logic makes more sense before the fix for issue 1.

[fix(ui): race condition when deleting a board and resetting selected/auto-add](https://github.com/invoke-ai/InvokeAI/commit/d804b6e1acd3f38d4d0c6efb1001c8ac4777c875)

We were checking the selected and auto-add board ids against the query cache to see if they still exist. If not, we reset.

This only works if the query cache is updated by the time we do the check - race condition!

We already have the board id from the query args, so there's no need to check the query cache - just compare the deleted board ID directly.

Previously this file's several listeners were all in a single one and I had adapted/split its logic up a bit wonkily, introducing these problems.

## Related Issues / Discussions

n/a

## QA Instructions

Two things to test. 

1. Reset selected/auto-add when hiding archived boards.
- Show archived boards
- Select an archived board and make it the auto-add board
- Hide archived boards
- Uncategorized should be the new selected & auto-add board

2. Race condition
- Select a board for auto-add
- Delete it
- Invoke
- The generated image should be added to the right board, with no error during generation while saving the image

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
