### PR TITLE
build: exclude matplotlib 3.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,8 @@ dependencies = [
   "easing-functions",
   "einops",
   "facexlib",
-  "matplotlib",       # needed for plotting of Penner easing functions
+  # Exclude 3.9.1 which has a problem on windows, see https://github.com/matplotlib/matplotlib/issues/28551
+  "matplotlib!=3.9.1",
   "npyscreen",
   "omegaconf",
   "picklescan",


### PR DESCRIPTION
## Summary

There was a problem w/ this release on windows and the builds were pulled from pypi. When installing invoke on windows, pip attempts to build from source, but most (all?) systems won't have the prerequisites for this and installs fail.

This also affects GH actions.

The simple fix is to exclude version 3.9.1 from our deps.

For more information, see https://github.com/matplotlib/matplotlib/issues/28551

## Related Issues / Discussions

- Closes #6717
- [Discord discussion on #dev chat](https://discord.com/channels/1020123559063990373/1049495067846524939/1269599836781416520)
- [Discord user report](https://discord.com/channels/1020123559063990373/1149510134058471514/1269687327446532187)

## QA Instructions

If CI passes, we're good.

We could also disallow building from source for matplotlib but we'd need to update installer scripts and GH actions and I'm not feeling inspired to make those changes. This is much simpler.

## Merge Plan

We aren't ready to release off `main`, so I'll cherry pick this onto a new branch off v4.2.7 and do a v4.2.7post1 release.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
