### PR TITLE
feat(ui): restore optional upper limit on upscale resolution size

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1673,6 +1673,8 @@
     },
     "upscaling": {
         "creativity": "Creativity",
+        "exceedsMaxSize": "Upscale settings exceed max size limit",
+        "exceedsMaxSizeDetails": "Max upscale limit is {{maxUpscaleDimension}}x{{maxUpscaleDimension}} pixels. Please try a smaller image or decrease your scale selection.",
         "structure": "Structure",
         "upscaleModel": "Upscale Model",
         "postProcessingModel": "Post-Processing Model",
@@ -1680,8 +1682,6 @@
         "postProcessingMissingModelWarning": "Visit the <LinkComponent>Model Manager</LinkComponent> to install a post-processing (image to image) model.",
         "missingModelsWarning": "Visit the <LinkComponent>Model Manager</LinkComponent> to install the required models:",
         "mainModelDesc": "Main model (SD1.5 or SDXL architecture)",
-        "outputTooLargeShort": "Output is too large to upscale",
-        "outputTooLarge": "Max upscale limit is 10,000x10,000 pixels. Please try a smaller image or decrease your scale selection.",
         "tileControlNetModelDesc": "Tile ControlNet model for the chosen main model architecture",
         "upscaleModelDesc": "Upscale (image to image) model",
         "missingUpscaleInitialImage": "Missing initial image for upscaling",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1052,11 +1052,7 @@
         "remixImage": "Remix Image",
         "usePrompt": "Use Prompt",
         "useSeed": "Use Seed",
-        "width": "Width",
-        "isAllowedToUpscale": {
-            "useX2Model": "Image is too large to upscale with x4 model, use x2 model",
-            "tooLarge": "Image is too large to upscale, select smaller image"
-        }
+        "width": "Width"
     },
     "dynamicPrompts": {
         "showDynamicPrompts": "Show Dynamic Prompts",
@@ -1684,6 +1680,8 @@
         "postProcessingMissingModelWarning": "Visit the <LinkComponent>Model Manager</LinkComponent> to install a post-processing (image to image) model.",
         "missingModelsWarning": "Visit the <LinkComponent>Model Manager</LinkComponent> to install the required models:",
         "mainModelDesc": "Main model (SD1.5 or SDXL architecture)",
+        "outputTooLargeShort": "Output is too large to upscale",
+        "outputTooLarge": "Max upscale limit is 10,000x10,000 pixels. Please try a smaller image or decrease your scale selection.",
         "tileControlNetModelDesc": "Tile ControlNet model for the chosen main model architecture",
         "upscaleModelDesc": "Upscale (image to image) model",
         "missingUpscaleInitialImage": "Missing initial image for upscaling",

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -65,6 +65,10 @@ export type AppConfig = {
    */
   shouldUpdateImagesOnConnect: boolean;
   shouldFetchMetadataFromApi: boolean;
+  /**
+   * Sets a size limit for outputs on the upscaling tab. This is a maximum dimension, so the actual max number of pixels
+   * will be the square of this value.
+   */
   maxUpscaleDimension?: number;
   allowPrivateBoards: boolean;
   disabledTabs: InvokeTabName[];

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -65,6 +65,7 @@ export type AppConfig = {
    */
   shouldUpdateImagesOnConnect: boolean;
   shouldFetchMetadataFromApi: boolean;
+  maxUpscalePixels?: number;
   allowPrivateBoards: boolean;
   disabledTabs: InvokeTabName[];
   disabledFeatures: AppFeature[];

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -65,7 +65,7 @@ export type AppConfig = {
    */
   shouldUpdateImagesOnConnect: boolean;
   shouldFetchMetadataFromApi: boolean;
-  maxUpscalePixels?: number;
+  maxUpscaleDimension?: number;
   allowPrivateBoards: boolean;
   disabledTabs: InvokeTabName[];
   disabledFeatures: AppFeature[];

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -213,9 +213,13 @@ const createSelector = (templates: Templates) =>
           if (!upscale.upscaleInitialImage) {
             reasons.push({ content: i18n.t('upscaling.missingUpscaleInitialImage') });
           } else if (config.maxUpscaleDimension) {
-            const upscaledPixels =
-              upscale.upscaleInitialImage.width * upscale.scale * upscale.upscaleInitialImage.height * upscale.scale;
-            if (upscaledPixels > config.maxUpscaleDimension) {
+            const { width, height } = upscale.upscaleInitialImage;
+            const { scale } = upscale;
+
+            const maxPixels = config.maxUpscaleDimension ** 2;
+            const upscaledPixels = width * scale * height * scale;
+
+            if (upscaledPixels > maxPixels) {
               reasons.push({ content: i18n.t('upscaling.exceedsMaxSize') });
             }
           }

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -16,6 +16,7 @@ import { selectWorkflowSettingsSlice } from 'features/nodes/store/workflowSettin
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { selectGenerationSlice } from 'features/parameters/store/generationSlice';
 import { selectUpscalelice } from 'features/parameters/store/upscaleSlice';
+import { selectConfigSlice } from 'features/system/store/configSlice';
 import { selectSystemSlice } from 'features/system/store/systemSlice';
 import { activeTabNameSelector } from 'features/ui/store/uiSelectors';
 import i18n from 'i18next';
@@ -42,6 +43,7 @@ const createSelector = (templates: Templates) =>
       selectControlLayersSlice,
       activeTabNameSelector,
       selectUpscalelice,
+      selectConfigSlice,
     ],
     (
       controlAdapters,
@@ -52,7 +54,8 @@ const createSelector = (templates: Templates) =>
       dynamicPrompts,
       controlLayers,
       activeTabName,
-      upscale
+      upscale,
+      config
     ) => {
       const { model } = generation;
       const { size } = controlLayers.present;
@@ -209,6 +212,12 @@ const createSelector = (templates: Templates) =>
         } else if (activeTabName === 'upscaling') {
           if (!upscale.upscaleInitialImage) {
             reasons.push({ content: i18n.t('upscaling.missingUpscaleInitialImage') });
+          } else if (config.maxUpscalePixels) {
+            const upscaledPixels =
+              upscale.upscaleInitialImage.width * upscale.scale * upscale.upscaleInitialImage.height * upscale.scale;
+            if (upscaledPixels > config.maxUpscalePixels) {
+              reasons.push({ content: i18n.t('upscaling.outputTooLargeShort') });
+            }
           }
           if (!upscale.upscaleModel) {
             reasons.push({ content: i18n.t('upscaling.missingUpscaleModel') });

--- a/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
+++ b/invokeai/frontend/web/src/common/hooks/useIsReadyToEnqueue.ts
@@ -212,11 +212,11 @@ const createSelector = (templates: Templates) =>
         } else if (activeTabName === 'upscaling') {
           if (!upscale.upscaleInitialImage) {
             reasons.push({ content: i18n.t('upscaling.missingUpscaleInitialImage') });
-          } else if (config.maxUpscalePixels) {
+          } else if (config.maxUpscaleDimension) {
             const upscaledPixels =
               upscale.upscaleInitialImage.width * upscale.scale * upscale.upscaleInitialImage.height * upscale.scale;
-            if (upscaledPixels > config.maxUpscalePixels) {
-              reasons.push({ content: i18n.t('upscaling.outputTooLargeShort') });
+            if (upscaledPixels > config.maxUpscaleDimension) {
+              reasons.push({ content: i18n.t('upscaling.exceedsMaxSize') });
             }
           }
           if (!upscale.upscaleModel) {

--- a/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
@@ -5,7 +5,7 @@ import { selectConfigSlice } from 'features/system/store/configSlice';
 import { useMemo } from 'react';
 import type { ImageDTO } from 'services/api/types';
 
-export const createIsTooLargeToUpscaleSelector = (imageDTO?: ImageDTO) =>
+const createIsTooLargeToUpscaleSelector = (imageDTO?: ImageDTO) =>
   createMemoizedSelector(selectUpscalelice, selectConfigSlice, (upscale, config) => {
     const { upscaleModel, scale } = upscale;
     const { maxUpscalePixels } = config;

--- a/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
@@ -5,21 +5,17 @@ import { selectConfigSlice } from 'features/system/store/configSlice';
 import { useMemo } from 'react';
 import type { ImageDTO } from 'services/api/types';
 
-
 export const createIsTooLargeToUpscaleSelector = (imageDTO?: ImageDTO) =>
   createMemoizedSelector(selectUpscalelice, selectConfigSlice, (upscale, config) => {
     const { upscaleModel, scale } = upscale;
     const { maxUpscalePixels } = config;
 
     if (!maxUpscalePixels || !upscaleModel || !imageDTO) {
-      return false
+      return false;
     }
 
     const upscaledPixels = imageDTO.width * scale * imageDTO.height * scale;
-    console.log({ upscaledPixels })
-    console.log({ maxUpscalePixels })
-    return upscaledPixels > maxUpscalePixels
-
+    return upscaledPixels > maxUpscalePixels;
   });
 
 export const useIsTooLargeToUpscale = (imageDTO?: ImageDTO) => {

--- a/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
@@ -11,11 +11,16 @@ const createIsTooLargeToUpscaleSelector = (imageDTO?: ImageDTO) =>
     const { maxUpscaleDimension } = config;
 
     if (!maxUpscaleDimension || !upscaleModel || !imageDTO) {
+      // When these are missing, another warning will be shown
       return false;
     }
 
-    const upscaledPixels = imageDTO.width * scale * imageDTO.height * scale;
-    return upscaledPixels > maxUpscaleDimension * maxUpscaleDimension;
+    const { width, height } = imageDTO;
+
+    const maxPixels = maxUpscaleDimension ** 2;
+    const upscaledPixels = width * scale * height * scale;
+
+    return upscaledPixels > maxPixels;
   });
 
 export const useIsTooLargeToUpscale = (imageDTO?: ImageDTO) => {

--- a/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
@@ -8,14 +8,14 @@ import type { ImageDTO } from 'services/api/types';
 const createIsTooLargeToUpscaleSelector = (imageDTO?: ImageDTO) =>
   createMemoizedSelector(selectUpscalelice, selectConfigSlice, (upscale, config) => {
     const { upscaleModel, scale } = upscale;
-    const { maxUpscalePixels } = config;
+    const { maxUpscaleDimension } = config;
 
-    if (!maxUpscalePixels || !upscaleModel || !imageDTO) {
+    if (!maxUpscaleDimension || !upscaleModel || !imageDTO) {
       return false;
     }
 
     const upscaledPixels = imageDTO.width * scale * imageDTO.height * scale;
-    return upscaledPixels > maxUpscalePixels;
+    return upscaledPixels > maxUpscaleDimension * maxUpscaleDimension;
   });
 
 export const useIsTooLargeToUpscale = (imageDTO?: ImageDTO) => {

--- a/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useIsTooLargeToUpscale.ts
@@ -1,0 +1,28 @@
+import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
+import { useAppSelector } from 'app/store/storeHooks';
+import { selectUpscalelice } from 'features/parameters/store/upscaleSlice';
+import { selectConfigSlice } from 'features/system/store/configSlice';
+import { useMemo } from 'react';
+import type { ImageDTO } from 'services/api/types';
+
+
+export const createIsTooLargeToUpscaleSelector = (imageDTO?: ImageDTO) =>
+  createMemoizedSelector(selectUpscalelice, selectConfigSlice, (upscale, config) => {
+    const { upscaleModel, scale } = upscale;
+    const { maxUpscalePixels } = config;
+
+    if (!maxUpscalePixels || !upscaleModel || !imageDTO) {
+      return false
+    }
+
+    const upscaledPixels = imageDTO.width * scale * imageDTO.height * scale;
+    console.log({ upscaledPixels })
+    console.log({ maxUpscalePixels })
+    return upscaledPixels > maxUpscalePixels
+
+  });
+
+export const useIsTooLargeToUpscale = (imageDTO?: ImageDTO) => {
+  const selectIsTooLargeToUpscale = useMemo(() => createIsTooLargeToUpscaleSelector(imageDTO), [imageDTO]);
+  return useAppSelector(selectIsTooLargeToUpscale);
+};

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleInitialImage.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleInitialImage.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@invoke-ai/ui-library';
+import { Flex, Text } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import IAIDndImage from 'common/components/IAIDndImage';
 import IAIDndImageIcon from 'common/components/IAIDndImageIcon';
@@ -41,13 +41,30 @@ export const UpscaleInitialImage = () => {
           postUploadAction={postUploadAction}
         />
         {imageDTO && (
-          <Flex position="absolute" flexDir="column" top={1} insetInlineEnd={1} gap={1}>
-            <IAIDndImageIcon
-              onClick={onReset}
-              icon={<PiArrowCounterClockwiseBold size={16} />}
-              tooltip={t('controlnet.resetControlImage')}
-            />
-          </Flex>
+          <>
+            <Flex position="absolute" flexDir="column" top={1} insetInlineEnd={1} gap={1}>
+              <IAIDndImageIcon
+                onClick={onReset}
+                icon={<PiArrowCounterClockwiseBold size={16} />}
+                tooltip={t('controlnet.resetControlImage')}
+              />
+            </Flex>
+            <Text
+              position="absolute"
+              background="base.900"
+              color="base.50"
+              fontSize="sm"
+              fontWeight="semibold"
+              bottom={0}
+              left={0}
+              opacity={0.7}
+              px={2}
+              lineHeight={1.25}
+              borderTopEndRadius="base"
+              borderBottomStartRadius="base"
+              pointerEvents="none"
+            >{`${imageDTO.width}x${imageDTO.height}`}</Text>
+          </>
         )}
       </Flex>
     </Flex>

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
@@ -1,12 +1,12 @@
 import { Button, Flex, ListItem, Text, UnorderedList } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { $installModelsTab } from 'features/modelManagerV2/subpanels/InstallModels';
+import { useIsTooLargeToUpscale } from 'features/parameters/hooks/useIsTooLargeToUpscale';
 import { tileControlnetModelChanged } from 'features/parameters/store/upscaleSlice';
 import { setActiveTab } from 'features/ui/store/uiSlice';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useControlNetModels } from 'services/api/hooks/modelsByType';
-import { useIsTooLargeToUpscale } from '../../../parameters/hooks/useIsTooLargeToUpscale';
 
 export const UpscaleWarning = () => {
   const { t } = useTranslation();
@@ -42,13 +42,12 @@ export const UpscaleWarning = () => {
   }, [model, tileControlnetModel, upscaleModel, t]);
 
   const otherWarnings = useMemo(() => {
-    console.log({ isTooLargeToUpscale });
     const _warnings: string[] = [];
     if (isTooLargeToUpscale) {
       _warnings.push(t('upscaling.outputTooLarge'));
     }
     return _warnings;
-  }, [isTooLargeToUpscale]);
+  }, [isTooLargeToUpscale, t]);
 
   const handleGoToModelManager = useCallback(() => {
     dispatch(setActiveTab('models'));

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
@@ -6,16 +6,19 @@ import { setActiveTab } from 'features/ui/store/uiSlice';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useControlNetModels } from 'services/api/hooks/modelsByType';
+import { useIsTooLargeToUpscale } from '../../../parameters/hooks/useIsTooLargeToUpscale';
 
 export const UpscaleWarning = () => {
   const { t } = useTranslation();
   const model = useAppSelector((s) => s.generation.model);
   const upscaleModel = useAppSelector((s) => s.upscale.upscaleModel);
   const tileControlnetModel = useAppSelector((s) => s.upscale.tileControlnetModel);
+  const upscaleInitialImage = useAppSelector((s) => s.upscale.upscaleInitialImage);
   const dispatch = useAppDispatch();
   const [modelConfigs, { isLoading }] = useControlNetModels();
   const disabledTabs = useAppSelector((s) => s.config.disabledTabs);
   const shouldShowButton = useMemo(() => !disabledTabs.includes('models'), [disabledTabs]);
+  const isTooLargeToUpscale = useIsTooLargeToUpscale(upscaleInitialImage || undefined);
 
   useEffect(() => {
     const validModel = modelConfigs.find((cnetModel) => {
@@ -24,7 +27,7 @@ export const UpscaleWarning = () => {
     dispatch(tileControlnetModelChanged(validModel || null));
   }, [model?.base, modelConfigs, dispatch]);
 
-  const warnings = useMemo(() => {
+  const modelWarnings = useMemo(() => {
     const _warnings: string[] = [];
     if (!model) {
       _warnings.push(t('upscaling.mainModelDesc'));
@@ -35,33 +38,43 @@ export const UpscaleWarning = () => {
     if (!upscaleModel) {
       _warnings.push(t('upscaling.upscaleModelDesc'));
     }
-
     return _warnings;
   }, [model, tileControlnetModel, upscaleModel, t]);
+
+  const otherWarnings = useMemo(() => {
+    console.log({ isTooLargeToUpscale });
+    const _warnings: string[] = [];
+    if (isTooLargeToUpscale) {
+      _warnings.push(t('upscaling.outputTooLarge'));
+    }
+    return _warnings;
+  }, [isTooLargeToUpscale]);
 
   const handleGoToModelManager = useCallback(() => {
     dispatch(setActiveTab('models'));
     $installModelsTab.set(3);
   }, [dispatch]);
 
-  if (!warnings.length || isLoading || !shouldShowButton) {
+  if ((!modelWarnings.length && !otherWarnings.length) || isLoading || !shouldShowButton) {
     return null;
   }
 
   return (
     <Flex bg="error.500" borderRadius="base" padding={4} direction="column" fontSize="sm" gap={2}>
-      <Text>
-        <Trans
-          i18nKey="upscaling.missingModelsWarning"
-          components={{
-            LinkComponent: (
-              <Button size="sm" flexGrow={0} variant="link" color="base.50" onClick={handleGoToModelManager} />
-            ),
-          }}
-        />
-      </Text>
+      {!!modelWarnings.length && (
+        <Text>
+          <Trans
+            i18nKey="upscaling.missingModelsWarning"
+            components={{
+              LinkComponent: (
+                <Button size="sm" flexGrow={0} variant="link" color="base.50" onClick={handleGoToModelManager} />
+              ),
+            }}
+          />
+        </Text>
+      )}
       <UnorderedList>
-        {warnings.map((warning) => (
+        {[...modelWarnings, ...otherWarnings].map((warning) => (
           <ListItem key={warning}>{warning}</ListItem>
         ))}
       </UnorderedList>

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
@@ -18,6 +18,7 @@ export const UpscaleWarning = () => {
   const [modelConfigs, { isLoading }] = useControlNetModels();
   const disabledTabs = useAppSelector((s) => s.config.disabledTabs);
   const shouldShowButton = useMemo(() => !disabledTabs.includes('models'), [disabledTabs]);
+  const maxUpscaleDimension = useAppSelector((s) => s.config.maxUpscaleDimension);
   const isTooLargeToUpscale = useIsTooLargeToUpscale(upscaleInitialImage || undefined);
 
   useEffect(() => {
@@ -43,11 +44,13 @@ export const UpscaleWarning = () => {
 
   const otherWarnings = useMemo(() => {
     const _warnings: string[] = [];
-    if (isTooLargeToUpscale) {
-      _warnings.push(t('upscaling.outputTooLarge'));
+    if (isTooLargeToUpscale && maxUpscaleDimension) {
+      _warnings.push(
+        t('upscaling.exceedsMaxSizeDetails', { maxUpscaleDimension: maxUpscaleDimension.toLocaleString() })
+      );
     }
     return _warnings;
-  }, [isTooLargeToUpscale, t]);
+  }, [isTooLargeToUpscale, t, maxUpscaleDimension]);
 
   const handleGoToModelManager = useCallback(() => {
     dispatch(setActiveTab('models'));


### PR DESCRIPTION
## Summary

* Restore and modify logic for having an optional limit on upscale output resolution size. A warning will be displayed and the Invoke button will be disabled if the output resolution (image width x image height x scale x scale) is above that amount.
* Adds image resolution badge to initial upscale image so make sure user knows where they are starting

<img width="474" alt="Screenshot 2024-08-05 at 11 59 57 AM" src="https://github.com/user-attachments/assets/99f8c5af-1f9e-4502-8484-653d1a901ff4">


## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
