### PR TITLE
Fix invoke.sh not detecting symlinks

### DIFF
--- a/installer/templates/invoke.sh.in
+++ b/installer/templates/invoke.sh.in
@@ -17,7 +17,7 @@
 set -eu
 
 # Ensure we're in the correct folder in case user's CWD is somewhere else
-scriptdir=$(dirname "$0")
+scriptdir=$(dirname $(readlink -f "$0"))
 cd "$scriptdir"
 
 . .venv/bin/activate


### PR DESCRIPTION
## Summary

When invoke.sh is executed using a symlink with a working directory outside of InvokeAI's root directory, it will fail with the following message:

`<path to symlink>: line 23: .venv/bin/activate: No such file or directory`

invoke.sh attempts to cd into the correct directory at the start of the script, but will cd into the directory of the symlink instead. This MR fixes that.

## QA Instructions

- Create a symlink to invoke.sh
- cd into any directory except InvokeAI's root directory
- Execute invoke.sh using the previously created symlink to verify that the initial problem is fixed
- Execute invoke.sh directly to verify that this still works

I performed these checks on Arch Linux 6.10.3-arch1-2 (64-bit). I did not test this MR on other Linux distributions or MacOS but to my knowledge `readlink` is available there as well by default.

## Additional Notes

A similar fix may be needed for invoke.bat. I don't have a windows machine and don't know batch well enough to be sure though.

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
