### PR TITLE
fix(ui): show warning for maxUpscaleDimension if model tab is disabled

### DIFF
--- a/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleWarning.tsx
@@ -57,7 +57,11 @@ export const UpscaleWarning = () => {
     $installModelsTab.set(3);
   }, [dispatch]);
 
-  if ((!modelWarnings.length && !otherWarnings.length) || isLoading || !shouldShowButton) {
+  if (modelWarnings.length && !shouldShowButton) {
+    return null;
+  }
+
+  if ((!modelWarnings.length && !otherWarnings.length) || isLoading) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fixes a but in the upscale tab logic that didn't render the warning for maxUpscaleDimension if the models tab was disabled

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
