### PR TITLE
fix(api): image downloads with correct filename

### DIFF
--- a/invokeai/app/api/routers/images.py
+++ b/invokeai/app/api/routers/images.py
@@ -253,6 +253,7 @@ async def get_image_full(
             content = f.read()
         response = Response(content, media_type="image/png")
         response.headers["Cache-Control"] = f"max-age={IMAGE_MAX_AGE}"
+        response.headers["Content-Disposition"] = f'inline; filename="{image_name}"'
         return response
     except Exception:
         raise HTTPException(status_code=404)


### PR DESCRIPTION
## Summary

In #6607 we fixed a race condition with deleting images. The fix inadvertently removed some headers from the image serving route that caused #6730. Headers restored

## Related Issues / Discussions

Closes #6730

## QA Instructions

Open image in new tab -> save image -> should use the correct filename

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
