### PR TITLE
Use Diffusers 0.30.0

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
+++ b/invokeai/backend/model_manager/load/model_loaders/stable_diffusion.py
@@ -118,13 +118,16 @@ class StableDiffusionDiffusersModel(GenericDiffusersLoader):
         # Some weights of the model checkpoint were not used when initializing CLIPTextModelWithProjection:
         # ['text_model.embeddings.position_ids']
 
+        original_config_file = self._app_config.legacy_conf_path / config.config_path
+
         with SilenceWarnings():
             pipeline = load_class.from_single_file(
                 config.path,
+                original_config_file=original_config_file,
                 torch_dtype=self._torch_dtype,
                 prediction_type=prediction_type,
                 upcast_attention=upcast_attention,
-                load_safety_checker=False,
+                kwargs={"load_safety_checker": False},
             )
 
         if not submodel_type:

--- a/invokeai/backend/util/hotfixes.py
+++ b/invokeai/backend/util/hotfixes.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import diffusers
 import torch
 from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.loaders import FromOriginalControlNetMixin
+from diffusers.loaders import FromOriginalModelMixin
 from diffusers.models.attention_processor import AttentionProcessor, AttnProcessor
 from diffusers.models.controlnet import ControlNetConditioningEmbedding, ControlNetOutput, zero_module
 from diffusers.models.embeddings import (
@@ -32,7 +32,7 @@ from invokeai.backend.util.logging import InvokeAILogger
 logger = InvokeAILogger.get_logger(__name__)
 
 
-class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlNetMixin):
+class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalModelMixin):
     """
     A ControlNet model.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ classifiers = [
 ]
 dependencies = [
   # Core generation dependencies, pinned for reproducible builds.
-  "accelerate==0.30.1",
+  "accelerate==0.31.0",
   "clip_anytorch==2.6.0",       # replacing "clip @ https://github.com/openai/CLIP/archive/eaa22acb90a5876642d0507623e859909230a52d.zip",
   "compel==2.0.2",
   "controlnet-aux==0.0.7",
-  "diffusers[torch]==0.27.2",
+  "diffusers[torch]==0.30.0",
   "invisible-watermark==0.2.0", # needed to install SDXL base and refiner using their repo_ids
   "mediapipe==0.10.7",          # needed for "mediapipeface" controlnet model
   "numpy==1.26.4",              # >1.24.0 is needed to use the 'strict' argument to np.testing.assert_array_equal()
@@ -57,7 +57,7 @@ dependencies = [
   # Core application dependencies, pinned for reproducible builds.
   "fastapi-events==0.11.1",
   "fastapi==0.111.0",
-  "huggingface-hub==0.23.1",
+  "huggingface-hub==0.23.5",
   "pydantic-settings==2.2.1",
   "pydantic==2.7.2",
   "python-socketio==5.11.1",


### PR DESCRIPTION
## Summary

This PR bumps `diffusers` to v0.30.0.

It also reinstates passing of the original stable diffusion `.yaml` file to the `load_single_file()` method. Unfortunately, although this was proposed as a fix to #6623, it doesn't have the desired effect because [load_single_file()](https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusionImg2ImgPipeline.from_single_file) needs to download and cache the `.json` config files for each of the components of the current model's base pipeline.  We *could* work around this by pre-caching those files at installation time, or distributing them in the git repository.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

This PR was triggered by bug report #6623, but doesn't fix it.

It also introduces a regression due to an apparent bug in diffusers-0.30. `load_single_file()` does not correctly recognize and handle stable diffusion 1.5 models that use a prediction type of `v_prediction`. As a result, these models will fail to render correctly despite having the correct prediction type and config file set. Several examples of this type of model can be found in the [EasyFluff collection](https://huggingface.co/zatochu/EasyFluff). Converting the model to diffusers doesn't help, as the conversion uses `load_single_file()`!

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

1. Test generation with sd-1, sd-2 and sdxl models.
2. Test controlnet guidance
3. Test ti-adapter guidance
4. Test ip-adapter guidance

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

Given that this introduces a regression for sd-1.5 models that use `v_prediction`, we should discuss whether to merge now or wait until the issue is fixed in diffusers.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
