### PR TITLE
fix: bundle style preset defaults, bump version to v4.2.8rc2

### DIFF
--- a/invokeai/version/invokeai_version.py
+++ b/invokeai/version/invokeai_version.py
@@ -1,1 +1,1 @@
-__version__ = "4.2.8rc1"
+__version__ = "4.2.8rc2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,10 @@ version = { attr = "invokeai.version.__version__" }
 [tool.setuptools.package-data]
 "invokeai.app.assets" = ["**/*.png"]
 "invokeai.app.services.workflow_records.default_workflows" = ["*.json"]
+"invokeai.app.services.style_preset_records" = ["*.json"]
+"invokeai.app.services.style_preset_images.default_style_preset_images" = [
+  "*.png",
+]
 "invokeai.assets.fonts" = ["**/*.ttf"]
 "invokeai.backend" = ["**.png"]
 "invokeai.configs" = ["*.example", "**/*.yaml", "*.txt"]


### PR DESCRIPTION
## Summary

We need to specify in `pyproject.toml` to include the default style presets data else the app fails to launch and is unable to seed the db.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1273946504427601992

## QA Instructions

To test the wheel:
- `make installer-zip`
- `pip install installer/dist/InvokeAI-4.2.8rc2-py3-none-any.whl`
- `invokeai-web`

Should load and show the default style presets with their images. I tested and everything works.

## Merge Plan

I will do another release when merged

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
