### PR TITLE
fix(ui): use translations for style preset strings

### DIFF
--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetForm/StylePresetForm.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetForm/StylePresetForm.tsx
@@ -93,8 +93,8 @@ export const StylePresetForm = ({
         </FormControl>
       </Flex>
 
-      <StylePresetPromptField label="Positive Prompt" control={control} name="positivePrompt" />
-      <StylePresetPromptField label="Negative Prompt" control={control} name="negativePrompt" />
+      <StylePresetPromptField label={t('stylePresets.positivePrompt')} control={control} name="positivePrompt" />
+      <StylePresetPromptField label={t('stylePresets.negativePrompt')} control={control} name="negativePrompt" />
       <Box>
         <Text variant="subtext">{t('stylePresets.promptTemplatesDesc1')}</Text>
         <Text variant="subtext">

--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetListItem.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetListItem.tsx
@@ -174,7 +174,8 @@ export const StylePresetListItem = ({ preset }: { preset: StylePresetRecordWithI
         onClose={onClose}
         title={t('stylePresets.deleteTemplate')}
         acceptCallback={handleDeletePreset}
-        acceptButtonText="Delete"
+        acceptButtonText={t('common.delete')}
+        cancelButtonText={t('common.cancel')}
       >
         <p>{t('stylePresets.deleteTemplate2')}</p>
       </ConfirmationAlertDialog>


### PR DESCRIPTION
## Summary

fix(ui): use translations for style preset strings

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1054129386447716433/1274085755517534218

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
