### PR TITLE
fix(ui): more prompt template follow-ups

### DIFF
--- a/invokeai/frontend/web/src/features/stylePresets/components/ActiveStylePreset.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/ActiveStylePreset.tsx
@@ -1,4 +1,4 @@
-import { Badge, Flex, IconButton, Text, Tooltip } from '@invoke-ai/ui-library';
+import { Badge, Flex, IconButton, Spacer, Text, Tooltip } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { negativePromptChanged, positivePromptChanged } from 'features/controlLayers/store/controlLayersSlice';
 import { usePresetModifiedPrompts } from 'features/stylePresets/hooks/usePresetModifiedPrompts';
@@ -69,45 +69,40 @@ export const ActiveStylePreset = () => {
     );
   }
   return (
-    <Flex justifyContent="space-between" flexGrow={1} alignItems="center" gap={2} overflow="hidden">
+    <Flex w="full" alignItems="center" gap={2} minW={0}>
       <StylePresetImage imageWidth={25} presetImageUrl={activeStylePreset.image} />
-      <Flex flexDir="column" flexGrow={1} overflow="hidden">
-        <Flex>
-          <Badge colorScheme="invokeBlue" variant="subtle">
-            {activeStylePreset.name}
-          </Badge>
-        </Flex>
-      </Flex>
-      <Flex gap={1}>
-        <Tooltip label={t('stylePresets.toggleViewMode')}>
-          <IconButton
-            onClick={handleToggleViewMode}
-            variant="outline"
-            size="sm"
-            aria-label={t('stylePresets.toggleViewMode')}
-            colorScheme={viewMode ? 'invokeBlue' : 'base'}
-            icon={<PiEyeBold />}
-          />
-        </Tooltip>
-        <Tooltip label={t('stylePresets.flatten')}>
-          <IconButton
-            onClick={handleFlattenPrompts}
-            variant="outline"
-            size="sm"
-            aria-label={t('stylePresets.flatten')}
-            icon={<PiStackSimpleBold />}
-          />
-        </Tooltip>
-        <Tooltip label={t('stylePresets.clearTemplateSelection')}>
-          <IconButton
-            onClick={handleClearActiveStylePreset}
-            variant="outline"
-            size="sm"
-            aria-label={t('stylePresets.clearTemplateSelection')}
-            icon={<PiXBold />}
-          />
-        </Tooltip>
-      </Flex>
+      <Badge colorScheme="invokeBlue" variant="subtle" justifySelf="flex-start">
+        {activeStylePreset.name}
+      </Badge>
+      <Spacer />
+      <Tooltip label={t('stylePresets.toggleViewMode')}>
+        <IconButton
+          onClick={handleToggleViewMode}
+          variant="outline"
+          size="sm"
+          aria-label={t('stylePresets.toggleViewMode')}
+          colorScheme={viewMode ? 'invokeBlue' : 'base'}
+          icon={<PiEyeBold />}
+        />
+      </Tooltip>
+      <Tooltip label={t('stylePresets.flatten')}>
+        <IconButton
+          onClick={handleFlattenPrompts}
+          variant="outline"
+          size="sm"
+          aria-label={t('stylePresets.flatten')}
+          icon={<PiStackSimpleBold />}
+        />
+      </Tooltip>
+      <Tooltip label={t('stylePresets.clearTemplateSelection')}>
+        <IconButton
+          onClick={handleClearActiveStylePreset}
+          variant="outline"
+          size="sm"
+          aria-label={t('stylePresets.clearTemplateSelection')}
+          icon={<PiXBold />}
+        />
+      </Tooltip>
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/stylePresets/components/ActiveStylePreset.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/ActiveStylePreset.tsx
@@ -69,10 +69,10 @@ export const ActiveStylePreset = () => {
     );
   }
   return (
-    <Flex justifyContent="space-between" w="full" alignItems="center">
-      <Flex gap={2} alignItems="center">
-        <StylePresetImage imageWidth={25} presetImageUrl={activeStylePreset.image} />
-        <Flex flexDir="column">
+    <Flex justifyContent="space-between" flexGrow={1} alignItems="center" gap={2} overflow="hidden">
+      <StylePresetImage imageWidth={25} presetImageUrl={activeStylePreset.image} />
+      <Flex flexDir="column" flexGrow={1} overflow="hidden">
+        <Flex>
           <Badge colorScheme="invokeBlue" variant="subtle">
             {activeStylePreset.name}
           </Badge>

--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetForm/StylePresetForm.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetForm/StylePresetForm.tsx
@@ -30,8 +30,8 @@ export const StylePresetForm = ({
   updatingStylePresetId: string | null;
   formData: StylePresetFormData | null;
 }) => {
-  const [createStylePreset] = useCreateStylePresetMutation();
-  const [updateStylePreset] = useUpdateStylePresetMutation();
+  const [createStylePreset, { isLoading: isCreating }] = useCreateStylePresetMutation();
+  const [updateStylePreset, { isLoading: isUpdating }] = useUpdateStylePresetMutation();
   const { t } = useTranslation();
   const allowPrivateStylePresets = useAppSelector((s) => s.config.allowPrivateStylePresets);
 
@@ -109,7 +109,11 @@ export const StylePresetForm = ({
 
       <Flex justifyContent="space-between" alignItems="flex-end" gap={10}>
         {allowPrivateStylePresets ? <StylePresetTypeField control={control} name="type" /> : <Spacer />}
-        <Button onClick={handleSubmit(handleClickSave)} isDisabled={!formState.isValid}>
+        <Button
+          onClick={handleSubmit(handleClickSave)}
+          isDisabled={!formState.isValid}
+          isLoading={isCreating || isUpdating}
+        >
           {t('common.save')}
         </Button>
       </Flex>

--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetForm/StylePresetModal.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetForm/StylePresetModal.tsx
@@ -48,9 +48,13 @@ export const StylePresetModal = () => {
       } else {
         let file = null;
         if (data.imageUrl) {
-          const blob = await convertImageUrlToBlob(data.imageUrl);
-          if (blob) {
-            file = new File([blob], 'style_preset.png', { type: 'image/png' });
+          try {
+            const blob = await convertImageUrlToBlob(data.imageUrl);
+            if (blob) {
+              file = new File([blob], 'style_preset.png', { type: 'image/png' });
+            }
+          } catch (error) {
+            // do nothing
           }
         }
         setFormData({

--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetImage.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetImage.tsx
@@ -21,6 +21,7 @@ const StylePresetImage = ({ presetImageUrl, imageWidth }: { presetImageUrl: stri
           />
         )
       }
+      p={2}
     >
       <Image
         src={presetImageUrl || ''}

--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetMenuTrigger.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetMenuTrigger.tsx
@@ -34,6 +34,7 @@ export const StylePresetMenuTrigger = () => {
       _hover={_hover}
       transitionProperty="background-color"
       transitionDuration="normal"
+      w="full"
     >
       <ActiveStylePreset />
 

--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetMenuTrigger.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetMenuTrigger.tsx
@@ -29,7 +29,7 @@ export const StylePresetMenuTrigger = () => {
       py={2}
       px={3}
       borderRadius="base"
-      gap={1}
+      gap={2}
       role="button"
       _hover={_hover}
       transitionProperty="background-color"
@@ -37,7 +37,6 @@ export const StylePresetMenuTrigger = () => {
       w="full"
     >
       <ActiveStylePreset />
-
       <IconButton aria-label={t('stylePresets.viewList')} variant="ghost" icon={<PiCaretDownBold />} size="sm" />
     </Flex>
   );

--- a/invokeai/frontend/web/src/services/api/endpoints/stylePresets.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/stylePresets.ts
@@ -94,7 +94,7 @@ export const stylePresetsApi = api.injectEndpoints({
     }),
     exportStylePresets: build.query<string, void>({
       query: () => ({
-        url: buildStylePresetsUrl('/export'),
+        url: buildStylePresetsUrl('export'),
         responseHandler: (response) => response.text(),
       }),
       providesTags: ['FetchOnReconnect', { type: 'StylePreset', id: LIST_TAG }],


### PR DESCRIPTION
## Summary

* add loading state to button when creating or updating a prompt template
* fix badge styling when template name is long
* fix extra slash in exports endpoint that UI calls
* fix(ui): error handling if unable to convert image URL to blob

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
