### PR TITLE
fix(ui): use empty string fallback if unable to parse prompts when creating style preset from existing image

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/hooks/useImageActions.ts
+++ b/invokeai/frontend/web/src/features/gallery/hooks/useImageActions.ts
@@ -92,12 +92,12 @@ export const useImageActions = (image_name?: string) => {
       try {
         positivePrompt = await handlers.positivePrompt.parse(metadata);
       } catch (error) {
-        positivePrompt = ""
+        positivePrompt = '';
       }
       try {
         negativePrompt = await handlers.negativePrompt.parse(metadata);
       } catch (error) {
-        negativePrompt = ""
+        negativePrompt = '';
       }
 
       $stylePresetModalState.set({

--- a/invokeai/frontend/web/src/features/gallery/hooks/useImageActions.ts
+++ b/invokeai/frontend/web/src/features/gallery/hooks/useImageActions.ts
@@ -86,8 +86,19 @@ export const useImageActions = (image_name?: string) => {
 
   const createAsPreset = useCallback(async () => {
     if (image_name && metadata && imageDTO) {
-      const positivePrompt = await handlers.positivePrompt.parse(metadata);
-      const negativePrompt = await handlers.negativePrompt.parse(metadata);
+      let positivePrompt;
+      let negativePrompt;
+
+      try {
+        positivePrompt = await handlers.positivePrompt.parse(metadata);
+      } catch (error) {
+        positivePrompt = ""
+      }
+      try {
+        negativePrompt = await handlers.negativePrompt.parse(metadata);
+      } catch (error) {
+        negativePrompt = ""
+      }
 
       $stylePresetModalState.set({
         prefilledFormData: {


### PR DESCRIPTION
## Summary

fix(ui): use empty string fallback if unable to parse prompts when creating style preset from existing image
discovered this using an outpainting image that had a positive prompt but no negative prompt

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
