### PR TITLE
fix(ui): disable export button if no non-default presets

### DIFF
--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetExportButton.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetExportButton.tsx
@@ -16,9 +16,9 @@ export const StylePresetExportButton = () => {
   const { t } = useTranslation();
   const { presetCount } = useListStylePresetsQuery(undefined, {
     selectFromResult: ({ data }) => {
-      const userPresets = data?.filter((preset) => preset.type === 'user') ?? EMPTY_ARRAY;
+      const presetsToExport = data?.filter((preset) => preset.type !== 'default') ?? EMPTY_ARRAY;
       return {
-        presetCount: userPresets.length,
+        presetCount: presetsToExport.length,
       };
     },
   });


### PR DESCRIPTION
## Summary

Instead of counting the number of user presets, count the number of non-default presets so that other types are included.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
