### PR TITLE
Switch UI for Image Viewer Toggle

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToggleMenu.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToggleMenu.tsx
@@ -2,68 +2,74 @@ import {
   Button,
   Flex,
   Icon,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
   Text,
+  Tooltip,
 } from '@invoke-ai/ui-library';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
+import { useCallback } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
-import { PiCaretDownBold, PiCheckBold, PiEyeBold, PiPencilBold } from 'react-icons/pi';
+import { PiEyeBold, PiPencilBold } from 'react-icons/pi';
 
 export const ViewerToggleMenu = () => {
   const { t } = useTranslation();
-  const imageViewer = useImageViewer();
-  useHotkeys('z', imageViewer.onToggle, [imageViewer]);
-  useHotkeys('esc', imageViewer.onClose, [imageViewer]);
+  const { isOpen, onToggle, onClose, onOpen } = useImageViewer();
+
+  const handleOpen = useCallback(() => onOpen(), [onOpen]);
+  const handleClose = useCallback(() => onClose(), [onClose]);
+
+  useHotkeys('z', onToggle, [onToggle]);
+  useHotkeys('esc', onClose, [onClose]);
 
   return (
-    <Popover isLazy>
-      <PopoverTrigger>
-        <Button variant="outline" data-testid="toggle-viewer-menu-button" pointerEvents="auto">
-          <Flex gap={3} w="full" alignItems="center">
-            {imageViewer.isOpen ? <Icon as={PiEyeBold} /> : <Icon as={PiPencilBold} />}
-            <Text fontSize="md">{imageViewer.isOpen ? t('common.viewing') : t('common.editing')}</Text>
-            <Icon as={PiCaretDownBold} />
-          </Flex>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent p={2} pointerEvents="auto">
-        <PopoverArrow />
-        <PopoverBody>
-          <Flex flexDir="column">
-            <Button onClick={imageViewer.onOpen} variant="ghost" h="auto" w="auto" p={2}>
-              <Flex gap={2} w="full">
-                <Icon as={PiCheckBold} visibility={imageViewer.isOpen ? 'visible' : 'hidden'} />
-                <Flex flexDir="column" gap={2} alignItems="flex-start">
-                  <Text fontWeight="semibold" color="base.100">
-                    {t('common.viewing')}
-                  </Text>
-                  <Text fontWeight="normal" color="base.300">
-                    {t('common.viewingDesc')}
-                  </Text>
-                </Flex>
-              </Flex>
-            </Button>
-            <Button onClick={imageViewer.onClose} variant="ghost" h="auto" w="auto" p={2}>
-              <Flex gap={2} w="full">
-                <Icon as={PiCheckBold} visibility={imageViewer.isOpen ? 'hidden' : 'visible'} />
-                <Flex flexDir="column" gap={2} alignItems="flex-start">
-                  <Text fontWeight="semibold" color="base.100">
-                    {t('common.editing')}
-                  </Text>
-                  <Text fontWeight="normal" color="base.300">
-                    {t('common.editingDesc')}
-                  </Text>
-                </Flex>
-              </Flex>
-            </Button>
-          </Flex>
-        </PopoverBody>
-      </PopoverContent>
-    </Popover>
+    <Flex
+      gap={4}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Text>{isOpen ? t('common.viewing') : t('common.editing')}</Text>
+      <Flex
+        gap={1}
+        alignItems="center"
+        borderWidth={1}
+        borderRadius="md"
+        padding={1}
+      >
+        <Tooltip
+          hasArrow
+          label={<Flex flexDir="column">
+            <Text fontWeight="semibold">{t('common.viewing')}</Text>
+            <Text fontWeight="normal">{t('common.viewingDesc')}</Text>
+          </Flex>}
+        >
+          <Button
+            onClick={handleOpen}
+            variant={isOpen ? 'solid' : 'ghost'}
+            colorScheme="invokeBlue"
+            size="sm"
+            aria-label={t('common.viewing')}
+          >
+            <Icon as={PiEyeBold} boxSize="0.95rem" />
+          </Button>
+        </Tooltip>
+        <Tooltip
+          hasArrow
+          label={<Flex flexDir="column">
+            <Text fontWeight="semibold">{t('common.editing')}</Text>
+            <Text fontWeight="normal">{t('common.editingDesc')}</Text>
+          </Flex>}
+        >
+          <Button
+            onClick={handleClose}
+            variant={!isOpen ? 'solid' : 'ghost'}
+            colorScheme="invokeBlue"
+            size="sm"
+            aria-label={t('common.editing')}
+          >
+            <Icon as={PiPencilBold} boxSize="0.95rem" />
+          </Button>
+        </Tooltip>
+      </Flex>
+    </Flex>
   );
 };

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToggleMenu.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToggleMenu.tsx
@@ -1,12 +1,6 @@
-import {
-  Button,
-  Flex,
-  Icon,
-  Text,
-  Tooltip,
-} from '@invoke-ai/ui-library';
+import { Button, Flex, Icon, Text, Tooltip } from '@invoke-ai/ui-library';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
-import { useCallback } from 'react'
+import { useCallback } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 import { PiEyeBold, PiPencilBold } from 'react-icons/pi';
@@ -22,25 +16,17 @@ export const ViewerToggleMenu = () => {
   useHotkeys('esc', onClose, [onClose]);
 
   return (
-    <Flex
-      gap={4}
-      alignItems="center"
-      justifyContent="center"
-    >
+    <Flex gap={4} alignItems="center" justifyContent="center">
       <Text>{isOpen ? t('common.viewing') : t('common.editing')}</Text>
-      <Flex
-        gap={1}
-        alignItems="center"
-        borderWidth={1}
-        borderRadius="md"
-        padding={1}
-      >
+      <Flex gap={1} alignItems="center" borderWidth={1} borderRadius="md" padding={1}>
         <Tooltip
           hasArrow
-          label={<Flex flexDir="column">
-            <Text fontWeight="semibold">{t('common.viewing')}</Text>
-            <Text fontWeight="normal">{t('common.viewingDesc')}</Text>
-          </Flex>}
+          label={
+            <Flex flexDir="column">
+              <Text fontWeight="semibold">{t('common.viewing')}</Text>
+              <Text fontWeight="normal">{t('common.viewingDesc')}</Text>
+            </Flex>
+          }
         >
           <Button
             onClick={handleOpen}
@@ -54,10 +40,12 @@ export const ViewerToggleMenu = () => {
         </Tooltip>
         <Tooltip
           hasArrow
-          label={<Flex flexDir="column">
-            <Text fontWeight="semibold">{t('common.editing')}</Text>
-            <Text fontWeight="normal">{t('common.editingDesc')}</Text>
-          </Flex>}
+          label={
+            <Flex flexDir="column">
+              <Text fontWeight="semibold">{t('common.editing')}</Text>
+              <Text fontWeight="normal">{t('common.editingDesc')}</Text>
+            </Flex>
+          }
         >
           <Button
             onClick={handleClose}


### PR DESCRIPTION
## Summary

Redesign the image viewer toggle from a dropdown UI to a switch. This approach requires one less click to toggle modes and makes more sense from a UX perspective.

![image](https://github.com/user-attachments/assets/4692b0e0-436d-47c5-8fff-bdf46288d426)


## Related Issues / Discussions

- Closes #6401 

## QA Instructions

Click eye icon for viewer mode, click pencil for editor mode.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
