### PR TITLE
Added support for bounding boxes in the Invocation API

### DIFF
--- a/invokeai/invocation_api/__init__.py
+++ b/invokeai/invocation_api/__init__.py
@@ -13,6 +13,7 @@ from invokeai.app.invocations.baseinvocation import (
 )
 from invokeai.app.invocations.fields import (
     BoardField,
+    BoundingBoxField,
     ColorField,
     ConditioningField,
     DenoiseMaskField,
@@ -46,6 +47,7 @@ from invokeai.app.invocations.model import (
 from invokeai.app.invocations.primitives import (
     BooleanCollectionOutput,
     BooleanOutput,
+    BoundingBoxOutput,
     ColorCollectionOutput,
     ColorOutput,
     ConditioningCollectionOutput,
@@ -92,6 +94,7 @@ __all__ = [
     "InvocationContext",
     # invokeai.app.invocations.fields
     "BoardField",
+    "BoundingBoxField",
     "ColorField",
     "ConditioningField",
     "DenoiseMaskField",
@@ -128,6 +131,7 @@ __all__ = [
     # invokeai.app.invocations.primitives
     "BooleanCollectionOutput",
     "BooleanOutput",
+    "BoundingBoxOutput",
     "ColorCollectionOutput",
     "ColorOutput",
     "ConditioningCollectionOutput",


### PR DESCRIPTION
Adding built-in bounding boxes as a core type would help developers of nodes that include bounding box support.

## Summary

In keeping with the core value that developers shouldn't pull in internal parts of Invoke, this change exposes the bounding
box field and output.

## Related Issues / Discussions

Primarily for node developers.

## QA Instructions

## Merge Plan

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
