### PR TITLE
build: remove broken scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,6 @@ dependencies = [
 
 [project.scripts]
 "invokeai-web" = "invokeai.app.run_app:run_app"
-"invokeai-import-images" = "invokeai.frontend.install.import_images:main"
-"invokeai-db-maintenance" = "invokeai.backend.util.db_maintenance:main"
 
 [project.urls]
 "Homepage" = "https://invoke-ai.github.io/InvokeAI/"


### PR DESCRIPTION
## Summary

These two scripts are broken and can cause data loss. Remove them.

They are not in the launcher script, but _are_ available to users in the terminal/file browser.

Hopefully, when we removing them here, `pip` will delete them on next installation of the package...

## Related Issues / Discussions

- Closes #6776
- Closes #6188
- Closes #5486
- Closes #6518

## QA Instructions

Whether this deletes the scripts on users' machines or not doesn't matter - this change is needed either way.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
