### PR TITLE
Update probe to install Invoke formatted clip embeds and t5 encoders

### DIFF
--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -304,6 +304,11 @@ class ModelProbe(object):
         else:
             error_hint = f"class {class_name} is not one of the supported classes [{', '.join(cls.CLASS2TYPE.keys())}]"
 
+        if (folder_path / "tokenizer").exists() and (folder_path / "text_encoder").exists():
+            return ModelType.CLIPEmbed
+        if (folder_path / "tokenizer_2").exists() and (folder_path / "text_encoder_2").exists():
+            return ModelType.T5Encoder
+
         # give up
         raise InvalidModelConfigException(
             f"Unable to determine model type for {folder_path}" + (f"; {error_hint}" if error_hint else "")
@@ -747,6 +752,10 @@ class TextualInversionFolderProbe(FolderProbeBase):
 
 
 class T5EncoderFolderProbe(FolderProbeBase):
+
+    def get_base_type(self) -> BaseModelType:
+        return BaseModelType.Any
+
     def get_format(self) -> ModelFormat:
         return ModelFormat.T5Encoder
 

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -752,7 +752,6 @@ class TextualInversionFolderProbe(FolderProbeBase):
 
 
 class T5EncoderFolderProbe(FolderProbeBase):
-
     def get_base_type(self) -> BaseModelType:
         return BaseModelType.Any
 


### PR DESCRIPTION
## Summary

Allows users to install the clip and t5 embed models in the probe if pulled from the InvokeAI hugging face repos. This will be made more robust in follow up PRs.

## QA Instructions

Attempt to install the following two models
- InvokeAI/t5-v1_1-xxl::bnb_llm_int8
- InvokeAI/clip-vit-large-patch14-text-encoder::bfloat16

## Merge Plan

Can be merged when approved

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
