### PR TITLE
Fix source string in hugging face installs with subfolders

### DIFF
--- a/invokeai/app/services/model_install/model_install_common.py
+++ b/invokeai/app/services/model_install/model_install_common.py
@@ -103,7 +103,7 @@ class HFModelSource(StringLikeSource):
         if self.variant:
             base += f":{self.variant or ''}"
         if self.subfolder:
-            base += f"::{self.subfolder}"
+            base += f"::{self.subfolder.as_posix()}"
         return base
 
 

--- a/invokeai/app/services/model_install/model_install_common.py
+++ b/invokeai/app/services/model_install/model_install_common.py
@@ -103,7 +103,7 @@ class HFModelSource(StringLikeSource):
         if self.variant:
             base += f":{self.variant or ''}"
         if self.subfolder:
-            base += f":{self.subfolder}"
+            base += f"::{self.subfolder}"
         return base
 
 


### PR DESCRIPTION
## Summary

This __string__ method is causing the model probe to insert incorrect sources into models installed via huggingface subfolders.

## QA Instructions

Install any flux model via starter models and ensure it changes to `Installed`

## Merge Plan

Can be merged when approved

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
