### PR TITLE
Add install probes for T5_encoder and ClipTextModel

### DIFF
--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -756,11 +756,17 @@ class TextualInversionFolderProbe(FolderProbeBase):
 
 
 class T5EncoderFolderProbe(FolderProbeBase):
-    def get_format(self) -> ModelFormat:
-        return ModelFormat.T5Encoder
-
     def get_base_type(self) -> BaseModelType:
         return BaseModelType.Flux
+
+    def get_format(self) -> ModelFormat:
+        path = self.model_path / "text_encoder_2"
+        if (path / "model.safetensors.index.json").exists():
+            return ModelFormat.T5Encoder
+        files = path.glob("*.safetensors")
+        if any(x for x in files if "llm_int8" in x.as_posix()):
+            return ModelFormat.BnbQuantizedLlmInt8b
+        raise f"{self.model_path.as_posix()}: unknown model format"
 
 
 class ONNXFolderProbe(PipelineFolderProbe):

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -757,7 +757,7 @@ class TextualInversionFolderProbe(FolderProbeBase):
 
 class T5EncoderFolderProbe(FolderProbeBase):
     def get_base_type(self) -> BaseModelType:
-        return BaseModelType.Flux
+        return BaseModelType.Any
 
     def get_format(self) -> ModelFormat:
         path = self.model_path / "text_encoder_2"


### PR DESCRIPTION
## Summary

During testing of the new Flux starter models, I found that installation of `clip-vit-large` and the quantized text encoders were failing during the model installer's model probe phase. This PR adds model probe support for the FLUX T5_encoder and ClipTextModel dependencies. This PR fixes "download failed" errors experienced when the FLUX starter models are installed.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

To confirm the original issue, please first remove the T5 quantized text encoder and clip-vit-large, and try to install one of the quantized Flux models from the Model manager starter models tab. This should fail.

After pulling this PR, these tasks should run to completion and flux-based workflows should work.

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

Merge when approved.

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _Documentation added / updated (if applicable)_
