### PR TITLE
feat: flux preview images

### DIFF
--- a/invokeai/app/invocations/flux_denoise.py
+++ b/invokeai/app/invocations/flux_denoise.py
@@ -2,7 +2,6 @@ from typing import Callable, Optional
 
 import torch
 import torchvision.transforms as tv_transforms
-from PIL import Image
 from torchvision.transforms.functional import resize as tv_resize
 
 from invokeai.app.invocations.baseinvocation import BaseInvocation, Classification, invocation
@@ -18,7 +17,6 @@ from invokeai.app.invocations.fields import (
 )
 from invokeai.app.invocations.model import TransformerField
 from invokeai.app.invocations.primitives import LatentsOutput
-from invokeai.app.services.session_processor.session_processor_common import CanceledException, ProgressImage
 from invokeai.app.services.shared.invocation_context import InvocationContext
 from invokeai.backend.flux.denoise import denoise
 from invokeai.backend.flux.inpaint_extension import InpaintExtension
@@ -34,7 +32,6 @@ from invokeai.backend.flux.sampling_utils import (
 from invokeai.backend.stable_diffusion.diffusers_pipeline import PipelineIntermediateState
 from invokeai.backend.stable_diffusion.diffusion.conditioning_data import FLUXConditioningInfo
 from invokeai.backend.util.devices import TorchDevice
-from invokeai.backend.util.util import image_to_dataURL
 
 
 @invocation(
@@ -244,51 +241,9 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         # `latents`.
         return mask.expand_as(latents)
 
-    def _build_step_callback(
-        self, context: InvocationContext
-    ) -> Callable[[torch.Tensor, PipelineIntermediateState], None]:
-        def step_callback(img: torch.Tensor, state: PipelineIntermediateState) -> None:
-            if context.util.is_canceled():
-                raise CanceledException
-            latent_rgb_factors = torch.tensor(
-                [
-                    [-0.0412, 0.0149, 0.0521],
-                    [0.0056, 0.0291, 0.0768],
-                    [0.0342, -0.0681, -0.0427],
-                    [-0.0258, 0.0092, 0.0463],
-                    [0.0863, 0.0784, 0.0547],
-                    [-0.0017, 0.0402, 0.0158],
-                    [0.0501, 0.1058, 0.1152],
-                    [-0.0209, -0.0218, -0.0329],
-                    [-0.0314, 0.0083, 0.0896],
-                    [0.0851, 0.0665, -0.0472],
-                    [-0.0534, 0.0238, -0.0024],
-                    [0.0452, -0.0026, 0.0048],
-                    [0.0892, 0.0831, 0.0881],
-                    [-0.1117, -0.0304, -0.0789],
-                    [0.0027, -0.0479, -0.0043],
-                    [-0.1146, -0.0827, -0.0598],
-                ],
-                dtype=img.dtype,
-                device=img.device,
-            )
-            latent_image = unpack(img.float(), self.height, self.width).squeeze()
-            latent_image_perm = latent_image.permute(1, 2, 0).to(dtype=img.dtype, device=img.device)
-            latent_image = latent_image_perm @ latent_rgb_factors
-            latents_ubyte = (
-                ((latent_image + 1) / 2).clamp(0, 1).mul(0xFF)  # change scale from -1..1 to 0..1  # to 0..255
-            ).to(device="cpu", dtype=torch.uint8)
-            image = Image.fromarray(latents_ubyte.cpu().numpy())
-            (width, height) = image.size
-            width *= 8
-            height *= 8
-            dataURL = image_to_dataURL(image, image_format="JPEG")
-
-            context._services.events.emit_invocation_denoise_progress(
-                context._data.queue_item,
-                context._data.invocation,
-                state,
-                ProgressImage(dataURL=dataURL, width=width, height=height),
-            )
+    def _build_step_callback(self, context: InvocationContext) -> Callable[[PipelineIntermediateState], None]:
+        def step_callback(state: PipelineIntermediateState) -> None:
+            state.latents = unpack(state.latents.float(), self.height, self.width).squeeze()
+            context.util.flux_step_callback(state)
 
         return step_callback

--- a/invokeai/app/services/shared/invocation_context.py
+++ b/invokeai/app/services/shared/invocation_context.py
@@ -14,7 +14,7 @@ from invokeai.app.services.image_records.image_records_common import ImageCatego
 from invokeai.app.services.images.images_common import ImageDTO
 from invokeai.app.services.invocation_services import InvocationServices
 from invokeai.app.services.model_records.model_records_base import UnknownModelException
-from invokeai.app.util.step_callback import stable_diffusion_step_callback
+from invokeai.app.util.step_callback import flux_step_callback, stable_diffusion_step_callback
 from invokeai.backend.model_manager.config import (
     AnyModel,
     AnyModelConfig,
@@ -553,6 +553,24 @@ class UtilInterface(InvocationContextInterface):
             context_data=self._data,
             intermediate_state=intermediate_state,
             base_model=base_model,
+            events=self._services.events,
+            is_canceled=self.is_canceled,
+        )
+
+    def flux_step_callback(self, intermediate_state: PipelineIntermediateState) -> None:
+        """
+        The step callback emits a progress event with the current step, the total number of
+        steps, a preview image, and some other internal metadata.
+
+        This should be called after each denoising step.
+
+        Args:
+            intermediate_state: The intermediate state of the diffusion pipeline.
+        """
+
+        flux_step_callback(
+            context_data=self._data,
+            intermediate_state=intermediate_state,
             events=self._services.events,
             is_canceled=self.is_canceled,
         )

--- a/invokeai/backend/flux/denoise.py
+++ b/invokeai/backend/flux/denoise.py
@@ -36,7 +36,7 @@ def denoise(
             timesteps=t_vec,
             guidance=guidance_vec,
         )
-
+        preview_img = img - t_curr * pred
         img = img + (t_prev - t_curr) * pred
 
         if inpaint_extension is not None:
@@ -48,7 +48,7 @@ def denoise(
                 order=1,
                 total_steps=len(timesteps),
                 timestep=int(t_curr),
-                latents=img,
+                latents=preview_img,
             ),
         )
         step += 1

--- a/invokeai/backend/flux/denoise.py
+++ b/invokeai/backend/flux/denoise.py
@@ -18,7 +18,7 @@ def denoise(
     vec: torch.Tensor,
     # sampling parameters
     timesteps: list[float],
-    step_callback: Callable[[torch.Tensor, PipelineIntermediateState], None],
+    step_callback: Callable[[PipelineIntermediateState], None],
     guidance: float,
     inpaint_extension: InpaintExtension | None,
 ):
@@ -43,7 +43,6 @@ def denoise(
             img = inpaint_extension.merge_intermediate_latents_with_init_latents(img, t_prev)
 
         step_callback(
-            img,
             PipelineIntermediateState(
                 step=step,
                 order=1,


### PR DESCRIPTION
## Summary

This PR adds in progress images to our flux nodes. It adds a new context util function for flux pipelines step callbacks. RGB Latent factors were generated by updating a brute force script provided by @StAlKeR7779 

https://github.com/user-attachments/assets/e5dc6e8d-36f2-4848-abd8-a24596f97e5d

## QA Instructions

Run a flux image generation workflow and validate the progress images look satisfactory.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
