### PR TITLE
feat: support checkpoint bundles containing more than the transformer

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/flux.py
+++ b/invokeai/backend/model_manager/load/model_loaders/flux.py
@@ -191,6 +191,8 @@ class FluxCheckpointModel(ModelLoader):
         with SilenceWarnings():
             model = Flux(params[config.config_path])
             sd = load_file(model_path)
+            if "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.scale" in sd:
+                sd = convert_bundle_to_flux_transformer_checkpoint(sd)
             model.load_state_dict(sd, assign=True)
         return model
 

--- a/invokeai/backend/model_manager/load/model_loaders/flux.py
+++ b/invokeai/backend/model_manager/load/model_loaders/flux.py
@@ -32,6 +32,7 @@ from invokeai.backend.model_manager.config import (
 )
 from invokeai.backend.model_manager.load.load_default import ModelLoader
 from invokeai.backend.model_manager.load.model_loader_registry import ModelLoaderRegistry
+from invokeai.backend.model_manager.util.model_util import convert_bundle_to_flux_transformer_checkpoint
 from invokeai.backend.util.silence_warnings import SilenceWarnings
 
 try:
@@ -230,5 +231,7 @@ class FluxBnbQuantizednf4bCheckpointModel(ModelLoader):
                 model = Flux(params[config.config_path])
                 model = quantize_model_nf4(model, modules_to_not_convert=set(), compute_dtype=torch.bfloat16)
             sd = load_file(model_path)
+            if "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.scale" in sd:
+                sd = convert_bundle_to_flux_transformer_checkpoint(sd)
             model.load_state_dict(sd, assign=True)
         return model

--- a/invokeai/backend/model_manager/probe.py
+++ b/invokeai/backend/model_manager/probe.py
@@ -231,7 +231,10 @@ class ModelProbe(object):
                     "cond_stage_model.",
                     "first_stage_model.",
                     "model.diffusion_model.",
+                    # FLUX models in the official BFL format contain keys with the "double_blocks." prefix.
                     "double_blocks.",
+                    # Some FLUX checkpoint files contain transformer keys prefixed with "model.diffusion_model".
+                    # This prefix is typically used to distinguish between multiple models bundled in a single file.
                     "model.diffusion_model.double_blocks.",
                 )
             ):

--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -139,6 +139,8 @@ def convert_bundle_to_flux_transformer_checkpoint(
     transformer_state_dict: dict[str, torch.Tensor],
 ) -> dict[str, torch.Tensor]:
     original_state_dict: dict[str, torch.Tensor] = {}
+    keys_to_remove: list[str] = []
+
     for k, v in transformer_state_dict.items():
         if not k.startswith("model.diffusion_model"):
             continue
@@ -146,5 +148,13 @@ def convert_bundle_to_flux_transformer_checkpoint(
             # Scale math must be done at bfloat16 due to our current flux model
             # support limitations at inference time
             v = v.to(dtype=torch.bfloat16)
-        original_state_dict[k.replace("model.diffusion_model.", "")] = v
+        new_key = k.replace("model.diffusion_model.", "")
+        original_state_dict[new_key] = v
+        keys_to_remove.append(k)
+
+    # Remove processed keys from the original dictionary, leaving others in case
+    # other model state dicts need to be pulled
+    for k in keys_to_remove:
+        del transformer_state_dict[k]
+
     return original_state_dict

--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -143,6 +143,8 @@ def convert_bundle_to_flux_transformer_checkpoint(
         if not k.startswith("model.diffusion_model"):
             continue
         if k.endswith("scale"):
+            # Scale math must be done at bfloat16 due to our current flux model
+            # support limitations at inference time
             v = v.to(dtype=torch.bfloat16)
         original_state_dict[k.replace("model.diffusion_model.", "")] = v
     return original_state_dict

--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -143,6 +143,7 @@ def convert_bundle_to_flux_transformer_checkpoint(
 
     for k, v in transformer_state_dict.items():
         if not k.startswith("model.diffusion_model"):
+            keys_to_remove.append(k)  # This can be removed in the future if we only want to delete transformer keys
             continue
         if k.endswith("scale"):
             # Scale math must be done at bfloat16 due to our current flux model

--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -133,3 +133,16 @@ def lora_token_vector_length(checkpoint: Dict[str, torch.Tensor]) -> Optional[in
             break
 
     return lora_token_vector_length
+
+
+def convert_bundle_to_flux_transformer_checkpoint(
+    transformer_state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    original_state_dict: dict[str, torch.Tensor] = {}
+    for k, v in transformer_state_dict.items():
+        if not k.startswith("model.diffusion_model"):
+            continue
+        if k.endswith("scale"):
+            v = v.to(dtype=torch.bfloat16)
+        original_state_dict[k.replace("model.diffusion_model.", "")] = v
+    return original_state_dict


### PR DESCRIPTION
## Summary

This update is meant to update our model loader and probe to support flux checkpoint bundles containing the transformer along with other models. We will update out loaders to support pulling out the encoders and other models from these in a future update. This PR enables users to leverage flux checkpoints commonly found on civitAI

## QA Instructions

Install checkpoint models such as [this one](https://civitai.com/models/652009/fluxrealisticv1?modelVersionId=733981) and ensure you're able to successfully run the flux workflows with it.


## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
