### PR TITLE
fix(ui): spandrel filter

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
@@ -108,7 +108,6 @@ const FilterBox = memo(({ adapter }: { adapter: CanvasEntityAdapterRasterLayer |
           onClick={adapter.filterer.cancel}
           isLoading={isProcessing}
           loadingText={t('controlLayers.filter.cancel')}
-          isDisabled={!isValid}
         >
           {t('controlLayers.filter.cancel')}
         </Button>

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterSpandrel.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterSpandrel.tsx
@@ -70,8 +70,9 @@ export const FilterSpandrel = ({ onChange, config }: Props) => {
   );
 
   useEffect(() => {
-    if (!config.model) {
-      onChangeModel(options[0] ?? null);
+    const firstModel = options[0];
+    if (!config.model && firstModel) {
+      onChangeModel(firstModel);
     }
   }, [config.model, onChangeModel, options]);
 

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterSpandrel.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterSpandrel.tsx
@@ -81,14 +81,14 @@ export const FilterSpandrel = ({ onChange, config }: Props) => {
       <FormControl w="full" orientation="vertical">
         <Flex w="full" alignItems="center">
           <FormLabel m={0} flexGrow={1}>
-            {t('controlLayers.filter.spandrel.paramAutoScale')}
+            {t('controlLayers.filter.spandrel_filter.autoScale')}
           </FormLabel>
           <Switch size="sm" isChecked={config.autoScale} onChange={onAutoscaleChanged} />
         </Flex>
-        <FormHelperText>{t('controlLayers.filter.spandrel.paramAutoScaleDesc')}</FormHelperText>
+        <FormHelperText>{t('controlLayers.filter.spandrel_filter.autoScaleDesc')}</FormHelperText>
       </FormControl>
       <FormControl isDisabled={!config.autoScale}>
-        <FormLabel m={0}>{t('controlLayers.filter.spandrel.paramScale')}</FormLabel>
+        <FormLabel m={0}>{t('controlLayers.filter.spandrel_filter.scale')}</FormLabel>
         <CompositeSlider
           value={config.scale}
           onChange={onScaleChanged}
@@ -105,7 +105,7 @@ export const FilterSpandrel = ({ onChange, config }: Props) => {
         />
       </FormControl>
       <FormControl>
-        <FormLabel m={0}>{t('controlLayers.filter.spandrel.paramModel')}</FormLabel>
+        <FormLabel m={0}>{t('controlLayers.filter.spandrel_filter.model')}</FormLabel>
         <Tooltip label={tooltipLabel}>
           <Box w="full">
             <Combobox


### PR DESCRIPTION
## Summary

- Fix: infinite recursion (i.e. a crash) when selecting spandrel filter w/ no spandrel models installed
- Fix: translations for spandrel filter

## Related Issues / Discussions

Closes #6835 

## QA Instructions

Spandrel (image-to-image) filter shouldn't crash when you have no spandrel models installed.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
