### PR TITLE
Invert the expected `denoise_mask` parameter to the FLUX Denoise node

### DIFF
--- a/invokeai/app/invocations/create_gradient_mask.py
+++ b/invokeai/app/invocations/create_gradient_mask.py
@@ -28,7 +28,10 @@ from invokeai.backend.stable_diffusion.diffusers_pipeline import image_resized_t
 class GradientMaskOutput(BaseInvocationOutput):
     """Outputs a denoise mask and an image representing the total gradient of the mask."""
 
-    denoise_mask: DenoiseMaskField = OutputField(description="Mask for denoise model run")
+    denoise_mask: DenoiseMaskField = OutputField(
+        description="Mask for denoise model run. Values of 0.0 represent the regions to be fully denoised, and 1.0 "
+        + "represent the regions to be preserved."
+    )
     expanded_mask_area: ImageField = OutputField(
         description="Image representing the total gradient area of the mask. For paste-back purposes."
     )

--- a/invokeai/app/invocations/fields.py
+++ b/invokeai/app/invocations/fields.py
@@ -181,7 +181,7 @@ class FieldDescriptions:
     )
     num_1 = "The first number"
     num_2 = "The second number"
-    denoise_mask = "A mask of the region to apply the denoising process to."
+    denoise_mask = "A mask of the region to apply the denoising process to. Values of 0.0 represent the regions to be fully denoised, and 1.0 represent the regions to be preserved."
     board = "The board to save the image to"
     image = "The image to process"
     tile_size = "Tile size"


### PR DESCRIPTION
Invert the expected `denoise_mask` parameter to the FLUX Denoise node to match the behaviour of Denoise Latents node used for SD.

## Summary

Changes the definition of the denoise_mask parameter on the "FLUX Denoise" node to match the "Denoise Latents" node. New definition: "Values of 0.0 represent the regions to be fully denoised, and 1.0 represent the regions to be preserved."

Also updates the docs in a few places to make this expectation more clear.

## QA Instructions

I tested on top of this branch: https://github.com/invoke-ai/InvokeAI/pull/6846

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
