### PR TITLE
fix(ui): remove accidentally added staging button

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/StagingAreaToolbar.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/StagingAreaToolbar.tsx
@@ -22,7 +22,6 @@ import {
   PiEyeBold,
   PiEyeSlashBold,
   PiFloppyDiskBold,
-  PiStackPlusBold,
   PiTrashSimpleBold,
   PiXBold,
 } from 'react-icons/pi';
@@ -179,14 +178,6 @@ export const StagingAreaToolbar = memo(() => {
           onClick={onSaveStagingImage}
           colorScheme="invokeBlue"
           isDisabled={!selectedImage || !selectedImage.imageDTO.is_intermediate}
-        />
-        <IconButton
-          tooltip={`${t('unifiedCanvas.saveToGallery')} (Shift+S)`}
-          aria-label={t('unifiedCanvas.saveToGallery')}
-          icon={<PiStackPlusBold />}
-          onClick={onSaveStagingImage}
-          colorScheme="invokeBlue"
-          isDisabled={!selectedImage}
         />
         <IconButton
           tooltip={`${t('unifiedCanvas.discardCurrent')}`}


### PR DESCRIPTION
## Summary

I had accidentally added a button to staging toolbar that shouldn't be there. Removing it.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
