### PR TITLE
fix(ui): restore Settings Modal functionality to render using children

### DIFF
--- a/invokeai/frontend/web/src/app/components/App.tsx
+++ b/invokeai/frontend/web/src/app/components/App.tsx
@@ -19,7 +19,6 @@ import { ClearQueueConfirmationsAlertDialog } from 'features/queue/components/Cl
 import { StylePresetModal } from 'features/stylePresets/components/StylePresetForm/StylePresetModal';
 import { activeStylePresetIdChanged } from 'features/stylePresets/store/stylePresetSlice';
 import RefreshAfterResetModal from 'features/system/components/SettingsModal/RefreshAfterResetModal';
-import SettingsModal from 'features/system/components/SettingsModal/SettingsModal';
 import { configChanged } from 'features/system/store/configSlice';
 import { selectLanguage } from 'features/system/store/systemSelectors';
 import { AppContent } from 'features/ui/components/AppContent';
@@ -138,7 +137,6 @@ const App = ({
       <StylePresetModal />
       <ClearQueueConfirmationsAlertDialog />
       <PreselectedImage selectedImage={selectedImage} />
-      <SettingsModal />
       <RefreshAfterResetModal />
       <DeleteBoardModal />
     </ErrorBoundary>

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsMenu.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsMenu.tsx
@@ -26,13 +26,12 @@ import {
 } from 'react-icons/pi';
 import { RiDiscordFill, RiGithubFill } from 'react-icons/ri';
 
-import { useSettingsModal } from './SettingsModal';
+import SettingsModal from './SettingsModal';
 import { SettingsUpsellMenuItem } from './SettingsUpsellMenuItem';
 const SettingsMenu = () => {
   const { t } = useTranslation();
   const { isOpen, onOpen, onClose } = useDisclosure();
   useGlobalMenuClose(onClose);
-  const settingsModal = useSettingsModal();
 
   const isBugLinkEnabled = useFeatureStatus('bugLink');
   const isDiscordLinkEnabled = useFeatureStatus('discordLink');
@@ -71,15 +70,18 @@ const SettingsMenu = () => {
               </MenuItem>
             )}
           </MenuGroup>
+
           <MenuGroup title={t('common.settingsLabel')}>
             <HotkeysModal>
               <MenuItem as="button" icon={<PiKeyboardBold />}>
                 {t('common.hotkeysLabel')}
               </MenuItem>
             </HotkeysModal>
-            <MenuItem onClick={settingsModal.setTrue} as="button" icon={<PiToggleRightFill />}>
-              {t('common.settingsLabel')}
-            </MenuItem>
+            <SettingsModal>
+              <MenuItem as="button" icon={<PiToggleRightFill />}>
+                {t('common.settingsLabel')}
+              </MenuItem>
+            </SettingsModal>
           </MenuGroup>
           <MenuGroup title={t('accessibility.about')}>
             <AboutModal>

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -42,8 +42,8 @@ import {
 } from 'features/system/store/systemSlice';
 import { selectShouldShowProgressInViewer } from 'features/ui/store/uiSelectors';
 import { setShouldShowProgressInViewer } from 'features/ui/store/uiSlice';
-import type { ChangeEvent } from 'react';
-import { memo, useCallback, useEffect } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import { cloneElement, memo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGetAppConfigQuery } from 'services/api/endpoints/appInfo';
 
@@ -64,12 +64,14 @@ const defaultConfig: ConfigOptions = {
 };
 
 type SettingsModalProps = {
+  /* The button to open the Settings Modal */
+  children: ReactElement;
   config?: ConfigOptions;
 };
 
-export const [useSettingsModal] = buildUseBoolean(false);
+const [useSettingsModal] = buildUseBoolean(false);
 
-const SettingsModal = ({ config = defaultConfig }: SettingsModalProps) => {
+const SettingsModal = ({ config = defaultConfig, children }: SettingsModalProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -162,108 +164,116 @@ const SettingsModal = ({ config = defaultConfig }: SettingsModalProps) => {
   );
 
   return (
-    <Modal isOpen={settingsModal.isTrue} onClose={settingsModal.setFalse} size="2xl" isCentered useInert={false}>
-      <ModalOverlay />
-      <ModalContent maxH="80vh" h="68rem">
-        <ModalHeader bg="none">{t('common.settingsLabel')}</ModalHeader>
-        <ModalCloseButton />
-        <ModalBody display="flex" flexDir="column" gap={4}>
-          <ScrollableContent>
-            <Flex flexDir="column" gap={4}>
-              <FormControlGroup formLabelProps={{ flexGrow: 1 }}>
-                <StickyScrollable title={t('settings.general')}>
-                  <FormControl>
-                    <FormLabel>{t('settings.confirmOnDelete')}</FormLabel>
-                    <Switch isChecked={shouldConfirmOnDelete} onChange={handleChangeShouldConfirmOnDelete} />
-                  </FormControl>
-                  <SettingsShowSendingToDifferentViewAlerts />
-                </StickyScrollable>
-
-                <StickyScrollable title={t('settings.generation')}>
-                  <FormControl isDisabled={!isNSFWCheckerAvailable}>
-                    <FormLabel>{t('settings.enableNSFWChecker')}</FormLabel>
-                    <Switch isChecked={shouldUseNSFWChecker} onChange={handleChangeShouldUseNSFWChecker} />
-                  </FormControl>
-                  <FormControl isDisabled={!isWatermarkerAvailable}>
-                    <FormLabel>{t('settings.enableInvisibleWatermark')}</FormLabel>
-                    <Switch isChecked={shouldUseWatermarker} onChange={handleChangeShouldUseWatermarker} />
-                  </FormControl>
-                </StickyScrollable>
-
-                <StickyScrollable title={t('settings.ui')}>
-                  <FormControl>
-                    <FormLabel>{t('settings.showProgressInViewer')}</FormLabel>
-                    <Switch isChecked={shouldShowProgressInViewer} onChange={handleChangeShouldShowProgressInViewer} />
-                  </FormControl>
-                  <FormControl>
-                    <FormLabel>{t('settings.antialiasProgressImages')}</FormLabel>
-                    <Switch
-                      isChecked={shouldAntialiasProgressImage}
-                      onChange={handleChangeShouldAntialiasProgressImage}
-                    />
-                  </FormControl>
-                  <FormControl>
-                    <InformationalPopover feature="noiseUseCPU" inPortal={false}>
-                      <FormLabel>{t('parameters.useCpuNoise')}</FormLabel>
-                    </InformationalPopover>
-                    <Switch isChecked={shouldUseCpuNoise} onChange={handleChangeShouldUseCpuNoise} />
-                  </FormControl>
-                  {Boolean(config?.shouldShowLocalizationToggle) && <SettingsLanguageSelect />}
-                  <FormControl>
-                    <FormLabel>{t('settings.enableInformationalPopovers')}</FormLabel>
-                    <Switch
-                      isChecked={shouldEnableInformationalPopovers}
-                      onChange={handleChangeShouldEnableInformationalPopovers}
-                    />
-                  </FormControl>
-                </StickyScrollable>
-
-                {Boolean(config?.shouldShowDeveloperSettings) && (
-                  <StickyScrollable title={t('settings.developer')}>
-                    <SettingsDeveloperLogIsEnabled />
-                    <SettingsDeveloperLogLevel />
-                    <SettingsDeveloperLogNamespaces />
+    <>
+      {cloneElement(children, {
+        onClick: settingsModal.setTrue,
+      })}
+      <Modal isOpen={settingsModal.isTrue} onClose={settingsModal.setFalse} size="2xl" isCentered useInert={false}>
+        <ModalOverlay />
+        <ModalContent maxH="80vh" h="68rem">
+          <ModalHeader bg="none">{t('common.settingsLabel')}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody display="flex" flexDir="column" gap={4}>
+            <ScrollableContent>
+              <Flex flexDir="column" gap={4}>
+                <FormControlGroup formLabelProps={{ flexGrow: 1 }}>
+                  <StickyScrollable title={t('settings.general')}>
+                    <FormControl>
+                      <FormLabel>{t('settings.confirmOnDelete')}</FormLabel>
+                      <Switch isChecked={shouldConfirmOnDelete} onChange={handleChangeShouldConfirmOnDelete} />
+                    </FormControl>
+                    <SettingsShowSendingToDifferentViewAlerts />
                   </StickyScrollable>
-                )}
 
-                {Boolean(config?.shouldShowClearIntermediates) && (
-                  <StickyScrollable title={t('settings.clearIntermediates')}>
-                    <Button
-                      tooltip={hasPendingItems ? t('settings.clearIntermediatesDisabled') : undefined}
-                      colorScheme="warning"
-                      onClick={clearIntermediates}
-                      isLoading={isLoadingClearIntermediates}
-                      isDisabled={!intermediatesCount || hasPendingItems}
-                    >
-                      {t('settings.clearIntermediatesWithCount', {
-                        count: intermediatesCount ?? 0,
-                      })}
-                    </Button>
-                    <Text fontWeight="bold">{t('settings.clearIntermediatesDesc1')}</Text>
-                    <Text variant="subtext">{t('settings.clearIntermediatesDesc2')}</Text>
-                    <Text variant="subtext">{t('settings.clearIntermediatesDesc3')}</Text>
+                  <StickyScrollable title={t('settings.generation')}>
+                    <FormControl isDisabled={!isNSFWCheckerAvailable}>
+                      <FormLabel>{t('settings.enableNSFWChecker')}</FormLabel>
+                      <Switch isChecked={shouldUseNSFWChecker} onChange={handleChangeShouldUseNSFWChecker} />
+                    </FormControl>
+                    <FormControl isDisabled={!isWatermarkerAvailable}>
+                      <FormLabel>{t('settings.enableInvisibleWatermark')}</FormLabel>
+                      <Switch isChecked={shouldUseWatermarker} onChange={handleChangeShouldUseWatermarker} />
+                    </FormControl>
                   </StickyScrollable>
-                )}
 
-                <StickyScrollable title={t('settings.resetWebUI')}>
-                  <Button colorScheme="error" onClick={handleClickResetWebUI}>
-                    {t('settings.resetWebUI')}
-                  </Button>
-                  {Boolean(config?.shouldShowResetWebUiText) && (
-                    <>
-                      <Text variant="subtext">{t('settings.resetWebUIDesc1')}</Text>
-                      <Text variant="subtext">{t('settings.resetWebUIDesc2')}</Text>
-                    </>
+                  <StickyScrollable title={t('settings.ui')}>
+                    <FormControl>
+                      <FormLabel>{t('settings.showProgressInViewer')}</FormLabel>
+                      <Switch
+                        isChecked={shouldShowProgressInViewer}
+                        onChange={handleChangeShouldShowProgressInViewer}
+                      />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel>{t('settings.antialiasProgressImages')}</FormLabel>
+                      <Switch
+                        isChecked={shouldAntialiasProgressImage}
+                        onChange={handleChangeShouldAntialiasProgressImage}
+                      />
+                    </FormControl>
+                    <FormControl>
+                      <InformationalPopover feature="noiseUseCPU" inPortal={false}>
+                        <FormLabel>{t('parameters.useCpuNoise')}</FormLabel>
+                      </InformationalPopover>
+                      <Switch isChecked={shouldUseCpuNoise} onChange={handleChangeShouldUseCpuNoise} />
+                    </FormControl>
+                    {Boolean(config?.shouldShowLocalizationToggle) && <SettingsLanguageSelect />}
+                    <FormControl>
+                      <FormLabel>{t('settings.enableInformationalPopovers')}</FormLabel>
+                      <Switch
+                        isChecked={shouldEnableInformationalPopovers}
+                        onChange={handleChangeShouldEnableInformationalPopovers}
+                      />
+                    </FormControl>
+                  </StickyScrollable>
+
+                  {Boolean(config?.shouldShowDeveloperSettings) && (
+                    <StickyScrollable title={t('settings.developer')}>
+                      <SettingsDeveloperLogIsEnabled />
+                      <SettingsDeveloperLogLevel />
+                      <SettingsDeveloperLogNamespaces />
+                    </StickyScrollable>
                   )}
-                </StickyScrollable>
-              </FormControlGroup>
-            </Flex>
-          </ScrollableContent>
-        </ModalBody>
 
-        <ModalFooter />
-      </ModalContent>
-    </Modal>
+                  {Boolean(config?.shouldShowClearIntermediates) && (
+                    <StickyScrollable title={t('settings.clearIntermediates')}>
+                      <Button
+                        tooltip={hasPendingItems ? t('settings.clearIntermediatesDisabled') : undefined}
+                        colorScheme="warning"
+                        onClick={clearIntermediates}
+                        isLoading={isLoadingClearIntermediates}
+                        isDisabled={!intermediatesCount || hasPendingItems}
+                      >
+                        {t('settings.clearIntermediatesWithCount', {
+                          count: intermediatesCount ?? 0,
+                        })}
+                      </Button>
+                      <Text fontWeight="bold">{t('settings.clearIntermediatesDesc1')}</Text>
+                      <Text variant="subtext">{t('settings.clearIntermediatesDesc2')}</Text>
+                      <Text variant="subtext">{t('settings.clearIntermediatesDesc3')}</Text>
+                    </StickyScrollable>
+                  )}
+
+                  <StickyScrollable title={t('settings.resetWebUI')}>
+                    <Button colorScheme="error" onClick={handleClickResetWebUI}>
+                      {t('settings.resetWebUI')}
+                    </Button>
+                    {Boolean(config?.shouldShowResetWebUiText) && (
+                      <>
+                        <Text variant="subtext">{t('settings.resetWebUIDesc1')}</Text>
+                        <Text variant="subtext">{t('settings.resetWebUIDesc2')}</Text>
+                      </>
+                    )}
+                  </StickyScrollable>
+                </FormControlGroup>
+              </Flex>
+            </ScrollableContent>
+          </ModalBody>
+
+          <ModalFooter />
+        </ModalContent>
+      </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Restores functionality where Settings Modal is rendered using children that trigger it

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Tested settings modal in OSS and commercial ✅ 

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
