### PR TITLE
fix(nodes): add thresholding to lineart & lineart anime nodes

### DIFF
--- a/invokeai/backend/image_util/lineart.py
+++ b/invokeai/backend/image_util/lineart.py
@@ -214,8 +214,14 @@ class LineartEdgeDetector:
             line = line.cpu().numpy()
             line = (line * 255.0).clip(0, 255).astype(np.uint8)
 
-        detected_map = line
+        detected_map = 255 - line
 
-        detected_map = 255 - detected_map
+        # The lineart model often outputs a lot of almost-black noise. SD1.5 ControlNets seem to be OK with this, but
+        # SDXL ControlNets are not - they need a cleaner map. 12 was experimentally determined to be a good threshold,
+        # eliminating all the noise while keeping the actual edges. Other approaches to thresholding may be better,
+        # for example stretching the contrast or removing noise.
+        detected_map[detected_map < 12] = 0
 
-        return np_to_pil(detected_map)
+        output = np_to_pil(detected_map)
+
+        return output

--- a/invokeai/backend/image_util/lineart_anime.py
+++ b/invokeai/backend/image_util/lineart_anime.py
@@ -260,8 +260,14 @@ class LineartAnimeEdgeDetector:
             line = cv2.resize(line, (width, height), interpolation=cv2.INTER_CUBIC)
             line = line.clip(0, 255).astype(np.uint8)
 
-        detected_map = line
-        detected_map = 255 - detected_map
+        detected_map = 255 - line
+
+        # The lineart model often outputs a lot of almost-black noise. SD1.5 ControlNets seem to be OK with this, but
+        # SDXL ControlNets are not - they need a cleaner map. 12 was experimentally determined to be a good threshold,
+        # eliminating all the noise while keeping the actual edges. Other approaches to thresholding may be better,
+        # for example stretching the contrast or removing noise.
+        detected_map[detected_map < 12] = 0
+
         output = np_to_pil(detected_map)
 
         return output


### PR DESCRIPTION
## Summary

The lineart model often outputs a lot of almost-black noise. SD1.5 ControlNets seem to be OK with this, but SDXL ControlNets are not - they need a cleaner map. 12 was experimentally determined to be a good threshold, eliminating all the noise while keeping the actual edges. Other approaches to thresholding may be better, for example stretching the contrast or removing noise.

I tried:
- Simple thresholding (as implemented here) - works fine.
- Adaptive thresholding - doesn't work, because the thresholding is done in the context of small blocks, while we want thresholding in the context of the whole image.
- Gamma adjustment - alters the white values too much. Hard to tuen.
- Contrast stretching, with and without pre-simple-thresholding - this allows us to treshold out the noise, then stretch everything above the threshold down to almost-zero. So you have a smoother gradient of lightness near zero. It works but it also stretches contrast near white down a bit, which is probably undesired.

In the end, simple thresholding works fine and is very simple.

## Related Issues / Discussions

Offline discussion

## QA Instructions

Test image 
![image](https://github.com/user-attachments/assets/0999f88f-6e59-4ec5-851d-35a8175e999a)

Original lineart output
![original lines](https://github.com/user-attachments/assets/d533f3d4-f736-48f7-9663-d1583a24e3ef)

Original lineart output w/ post-processing applied to show the noise
![original lines w levels](https://github.com/user-attachments/assets/02f6e21b-ac2f-4c17-a5f2-20d3083876e0)

New thresholded lineart output
![thresholded lines](https://github.com/user-attachments/assets/60028edb-4e25-40c2-adc3-fb82efceeeeb)

New thresholded lineart output w/ same post-processing, note lack of noise
![thresholded lines w levels](https://github.com/user-attachments/assets/1b338e00-7ed9-45cf-b4be-be3a4b1db95f)

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
