### PR TITLE
fix(ui): canvas followups 10

### DIFF
--- a/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
@@ -66,7 +66,7 @@ type IAIDndImageProps = FlexProps & {
   fitContainer?: boolean;
   droppableData?: TypesafeDroppableData;
   draggableData?: TypesafeDraggableData;
-  dropLabel?: ReactNode;
+  dropLabel?: string;
   isSelected?: boolean;
   isSelectedForCompare?: boolean;
   thumbnail?: boolean;

--- a/invokeai/frontend/web/src/common/components/IAIDropOverlay.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDropOverlay.tsx
@@ -1,13 +1,12 @@
 import { Flex, Text } from '@invoke-ai/ui-library';
 import type { AnimationProps } from 'framer-motion';
 import { motion } from 'framer-motion';
-import type { ReactNode } from 'react';
 import { memo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 type Props = {
   isOver: boolean;
-  label?: ReactNode;
+  label?: string;
 };
 
 const initial: AnimationProps['initial'] = {
@@ -64,7 +63,7 @@ const IAIDropOverlay = (props: Props) => {
           p={4}
         >
           <Text
-            fontSize="xl"
+            fontSize="lg"
             fontWeight="semibold"
             color={isOver ? 'invokeYellow.300' : 'base.500'}
             transitionProperty="common"

--- a/invokeai/frontend/web/src/common/components/IAIDroppable.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDroppable.tsx
@@ -3,14 +3,13 @@ import { useDroppableTypesafe } from 'features/dnd/hooks/typesafeHooks';
 import type { TypesafeDroppableData } from 'features/dnd/types';
 import { isValidDrop } from 'features/dnd/util/isValidDrop';
 import { AnimatePresence } from 'framer-motion';
-import type { ReactNode } from 'react';
 import { memo, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import IAIDropOverlay from './IAIDropOverlay';
 
 type IAIDroppableProps = {
-  dropLabel?: ReactNode;
+  dropLabel?: string;
   disabled?: boolean;
   data?: TypesafeDroppableData;
 };

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasResetLayerHotkey.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasResetLayerHotkey.ts
@@ -25,11 +25,12 @@ export function useCanvasResetLayerHotkey() {
   const isInteractable = useStore(adapter?.$isInteractable ?? $false);
 
   const resetSelectedLayer = useCallback(() => {
-    if (selectedEntityIdentifier === null) {
+    if (selectedEntityIdentifier === null || adapter === null) {
       return;
     }
+    adapter.bufferRenderer.clearBuffer();
     dispatch(entityReset({ entityIdentifier: selectedEntityIdentifier }));
-  }, [dispatch, selectedEntityIdentifier]);
+  }, [adapter, dispatch, selectedEntityIdentifier]);
 
   const isResetEnabled = useMemo(
     () => selectedEntityIdentifier !== null && isMaskEntityIdentifier(selectedEntityIdentifier),

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/GalleryBoard.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/GalleryBoard.tsx
@@ -169,7 +169,7 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
             {board.archived && !editingDisclosure.isOpen && <Icon as={PiArchiveBold} fill="base.300" />}
             {!editingDisclosure.isOpen && <Text variant="subtext">{board.image_count}</Text>}
 
-            <IAIDroppable data={droppableData} dropLabel={<Text fontSize="lg">{t('unifiedCanvas.move')}</Text>} />
+            <IAIDroppable data={droppableData} dropLabel={t('unifiedCanvas.move')} />
           </Flex>
         </Tooltip>
       )}

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
@@ -92,7 +92,7 @@ const NoBoardBoard = memo(({ isSelected }: Props) => {
             </Text>
             {autoAddBoardId === 'none' && <AutoAddBadge />}
             <Text variant="subtext">{imagesTotal}</Text>
-            <IAIDroppable data={droppableData} dropLabel={<Text fontSize="lg">{t('unifiedCanvas.move')}</Text>} />
+            <IAIDroppable data={droppableData} dropLabel={t('unifiedCanvas.move')} />
           </Flex>
         </Tooltip>
       )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/ImageFieldInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/ImageFieldInputComponent.tsx
@@ -75,7 +75,6 @@ const ImageFieldInputComponent = (props: FieldComponentProps<ImageFieldInputInst
         postUploadAction={postUploadAction}
         useThumbailFallback
         uploadElement={<UploadElement />}
-        dropLabel={<DropLabel />}
         minSize={8}
       >
         <IAIDndImageIcon
@@ -100,14 +99,3 @@ const UploadElement = memo(() => {
 });
 
 UploadElement.displayName = 'UploadElement';
-
-const DropLabel = memo(() => {
-  const { t } = useTranslation();
-  return (
-    <Text fontSize={16} fontWeight="semibold">
-      {t('gallery.drop')}
-    </Text>
-  );
-});
-
-DropLabel.displayName = 'DropLabel';


### PR DESCRIPTION
## Summary

Two small fixes:
- When you hit `shift+c` while in the middle of drawing on a layer, there's a bit of a janky delay as the reset propagates from redux and to the canvas classes. The hotkey now cancels the in-progress drawing, indirectly fixing the jank.
- Not sure how I've missed this before but there was a React error w/ the dnd drop zone labels which accepted a react node. Fixed this, drop zones labels must now be strings.

## Related Issues / Discussions

Shift+c issue reported on discord.

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
