### PR TITLE
feat(ui): canvas error handling

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
@@ -106,7 +106,6 @@ const FilterBox = memo(({ adapter }: { adapter: CanvasEntityAdapterRasterLayer |
           variant="ghost"
           leftIcon={<PiXBold />}
           onClick={adapter.filterer.cancel}
-          isLoading={isProcessing}
           loadingText={t('controlLayers.filter.cancel')}
         >
           {t('controlLayers.filter.cancel')}

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
@@ -14,7 +14,7 @@ import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
 import { atom, computed } from 'nanostores';
 import type { Logger } from 'roarr';
 import type { UploadOptions } from 'services/api/endpoints/images';
-import { getImageDTO, uploadImage } from 'services/api/endpoints/images';
+import { getImageDTOSafe, uploadImage } from 'services/api/endpoints/images';
 import type { ImageDTO } from 'services/api/types';
 import stableHash from 'stable-hash';
 import { assert } from 'tsafe';
@@ -210,7 +210,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
     const cachedImageName = this.manager.cache.imageNameCache.get(hash);
 
     if (cachedImageName) {
-      imageDTO = await getImageDTO(cachedImageName);
+      imageDTO = await getImageDTOSafe(cachedImageName);
       if (imageDTO) {
         this.log.trace({ rect, imageName: cachedImageName, imageDTO }, 'Using cached composite raster layer image');
         return imageDTO;
@@ -374,7 +374,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
     const cachedImageName = this.manager.cache.imageNameCache.get(hash);
 
     if (cachedImageName) {
-      imageDTO = await getImageDTO(cachedImageName);
+      imageDTO = await getImageDTOSafe(cachedImageName);
       if (imageDTO) {
         this.log.trace({ rect, cachedImageName, imageDTO }, 'Using cached composite inpaint mask image');
         return imageDTO;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -1,5 +1,6 @@
 import { $authToken } from 'app/store/nanostores/authToken';
 import { rgbColorToString } from 'common/util/colorCodeTransformers';
+import { withResult } from 'common/util/result';
 import { SyncableMap } from 'common/util/SyncableMap/SyncableMap';
 import type { CanvasEntityAdapter } from 'features/controlLayers/konva/CanvasEntity/types';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
@@ -356,14 +357,25 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
   };
 
   /**
-   * Rasterizes the parent entity. If the entity has a rasterization cache for the given rect, the cached image is
-   * returned. Otherwise, the entity is rasterized and the image is uploaded to the server.
+   * Rasterizes the parent entity, returning a promise that resolves to the image DTO.
+   *
+   * If the entity has a rasterization cache for the given rect, the cached image is returned. Otherwise, the entity is
+   * rasterized and the image is uploaded to the server.
    *
    * The rasterization cache is reset when the entity's state changes. The buffer object is not considered part of the
    * entity state for this purpose as it is a temporary object.
    *
-   * @param rect The rect to rasterize. If omitted, the entity's full rect will be used.
-   * @returns A promise that resolves to the rasterized image DTO.
+   * If rasterization fails for any reason, the promise will reject.
+   *
+   * @param options The rasterization options.
+   * @param options.rect The region of the entity to rasterize.
+   * @param options.replaceObjects Whether to replace the entity's objects with the rasterized image. If you just want
+   * the entity's image, omit or set this to false.
+   * @param options.attrs The Konva node attributes to apply to the rasterized image group. For example, you might want
+   * to disable filters or set the opacity to the rasterized image.
+   * @param options.bg Draws the entity on a canvas with the given background color. If omitted, the entity is drawn on
+   * a transparent canvas.
+   * @returns A promise that resolves to the rasterized image DTO or rejects if rasterization fails.
    */
   rasterize = async (options: {
     rect: Rect;
@@ -423,26 +435,38 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
     if (this.parent.transformer.$isPendingRectCalculation.get()) {
       return;
     }
+
     const pixelRect = this.parent.transformer.$pixelRect.get();
     if (pixelRect.width === 0 || pixelRect.height === 0) {
       return;
     }
-    try {
-      // TODO(psyche): This is an internal Konva method, so it may break in the future. Can we make this API public?
-      const canvas = this.konva.objectGroup._getCachedSceneCanvas()._canvas as HTMLCanvasElement | undefined | null;
-      if (canvas) {
-        const nodeRect = this.parent.transformer.$nodeRect.get();
-        const rect = {
-          x: pixelRect.x - nodeRect.x,
-          y: pixelRect.y - nodeRect.y,
-          width: pixelRect.width,
-          height: pixelRect.height,
-        };
-        this.$canvasCache.set({ rect, canvas });
-      }
-    } catch (error) {
+
+    /**
+     * TODO(psyche): This is an internal Konva method, so it may break in the future. Can we make this API public?
+     *
+     * This method's API is unknown. It has been experimentally determined that it may throw, so we need to handle
+     * errors.
+     */
+    const getCacheCanvasResult = withResult(
+      () => this.konva.objectGroup._getCachedSceneCanvas()._canvas as HTMLCanvasElement | undefined | null
+    );
+    if (getCacheCanvasResult.isErr()) {
       // We are using an internal Konva method, so we need to catch any errors that may occur.
-      this.log.warn({ error: serializeError(error) }, 'Failed to update preview canvas');
+      this.log.warn({ error: serializeError(getCacheCanvasResult.error) }, 'Failed to update preview canvas');
+      return;
+    }
+
+    const canvas = getCacheCanvasResult.value;
+
+    if (canvas) {
+      const nodeRect = this.parent.transformer.$nodeRect.get();
+      const rect = {
+        x: pixelRect.x - nodeRect.x,
+        y: pixelRect.y - nodeRect.y,
+        width: pixelRect.width,
+        height: pixelRect.height,
+      };
+      this.$canvasCache.set({ rect, canvas });
     }
   }, 300);
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -27,7 +27,7 @@ import { debounce } from 'lodash-es';
 import { atom } from 'nanostores';
 import type { Logger } from 'roarr';
 import { serializeError } from 'serialize-error';
-import { getImageDTO, uploadImage } from 'services/api/endpoints/images';
+import { getImageDTOSafe, uploadImage } from 'services/api/endpoints/images';
 import type { ImageDTO } from 'services/api/types';
 import { assert } from 'tsafe';
 
@@ -383,7 +383,7 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
     const cachedImageName = this.manager.cache.imageNameCache.get(hash);
 
     if (cachedImageName) {
-      imageDTO = await getImageDTO(cachedImageName);
+      imageDTO = await getImageDTOSafe(cachedImageName);
       if (imageDTO) {
         this.log.trace({ rect, cachedImageName, imageDTO }, 'Using cached rasterized image');
         return imageDTO;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
@@ -11,7 +11,7 @@ import type { CanvasImageState } from 'features/controlLayers/store/types';
 import { t } from 'i18next';
 import Konva from 'konva';
 import type { Logger } from 'roarr';
-import { getImageDTO } from 'services/api/endpoints/images';
+import { getImageDTOSafe } from 'services/api/endpoints/images';
 
 export class CanvasObjectImage extends CanvasModuleBase {
   readonly type = 'object_image';
@@ -100,7 +100,7 @@ export class CanvasObjectImage extends CanvasModuleBase {
         this.konva.placeholder.text.text(t('common.loadingImage', 'Loading Image'));
       }
 
-      const imageDTO = await getImageDTO(imageName);
+      const imageDTO = await getImageDTOSafe(imageName);
       if (imageDTO === null) {
         this.onFailedToLoadImage();
         return;

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -7,7 +7,7 @@ import {
   zParameterNegativePrompt,
   zParameterPositivePrompt,
 } from 'features/parameters/types/parameterSchemas';
-import { getImageDTO } from 'services/api/endpoints/images';
+import { getImageDTOSafe } from 'services/api/endpoints/images';
 import type { ImageDTO } from 'services/api/types';
 import { z } from 'zod';
 
@@ -31,7 +31,7 @@ const zImageWithDims = z
   })
   .refine(async (v) => {
     const { image_name } = v;
-    const imageDTO = await getImageDTO(image_name, true);
+    const imageDTO = await getImageDTOSafe(image_name, { forceRefetch: true });
     return imageDTO !== null;
   });
 export type ImageWithDims = z.infer<typeof zImageWithDims>;

--- a/invokeai/frontend/web/src/features/metadata/util/parsers.ts
+++ b/invokeai/frontend/web/src/features/metadata/util/parsers.ts
@@ -67,7 +67,7 @@ import {
   isParameterWidth,
 } from 'features/parameters/types/parameterSchemas';
 import { get, isArray, isString } from 'lodash-es';
-import { getImageDTO } from 'services/api/endpoints/images';
+import { getImageDTOSafe } from 'services/api/endpoints/images';
 import {
   isControlNetModelConfig,
   isIPAdapterModelConfig,
@@ -603,7 +603,7 @@ const parseIPAdapterToIPAdapterLayer: MetadataParseFunc<CanvasReferenceImageStat
     begin_step_percent ?? initialIPAdapter.beginEndStepPct[0],
     end_step_percent ?? initialIPAdapter.beginEndStepPct[1],
   ];
-  const imageDTO = image ? await getImageDTO(image.image_name) : null;
+  const imageDTO = image ? await getImageDTOSafe(image.image_name) : null;
 
   const layer: CanvasReferenceImageState = {
     id: getPrefixedId('ip_adapter'),

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/Graph.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/Graph.test.ts
@@ -2,7 +2,6 @@ import { deepClone } from 'common/util/deepClone';
 import { Graph } from 'features/nodes/util/graph/generation/Graph';
 import type { AnyInvocation, Invocation } from 'services/api/types';
 import { assert, AssertionError, is } from 'tsafe';
-import { validate } from 'uuid';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -11,11 +10,12 @@ describe('Graph', () => {
     it('should create a new graph with the correct id', () => {
       const g = new Graph('test-id');
       expect(g._graph.id).toBe('test-id');
+      expect(g.id).toBe('test-id');
     });
-    it('should create a new graph with a uuid id if none is provided', () => {
+    it('should create an id if none is provided', () => {
       const g = new Graph();
       expect(g._graph.id).not.toBeUndefined();
-      expect(validate(g._graph.id)).toBeTruthy();
+      expect(g.id).not.toBeUndefined();
     });
   });
 

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/Graph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/Graph.ts
@@ -32,10 +32,12 @@ export type GraphType = { id: string; nodes: Record<string, AnyInvocation>; edge
 export class Graph {
   _graph: GraphType;
   _metadataNodeId = getPrefixedId('core_metadata');
+  id: string;
 
   constructor(id?: string) {
+    this.id = id ?? Graph.getId('graph');
     this._graph = {
-      id: id ?? uuidv4(),
+      id: this.id,
       nodes: {},
       edges: [],
     };

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -1,3 +1,4 @@
+import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/dist/query/core/buildInitiate';
 import { getStore } from 'app/store/nanostores/store';
 import type { SerializableObject } from 'common/types';
 import type { BoardId } from 'features/gallery/store/types';
@@ -568,23 +569,38 @@ export const {
 /**
  * Imperative RTKQ helper to fetch an ImageDTO.
  * @param image_name The name of the image to fetch
- * @param forceRefetch Whether to force a refetch of the image
- * @returns
+ * @param options The options for the query. By default, the query will not subscribe to the store.
+ * @returns The ImageDTO if found, otherwise null
  */
-export const getImageDTO = async (image_name: string, forceRefetch?: boolean): Promise<ImageDTO | null> => {
-  const options = {
+export const getImageDTOSafe = async (
+  image_name: string,
+  options?: StartQueryActionCreatorOptions
+): Promise<ImageDTO | null> => {
+  const _options = {
     subscribe: false,
-    forceRefetch,
+    ...options,
   };
-  const req = getStore().dispatch(imagesApi.endpoints.getImageDTO.initiate(image_name, options));
+  const req = getStore().dispatch(imagesApi.endpoints.getImageDTO.initiate(image_name, _options));
   try {
-    const imageDTO = await req.unwrap();
-    req.unsubscribe();
-    return imageDTO;
+    return await req.unwrap();
   } catch {
-    req.unsubscribe();
     return null;
   }
+};
+
+/**
+ * Imperative RTKQ helper to fetch an ImageDTO.
+ * @param image_name The name of the image to fetch
+ * @param options The options for the query. By default, the query will not subscribe to the store.
+ * @raises Error if the image is not found or there is an error fetching the image
+ */
+export const getImageDTO = (image_name: string, options?: StartQueryActionCreatorOptions): Promise<ImageDTO> => {
+  const _options = {
+    subscribe: false,
+    ...options,
+  };
+  const req = getStore().dispatch(imagesApi.endpoints.getImageDTO.initiate(image_name, _options));
+  return req.unwrap();
 };
 
 export type UploadOptions = {

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -612,7 +612,7 @@ export type UploadOptions = {
   board_id?: BoardId;
   metadata?: SerializableObject;
 };
-export const uploadImage = async (arg: UploadOptions): Promise<ImageDTO> => {
+export const uploadImage = (arg: UploadOptions): Promise<ImageDTO> => {
   const { blob, fileName, image_category, is_intermediate, crop_visible = false, board_id, metadata } = arg;
 
   const { dispatch } = getStore();
@@ -628,5 +628,5 @@ export const uploadImage = async (arg: UploadOptions): Promise<ImageDTO> => {
     })
   );
   req.reset();
-  return await req.unwrap();
+  return req.unwrap();
 };

--- a/invokeai/frontend/web/src/services/events/errors.ts
+++ b/invokeai/frontend/web/src/services/events/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * A custom error class for queue event errors. These errors have a type, message and traceback.
+ */
+
+export class QueueError extends Error {
+  type: string;
+  traceback: string;
+
+  constructor(type: string, message: string, traceback: string) {
+    super(message);
+    this.name = 'QueueError';
+    this.type = type;
+    this.traceback = traceback;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, QueueError);
+    }
+  }
+
+  toString() {
+    return `${this.name} [${this.type}]: ${this.message}\nTraceback:\n${this.traceback}`;
+  }
+}

--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -7,7 +7,7 @@ import { boardIdSelected, galleryViewChanged, imageSelected, offsetChanged } fro
 import { $nodeExecutionStates, upsertExecutionState } from 'features/nodes/hooks/useExecutionState';
 import { zNodeStatus } from 'features/nodes/types/invocation';
 import { boardsApi } from 'services/api/endpoints/boards';
-import { getImageDTO, imagesApi } from 'services/api/endpoints/images';
+import { getImageDTOSafe, imagesApi } from 'services/api/endpoints/images';
 import type { ImageDTO, S } from 'services/api/types';
 import { getCategories, getListImagesUrl } from 'services/api/util';
 import { $lastProgressEvent } from 'services/events/stores';
@@ -87,10 +87,8 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
 
   const getResultImageDTO = (data: S['InvocationCompleteEvent']) => {
     const { result } = data;
-    if (result.type === 'image_output') {
-      return getImageDTO(result.image.image_name);
-    } else if (result.type === 'canvas_v2_mask_and_crop_output') {
-      return getImageDTO(result.image.image_name);
+    if (result.type === 'image_output' || result.type === 'canvas_v2_mask_and_crop_output') {
+      return getImageDTOSafe(result.image.image_name);
     }
     return null;
   };


### PR DESCRIPTION
## Summary

I reviewed the canvas codebase to find places where errors could occur. Two categories:
- Network requests (e.g. getting images, uploading images, queuing graphs)
- Canvas operations (e.g. exporting canvas to `Blob`)

All instances of these things now have error handling at some level - either close to the error-producing code or higher up where the code is consumed.

Canvas filters were the most complex thing to handle. The filter queues a graph, waits for a specific node to finish and retrieves an output image. Handling all the possible cases requires care. There's a new method that wraps up executing a graph to get an image output into a single async function call. This is well-documented.

While iterating on filters, I made an internal change to how filter graphs are generated. Instead defining a node, filters define a graph and a node that outputs an image. This makes filters very flexible - so long as the graph has a node that outputs an image, it can be run as a filter.

See commit messages and code for details.

## Related Issues / Discussions

Discord & offline discussion

## QA Instructions

Hit the things that changed:
- Run some filters.
- Run a long-running filter (e.g. depth anything on a huge layer) and cancel it.
- Do some transforms (has improved error handling).
- Run a graph w/ a controlnet, t2i adapter and regional guidance (these now have error handling).

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
