### PR TITLE
fix(ui): track whether studio destination hook fn has already fired

### DIFF
--- a/invokeai/frontend/web/src/app/hooks/useHandleStudioDestination.ts
+++ b/invokeai/frontend/web/src/app/hooks/useHandleStudioDestination.ts
@@ -4,7 +4,7 @@ import { useImageViewer } from 'features/gallery/components/ImageViewer/useImage
 import { $isMenuOpen } from 'features/stylePresets/store/isMenuOpen';
 import { setActiveTab } from 'features/ui/store/uiSlice';
 import { useWorkflowLibraryModal } from 'features/workflowLibrary/store/isWorkflowLibraryModalOpen';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 export type StudioDestination =
   | 'generation'
@@ -16,22 +16,26 @@ export type StudioDestination =
 
 export const useHandleStudioDestination = () => {
   const dispatch = useAppDispatch();
-  const imageViewer = useImageViewer();
+  const { open: imageViewerOpen, close: imageViewerClose } = useImageViewer();
+  const [initialized, setInitialized] = useState(false);
 
   const workflowLibraryModal = useWorkflowLibraryModal();
 
   const handleStudioDestination = useCallback(
     (destination: StudioDestination) => {
+      if (initialized) {
+        return;
+      }
       switch (destination) {
         case 'generation':
           dispatch(setActiveTab('canvas'));
           dispatch(settingsSendToCanvasChanged(false));
-          imageViewer.open();
+          imageViewerOpen();
           break;
         case 'canvas':
           dispatch(setActiveTab('canvas'));
           dispatch(settingsSendToCanvasChanged(true));
-          imageViewer.close();
+          imageViewerClose();
           break;
         case 'workflows':
           dispatch(setActiveTab('workflows'));
@@ -41,7 +45,7 @@ export const useHandleStudioDestination = () => {
           break;
         case 'viewAllWorkflows':
           dispatch(setActiveTab('workflows'));
-          workflowLibraryModal.setFalse();
+          workflowLibraryModal.setTrue();
           break;
         case 'viewAllStylePresets':
           dispatch(setActiveTab('canvas'));
@@ -51,8 +55,9 @@ export const useHandleStudioDestination = () => {
           dispatch(setActiveTab('canvas'));
           break;
       }
+      setInitialized(true);
     },
-    [dispatch, imageViewer, workflowLibraryModal]
+    [dispatch, imageViewerOpen, imageViewerClose, workflowLibraryModal, initialized]
   );
 
   return handleStudioDestination;


### PR DESCRIPTION
## Summary

* track whether studio destination hook fn has already fired to prevent it firing multiple times
* fix workflow library modal when `viewAllWorkflows`

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
