### PR TITLE
(fix) fixed bbox size reset to optimals on 'Use All' (Asterisk) button press

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -1057,14 +1057,13 @@ export const canvasSlice = createSlice({
       }
     },
     canvasMetadataRecalled: (state, action: PayloadAction<CanvasMetadata>) => {
-      const newState = resetState(state);
       const { controlLayers, inpaintMasks, rasterLayers, referenceImages, regionalGuidance } = action.payload;
-      newState.controlLayers.entities = controlLayers;
-      newState.inpaintMasks.entities = inpaintMasks;
-      newState.rasterLayers.entities = rasterLayers;
-      newState.referenceImages.entities = referenceImages;
-      newState.regionalGuidance.entities = regionalGuidance;
-      return newState;
+      state.controlLayers.entities = controlLayers;
+      state.inpaintMasks.entities = inpaintMasks;
+      state.rasterLayers.entities = rasterLayers;
+      state.referenceImages.entities = referenceImages;
+      state.regionalGuidance.entities = regionalGuidance;
+      return state;
     },
     canvasUndo: () => {},
     canvasRedo: () => {},


### PR DESCRIPTION
## Summary

This PR addresses a problem when user commands to recall all metadata from the generated image. While recalling only partial metadata everything works fine, but 'Use All' aka the Asterisk button resets state of canvas bbox to model optimal dimensions.


https://github.com/user-attachments/assets/3a9f5c9c-c216-41b0-8ccc-383332af90a0

## Related Issues / Discussions

 - Addresses problem discussed on Discord: https://discordapp.com/channels/1020123559063990373/1149506274971631688/1287160033657884907

## QA Instructions

 - Generate a sample image with dimensions other than defaults for the selected model.
 - Perform WebUI reset and localStorage.clear(), clear cache, reload CanvasV2 Viewer.
 - Use Asterisk (Use All) command to recall all generation parameters from the generated image.
 - Invoke a new image using recalled parameters.
 - Sample image and newly-generated one should be the same.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ + ] _The PR has a short but descriptive title, suitable for a changelog_
- [ N/A ] _Tests added / updated (if applicable)_
- [ N/A ] _Documentation added / updated (if applicable)_
