### PR TITLE
fix(ui): race condition when filtering causing errors/stuck filter

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -141,6 +141,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     this.abortController = controller;
 
     const { graph, outputNodeId } = buildGraphResult.value;
+
     const filterResult = await withResultAsync(() =>
       this.manager.stateApi.runGraphAndReturnImageOutput({
         graph,


### PR DESCRIPTION
## Summary

There's a situation in which the enqueue response comes after the graph actually executes. This was unexpected when I first wrote the logic. I suppose it has to do with the async endpoint handling.

## Related Issues / Discussions

offline discussion

## QA Instructions

Really hammer filtering. Use the fastest filter you can - probably color map? - as this is expected to trigger the race condition the most reliably. 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
