### PR TITLE
fix(ui): prefer 'lama' infill when handling infill fallback

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/appConfigReceived.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/appConfigReceived.ts
@@ -11,9 +11,10 @@ export const addAppConfigReceivedListener = (startAppListening: AppStartListenin
       const infillMethod = getState().params.infillMethod;
 
       if (!infill_methods.includes(infillMethod)) {
-        // if there is no infill method, set it to the first one
-        // if there is no first one... god help us
-        dispatch(setInfillMethod(infill_methods[0] as string));
+        // If the selected infill method does not exist, prefer 'lama' if it's in the list, otherwise 'tile'.
+        // TODO(psyche): lama _should_ always be in the list, but the API doesn't guarantee it...
+        const infillMethod = infill_methods.includes('lama') ? 'lama' : 'tile';
+        dispatch(setInfillMethod(infillMethod));
       }
 
       if (!nsfw_methods.includes('nsfw_checker')) {


### PR DESCRIPTION
## Summary

LaMA is the next best infill after patchmatch - prefer it.

## Related Issues / Discussions

offline discussion

## QA Instructions

- Ensure you have patchmatch selected for infill
- Add `patchmatch: false` to `invokeai.yaml`
- Restart server
- It should auto-switch to lama

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
