### PR TITLE
fix,feat: canvas followups 16

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -523,35 +523,35 @@
             "title": "Workflows",
             "addNode": {
                 "title": "Add Node",
-                "descl": "Open the add node menu."
+                "desc": "Open the add node menu."
             },
             "copySelection": {
                 "title": "Copy",
-                "descl": "Copy selected nodes and edges."
+                "desc": "Copy selected nodes and edges."
             },
             "pasteSelection": {
                 "title": "Paste",
-                "descl": "Paste copied nodes and edges."
+                "desc": "Paste copied nodes and edges."
             },
             "pasteSelectionWithEdges": {
                 "title": "Paste with Edges",
-                "descl": "Paste copied nodes, edges, and all edges connected to copied nodes."
+                "desc": "Paste copied nodes, edges, and all edges connected to copied nodes."
             },
             "selectAll": {
                 "title": "Select All",
-                "descl": "Select all nodes and edges."
+                "desc": "Select all nodes and edges."
             },
             "deleteSelection": {
                 "title": "Delete",
-                "descl": "Delete selected nodes and edges."
+                "desc": "Delete selected nodes and edges."
             },
             "undo": {
                 "title": "Undo",
-                "descl": "Undo the last workflow action."
+                "desc": "Undo the last workflow action."
             },
             "redo": {
                 "title": "Redo",
-                "descl": "Redo the last workflow action."
+                "desc": "Redo the last workflow action."
             }
         },
         "viewer": {

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/modelSelected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/modelSelected.ts
@@ -4,6 +4,7 @@ import { bboxSyncedToOptimalDimension } from 'features/controlLayers/store/canva
 import { selectIsStaging } from 'features/controlLayers/store/canvasStagingAreaSlice';
 import { loraDeleted } from 'features/controlLayers/store/lorasSlice';
 import { modelChanged, vaeSelected } from 'features/controlLayers/store/paramsSlice';
+import { selectBboxModelBase } from 'features/controlLayers/store/selectors';
 import { modelSelected } from 'features/parameters/store/actions';
 import { zParameterModel } from 'features/parameters/types/parameterSchemas';
 import { toast } from 'features/toast/toast';
@@ -70,7 +71,8 @@ export const addModelSelectedListener = (startAppListening: AppStartListening) =
       }
 
       dispatch(modelChanged({ model: newModel, previousModel: state.params.model }));
-      if (!selectIsStaging(state)) {
+      const modelBase = selectBboxModelBase(state);
+      if (!selectIsStaging(state) && modelBase !== state.params.model?.base) {
         dispatch(bboxSyncedToOptimalDimension());
       }
     },

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/modelsLoaded.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/modelsLoaded.ts
@@ -3,12 +3,10 @@ import type { AppStartListening } from 'app/store/middleware/listenerMiddleware'
 import type { AppDispatch, RootState } from 'app/store/store';
 import type { SerializableObject } from 'common/types';
 import {
-  bboxSyncedToOptimalDimension,
   controlLayerModelChanged,
   referenceImageIPAdapterModelChanged,
   rgIPAdapterModelChanged,
 } from 'features/controlLayers/store/canvasSlice';
-import { selectIsStaging } from 'features/controlLayers/store/canvasStagingAreaSlice';
 import { loraDeleted } from 'features/controlLayers/store/lorasSlice';
 import {
   clipEmbedModelSelected,
@@ -20,6 +18,7 @@ import {
 } from 'features/controlLayers/store/paramsSlice';
 import { selectCanvasSlice } from 'features/controlLayers/store/selectors';
 import { getEntityIdentifier } from 'features/controlLayers/store/types';
+import { modelSelected } from 'features/parameters/store/actions';
 import { postProcessingModelChanged, upscaleModelChanged } from 'features/parameters/store/upscaleSlice';
 import {
   zParameterCLIPEmbedModel,
@@ -120,10 +119,7 @@ const handleMainModels: ModelHandler = (models, state, dispatch, log) => {
         { selectedMainModel, defaultModel },
         'No selected main model or selected main model is not available, selecting default model'
       );
-      dispatch(modelChanged({ model: zParameterModel.parse(defaultModel), previousModel: selectedMainModel }));
-      if (!selectIsStaging(state)) {
-        dispatch(bboxSyncedToOptimalDimension());
-      }
+      dispatch(modelSelected(defaultModel));
       return;
     }
   }
@@ -132,10 +128,7 @@ const handleMainModels: ModelHandler = (models, state, dispatch, log) => {
     { selectedMainModel, firstModel },
     'No selected main model or selected main model is not available, selecting first available model'
   );
-  dispatch(modelChanged({ model: zParameterModel.parse(firstModel), previousModel: selectedMainModel }));
-  if (!selectIsStaging(state)) {
-    dispatch(bboxSyncedToOptimalDimension());
-  }
+  dispatch(modelSelected(firstModel));
 };
 
 const handleUpscalingModels: ModelHandler = (models, state, dispatch, log) => {

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasAlerts/CanvasAlertsSendingTo.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasAlerts/CanvasAlertsSendingTo.tsx
@@ -8,6 +8,7 @@ import {
 } from 'features/controlLayers/store/ephemeral';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useCurrentDestination } from 'features/queue/hooks/useCurrentDestination';
+import { selectActiveTab } from 'features/ui/store/uiSelectors';
 import { setActiveTab } from 'features/ui/store/uiSlice';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { PropsWithChildren, ReactNode } from 'react';
@@ -30,13 +31,18 @@ const ActivateImageViewerButton = (props: PropsWithChildren) => {
 export const CanvasAlertsSendingToGallery = () => {
   const { t } = useTranslation();
   const destination = useCurrentDestination();
+  const tab = useAppSelector(selectActiveTab);
   const isVisible = useMemo(() => {
+    // This alert should only be visible when the destination is gallery and the tab is canvas
+    if (tab !== 'canvas') {
+      return false;
+    }
     if (!destination) {
       return false;
     }
 
     return destination === 'gallery';
-  }, [destination]);
+  }, [destination, tab]);
 
   return (
     <AlertWrapper
@@ -68,7 +74,13 @@ export const CanvasAlertsSendingToCanvas = () => {
   const { t } = useTranslation();
   const destination = useCurrentDestination();
   const isStaging = useAppSelector(selectIsStaging);
+  const tab = useAppSelector(selectActiveTab);
   const isVisible = useMemo(() => {
+    // When we are on a non-canvas tab, and the current generation's destination is not the canvas, we don't show the alert
+    // For example, on the workflows tab, when the destinatin is gallery, we don't show the alert
+    if (tab !== 'canvas' && destination !== 'canvas') {
+      return false;
+    }
     if (isStaging) {
       return true;
     }
@@ -78,7 +90,7 @@ export const CanvasAlertsSendingToCanvas = () => {
     }
 
     return destination === 'canvas';
-  }, [destination, isStaging]);
+  }, [destination, isStaging, tab]);
 
   return (
     <AlertWrapper

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasBboxModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasBboxModule.ts
@@ -243,7 +243,7 @@ export class CanvasBboxModule extends CanvasModuleBase {
   onDragMove = () => {
     // The grid size here is the _position_ grid size, not the _dimension_ grid size - it is not constratined by the
     // currently-selected model.
-    const gridSize = this.manager.stateApi.$ctrlKey.get() || this.manager.stateApi.$metaKey.get() ? 8 : 64;
+    const gridSize = this.manager.stateApi.getGridSize();
     const bbox = this.manager.stateApi.getBbox();
     const bboxRect: Rect = {
       ...bbox.rect,

--- a/invokeai/frontend/web/src/features/controlLayers/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/selectors.ts
@@ -338,6 +338,7 @@ export const selectAspectRatioValue = createSelector(selectCanvasSlice, (canvas)
 export const selectScaledSize = createSelector(selectBbox, (bbox) => bbox.scaledSize);
 export const selectScaleMethod = createSelector(selectBbox, (bbox) => bbox.scaleMethod);
 export const selectBboxRect = createSelector(selectBbox, (bbox) => bbox.rect);
+export const selectBboxModelBase = createSelector(selectBbox, (bbox) => bbox.modelBase);
 
 export const selectCanvasMetadata = createSelector(
   selectCanvasSlice,

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImagePreview.tsx
@@ -12,7 +12,7 @@ import type { AnimationProps } from 'framer-motion';
 import { AnimatePresence, motion } from 'framer-motion';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useGetImageDTOQuery } from 'services/api/endpoints/images';
-import { $hasProgress, $isProgressFromCanvas } from 'services/events/stores';
+import { $hasProgressImage, $isProgressFromCanvas } from 'services/events/stores';
 
 import { NoContentForViewer } from './NoContentForViewer';
 import ProgressImage from './ProgressImage';
@@ -20,7 +20,7 @@ import ProgressImage from './ProgressImage';
 const CurrentImagePreview = () => {
   const shouldShowImageDetails = useAppSelector(selectShouldShowImageDetails);
   const imageName = useAppSelector(selectLastSelectedImageName);
-  const hasDenoiseProgress = useStore($hasProgress);
+  const hasProgressImage = useStore($hasProgressImage);
   const isProgressFromCanvas = useStore($isProgressFromCanvas);
   const shouldShowProgressInViewer = useAppSelector(selectShouldShowProgressInViewer);
 
@@ -59,7 +59,7 @@ const CurrentImagePreview = () => {
       justifyContent="center"
       position="relative"
     >
-      {hasDenoiseProgress && !isProgressFromCanvas && shouldShowProgressInViewer ? (
+      {hasProgressImage && !isProgressFromCanvas && shouldShowProgressInViewer ? (
         <ProgressImage />
       ) : (
         <IAIDndImage

--- a/invokeai/frontend/web/src/services/events/stores.ts
+++ b/invokeai/frontend/web/src/services/events/stores.ts
@@ -9,4 +9,5 @@ export const $isConnected = atom<boolean>(false);
 export const $lastProgressEvent = atom<S['InvocationProgressEvent'] | null>(null);
 export const $hasProgress = computed($lastProgressEvent, (val) => Boolean(val));
 export const $progressImage = computed($lastProgressEvent, (val) => val?.image ?? null);
+export const $hasProgressImage = computed($lastProgressEvent, (val) => Boolean(val?.image));
 export const $isProgressFromCanvas = computed($lastProgressEvent, (val) => val?.destination === 'canvas');

--- a/invokeai/frontend/web/src/services/events/stores.ts
+++ b/invokeai/frontend/web/src/services/events/stores.ts
@@ -7,7 +7,6 @@ export const $socket = atom<AppSocket | null>(null);
 export const $socketOptions = map<Partial<ManagerOptions & SocketOptions>>({});
 export const $isConnected = atom<boolean>(false);
 export const $lastProgressEvent = atom<S['InvocationProgressEvent'] | null>(null);
-export const $hasProgress = computed($lastProgressEvent, (val) => Boolean(val));
 export const $progressImage = computed($lastProgressEvent, (val) => val?.image ?? null);
 export const $hasProgressImage = computed($lastProgressEvent, (val) => Boolean(val?.image));
 export const $isProgressFromCanvas = computed($lastProgressEvent, (val) => val?.destination === 'canvas');


### PR DESCRIPTION
## Summary

- Fix: Bbox respects snap to grid setting when moving it
- Fix: Workflows hotkey translations
- Fix: Do not update bbox when changing models, if the model's base type doesn't change
- Fix: Canvas staging alerts displayed erroneously on workflows/upscaling tabs
- Fix: Invalid workflow model selected on first app launch or after reset web UI
- Fix: Blank viewer when progress does not have an image (e.g. spandrel upscale)
- Fix: Workaround 🤞 for out-of-order events

## Related Issues / Discussions

discord, offline discussion

## QA Instructions

try the fixes out

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
