### PR TITLE
fix(ui): reduce extraneous image selection

### DIFF
--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -34,7 +34,6 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
     // update the total images for the board
     dispatch(
       boardsApi.util.updateQueryData('getBoardImagesTotal', imageDTO.board_id ?? 'none', (draft) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         draft.total += 1;
       })
     );
@@ -52,15 +51,11 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
       ])
     );
 
-    const { shouldAutoSwitch, galleryView, selectedBoardId } = getState().gallery;
+    const { shouldAutoSwitch, selectedBoardId } = getState().gallery;
 
     // If auto-switch is enabled, select the new image
     if (shouldAutoSwitch) {
-      // if auto-add is enabled, switch the gallery view and board if needed as the image comes in
-      if (galleryView !== 'images') {
-        dispatch(galleryViewChanged('images'));
-      }
-
+      // If the image is from a different board, switch to that board - this will also select the image
       if (imageDTO.board_id && imageDTO.board_id !== selectedBoardId) {
         dispatch(
           boardIdSelected({
@@ -68,20 +63,21 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
             selectedImageName: imageDTO.image_name,
           })
         );
-      }
-
-      dispatch(offsetChanged({ offset: 0 }));
-
-      if (!imageDTO.board_id && selectedBoardId !== 'none') {
+      } else if (!imageDTO.board_id && selectedBoardId !== 'none') {
         dispatch(
           boardIdSelected({
             boardId: 'none',
             selectedImageName: imageDTO.image_name,
           })
         );
+      } else {
+        // Else just select the image
+        dispatch(imageSelected(imageDTO));
       }
 
-      dispatch(imageSelected(imageDTO));
+      // We also need to update the gallery view to images and reset the offset to 0
+      dispatch(galleryViewChanged('images'));
+      dispatch(offsetChanged({ offset: 0 }));
     }
   };
 


### PR DESCRIPTION
## Summary

Two changes to reduce extraneous image selection changes.

### Invocation complete handler

In the invocation complete handler, if it outputs an image, we refresh the gallery images list and select the new image.

We were inadvertently selecting the image _twice_ in some situations: if `auto-switch to new images` was enabled, and the currently-selected board is not the board of the new image, we would select the image twice.

@JPPhoto [has an issue](https://discord.com/channels/1020123559063990373/1278037635230863411/1287838550846476309) that I initially thought could be caused by this. After pondering I doubt it will fix his problem, but it's good to fix it anyways.

The fix simply skips the redundant image selection call.

### Image selection reducers

In the `gallerySlice` reducers for `imageSelected` and `selectionChanged` (why does these both exist? they do the same thing... mysterious but anyways), we commit a classic redux blunder - we unnecessarily update the state in some situation.

For example, when you click an image, we _always_ set the selection to a new array w/ that image, even if we were clicking on the currently-selected image. Because we make a new array, we trigger a cascade of re-renders in the UI, even though the selected image is identical.

The fix adds some logic in the reducer to check if the new selection contains the same images, and if so, does not change the selection.

## Related Issues / Discussions

- JP's issue: https://discord.com/channels/1020123559063990373/1278037635230863411/1287838550846476309

## QA Instructions

Behaviour when generating new images or clicking in gallery should be unchanged, but a bit snappier.

## Merge Plan

This should only be merged after v5 is released.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
