### PR TITLE
feat(ui): cleanup resizable panels

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -25,17 +25,16 @@ const GalleryPanelContent = () => {
   const boardSearchText = useAppSelector(selectBoardSearchText);
   const dispatch = useAppDispatch();
   const boardSearchDisclosure = useDisclosure({ defaultIsOpen: !!boardSearchText.length });
-  const panelGroupRef = useRef<ImperativePanelGroupHandle>(null);
+  const imperativePanelGroupRef = useRef<ImperativePanelGroupHandle>(null);
   const ref = useRef<HTMLDivElement>(null);
   useScopeOnFocus('gallery', ref);
 
   const boardsListPanelOptions = useMemo<UsePanelOptions>(
     () => ({
       id: 'boards-list-panel',
-      unit: 'pixels',
       minSize: 128,
-      defaultSize: 20,
-      panelGroupRef,
+      defaultSize: 208,
+      imperativePanelGroupRef,
       panelGroupDirection: 'vertical',
     }),
     []
@@ -81,7 +80,7 @@ const GalleryPanelContent = () => {
         </Flex>
       </Flex>
 
-      <PanelGroup ref={panelGroupRef} direction="vertical" autoSaveId="boards-list-panel">
+      <PanelGroup ref={imperativePanelGroupRef} direction="vertical" autoSaveId="boards-list-panel">
         <Panel collapsible {...boardsListPanel.panelProps}>
           <Flex flexDir="column" w="full" h="full">
             <Collapse in={boardSearchDisclosure.isOpen} style={COLLAPSE_STYLES}>

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -33,7 +33,7 @@ const GalleryPanelContent = () => {
     () => ({
       id: 'boards-list-panel',
       minSize: 128,
-      defaultSize: 208,
+      defaultSize: 256,
       imperativePanelGroupRef,
       panelGroupDirection: 'vertical',
     }),

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -92,7 +92,7 @@ const GalleryPanelContent = () => {
             <BoardsListWrapper />
           </Flex>
         </Panel>
-        <ResizeHandle id="gallery-panel-handle" orientation="horizontal" {...boardsListPanel.resizeHandleProps} />
+        <ResizeHandle id="gallery-panel-handle" {...boardsListPanel.resizeHandleProps} />
         <Panel id="gallery-wrapper-panel" minSize={20}>
           <Gallery />
         </Panel>

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonSideBySide.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonSideBySide.tsx
@@ -42,11 +42,7 @@ export const ImageComparisonSideBySide = memo(({ firstImage, secondImage }: Comp
               </Flex>
             </Flex>
           </Panel>
-          <ResizeHandle
-            id="image-comparison-side-by-side-handle"
-            onDoubleClick={onDoubleClickHandle}
-            orientation="vertical"
-          />
+          <ResizeHandle id="image-comparison-side-by-side-handle" onDoubleClick={onDoubleClickHandle} />
 
           <Panel minSize={20}>
             <Flex position="relative" w="full" h="full" alignItems="center" justifyContent="center">

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/NodeEditorPanelGroup.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/NodeEditorPanelGroup.tsx
@@ -51,7 +51,7 @@ const NodeEditorPanelGroup = () => {
           <Panel id="workflow" collapsible minSize={25}>
             <WorkflowPanel />
           </Panel>
-          <ResizeHandle orientation="horizontal" onDoubleClick={handleDoubleClickHandle} />
+          <ResizeHandle onDoubleClick={handleDoubleClickHandle} />
           <Panel id="inspector" collapsible minSize={25}>
             <InspectorPanel />
           </Panel>

--- a/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
@@ -21,9 +21,7 @@ import { selectActiveTab } from 'features/ui/store/uiSelectors';
 import {
   $isLeftPanelOpen,
   $isRightPanelOpen,
-  LEFT_PANEL_MIN_SIZE_PCT,
   LEFT_PANEL_MIN_SIZE_PX,
-  RIGHT_PANEL_MIN_SIZE_PCT,
   RIGHT_PANEL_MIN_SIZE_PX,
   selectWithLeftPanel,
   selectWithRightPanel,
@@ -45,16 +43,15 @@ export const AppContent = memo(() => {
   const ref = useRef<HTMLDivElement>(null);
   useScopeOnFocus('gallery', ref);
 
-  const panelGroupRef = useRef<ImperativePanelGroupHandle>(null);
+  const imperativePanelGroupRef = useRef<ImperativePanelGroupHandle>(null);
 
   const withLeftPanel = useAppSelector(selectWithLeftPanel);
   const leftPanelUsePanelOptions = useMemo<UsePanelOptions>(
     () => ({
       id: 'left-panel',
-      unit: 'pixels',
       minSize: LEFT_PANEL_MIN_SIZE_PX,
-      defaultSize: LEFT_PANEL_MIN_SIZE_PCT,
-      panelGroupRef,
+      defaultSize: LEFT_PANEL_MIN_SIZE_PX,
+      imperativePanelGroupRef,
       panelGroupDirection: 'horizontal',
       onCollapse: onLeftPanelCollapse,
     }),
@@ -73,10 +70,9 @@ export const AppContent = memo(() => {
   const rightPanelUsePanelOptions = useMemo<UsePanelOptions>(
     () => ({
       id: 'right-panel',
-      unit: 'pixels',
       minSize: RIGHT_PANEL_MIN_SIZE_PX,
-      defaultSize: RIGHT_PANEL_MIN_SIZE_PCT,
-      panelGroupRef,
+      defaultSize: RIGHT_PANEL_MIN_SIZE_PX,
+      imperativePanelGroupRef,
       panelGroupDirection: 'horizontal',
       onCollapse: onRightPanelCollapse,
     }),
@@ -127,7 +123,7 @@ export const AppContent = memo(() => {
       <VerticalNavBar />
       <Flex position="relative" w="full" h="full" gap={4} minW={0}>
         <PanelGroup
-          ref={panelGroupRef}
+          ref={imperativePanelGroupRef}
           id="app-panel-group"
           autoSaveId="app-panel-group"
           direction="horizontal"

--- a/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
@@ -139,7 +139,7 @@ export const AppContent = memo(() => {
                   </Box>
                 </Flex>
               </Panel>
-              <ResizeHandle id="left-main-handle" orientation="vertical" {...leftPanel.resizeHandleProps} />
+              <ResizeHandle id="left-main-handle" {...leftPanel.resizeHandleProps} />
             </>
           )}
           <Panel id="main-panel" order={1} minSize={20} style={panelStyles}>
@@ -147,7 +147,7 @@ export const AppContent = memo(() => {
           </Panel>
           {withRightPanel && (
             <>
-              <ResizeHandle id="main-right-handle" orientation="vertical" {...rightPanel.resizeHandleProps} />
+              <ResizeHandle id="main-right-handle" {...rightPanel.resizeHandleProps} />
               <Panel order={2} style={panelStyles} collapsible {...rightPanel.panelProps}>
                 <RightPanelContent />
               </Panel>

--- a/invokeai/frontend/web/src/features/ui/components/tabs/ResizeHandle.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/tabs/ResizeHandle.tsx
@@ -1,61 +1,60 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
-import { Box, chakra, Flex } from '@invoke-ai/ui-library';
+import { chakra } from '@invoke-ai/ui-library';
 import { memo } from 'react';
 import type { PanelResizeHandleProps } from 'react-resizable-panels';
 import { PanelResizeHandle } from 'react-resizable-panels';
 
-type ResizeHandleProps = PanelResizeHandleProps & {
-  orientation: 'horizontal' | 'vertical';
-};
-
 const ChakraPanelResizeHandle = chakra(PanelResizeHandle);
 
-const ResizeHandle = (props: ResizeHandleProps) => {
-  const { orientation, ...rest } = props;
-
-  return (
-    <ChakraPanelResizeHandle {...rest}>
-      <Flex sx={sx} data-orientation={orientation}>
-        <Box className="resize-handle-inner" data-orientation={orientation} />
-      </Flex>
-    </ChakraPanelResizeHandle>
-  );
+const ResizeHandle = (props: Omit<PanelResizeHandleProps, 'style'>) => {
+  return <ChakraPanelResizeHandle {...props} sx={sx} />;
 };
 
 export default memo(ResizeHandle);
 
 const sx: SystemStyleObject = {
-  display: 'flex',
-  pos: 'relative',
-  '&[data-orientation="horizontal"]': {
-    w: 'full',
-    h: 5,
-  },
-  '&[data-orientation="vertical"]': { w: 5, h: 'full' },
-  alignItems: 'center',
-  justifyContent: 'center',
-  div: {
-    bg: 'base.800',
-  },
-  _hover: {
-    div: { bg: 'base.700' },
-  },
-  _active: {
-    div: { bg: 'base.600' },
-  },
-  transitionProperty: 'common',
-  transitionDuration: 'normal',
-  '.resize-handle-inner': {
-    '&[data-orientation="horizontal"]': {
-      w: '100%',
-      h: '2px',
+  '&[data-resize-handle-state="hover"]': {
+    _before: {
+      background: 'base.600 !important',
     },
-    '&[data-orientation="vertical"]': {
+  },
+  '&[data-resize-handle-state="drag"]': {
+    _before: {
+      background: 'base.500 !important',
+    },
+  },
+  '&[data-panel-group-direction="horizontal"]': {
+    w: 4,
+    h: 'full',
+    position: 'relative',
+    _before: {
+      transitionProperty: 'background',
+      transitionDuration: 'normal',
+      content: '""',
       w: '2px',
-      h: '100%',
+      h: 'full',
+      background: 'base.800',
+      position: 'absolute',
+      left: '50%',
+      top: 0,
+      transform: 'translateX(-50%)',
     },
-    borderRadius: 'base',
-    transitionProperty: 'inherit',
-    transitionDuration: 'inherit',
+  },
+  '&[data-panel-group-direction="vertical"]': {
+    h: 4,
+    w: 'full',
+    position: 'relative',
+    _before: {
+      transitionProperty: 'background',
+      transitionDuration: 'normal',
+      content: '""',
+      w: 'full',
+      h: '2px',
+      background: 'base.800',
+      position: 'absolute',
+      top: '50%',
+      left: 0,
+      transform: 'translateY(-50%)',
+    },
   },
 };

--- a/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
+++ b/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
@@ -250,5 +250,5 @@ const getSizeAsPercentage = (
   });
 
   // The final value is a percentage of the available space
-  return (sizeInPixels / availableSpace) * 100;
+  return Math.min((sizeInPixels / availableSpace) * 100, 100);
 };

--- a/invokeai/frontend/web/src/features/ui/store/uiSlice.ts
+++ b/invokeai/frontend/web/src/features/ui/store/uiSlice.ts
@@ -82,14 +82,12 @@ export const uiPersistConfig: PersistConfig<UIState> = {
   persistDenylist: ['shouldShowImageDetails'],
 };
 
-export const LEFT_PANEL_MIN_SIZE_PX = 400;
-export const LEFT_PANEL_MIN_SIZE_PCT = 20;
 const TABS_WITH_LEFT_PANEL: TabName[] = ['canvas', 'upscaling', 'workflows'] as const;
+export const LEFT_PANEL_MIN_SIZE_PX = 400;
 export const $isLeftPanelOpen = atom(true);
 export const selectWithLeftPanel = createSelector(selectUiSlice, (ui) => TABS_WITH_LEFT_PANEL.includes(ui.activeTab));
 
 const TABS_WITH_RIGHT_PANEL: TabName[] = ['canvas', 'upscaling', 'workflows'] as const;
 export const RIGHT_PANEL_MIN_SIZE_PX = 390;
-export const RIGHT_PANEL_MIN_SIZE_PCT = 20;
 export const $isRightPanelOpen = atom(true);
 export const selectWithRightPanel = createSelector(selectUiSlice, (ui) => TABS_WITH_RIGHT_PANEL.includes(ui.activeTab));


### PR DESCRIPTION
## Summary

- Remove extraneous percentage layout logic from `usePanel`
- Fix bug where default size is handled as percentage instead of pixel (well, not really a bug, just a weird behaviour)
- Fix resize handle styling issues

## Related Issues / Discussions

n/a

## QA Instructions

panels should work the same

## Merge Plan

Should not be merged before v5

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
