### PR TITLE
fix(ui): truncate error description so toast is always close-able

### DIFF
--- a/invokeai/frontend/web/src/features/toast/ErrorToastDescription.tsx
+++ b/invokeai/frontend/web/src/features/toast/ErrorToastDescription.tsx
@@ -36,7 +36,11 @@ export default function ErrorToastDescription({ errorType, errorMessage, session
   }, [errorMessage, errorType, isLocal, t]);
   return (
     <Flex flexDir="column">
-      {description && <Text fontSize="md">{description}</Text>}
+      {description && (
+        <Text noOfLines={4} fontSize="md">
+          {description}
+        </Text>
+      )}
       {!isLocal && (
         <Flex gap="2" alignItems="center">
           <Text fontSize="sm" fontStyle="italic">


### PR DESCRIPTION
## Summary

If an invocation error happens that results in a very long `description`, the toast can take over the vertical space on screen and be impossible to close without refreshing the page. This limits the toast description for these errors to 4 lines.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
