### PR TITLE
fix(ui): handle resizable panels not rendered in DOM

### DIFF
--- a/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
+++ b/invokeai/frontend/web/src/features/ui/hooks/usePanel.ts
@@ -101,7 +101,7 @@ export const usePanel = (arg: UsePanelOptions): UsePanelReturn => {
         arg.panelGroupDirection
       );
 
-      if (minSizePct > 100) {
+      if (!minSizePct || minSizePct > 100 || !defaultSizePct || defaultSizePct > 100) {
         // This can happen when the panel is hidden
         return;
       }
@@ -243,6 +243,11 @@ const getSizeAsPercentage = (
   // The available space is the width/height of the panel group...
   let availableSpace =
     panelGroupDirection === 'horizontal' ? panelGroupElement.offsetWidth : panelGroupElement.offsetHeight;
+
+  if (!availableSpace) {
+    // No available space, size is 0
+    return 0;
+  }
 
   // ...minus the width/height of the resize handles
   getResizeHandleElementsForGroup(id).forEach((el) => {


### PR DESCRIPTION
## Summary

Fixes a bug introduced in a different bug fix in 9c0d357817a0a756543c3aa56de4b08bb1933a79.

## Related Issues / Discussions

Discord: https://discord.com/channels/1020123559063990373/1149506274971631688/1288538365011951636


## QA Instructions

Switch between layers & gallery tabs, with boards list open and closed. Its default size should never be reset or fill up the panel.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
