### PR TITLE
fix(ui): new image selection logic

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/boardIdSelected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/boardIdSelected.ts
@@ -1,12 +1,7 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import { selectListImagesQueryArgs } from 'features/gallery/store/gallerySelectors';
-import {
-  boardIdSelected,
-  galleryViewChanged,
-  imageSelected,
-  selectionChanged,
-} from 'features/gallery/store/gallerySlice';
+import { boardIdSelected, galleryViewChanged, imageSelected } from 'features/gallery/store/gallerySlice';
 import { imagesApi } from 'services/api/endpoints/images';
 
 export const addBoardIdSelectedListener = (startAppListening: AppStartListening) => {
@@ -19,8 +14,6 @@ export const addBoardIdSelectedListener = (startAppListening: AppStartListening)
       const state = getState();
 
       const queryArgs = selectListImagesQueryArgs(state);
-
-      dispatch(selectionChanged([]));
 
       // wait until the board has some images - maybe it already has some from a previous fetch
       // must use getState() to ensure we do not have stale state

--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -51,7 +51,7 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
       ])
     );
 
-    const { shouldAutoSwitch, selectedBoardId } = getState().gallery;
+    const { shouldAutoSwitch, selectedBoardId, galleryView, offset } = getState().gallery;
 
     // If auto-switch is enabled, select the new image
     if (shouldAutoSwitch) {
@@ -73,11 +73,14 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
       } else {
         // Else just select the image
         dispatch(imageSelected(imageDTO));
+        if (galleryView !== 'images') {
+          // We also need to update the gallery view to images
+          dispatch(galleryViewChanged('images'));
+        } else if (offset > 0) {
+          // If we are not at the start of the gallery, reset the offset
+          dispatch(offsetChanged({ offset: 0 }));
+        }
       }
-
-      // We also need to update the gallery view to images and reset the offset to 0
-      dispatch(galleryViewChanged('images'));
-      dispatch(offsetChanged({ offset: 0 }));
     }
   };
 

--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -71,13 +71,14 @@ export const buildOnInvocationComplete = (getState: () => RootState, dispatch: A
           })
         );
       } else {
-        // Else just select the image
+        // Else just select the image, no need to switch boards
         dispatch(imageSelected(imageDTO));
+
         if (galleryView !== 'images') {
-          // We also need to update the gallery view to images
+          // We also need to update the gallery view to images. This also updates the offset.
           dispatch(galleryViewChanged('images'));
         } else if (offset > 0) {
-          // If we are not at the start of the gallery, reset the offset
+          // If we are not at the start of the gallery, reset the offset.
           dispatch(offsetChanged({ offset: 0 }));
         }
       }


### PR DESCRIPTION
## Summary

New images weren't being selected. Actually, they were, but then they were quickly unselected.

The changes in #6930 unmasked a deeper logic issue that then became a bug.

## Related Issues / Discussions

n/a

## QA Instructions

Test with auto-switch enabled.

Test matrix:
- Auto-add board selected vs non-auto-add board selected
- On images tab vs on assets tab

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
