### PR TITLE
fix(ui): resizable panels collapsed on first app startup

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -32,8 +32,8 @@ const GalleryPanelContent = () => {
   const boardsListPanelOptions = useMemo<UsePanelOptions>(
     () => ({
       id: 'boards-list-panel',
-      minSize: 128,
-      defaultSize: 256,
+      minSizePx: 128,
+      defaultSizePx: 256,
       imperativePanelGroupRef,
       panelGroupDirection: 'vertical',
     }),

--- a/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
@@ -49,8 +49,8 @@ export const AppContent = memo(() => {
   const leftPanelUsePanelOptions = useMemo<UsePanelOptions>(
     () => ({
       id: 'left-panel',
-      minSize: LEFT_PANEL_MIN_SIZE_PX,
-      defaultSize: LEFT_PANEL_MIN_SIZE_PX,
+      minSizePx: LEFT_PANEL_MIN_SIZE_PX,
+      defaultSizePx: LEFT_PANEL_MIN_SIZE_PX,
       imperativePanelGroupRef,
       panelGroupDirection: 'horizontal',
       onCollapse: onLeftPanelCollapse,
@@ -70,8 +70,8 @@ export const AppContent = memo(() => {
   const rightPanelUsePanelOptions = useMemo<UsePanelOptions>(
     () => ({
       id: 'right-panel',
-      minSize: RIGHT_PANEL_MIN_SIZE_PX,
-      defaultSize: RIGHT_PANEL_MIN_SIZE_PX,
+      minSizePx: RIGHT_PANEL_MIN_SIZE_PX,
+      defaultSizePx: RIGHT_PANEL_MIN_SIZE_PX,
       imperativePanelGroupRef,
       panelGroupDirection: 'horizontal',
       onCollapse: onRightPanelCollapse,


### PR DESCRIPTION
## Summary

`usePanel` started panels with a `minSize` and `defaultSize` of 0, which means collapsed. This causes panels to load as collapsed on the very first app load. Then, in the layout effect, we see the panel as collapsed and skip setting it to the correct size.

Reviewing the library's API, `minSize` and `defaultSize` should not be lower than 1. Thankfully, setting this to 1 also prevents the issue described above.

- `minSize` and `defaultSize` start at 1
- Return a sentinel value when converting percentages to pixels, if the panel's container has no size. When that happens, we should not update the `minSize` or `defaultSize`.
- Split observer callback into its own function, so that the exact same logic can be used on the first run of hte effect.
- Update prop names and docstrings to accurately reflect that the numerical values are in pixels

## Related Issues / Discussions

offline discussion

## QA Instructions

- Reset web UI -> panels should start at the expected state e.g. left panel open, right panel open
- Resize panels and refresh page -> panels should remember last sizes

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
