### PR TITLE
fix(ui): canvas interactable after refresh while staging

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStagingAreaModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStagingAreaModule.ts
@@ -62,6 +62,7 @@ export class CanvasStagingAreaModule extends CanvasModuleBase {
   initialize = () => {
     this.log.debug('Initializing module');
     this.render();
+    this.$isStaging.set(this.manager.stateApi.runSelector(selectIsStaging));
   };
 
   render = async () => {


### PR DESCRIPTION
## Summary

Fixes a case where the canvas is erroneously interactable after refreshing the page while currently staging.

## Related Issues / Discussions

n/a

## QA Instructions

- Generate on canvas, getting an image or two onto the staging area
- Refresh the page
- The canvas should be locked down and not allow you to draw/move/etc

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
