### PR TITLE
feat(ui): show CLIP Vision models in model manager UI

### DIFF
--- a/invokeai/frontend/web/src/features/modelManagerV2/store/modelManagerV2Slice.ts
+++ b/invokeai/frontend/web/src/features/modelManagerV2/store/modelManagerV2Slice.ts
@@ -3,7 +3,7 @@ import { createSelector, createSlice } from '@reduxjs/toolkit';
 import type { PersistConfig, RootState } from 'app/store/store';
 import type { ModelType } from 'services/api/types';
 
-export type FilterableModelType = Exclude<ModelType, 'onnx' | 'clip_vision'> | 'refiner';
+export type FilterableModelType = Exclude<ModelType, 'onnx'> | 'refiner';
 
 type ModelManagerState = {
   _version: 1;

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelManagerPanel/ModelList.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelManagerPanel/ModelList.tsx
@@ -10,6 +10,7 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useCLIPEmbedModels,
+  useCLIPVisionModels,
   useControlNetModels,
   useEmbeddingModels,
   useIPAdapterModels,
@@ -73,6 +74,12 @@ const ModelList = () => {
     [ipAdapterModels, searchTerm, filteredModelType]
   );
 
+  const [clipVisionModels, { isLoading: isLoadingCLIPVisionModels }] = useCLIPVisionModels();
+  const filteredCLIPVisionModels = useMemo(
+    () => modelsFilter(clipVisionModels, searchTerm, filteredModelType),
+    [clipVisionModels, searchTerm, filteredModelType]
+  );
+
   const [vaeModels, { isLoading: isLoadingVAEModels }] = useVAEModels();
   const filteredVAEModels = useMemo(
     () => modelsFilter(vaeModels, searchTerm, filteredModelType),
@@ -107,6 +114,7 @@ const ModelList = () => {
       filteredControlNetModels.length +
       filteredT2IAdapterModels.length +
       filteredIPAdapterModels.length +
+      filteredCLIPVisionModels.length +
       filteredVAEModels.length +
       filteredSpandrelImageToImageModels.length +
       t5EncoderModels.length +
@@ -116,6 +124,7 @@ const ModelList = () => {
     filteredControlNetModels.length,
     filteredEmbeddingModels.length,
     filteredIPAdapterModels.length,
+    filteredCLIPVisionModels.length,
     filteredLoRAModels.length,
     filteredMainModels.length,
     filteredRefinerModels.length,
@@ -170,6 +179,11 @@ const ModelList = () => {
         {isLoadingIPAdapterModels && <FetchingModelsLoader loadingMessage="Loading IP Adapters..." />}
         {!isLoadingIPAdapterModels && filteredIPAdapterModels.length > 0 && (
           <ModelListWrapper title={t('common.ipAdapter')} modelList={filteredIPAdapterModels} key="ip-adapters" />
+        )}
+        {/* CLIP Vision List */}
+        {isLoadingCLIPVisionModels && <FetchingModelsLoader loadingMessage="Loading CLIP Vision Models..." />}
+        {!isLoadingCLIPVisionModels && filteredCLIPVisionModels.length > 0 && (
+          <ModelListWrapper title="CLIP Vision" modelList={filteredCLIPVisionModels} key="clip-vision" />
         )}
         {/* T2I Adapters List */}
         {isLoadingT2IAdapterModels && <FetchingModelsLoader loadingMessage="Loading T2I Adapters..." />}

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelManagerPanel/ModelTypeFilter.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelManagerPanel/ModelTypeFilter.tsx
@@ -22,6 +22,7 @@ export const ModelTypeFilter = memo(() => {
       t5_encoder: t('modelManager.t5Encoder'),
       clip_embed: t('modelManager.clipEmbed'),
       ip_adapter: t('common.ipAdapter'),
+      clip_vision: 'CLIP Vision',
       spandrel_image_to_image: t('modelManager.spandrelImageToImage'),
     }),
     [t]

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
@@ -120,14 +120,18 @@ export const ModelEdit = memo(({ modelConfig }: Props) => {
                 <Textarea {...form.register('description')} minH={32} />
               </FormControl>
             </Flex>
-            <Heading as="h3" fontSize="md" mt="4">
-              {t('modelManager.modelSettings')}
-            </Heading>
+            {modelConfig.type !== 'clip_vision' && (
+              <Heading as="h3" fontSize="md" mt="4">
+                {t('modelManager.modelSettings')}
+              </Heading>
+            )}
             <SimpleGrid columns={2} gap={4}>
-              <FormControl flexDir="column" alignItems="flex-start" gap={1}>
-                <FormLabel>{t('modelManager.baseModel')}</FormLabel>
-                <BaseModelSelect control={form.control} />
-              </FormControl>
+              {modelConfig.type !== 'clip_vision' && (
+                <FormControl flexDir="column" alignItems="flex-start" gap={1}>
+                  <FormLabel>{t('modelManager.baseModel')}</FormLabel>
+                  <BaseModelSelect control={form.control} />
+                </FormControl>
+              )}
               {modelConfig.type === 'main' && (
                 <FormControl flexDir="column" alignItems="flex-start" gap={1}>
                   <FormLabel>{t('modelManager.variant')}</FormLabel>

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelView.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelView.tsx
@@ -4,7 +4,7 @@ import { ModelConvertButton } from 'features/modelManagerV2/subpanels/ModelPanel
 import { ModelEditButton } from 'features/modelManagerV2/subpanels/ModelPanel/ModelEditButton';
 import { ModelHeader } from 'features/modelManagerV2/subpanels/ModelPanel/ModelHeader';
 import { TriggerPhrases } from 'features/modelManagerV2/subpanels/ModelPanel/TriggerPhrases';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AnyModelConfig } from 'services/api/types';
 
@@ -17,6 +17,20 @@ type Props = {
 
 export const ModelView = memo(({ modelConfig }: Props) => {
   const { t } = useTranslation();
+  const withSettings = useMemo(() => {
+    if (modelConfig.type === 'main' && modelConfig.base !== 'sdxl-refiner') {
+      return true;
+    }
+    if (modelConfig.type === 'controlnet' || modelConfig.type === 't2i_adapter') {
+      return true;
+    }
+    if (modelConfig.type === 'main' || modelConfig.type === 'lora') {
+      return true;
+    }
+
+    return false;
+  }, [modelConfig.base, modelConfig.type]);
+
   return (
     <Flex flexDir="column" gap={4}>
       <ModelHeader modelConfig={modelConfig}>
@@ -50,15 +64,19 @@ export const ModelView = memo(({ modelConfig }: Props) => {
             )}
           </SimpleGrid>
         </Box>
-        <Box layerStyle="second" borderRadius="base" p={4}>
-          {modelConfig.type === 'main' && modelConfig.base !== 'sdxl-refiner' && (
-            <MainModelDefaultSettings modelConfig={modelConfig} />
-          )}
-          {(modelConfig.type === 'controlnet' || modelConfig.type === 't2i_adapter') && (
-            <ControlNetOrT2IAdapterDefaultSettings modelConfig={modelConfig} />
-          )}
-          {(modelConfig.type === 'main' || modelConfig.type === 'lora') && <TriggerPhrases modelConfig={modelConfig} />}
-        </Box>
+        {withSettings && (
+          <Box layerStyle="second" borderRadius="base" p={4}>
+            {modelConfig.type === 'main' && modelConfig.base !== 'sdxl-refiner' && (
+              <MainModelDefaultSettings modelConfig={modelConfig} />
+            )}
+            {(modelConfig.type === 'controlnet' || modelConfig.type === 't2i_adapter') && (
+              <ControlNetOrT2IAdapterDefaultSettings modelConfig={modelConfig} />
+            )}
+            {(modelConfig.type === 'main' || modelConfig.type === 'lora') && (
+              <TriggerPhrases modelConfig={modelConfig} />
+            )}
+          </Box>
+        )}
       </Flex>
     </Flex>
   );

--- a/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
+++ b/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
@@ -10,6 +10,7 @@ import {
 import type { AnyModelConfig } from 'services/api/types';
 import {
   isCLIPEmbedModelConfig,
+  isCLIPVisionModelConfig,
   isControlNetModelConfig,
   isControlNetOrT2IAdapterModelConfig,
   isFluxMainModelModelConfig,
@@ -58,6 +59,7 @@ export const useIPAdapterModels = buildModelsHook(isIPAdapterModelConfig);
 export const useEmbeddingModels = buildModelsHook(isTIModelConfig);
 export const useVAEModels = buildModelsHook(isVAEModelConfig);
 export const useFluxVAEModels = buildModelsHook(isFluxVAEModelConfig);
+export const useCLIPVisionModels = buildModelsHook(isCLIPVisionModelConfig);
 
 // const buildModelsSelector =
 //   <T extends AnyModelConfig>(typeGuard: (config: AnyModelConfig) => config is T): Selector<RootState, T[]> =>

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -99,6 +99,10 @@ export const isIPAdapterModelConfig = (config: AnyModelConfig): config is IPAdap
   return config.type === 'ip_adapter';
 };
 
+export const isCLIPVisionModelConfig = (config: AnyModelConfig): config is CLIPVisionDiffusersConfig => {
+  return config.type === 'clip_vision';
+};
+
 export const isT2IAdapterModelConfig = (config: AnyModelConfig): config is T2IAdapterModelConfig => {
   return config.type === 't2i_adapter';
 };


### PR DESCRIPTION
## Summary

Not sure why they were hidden but it makes it hard to delete them if they are borked for some reason (have to go thru API docs page or do DB surgery).

## Related Issues / Discussions

- [discord](https://discord.com/channels/1020123559063990373/1020123559831539744/1290433044523782194)

## QA Instructions

Should be able to see and delete CLIP vision models in the MM tab

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
