### PR TITLE
feat(context menu): :sparkles: condense top row of image context menu

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemCopy.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemCopy.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
 import { useCopyImageToClipboard } from 'common/hooks/useCopyImageToClipboard';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { memo, useCallback } from 'react';
@@ -19,9 +19,14 @@ export const ImageMenuItemCopy = memo(() => {
   }
 
   return (
-    <MenuItem icon={<PiCopyBold />} onClickCapture={onClick}>
-      {t('parameters.copyImage')}
-    </MenuItem>
+    <IconButton
+      icon={<PiCopyBold />}
+      aria-label={t('parameters.copyImage')}
+      tooltip={t('parameters.copyImage')}
+      onClickCapture={onClick}
+      variant="ghost"
+      colorScheme="base"
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemDelete.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemDelete.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { imagesToDeleteSelected } from 'features/deleteImageModal/store/slice';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
@@ -16,9 +16,14 @@ export const ImageMenuItemDelete = memo(() => {
   }, [dispatch, imageDTO]);
 
   return (
-    <MenuItem isDestructive icon={<PiTrashSimpleBold />} onClickCapture={onClick}>
-      {t('gallery.deleteImage', { count: 1 })}
-    </MenuItem>
+    <IconButton
+      icon={<PiTrashSimpleBold />}
+      onClickCapture={onClick}
+      aria-label={t('gallery.deleteImage', { count: 1 })}
+      tooltip={t('gallery.deleteImage', { count: 1 })}
+      variant="ghost"
+      colorScheme="red"
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemDownload.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemDownload.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
 import { useDownloadImage } from 'common/hooks/useDownloadImage';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { memo, useCallback } from 'react';
@@ -15,9 +15,14 @@ export const ImageMenuItemDownload = memo(() => {
   }, [downloadImage, imageDTO.image_name, imageDTO.image_url]);
 
   return (
-    <MenuItem icon={<PiDownloadSimpleBold />} onClickCapture={onClick}>
-      {t('parameters.downloadImage')}
-    </MenuItem>
+    <IconButton
+      icon={<PiDownloadSimpleBold />}
+      aria-label={t('parameters.downloadImage')}
+      tooltip={t('parameters.downloadImage')}
+      variant="ghost"
+      colorScheme="base"
+      onClick={onClick}
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemOpenInNewTab.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemOpenInNewTab.tsx
@@ -1,17 +1,25 @@
-import { MenuItem } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiArrowSquareOutBold } from 'react-icons/pi';
 
 export const ImageMenuItemOpenInNewTab = memo(() => {
   const { t } = useTranslation();
   const imageDTO = useImageDTOContext();
+  const onClick = useCallback(() => {
+    window.open(imageDTO.image_url, '_blank');
+  }, [imageDTO.image_url]);
 
   return (
-    <MenuItem as="a" href={imageDTO.image_url} target="_blank" icon={<PiArrowSquareOutBold />}>
-      {t('common.openInNewTab')}
-    </MenuItem>
+    <IconButton
+      onClickCapture={onClick}
+      aria-label={t('common.openInNewTab')}
+      tooltip={t('common.openInNewTab')}
+      icon={<PiArrowSquareOutBold />}
+      variant="ghost"
+      colorScheme="base"
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemOpenInViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemOpenInViewer.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { memo, useCallback } from 'react';
@@ -14,9 +14,14 @@ export const ImageMenuItemOpenInViewer = memo(() => {
   }, [imageDTO, imageViewer]);
 
   return (
-    <MenuItem icon={<PiArrowsOutBold />} onClick={onClick}>
-      {t('gallery.openInViewer')}
-    </MenuItem>
+    <IconButton
+      icon={<PiArrowsOutBold />}
+      onClick={onClick}
+      aria-label={t('common.openInViewer')}
+      tooltip={t('common.openInViewer')}
+      variant="ghost"
+      colorScheme="base"
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemSelectForCompare.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemSelectForCompare.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
@@ -22,9 +22,15 @@ export const ImageMenuItemSelectForCompare = memo(() => {
   }, [dispatch, imageDTO]);
 
   return (
-    <MenuItem icon={<PiImagesBold />} isDisabled={!maySelectForCompare} onClick={onClick}>
-      {t('gallery.selectForCompare')}
-    </MenuItem>
+    <IconButton
+      icon={<PiImagesBold />}
+      isDisabled={!maySelectForCompare}
+      onClick={onClick}
+      aria-label={t('gallery.selectForCompare')}
+      tooltip={t('gallery.selectForCompare')}
+      variant="ghost"
+      colorScheme="base"
+    />
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
@@ -1,4 +1,4 @@
-import { MenuDivider } from '@invoke-ai/ui-library';
+import { Flex, MenuDivider } from '@invoke-ai/ui-library';
 import { ImageMenuItemChangeBoard } from 'features/gallery/components/ImageContextMenu/ImageMenuItemChangeBoard';
 import { ImageMenuItemCopy } from 'features/gallery/components/ImageContextMenu/ImageMenuItemCopy';
 import { ImageMenuItemDelete } from 'features/gallery/components/ImageContextMenu/ImageMenuItemDelete';
@@ -23,11 +23,14 @@ type SingleSelectionMenuItemsProps = {
 const SingleSelectionMenuItems = ({ imageDTO }: SingleSelectionMenuItemsProps) => {
   return (
     <ImageDTOContextProvider value={imageDTO}>
-      <ImageMenuItemOpenInNewTab />
-      <ImageMenuItemCopy />
-      <ImageMenuItemDownload />
-      <ImageMenuItemOpenInViewer />
-      <ImageMenuItemSelectForCompare />
+      <Flex gap={2}>
+        <ImageMenuItemOpenInNewTab />
+        <ImageMenuItemCopy />
+        <ImageMenuItemDownload />
+        <ImageMenuItemOpenInViewer />
+        <ImageMenuItemSelectForCompare />
+        <ImageMenuItemDelete />
+      </Flex>
       <MenuDivider />
       <ImageMenuItemLoadWorkflow />
       <ImageMenuItemMetadataRecallActions />
@@ -38,8 +41,6 @@ const SingleSelectionMenuItems = ({ imageDTO }: SingleSelectionMenuItemsProps) =
       <MenuDivider />
       <ImageMenuItemChangeBoard />
       <ImageMenuItemStarUnstar />
-      <MenuDivider />
-      <ImageMenuItemDelete />
     </ImageDTOContextProvider>
   );
 };


### PR DESCRIPTION
## Summary

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

Condensed top row of image context menus. This felt like a good short term necessary step to keep the image context menu from becoming too big and overwhelming.
Since submenus are a more complicated endeavor due to the current libraries being used, I took inspiration from Windows 11's infamous quick shortcuts ui pattern, which proved to be a great solution here.

![image](https://github.com/user-attachments/assets/432f9b57-3b5c-4b72-9226-00212d583ef9)

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
