### PR TITLE
fix(ui): show color picker when using pen

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolColorPicker.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolColorPicker.ts
@@ -205,14 +205,6 @@ export class CanvasToolColorPicker extends CanvasModuleBase {
       return;
     }
 
-    const isMouseDown = this.parent.$isMouseDown.get();
-    const lastPointerType = this.parent.$lastPointerType.get();
-
-    if (lastPointerType !== 'mouse' && !isMouseDown) {
-      this.setVisibility(false);
-      return;
-    }
-
     this.setVisibility(true);
 
     const settings = this.manager.stateApi.getSettings();


### PR DESCRIPTION
## Summary

Fixes an issue where the color picker didn't display while hovering with a pen input device

## Related Issues / Discussions

discord convo

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
