### PR TITLE
fix(ui): duplicating regional guidance layer breaks graph generation

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -857,6 +857,9 @@ export const canvasSlice = createSlice({
           break;
         case 'regional_guidance':
           newEntity.id = getPrefixedId('regional_guidance');
+          for (const refImage of newEntity.referenceImages) {
+            refImage.id = getPrefixedId('regional_guidance_ip_adapter');
+          }
           state.regionalGuidance.entities.push(newEntity);
           break;
         case 'reference_image':


### PR DESCRIPTION
## Summary

[fix(ui): give unique ID to duplicated regional guidance layers' ref images](https://github.com/invoke-ai/InvokeAI/commit/b69558fbc06e93f338fcbfb3817c64e0ef15ebe7)

## Related Issues / Discussions

Closes #6995

## QA Instructions

- Duplicate a regional guidance layer w/ a reference image
- Generation should still work

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
