### PR TITLE
fix(ui): recall LoRAs may create duplicates

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/store/lorasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/lorasSlice.ts
@@ -37,6 +37,7 @@ export const lorasSlice = createSlice({
     },
     loraRecalled: (state, action: PayloadAction<{ lora: LoRA }>) => {
       const { lora } = action.payload;
+      state.loras = state.loras.filter((l) => l.model.key !== lora.model.key && l.id !== lora.id);
       state.loras.push(lora);
     },
     loraDeleted: (state, action: PayloadAction<{ id: string }>) => {


### PR DESCRIPTION
## Summary

fix(ui): recall LoRAs may create duplicates

## Related Issues / Discussions

Closes #7004

## QA Instructions

- Generate w/ a LoRA
- Change the weight of the LoRA so when you recall, you know it replaced the existing LoRA
- Recall that LoRA from the image you just generated
- It should replace the existing LoRA and not duplicate it

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
