### PR TITLE
fix(ui): prevent unhandled promise rejections

### DIFF
--- a/invokeai/frontend/web/src/features/metadata/components/MetadataLoRAs.tsx
+++ b/invokeai/frontend/web/src/features/metadata/components/MetadataLoRAs.tsx
@@ -47,7 +47,9 @@ const MetadataViewLoRA = ({
     if (!handlers.recallItem) {
       return;
     }
-    handlers.recallItem(lora, true);
+    handlers.recallItem(lora, true).catch(() => {
+      // no-op, the toast will show the error
+    });
   }, [handlers, lora]);
 
   const [renderedValue, setRenderedValue] = useState<React.ReactNode>(null);

--- a/invokeai/frontend/web/src/features/metadata/hooks/useMetadataItem.tsx
+++ b/invokeai/frontend/web/src/features/metadata/hooks/useMetadataItem.tsx
@@ -21,13 +21,15 @@ export const useMetadataItem = <T,>(metadata: unknown, handlers: MetadataHandler
   const [renderedValueInternal, setRenderedValueInternal] = useState<React.ReactNode>(null);
 
   useEffect(() => {
-    const _parse = async () => {
-      try {
-        const parsed = await handlers.parse(metadata);
-        setValue(parsed);
-      } catch (e) {
-        setValue(MetadataParseFailedToken);
-      }
+    const _parse = () => {
+      handlers
+        .parse(metadata)
+        .then((parsed) => {
+          setValue(parsed);
+        })
+        .catch(() => {
+          setValue(MetadataParseFailedToken);
+        });
     };
     _parse();
   }, [handlers, metadata]);
@@ -37,7 +39,7 @@ export const useMetadataItem = <T,>(metadata: unknown, handlers: MetadataHandler
   const label = useMemo(() => handlers.getLabel(), [handlers]);
 
   useEffect(() => {
-    const _renderValue = async () => {
+    const _renderValue = () => {
       if (value === MetadataParsePendingToken) {
         setRenderedValueInternal(null);
         return;
@@ -47,9 +49,14 @@ export const useMetadataItem = <T,>(metadata: unknown, handlers: MetadataHandler
         return;
       }
 
-      const rendered = await handlers.renderValue(value);
-
-      setRenderedValueInternal(rendered);
+      handlers
+        .renderValue(value)
+        .then((rendered) => {
+          setRenderedValueInternal(rendered);
+        })
+        .catch(() => {
+          // no-op
+        });
     };
 
     _renderValue();
@@ -69,7 +76,9 @@ export const useMetadataItem = <T,>(metadata: unknown, handlers: MetadataHandler
     if (!handlers.recall || value === MetadataParsePendingToken || value === MetadataParseFailedToken) {
       return null;
     }
-    handlers.recall(value, true);
+    handlers.recall(value, true).catch(() => {
+      // no-op, the toast will show the error
+    });
   }, [handlers, value]);
 
   const valueOrNull = useMemo(() => {


### PR DESCRIPTION
## Summary

There were a few places where metadata-related promise rejections were unhandled. Any instrumentation added to the app would see the rejections and log them, but these rejections are all no-ops and should jsut be ignored.

In this change, I reviewed the metadata recall logic to add handling everywhere rejections were unhandled. Think I got them all.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
