### PR TITLE
Bump xformers for compatibility with torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dependencies = [
 [project.optional-dependencies]
 "xformers" = [
   # Core generation dependencies, pinned for reproducible builds.
-  "xformers==0.0.25post1; sys_platform!='darwin'",
+  "xformers==0.0.28.post1; sys_platform!='darwin'",
   # Auxiliary dependencies, pinned only if necessary.
   "triton; sys_platform=='linux'",
 ]


### PR DESCRIPTION
## Summary

#6890 bumped torch, which caused an incompatibility with xformers when installing with `pip install ".[xformers]"`. This PR bumps xformers.

## QA Instructions

I ran some smoke tests to confirm that generating with xformers still works.

In my tests on an A100, there is a performance regression after bumping xformers (2.7 it/s vs 3.2 it/s). I think it is ok to ignore this for A100s, since users should be using torch-sdp, which is much faster (4.3 it/s). But, we should test for regression on older cards where xformers is still recommended.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
