### PR TITLE
fix(ui): board title editable

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -53,7 +53,8 @@
         "imagesWithCount_one": "{{count}} image",
         "imagesWithCount_other": "{{count}} images",
         "assetsWithCount_one": "{{count}} asset",
-        "assetsWithCount_other": "{{count}} assets"
+        "assetsWithCount_other": "{{count}} assets",
+        "updateBoardError": "Error updating board"
     },
     "accordions": {
         "generation": {

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardEditableTitle.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardEditableTitle.tsx
@@ -1,0 +1,98 @@
+import { Input, Text } from '@invoke-ai/ui-library';
+import { useBoolean } from 'common/hooks/useBoolean';
+import { withResultAsync } from 'common/util/result';
+import { toast } from 'features/toast/toast';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useUpdateBoardMutation } from 'services/api/endpoints/boards';
+import type { BoardDTO } from 'services/api/types';
+
+type Props = {
+  board: BoardDTO;
+  isSelected: boolean;
+};
+
+export const BoardEditableTitle = memo(({ board, isSelected }: Props) => {
+  const { t } = useTranslation();
+  const isEditing = useBoolean(false);
+  const [localTitle, setLocalTitle] = useState(board.board_name);
+  const ref = useRef<HTMLInputElement>(null);
+  const [updateBoard, updateBoardResult] = useUpdateBoardMutation();
+
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setLocalTitle(e.target.value);
+  }, []);
+
+  const onBlur = useCallback(async () => {
+    const trimmedTitle = localTitle.trim();
+    isEditing.setFalse();
+    if (trimmedTitle.length === 0) {
+      setLocalTitle(board.board_name);
+    } else if (trimmedTitle !== board.board_name) {
+      setLocalTitle(trimmedTitle);
+      const result = await withResultAsync(() =>
+        updateBoard({ board_id: board.board_id, changes: { board_name: trimmedTitle } }).unwrap()
+      );
+      if (result.isErr()) {
+        setLocalTitle(board.board_name);
+        toast({
+          status: 'error',
+          title: t('boards.updateBoardError'),
+        });
+      } else {
+        setLocalTitle(result.value.board_name);
+      }
+    }
+  }, [board.board_id, board.board_name, isEditing, localTitle, updateBoard, t]);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        onBlur();
+      } else if (e.key === 'Escape') {
+        setLocalTitle(board.board_name);
+        isEditing.setFalse();
+      }
+    },
+    [board.board_name, isEditing, onBlur]
+  );
+
+  useEffect(() => {
+    if (isEditing.isTrue) {
+      ref.current?.focus();
+      ref.current?.select();
+    }
+  }, [isEditing.isTrue]);
+
+  if (!isEditing.isTrue) {
+    return (
+      <Text
+        size="sm"
+        fontWeight="semibold"
+        userSelect="none"
+        color={isSelected ? 'base.100' : 'base.300'}
+        onDoubleClick={isEditing.setTrue}
+        cursor="text"
+        minW={16}
+      >
+        {localTitle}
+      </Text>
+    );
+  }
+
+  return (
+    <Input
+      ref={ref}
+      value={localTitle}
+      onChange={onChange}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      variant="outline"
+      isDisabled={updateBoardResult.isLoading}
+      _focusVisible={{ borderWidth: 1, borderColor: 'invokeBlueAlpha.400', borderRadius: 'base' }}
+    />
+  );
+});
+
+BoardEditableTitle.displayName = 'CanvasEntityTitleEdit';

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/GalleryBoard.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/GalleryBoard.tsx
@@ -1,22 +1,12 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
-import {
-  Editable,
-  EditableInput,
-  EditablePreview,
-  Flex,
-  Icon,
-  Image,
-  Text,
-  Tooltip,
-  useDisclosure,
-  useEditableControls,
-} from '@invoke-ai/ui-library';
+import { Flex, Icon, Image, Text, Tooltip } from '@invoke-ai/ui-library';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import IAIDroppable from 'common/components/IAIDroppable';
 import type { AddToBoardDropData } from 'features/dnd/types';
 import { AutoAddBadge } from 'features/gallery/components/Boards/AutoAddBadge';
 import BoardContextMenu from 'features/gallery/components/Boards/BoardContextMenu';
+import { BoardEditableTitle } from 'features/gallery/components/Boards/BoardsList/BoardEditableTitle';
 import { BoardTooltip } from 'features/gallery/components/Boards/BoardsList/BoardTooltip';
 import {
   selectAutoAddBoardId,
@@ -24,22 +14,11 @@ import {
   selectSelectedBoardId,
 } from 'features/gallery/store/gallerySelectors';
 import { autoAddBoardIdChanged, boardIdSelected } from 'features/gallery/store/gallerySlice';
-import type { MouseEvent, MouseEventHandler, MutableRefObject } from 'react';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiArchiveBold, PiImageSquare } from 'react-icons/pi';
-import { useUpdateBoardMutation } from 'services/api/endpoints/boards';
 import { useGetImageDTOQuery } from 'services/api/endpoints/images';
 import type { BoardDTO } from 'services/api/types';
-
-const editableInputStyles: SystemStyleObject = {
-  p: 0,
-  fontSize: 'md',
-  w: '100%',
-  _focusVisible: {
-    p: 0,
-  },
-};
 
 const _hover: SystemStyleObject = {
   bg: 'base.850',
@@ -56,9 +35,6 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
   const autoAddBoardId = useAppSelector(selectAutoAddBoardId);
   const autoAssignBoardOnClick = useAppSelector(selectAutoAssignBoardOnClick);
   const selectedBoardId = useAppSelector(selectSelectedBoardId);
-  const editingDisclosure = useDisclosure();
-  const [localBoardName, setLocalBoardName] = useState(board.board_name);
-  const onStartEditingRef = useRef<MouseEventHandler | undefined>(undefined);
 
   const onPointerUp = useCallback(() => {
     if (selectedBoardId !== board.board_id) {
@@ -69,8 +45,6 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
     }
   }, [selectedBoardId, board.board_id, autoAssignBoardOnClick, autoAddBoardId, dispatch]);
 
-  const [updateBoard, { isLoading: isUpdateBoardLoading }] = useUpdateBoardMutation();
-
   const droppableData: AddToBoardDropData = useMemo(
     () => ({
       id: board.board_id,
@@ -80,42 +54,6 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
     [board.board_id]
   );
 
-  const onSubmit = useCallback(
-    async (newBoardName: string) => {
-      if (!newBoardName.trim()) {
-        // empty strings are not allowed
-        setLocalBoardName(board.board_name);
-      } else if (newBoardName === board.board_name) {
-        // don't updated the board name if it hasn't changed
-      } else {
-        try {
-          const { board_name } = await updateBoard({
-            board_id: board.board_id,
-            changes: { board_name: newBoardName },
-          }).unwrap();
-
-          // update local state
-          setLocalBoardName(board_name);
-        } catch {
-          // revert on error
-          setLocalBoardName(board.board_name);
-        }
-      }
-      editingDisclosure.onClose();
-    },
-    [board.board_id, board.board_name, editingDisclosure, updateBoard]
-  );
-
-  const onChange = useCallback((newBoardName: string) => {
-    setLocalBoardName(newBoardName);
-  }, []);
-
-  const onDoubleClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
-    if (onStartEditingRef.current) {
-      onStartEditingRef.current(e);
-    }
-  }, []);
-
   return (
     <BoardContextMenu board={board}>
       {(ref) => (
@@ -124,7 +62,6 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
             position="relative"
             ref={ref}
             onPointerUp={onPointerUp}
-            onDoubleClick={onDoubleClick}
             w="full"
             alignItems="center"
             borderRadius="base"
@@ -138,36 +75,12 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
             h={12}
           >
             <CoverImage board={board} />
-            <Editable
-              as={Flex}
-              alignItems="center"
-              gap={4}
-              flexGrow={1}
-              onEdit={editingDisclosure.onOpen}
-              value={localBoardName}
-              isDisabled={isUpdateBoardLoading}
-              submitOnBlur={true}
-              onChange={onChange}
-              onSubmit={onSubmit}
-              isPreviewFocusable={false}
-              fontSize="sm"
-            >
-              <EditablePreview
-                cursor="pointer"
-                p={0}
-                fontSize="sm"
-                textOverflow="ellipsis"
-                noOfLines={1}
-                w="fit-content"
-                wordBreak="break-all"
-                fontWeight={isSelected ? 'bold' : 'normal'}
-              />
-              <EditableInput sx={editableInputStyles} />
-              <JankEditableHijack onStartEditingRef={onStartEditingRef} />
-            </Editable>
-            {autoAddBoardId === board.board_id && !editingDisclosure.isOpen && <AutoAddBadge />}
-            {board.archived && !editingDisclosure.isOpen && <Icon as={PiArchiveBold} fill="base.300" />}
-            {!editingDisclosure.isOpen && <Text variant="subtext">{board.image_count}</Text>}
+            <Flex w="full">
+              <BoardEditableTitle board={board} isSelected={isSelected} />
+            </Flex>
+            {autoAddBoardId === board.board_id && <AutoAddBadge />}
+            {board.archived && <Icon as={PiArchiveBold} fill="base.300" />}
+            <Text variant="subtext">{board.image_count}</Text>
 
             <IAIDroppable data={droppableData} dropLabel={t('gallery.move')} />
           </Flex>
@@ -176,16 +89,6 @@ const GalleryBoard = ({ board, isSelected }: GalleryBoardProps) => {
     </BoardContextMenu>
   );
 };
-
-const JankEditableHijack = memo((props: { onStartEditingRef: MutableRefObject<MouseEventHandler | undefined> }) => {
-  const editableControls = useEditableControls();
-  useEffect(() => {
-    props.onStartEditingRef.current = editableControls.getEditButtonProps().onPointerUp;
-  }, [props, editableControls]);
-  return null;
-});
-
-JankEditableHijack.displayName = 'JankEditableHijack';
 
 export default memo(GalleryBoard);
 

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
@@ -87,7 +87,7 @@ const NoBoardBoard = memo(({ isSelected }: Props) => {
               </Icon>
             </Flex>
 
-            <Text fontSize="sm" fontWeight={isSelected ? 'bold' : 'normal'} noOfLines={1} flexGrow={1}>
+            <Text fontSize="sm" color={isSelected ? 'base.100' : 'base.300'} fontWeight="semibold" noOfLines={1} flexGrow={1}>
               {boardName}
             </Text>
             {autoAddBoardId === 'none' && <AutoAddBadge />}

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/NoBoardBoard.tsx
@@ -87,7 +87,13 @@ const NoBoardBoard = memo(({ isSelected }: Props) => {
               </Icon>
             </Flex>
 
-            <Text fontSize="sm" color={isSelected ? 'base.100' : 'base.300'} fontWeight="semibold" noOfLines={1} flexGrow={1}>
+            <Text
+              fontSize="sm"
+              color={isSelected ? 'base.100' : 'base.300'}
+              fontWeight="semibold"
+              noOfLines={1}
+              flexGrow={1}
+            >
               {boardName}
             </Text>
             {autoAddBoardId === 'none' && <AutoAddBadge />}


### PR DESCRIPTION
## Summary

Dunno exactly why this broke but it did. I replaced the janky old hacked editable with the DIY editable I made for the canvas, which works much better and looks better too.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1291791807021191209

## QA Instructions

Double click board title to edit

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
