### PR TITLE
feat(ui): allow for a broader range of guidance values for flux models

### DIFF
--- a/invokeai/frontend/web/src/features/system/store/configSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/configSlice.ts
@@ -172,10 +172,10 @@ const initialConfigState: AppConfig = {
       initial: 4,
       sliderMin: 2,
       sliderMax: 6,
-      numberInputMin: 2,
-      numberInputMax: 6,
+      numberInputMin: 1,
+      numberInputMax: 20,
       fineStep: 0.1,
-      coarseStep: 1,
+      coarseStep: 0.5,
     },
   },
 };


### PR DESCRIPTION
## Summary

The current range of 2-6 produces consistent images and serves as a good default for regular users. However, it can be somewhat restrictive in certain situations. For example, when creating more painterly images, using a value lower than 2 can yield interesting results.

This PR modifies the less visible input range to allow for a broader range of values.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
