### PR TITLE
fix(ui): duplicate translation string for "layer"

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1652,7 +1652,6 @@
         "rasterLayers_withCount_visible": "Raster Layers ({{count}})",
         "globalReferenceImages_withCount_visible": "Global Reference Images ({{count}})",
         "inpaintMasks_withCount_visible": "Inpaint Masks ({{count}})",
-        "layer": "Layer",
         "layer_one": "Layer",
         "layer_other": "Layers",
         "layer_withCount_one": "Layer ({{count}})",


### PR DESCRIPTION
## Summary

There was a duplicate string for "layer" causing a weblate issue. 

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1054129386447716433/1292795435689312299

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
