### PR TITLE
perf(ui): rendering optimizations

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasBackgroundModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasBackgroundModule.ts
@@ -69,7 +69,7 @@ export class CanvasBackgroundModule extends CanvasModuleBase {
       layer: new Konva.Layer({ name: `${this.type}:layer`, listening: false, imageSmoothingEnabled: false }),
       linesGroup: new Konva.Group({ name: `${this.type}:linesGroup` }),
       lines: [],
-      patternRect: new Konva.Rect({ name: `${this.type}:patternRect` }),
+      patternRect: new Konva.Rect({ name: `${this.type}:patternRect`, perfectDrawEnabled: false }),
     };
 
     this.konva.layer.add(this.konva.patternRect);
@@ -174,6 +174,7 @@ export class CanvasBackgroundModule extends CanvasModuleBase {
         stroke: _x % 64 ? this.config.GRID_LINE_COLOR_FINE : this.config.GRID_LINE_COLOR_COARSE,
         strokeWidth,
         listening: false,
+        perfectDrawEnabled: false,
       });
       this.konva.lines.push(line);
       this.konva.linesGroup.add(line);
@@ -187,6 +188,7 @@ export class CanvasBackgroundModule extends CanvasModuleBase {
         stroke: _y % 64 ? this.config.GRID_LINE_COLOR_FINE : this.config.GRID_LINE_COLOR_COARSE,
         strokeWidth,
         listening: false,
+        perfectDrawEnabled: false,
       });
       this.konva.lines.push(line);
       this.konva.linesGroup.add(line);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasBboxModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasBboxModule.ts
@@ -83,6 +83,7 @@ export class CanvasBboxModule extends CanvasModuleBase {
         stroke: 'rgb(42,42,42)',
         strokeWidth: 1,
         strokeScaleEnabled: false,
+        perfectDrawEnabled: false,
       }),
       overlayGroup: new Konva.Group({
         name: `${this.type}:overlayGroup`,
@@ -123,6 +124,7 @@ export class CanvasBboxModule extends CanvasModuleBase {
         strokeEnabled: false,
         draggable: false,
         fill: 'hsl(220 12% 10% / 0.8)',
+        perfectDrawEnabled: false,
       }),
       transformer: new Konva.Transformer({
         name: `${this.type}:transformer`,

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -87,7 +87,7 @@ export abstract class CanvasEntityAdapterBase<
    */
   abstract getHashableState: () => SerializableObject;
 
-  private _selectIsHidden: Selector<RootState, boolean> | null = null;
+  selectIsHidden: Selector<RootState, boolean>;
 
   /**
    * The Konva nodes that make up the entity adapter:
@@ -171,6 +171,8 @@ export abstract class CanvasEntityAdapterBase<
     assert(state !== undefined, 'Missing entity state on creation');
     this.state = state;
 
+    this.selectIsHidden = buildEntityIsHiddenSelector(this.entityIdentifier);
+
     /**
      * There are a number of reason we may need to show or hide a layer:
      * - The entity is enabled/disabled
@@ -223,14 +225,6 @@ export abstract class CanvasEntityAdapterBase<
    * A redux selector that selects the entity's position from the canvas slice.
    */
   selectPosition = createSelector(this.selectState, (entity) => entity?.position);
-
-  get selectIsHidden() {
-    // This must be a getter because the selector depends on the entityIdentifier, which is set in the constructor.
-    if (!this._selectIsHidden) {
-      this._selectIsHidden = buildEntityIsHiddenSelector(this.entityIdentifier);
-    }
-    return this._selectIsHidden;
-  }
 
   syncIsOnscreen = () => {
     const stageRect = this.manager.stage.getScaledStageRect();

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -390,12 +390,18 @@ export abstract class CanvasEntityAdapterBase<
   });
 
   setVisibility = (isVisible: boolean) => {
-    if (this.$isHidden.get() === !isVisible && this.konva.layer.visible() === isVisible) {
+    const isHidden = this.$isHidden.get();
+    const isLayerVisible = this.konva.layer.visible();
+
+    if (isHidden === !isVisible && isLayerVisible === isVisible) {
+      // No change
       return;
     }
     this.log.trace(isVisible ? 'Showing' : 'Hiding');
     this.$isHidden.set(!isVisible);
     this.konva.layer.visible(isVisible);
+
+    this.renderer.syncCache();
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -320,7 +320,7 @@ export abstract class CanvasEntityAdapterBase<
   syncIsEnabled = () => {
     this.log.trace('Updating visibility');
     this.konva.layer.visible(this.state.isEnabled);
-    this.renderer.syncCache(this.state.isEnabled);
+    this.renderer.syncKonvaCache(this.state.isEnabled);
     this.transformer.syncInteractionState();
     this.$isDisabled.set(!this.state.isEnabled);
   };
@@ -401,7 +401,7 @@ export abstract class CanvasEntityAdapterBase<
     this.$isHidden.set(!isVisible);
     this.konva.layer.visible(isVisible);
 
-    this.renderer.syncCache();
+    this.renderer.syncKonvaCache();
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -9,7 +9,7 @@ import type { CanvasEntityObjectRenderer } from 'features/controlLayers/konva/Ca
 import type { CanvasEntityTransformer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
 import { CanvasModuleBase } from 'features/controlLayers/konva/CanvasModuleBase';
-import { getRectIntersection } from 'features/controlLayers/konva/util';
+import { getKonvaNodeDebugAttrs, getRectIntersection } from 'features/controlLayers/konva/util';
 import {
   selectIsolatedFilteringPreview,
   selectIsolatedTransformingPreview,
@@ -453,6 +453,14 @@ export abstract class CanvasEntityAdapterBase<
       bufferRenderer: this.bufferRenderer.repr(),
       filterer: this.filterer?.repr(),
       hasCache: this.$canvasCache.get() !== null,
+      isLocked: this.$isLocked.get(),
+      isDisabled: this.$isDisabled.get(),
+      isHidden: this.$isHidden.get(),
+      isEmpty: this.$isEmpty.get(),
+      isInteractable: this.$isInteractable.get(),
+      isOnScreen: this.$isOnScreen.get(),
+      intersectsBbox: this.$intersectsBbox.get(),
+      konva: getKonvaNodeDebugAttrs(this.konva.layer),
     };
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -124,6 +124,10 @@ export abstract class CanvasEntityAdapterBase<
   $isInteractable = computed([this.$isLocked, this.$isDisabled, this.$isHidden], (isLocked, isDisabled, isHidden) => {
     return !isLocked && !isDisabled && !isHidden;
   });
+  /**
+   * A cache of the entity's canvas element. This is generated from a clone of the entity's Konva layer.
+   */
+  $canvasCache = atom<HTMLCanvasElement | null>(null);
 
   constructor(entityIdentifier: CanvasEntityIdentifier<T['type']>, manager: CanvasManager, adapterType: U) {
     super();
@@ -333,6 +337,7 @@ export abstract class CanvasEntityAdapterBase<
       renderer: this.renderer.repr(),
       bufferRenderer: this.bufferRenderer.repr(),
       filterer: this.filterer?.repr(),
+      hasCache: this.$canvasCache.get() !== null,
     };
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterControlLayer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterControlLayer.ts
@@ -69,7 +69,7 @@ export class CanvasEntityAdapterControlLayer extends CanvasEntityAdapterBase<
     this.log.trace({ rect }, 'Getting canvas');
     // The opacity may have been changed in response to user selecting a different entity category, so we must restore
     // the original opacity before rendering the canvas
-    const attrs: GroupConfig = { opacity: this.state.opacity };
+    const attrs: GroupConfig = { opacity: this.state.opacity, filters: [] };
     const canvas = this.renderer.getCanvas({ rect, attrs });
     return canvas;
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterInpaintMask.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterInpaintMask.ts
@@ -39,6 +39,9 @@ export class CanvasEntityAdapterInpaintMask extends CanvasEntityAdapterBase<
       return;
     }
 
+    // If prevState is undefined, this is the first render. Some logic is only needed on the first render, or required
+    // on first render.
+
     if (!prevState || this.state.isEnabled !== prevState.isEnabled) {
       this.syncIsEnabled();
     }
@@ -55,19 +58,14 @@ export class CanvasEntityAdapterInpaintMask extends CanvasEntityAdapterBase<
       this.syncOpacity();
     }
     if (!prevState || this.state.fill !== prevState.fill) {
-      this.syncCompositingRectFill();
+      // On first render, we must force the update
+      this.renderer.updateCompositingRectFill(!prevState);
     }
     if (!prevState) {
-      this.syncCompositingRectSize();
+      // On first render, we must force the updates
+      this.renderer.updateCompositingRectSize(true);
+      this.renderer.updateCompositingRectPosition(true);
     }
-  };
-
-  syncCompositingRectSize = () => {
-    this.renderer.updateCompositingRectSize();
-  };
-
-  syncCompositingRectFill = () => {
-    this.renderer.updateCompositingRectFill();
   };
 
   getHashableState = (): SerializableObject => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterInpaintMask.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterInpaintMask.ts
@@ -78,7 +78,7 @@ export class CanvasEntityAdapterInpaintMask extends CanvasEntityAdapterBase<
   getCanvas = (rect?: Rect): HTMLCanvasElement => {
     // The opacity may have been changed in response to user selecting a different entity category, and the mask regions
     // should be fully opaque - set opacity to 1 before rendering the canvas
-    const attrs: GroupConfig = { opacity: 1 };
+    const attrs: GroupConfig = { opacity: 1, filters: [] };
     const canvas = this.renderer.getCanvas({ rect, attrs });
     return canvas;
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRasterLayer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRasterLayer.ts
@@ -62,7 +62,7 @@ export class CanvasEntityAdapterRasterLayer extends CanvasEntityAdapterBase<
     this.log.trace({ rect }, 'Getting canvas');
     // The opacity may have been changed in response to user selecting a different entity category, so we must restore
     // the original opacity before rendering the canvas
-    const attrs: GroupConfig = { opacity: this.state.opacity };
+    const attrs: GroupConfig = { opacity: this.state.opacity, filters: [] };
     const canvas = this.renderer.getCanvas({ rect, attrs });
     return canvas;
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance.ts
@@ -78,7 +78,7 @@ export class CanvasEntityAdapterRegionalGuidance extends CanvasEntityAdapterBase
   getCanvas = (rect?: Rect): HTMLCanvasElement => {
     // The opacity may have been changed in response to user selecting a different entity category, and the mask regions
     // should be fully opaque - set opacity to 1 before rendering the canvas
-    const attrs: GroupConfig = { opacity: 1 };
+    const attrs: GroupConfig = { opacity: 1, filters: [] };
     const canvas = this.renderer.getCanvas({ rect, attrs });
     return canvas;
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance.ts
@@ -39,6 +39,9 @@ export class CanvasEntityAdapterRegionalGuidance extends CanvasEntityAdapterBase
       return;
     }
 
+    // If prevState is undefined, this is the first render. Some logic is only needed on the first render, or required
+    // on first render.
+
     if (!prevState || this.state.isEnabled !== prevState.isEnabled) {
       this.syncIsEnabled();
     }
@@ -55,19 +58,14 @@ export class CanvasEntityAdapterRegionalGuidance extends CanvasEntityAdapterBase
       this.syncOpacity();
     }
     if (!prevState || this.state.fill !== prevState.fill) {
-      this.syncCompositingRectFill();
+      // On first render, we must force the update
+      this.renderer.updateCompositingRectFill(!prevState);
     }
     if (!prevState) {
-      this.syncCompositingRectSize();
+      // On first render, we must force the updates
+      this.renderer.updateCompositingRectSize(true);
+      this.renderer.updateCompositingRectPosition(true);
     }
-  };
-
-  syncCompositingRectSize = () => {
-    this.renderer.updateCompositingRectSize();
-  };
-
-  syncCompositingRectFill = () => {
-    this.renderer.updateCompositingRectFill();
   };
 
   getHashableState = (): SerializableObject => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -216,7 +216,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     this.abortController = null;
     this.parent.bufferRenderer.clearBuffer();
     this.parent.transformer.updatePosition();
-    this.parent.renderer.syncCache(true);
+    this.parent.renderer.syncKonvaCache(true);
     this.imageState = null;
     this.$hasProcessed.set(false);
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -193,7 +193,14 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
     if (this.renderers.size === 0) {
       this.log.trace('Clearing object group cache');
       this.konva.objectGroup.clearCache();
-    } else if (force || !this.konva.objectGroup.isCached()) {
+      return;
+    }
+
+    // We should never cache the entity if it is not visible - it will cache as a transparent image.
+    const isVisible = this.parent.konva.layer.visible();
+    const isCached = this.konva.objectGroup.isCached();
+
+    if (isVisible && (force || !isCached)) {
       this.log.trace('Caching object group');
       this.konva.objectGroup.clearCache();
       this.konva.objectGroup.cache({ pixelRatio: 1, imageSmoothingEnabled: false });

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -179,7 +179,7 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
       didRender = (await this.renderObject(obj)) || didRender;
     }
 
-    this.syncCache(didRender);
+    this.syncKonvaCache(didRender);
 
     return didRender;
   };
@@ -189,7 +189,7 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
     renderer.konva.group.moveTo(this.konva.objectGroup);
   };
 
-  syncCache = (force: boolean = false) => {
+  syncKonvaCache = (force: boolean = false) => {
     if (this.renderers.size === 0) {
       this.log.trace('Clearing object group cache');
       this.konva.objectGroup.clearCache();

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -189,7 +189,7 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
         name: `${this.type}:outline_rect`,
         stroke: this.config.OUTLINE_COLOR,
         perfectDrawEnabled: false,
-        strokeHitEnabled: false,
+        hitStrokeWidth: 0,
       }),
       transformer: new Konva.Transformer({
         name: `${this.type}:transformer`,

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectBrushLine.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectBrushLine.ts
@@ -47,6 +47,7 @@ export class CanvasObjectBrushLine extends CanvasModuleBase {
         lineCap: 'round',
         lineJoin: 'round',
         globalCompositeOperation: 'source-over',
+        perfectDrawEnabled: false,
       }),
     };
     this.konva.group.add(this.konva.line);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectBrushLineWithPressure.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectBrushLineWithPressure.ts
@@ -48,6 +48,7 @@ export class CanvasObjectBrushLineWithPressure extends CanvasModuleBase {
         listening: false,
         shadowForStrokeEnabled: false,
         globalCompositeOperation: 'source-over',
+        perfectDrawEnabled: false,
       }),
     };
     this.konva.group.add(this.konva.line);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectEraserLine.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectEraserLine.ts
@@ -46,6 +46,7 @@ export class CanvasObjectEraserLine extends CanvasModuleBase {
         lineCap: 'round',
         lineJoin: 'round',
         globalCompositeOperation: 'destination-out',
+        perfectDrawEnabled: false,
       }),
     };
     this.konva.group.add(this.konva.line);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectEraserLineWithPressure.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectEraserLineWithPressure.ts
@@ -48,6 +48,7 @@ export class CanvasObjectEraserLineWithPressure extends CanvasModuleBase {
         fill: 'red', // Eraser lines use compositing, does not matter what color they have
         shadowForStrokeEnabled: false,
         globalCompositeOperation: 'destination-out',
+        perfectDrawEnabled: false,
       }),
     };
     this.konva.group.add(this.konva.line);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
@@ -65,6 +65,7 @@ export class CanvasObjectImage extends CanvasModuleBase {
           width,
           height,
           listening: false,
+          perfectDrawEnabled: false,
         }),
         text: new Konva.Text({
           name: `${this.type}:placeholder_text`,
@@ -78,6 +79,7 @@ export class CanvasObjectImage extends CanvasModuleBase {
           fontStyle: '600',
           text: t('common.loadingImage', 'Loading Image'),
           listening: false,
+          perfectDrawEnabled: false,
         }),
       },
       image: null,
@@ -144,6 +146,7 @@ export class CanvasObjectImage extends CanvasModuleBase {
             image: this.imageElement,
             width,
             height,
+            perfectDrawEnabled: false,
           });
           this.konva.group.add(this.konva.image);
         }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectRect.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectRect.ts
@@ -35,7 +35,7 @@ export class CanvasObjectRect extends CanvasModuleBase {
 
     this.konva = {
       group: new Konva.Group({ name: `${this.type}:group`, listening: false }),
-      rect: new Konva.Rect({ name: `${this.type}:rect`, listening: false }),
+      rect: new Konva.Rect({ name: `${this.type}:rect`, listening: false, perfectDrawEnabled: false }),
     };
     this.konva.group.add(this.konva.rect);
     this.state = state;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasProgressImageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasProgressImageModule.ts
@@ -140,6 +140,7 @@ export class CanvasProgressImageModule extends CanvasModuleBase {
           y,
           width,
           height,
+          perfectDrawEnabled: false,
         });
         this.konva.group.add(this.konva.image);
       }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -411,16 +411,18 @@ export class CanvasStageModule extends CanvasModuleBase {
   /**
    * Gets the rectangle of the stage in the absolute coordinates. This can be used to draw a rect that covers the
    * entire stage.
+   * @param snapToInteger Whether to snap the values to integers. Default is true. This is useful when the stage is
+   * scaled in such a way that the absolute (screen) coordinates or dimensions are not integers.
    */
-  getScaledStageRect = (): Rect => {
+  getScaledStageRect = (snapToInteger: boolean = true): Rect => {
     const { x, y } = this.getPosition();
     const { width, height } = this.getSize();
     const scale = this.getScale();
     return {
-      x: -x / scale,
-      y: -y / scale,
-      width: width / scale,
-      height: height / scale,
+      x: snapToInteger ? Math.floor(-x / scale) : -x / scale,
+      y: snapToInteger ? Math.floor(-y / scale) : -y / scale,
+      width: snapToInteger ? Math.ceil(width / scale) : width / scale,
+      height: snapToInteger ? Math.ceil(height / scale) : height / scale,
     };
   };
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolBrush.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolBrush.ts
@@ -71,6 +71,7 @@ export class CanvasToolBrush extends CanvasModuleBase {
         name: `${this.type}:brush_fill_circle`,
         listening: false,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       innerBorder: new Konva.Ring({
         name: `${this.type}:brush_inner_border_ring`,
@@ -79,6 +80,7 @@ export class CanvasToolBrush extends CanvasModuleBase {
         outerRadius: 0,
         fill: this.config.BORDER_INNER_COLOR,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       outerBorder: new Konva.Ring({
         name: `${this.type}:brush_outer_border_ring`,
@@ -87,6 +89,7 @@ export class CanvasToolBrush extends CanvasModuleBase {
         outerRadius: 0,
         fill: this.config.BORDER_OUTER_COLOR,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
     };
     this.konva.group.add(this.konva.fillCircle, this.konva.innerBorder, this.konva.outerBorder);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolColorPicker.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolColorPicker.ts
@@ -114,6 +114,7 @@ export class CanvasToolColorPicker extends CanvasModuleBase {
         innerRadius: 0,
         outerRadius: 0,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       ringCurrentColor: new Konva.Arc({
         name: `${this.type}:color_picker_current_color_arc`,
@@ -121,6 +122,7 @@ export class CanvasToolColorPicker extends CanvasModuleBase {
         outerRadius: 0,
         angle: 180,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       ringInnerBorder: new Konva.Ring({
         name: `${this.type}:color_picker_inner_border_ring`,
@@ -128,6 +130,7 @@ export class CanvasToolColorPicker extends CanvasModuleBase {
         outerRadius: 0,
         fill: this.config.RING_BORDER_INNER_COLOR,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       ringOuterBorder: new Konva.Ring({
         name: `${this.type}:color_picker_outer_border_ring`,
@@ -135,38 +138,47 @@ export class CanvasToolColorPicker extends CanvasModuleBase {
         outerRadius: 0,
         fill: this.config.RING_BORDER_OUTER_COLOR,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       crosshairNorthInner: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_north1_line`,
         stroke: this.config.CROSSHAIR_LINE_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairNorthOuter: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_north2_line`,
         stroke: this.config.CROSSHAIR_BORDER_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairEastInner: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_east1_line`,
         stroke: this.config.CROSSHAIR_LINE_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairEastOuter: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_east2_line`,
         stroke: this.config.CROSSHAIR_BORDER_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairSouthInner: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_south1_line`,
         stroke: this.config.CROSSHAIR_LINE_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairSouthOuter: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_south2_line`,
         stroke: this.config.CROSSHAIR_BORDER_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairWestInner: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_west1_line`,
         stroke: this.config.CROSSHAIR_LINE_COLOR,
+        perfectDrawEnabled: false,
       }),
       crosshairWestOuter: new Konva.Line({
         name: `${this.type}:color_picker_crosshair_west2_line`,
         stroke: this.config.CROSSHAIR_BORDER_COLOR,
+        perfectDrawEnabled: false,
       }),
     };
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolEraser.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolEraser.ts
@@ -57,6 +57,7 @@ export class CanvasToolEraser extends CanvasModuleBase {
         // The fill is used only to erase what is underneath it, so its color doesn't matter - just needs to be opaque
         fill: 'white',
         globalCompositeOperation: 'destination-out',
+        perfectDrawEnabled: false,
       }),
       innerBorder: new Konva.Ring({
         name: `${this.type}:eraser_inner_border_ring`,
@@ -65,6 +66,7 @@ export class CanvasToolEraser extends CanvasModuleBase {
         outerRadius: 0,
         fill: this.config.BORDER_INNER_COLOR,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
       outerBorder: new Konva.Ring({
         name: `${this.type}:eraser_outer_border_ring`,
@@ -72,6 +74,7 @@ export class CanvasToolEraser extends CanvasModuleBase {
         outerRadius: 0,
         fill: this.config.BORDER_OUTER_COLOR,
         strokeEnabled: false,
+        perfectDrawEnabled: false,
       }),
     };
     this.konva.group.add(this.konva.cutoutCircle, this.konva.innerBorder, this.konva.outerBorder);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
@@ -506,6 +506,36 @@ export const getRectUnion = (...rects: Rect[]): Rect => {
 };
 
 /**
+ * Gets the intersection of any number of rects.
+ * @params rects The rects to intersect
+ * @returns The intersection of the rects, or an empty rect if no intersection exists
+ */
+export const getRectIntersection = (...rects: Rect[]): Rect => {
+  const firstRect = rects.shift();
+
+  if (!firstRect) {
+    return getEmptyRect();
+  }
+
+  const rect = rects.reduce<Rect>((acc, r) => {
+    const x = Math.max(acc.x, r.x);
+    const y = Math.max(acc.y, r.y);
+    const width = Math.min(acc.x + acc.width, r.x + r.width) - x;
+    const height = Math.min(acc.y + acc.height, r.y + r.height) - y;
+
+    // We continue even if width or height is negative, and check at the end
+    return { x, y, width, height };
+  }, firstRect);
+
+  // Final check to ensure positive width and height, else return empty rect
+  if (rect.width < 0 || rect.height < 0) {
+    return getEmptyRect();
+  }
+
+  return rect || getEmptyRect();
+};
+
+/**
  * Asserts that the value is never reached. Used for exhaustive checks in switch statements or conditional logic to ensure
  * that all possible values are handled.
  * @param value The value that should never be reached

--- a/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
@@ -333,7 +333,7 @@ export const dataURLToImageData = (dataURL: string, width: number, height: numbe
 
 export const konvaNodeToCanvas = (arg: { node: Konva.Node; rect?: Rect; bg?: string }): HTMLCanvasElement => {
   const { node, rect, bg } = arg;
-  const canvas = node.toCanvas({ ...(rect ?? {}), imageSmoothingEnabled: false });
+  const canvas = node.toCanvas({ ...(rect ?? {}), imageSmoothingEnabled: false, pixelRatio: 1 });
 
   if (!bg) {
     return canvas;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
@@ -612,6 +612,9 @@ export const getKonvaNodeDebugAttrs = (node: Konva.Node) => {
     offsetX: node.offsetX(),
     offsetY: node.offsetY(),
     rotation: node.rotation(),
+    isCached: node.isCached(),
+    visible: node.visible(),
+    listening: node.listening(),
   };
 };
 


### PR DESCRIPTION
## Summary

Handful of optimizations implemented while attempting to get a performant full canvas preview (unfortunately unsuccessful).

- Do not rely on internal Konva API for layer preview canvas (indirectly addresses #6950) 
- Track whether layers intersect the bbox
- Track whether layers are on-screen
- Disable Konva's "perfect draw" for all shapes
- Hide layers when they are both off-screen and not the selected layer
- Throttle opacity and compositing fill rendering to 100ms
- Reduce compositing rect rendering to minimum

## Related Issues / Discussions

Closes #6950

## QA Instructions

Have a play, should be no change to behaviour. I _think_ I can feel it is a bit snappier but could be wishful thinking. 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
