### PR TITLE
Get Flux working on MPS when torch 2.5.0 test or nightlies are installed

### DIFF
--- a/invokeai/backend/flux/math.py
+++ b/invokeai/backend/flux/math.py
@@ -16,7 +16,7 @@ def attention(q: Tensor, k: Tensor, v: Tensor, pe: Tensor) -> Tensor:
 
 def rope(pos: Tensor, dim: int, theta: int) -> Tensor:
     assert dim % 2 == 0
-    scale = torch.arange(0, dim, 2, dtype=torch.float64, device=pos.device) / dim
+    scale = torch.arange(0, dim, 2, dtype=torch.float32 if pos.device.type == 'mps' else torch.float64 , device=pos.device) / dim
     omega = 1.0 / (theta**scale)
     out = torch.einsum("...n,d->...nd", pos, omega)
     out = torch.stack([torch.cos(out), -torch.sin(out), torch.sin(out), torch.cos(out)], dim=-1)

--- a/invokeai/backend/flux/math.py
+++ b/invokeai/backend/flux/math.py
@@ -16,7 +16,10 @@ def attention(q: Tensor, k: Tensor, v: Tensor, pe: Tensor) -> Tensor:
 
 def rope(pos: Tensor, dim: int, theta: int) -> Tensor:
     assert dim % 2 == 0
-    scale = torch.arange(0, dim, 2, dtype=torch.float32 if pos.device.type == 'mps' else torch.float64 , device=pos.device) / dim
+    scale = (
+        torch.arange(0, dim, 2, dtype=torch.float32 if pos.device.type == "mps" else torch.float64, device=pos.device)
+        / dim
+    )
     omega = 1.0 / (theta**scale)
     out = torch.einsum("...n,d->...nd", pos, omega)
     out = torch.stack([torch.cos(out), -torch.sin(out), torch.sin(out), torch.cos(out)], dim=-1)


### PR DESCRIPTION
## Summary

A simple fix to use float32 in the rope function instead of float64 when the pos tensor is currently on a MPS device  
as MPS doesn't support float64 and isn't likely too any time soon.

## Related Issues / Discussions

Related issue is Flux doesn't work on MPS, InvokeAI 5.1.0 has moved to torch 2.4.1, this should fix #6991 but will lead to 
the next issue, which is fixed by this PR. After that you'll get the mps_arrange function not being present for bfloat16
tensors, that is fixed in PyTorch 2.5.0. and the nightlies(it could also be fixed in InvokeAIs code too depending on when you plan to upgrade to PyTorch 2.5.0 after its out, I feel thats better in another PR).

## QA Instructions

Test its not broke on CUDA as I have no access to that. I've been running with this code since 5.0.1 was released
so I know it doesn't break anything on MPS and gets flux working with an appropriate version of PyTorch.

## Merge Plan

its a purely code merge so should merge without issue.

## Checklist

- [x ] _The PR has a short but descriptive title, suitable for a changelog_
- [x ] _Tests added / updated (if applicable)_
- [x ] _Documentation added / updated (if applicable)_
