### PR TITLE
Allow explicitly selecting xFormers at install time

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     elif [ "$GPU_DRIVER" = "rocm" ]; then \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/rocm5.6"; \
     else \
-        extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu121"; \
+        extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu124"; \
     fi &&\
 
     # xformers + triton fails to install on arm64

--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -282,12 +282,6 @@ class InvokeAiInstance:
             shutil.copy(src, dest)
             os.chmod(dest, 0o0755)
 
-    def update(self):
-        pass
-
-    def remove(self):
-        pass
-
 
 ### Utility functions ###
 
@@ -402,7 +396,7 @@ def get_torch_source() -> Tuple[str | None, str | None]:
     :rtype: list
     """
 
-    from messages import select_gpu
+    from messages import GpuType, select_gpu
 
     # device can be one of: "cuda", "rocm", "cpu", "cuda_and_dml, autodetect"
     device = select_gpu()
@@ -412,16 +406,20 @@ def get_torch_source() -> Tuple[str | None, str | None]:
     url = None
     optional_modules: str | None = None
     if OS == "Linux":
-        if device.value == "rocm":
+        if device == GpuType.ROCM:
             url = "https://download.pytorch.org/whl/rocm5.6"
-        elif device.value == "cpu":
+        elif device == GpuType.CPU:
             url = "https://download.pytorch.org/whl/cpu"
-        elif device.value == "cuda":
-            # CUDA uses the default PyPi index
+        # CUDA uses the default PyPi index
+        elif device == GpuType.CUDA:
+            optional_modules = "[onnx-cuda]"
+        elif device == GpuType.CUDA_WITH_XFORMERS:
             optional_modules = "[xformers,onnx-cuda]"
     elif OS == "Windows":
-        if device.value == "cuda":
+        if device == GpuType.CUDA:
             url = "https://download.pytorch.org/whl/cu124"
+            optional_modules = "[onnx-cuda]"
+        elif device == GpuType.CUDA_WITH_XFORMERS:
             optional_modules = "[xformers,onnx-cuda]"
         elif device.value == "cpu":
             # CPU  uses the default PyPi index, no optional modules

--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -410,16 +410,18 @@ def get_torch_source() -> Tuple[str | None, str | None]:
             url = "https://download.pytorch.org/whl/rocm5.6"
         elif device == GpuType.CPU:
             url = "https://download.pytorch.org/whl/cpu"
-        # CUDA uses the default PyPi index
         elif device == GpuType.CUDA:
+            url = "https://download.pytorch.org/whl/cu124"
             optional_modules = "[onnx-cuda]"
         elif device == GpuType.CUDA_WITH_XFORMERS:
+            url = "https://download.pytorch.org/whl/cu124"
             optional_modules = "[xformers,onnx-cuda]"
     elif OS == "Windows":
         if device == GpuType.CUDA:
             url = "https://download.pytorch.org/whl/cu124"
             optional_modules = "[onnx-cuda]"
         elif device == GpuType.CUDA_WITH_XFORMERS:
+            url = "https://download.pytorch.org/whl/cu124"
             optional_modules = "[xformers,onnx-cuda]"
         elif device.value == "cpu":
             # CPU  uses the default PyPi index, no optional modules

--- a/installer/lib/messages.py
+++ b/installer/lib/messages.py
@@ -206,6 +206,7 @@ def dest_path(dest: Optional[str | Path] = None) -> Path | None:
 
 
 class GpuType(Enum):
+    CUDA_WITH_XFORMERS = "xformers"
     CUDA = "cuda"
     ROCM = "rocm"
     CPU = "cpu"
@@ -221,11 +222,15 @@ def select_gpu() -> GpuType:
         return GpuType.CPU
 
     nvidia = (
-        "an [gold1 b]NVIDIA[/] GPU (using CUDA™)",
+        "an [gold1 b]NVIDIA[/] RTX 3060 or newer GPU using CUDA",
         GpuType.CUDA,
     )
+    vintage_nvidia = (
+        "an [gold1 b]NVIDIA[/] RTX 20xx or older GPU using CUDA+xFormers",
+        GpuType.CUDA_WITH_XFORMERS,
+    )
     amd = (
-        "an [gold1 b]AMD[/] GPU (using ROCm™)",
+        "an [gold1 b]AMD[/] GPU using ROCm",
         GpuType.ROCM,
     )
     cpu = (
@@ -235,14 +240,13 @@ def select_gpu() -> GpuType:
 
     options = []
     if OS == "Windows":
-        options = [nvidia, cpu]
+        options = [nvidia, vintage_nvidia, cpu]
     if OS == "Linux":
-        options = [nvidia, amd, cpu]
+        options = [nvidia, vintage_nvidia, amd, cpu]
     elif OS == "Darwin":
         options = [cpu]
 
     if len(options) == 1:
-        print(f'Your platform [gold1]{OS}-{ARCH}[/] only supports the "{options[0][1]}" driver. Proceeding with that.')
         return options[0][1]
 
     options = {str(i): opt for i, opt in enumerate(options, 1)}


### PR DESCRIPTION
## Summary

A recent Torch upgrade introduced a performance regression on modern Nvidia GPUs when using xformers.
This PR adds an install option to select xFormers for older GPUs, where it's needed, and avoid it for the newer cards that can use `torch-sdp` or other attention types.

This PR also points `torch` to the CUDA v12.4 extra-index-url for cpu-only Docker builds (not related to xformers issues).

## QA Instructions

The updated installer, built from this PR, is attached here.. Please test it on Windows and macOS for completeness. On the mac it should simply proceed with the installation without displaying the GPU selection menu, and should result in a working install.


[InvokeAI-installer-v5.1.0.zip](https://github.com/user-attachments/files/17294883/InvokeAI-installer-v5.1.0.zip)  


1. Unzip the installer and run it using `install.sh`
2. Install using option 2 (older nvidia GPU with xformers).
3. Activate the virtual environment and validate that `xformers` is installed (`pip freeze | grep xformers`)
4. Repeat this with option 1, and validate that `xformers` is NOT installed.


## Merge Plan

Merge anytime

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
