### PR TITLE
fix(ui): sync pointer position on pointerdown

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
@@ -395,6 +395,7 @@ export class CanvasToolModule extends CanvasModuleBase {
       const isMouseDown = getIsPrimaryMouseDown(e);
       this.$isMouseDown.set(isMouseDown);
 
+      this.syncCursorPositions();
       const cursorPos = this.$cursorPos.get();
       const tool = this.$tool.get();
       const settings = this.manager.stateApi.getSettings();


### PR DESCRIPTION
## Summary

There's a Konva bug where `pointerenter` & `pointerleave` events aren't fired correctly on the stage.

In 87fdea4cc65f70b4890e52089916751d479059f0 I made a change that surfaced this bug, breaking touch and Apple Pencil interactions, because the cursor position doesn't get updated.

Simple fix - ensure we update the cursor on `pointerdown` events, even though we shouldn't need to.

Will make a bug report upstream

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1293375942416273479

## QA Instructions

Use finger and Apple Pencil

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
