### PR TITLE
feat(ui): img2img UX 2

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1641,6 +1641,7 @@
         "sendToCanvas": "Send To Canvas",
         "newLayerFromImage": "New Layer from Image",
         "newCanvasFromImage": "New Canvas from Image",
+        "newImg2ImgCanvasFromImage": "New Img2Img from Image",
         "copyToClipboard": "Copy to Clipboard",
         "sendToCanvasDesc": "Pressing Invoke stages your work in progress on the canvas.",
         "viewProgressInViewer": "View progress and outputs in the <Btn>Image Viewer</Btn>.",

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -432,6 +432,7 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
       return;
     }
     const { rect } = this.manager.stateApi.getBbox();
+    const gridSize = this.manager.stateApi.getGridSize();
     const width = this.konva.proxyRect.width();
     const height = this.konva.proxyRect.height();
     const scaleX = rect.width / width;
@@ -445,8 +446,8 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
     const offsetY = (rect.height - height * scale) / 2;
 
     this.konva.proxyRect.setAttrs({
-      x: clamp(Math.round(rect.x + offsetX), rect.x, rect.x + rect.width),
-      y: clamp(Math.round(rect.y + offsetY), rect.y, rect.y + rect.height),
+      x: clamp(roundToMultiple(rect.x + offsetX, gridSize), rect.x, rect.x + rect.width),
+      y: clamp(roundToMultiple(rect.y + offsetY, gridSize), rect.y, rect.y + rect.height),
       scaleX: scale,
       scaleY: scale,
       rotation: 0,
@@ -463,6 +464,7 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
       return;
     }
     const { rect } = this.manager.stateApi.getBbox();
+    const gridSize = this.manager.stateApi.getGridSize();
     const width = this.konva.proxyRect.width();
     const height = this.konva.proxyRect.height();
     const scaleX = rect.width / width;
@@ -476,8 +478,8 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
     const offsetY = (rect.height - height * scale) / 2;
 
     this.konva.proxyRect.setAttrs({
-      x: Math.round(rect.x + offsetX),
-      y: Math.round(rect.y + offsetY),
+      x: roundToMultiple(rect.x + offsetX, gridSize),
+      y: roundToMultiple(rect.y + offsetY, gridSize),
       scaleX: scale,
       scaleY: scale,
       rotation: 0,

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -25,7 +25,6 @@ import {
   getScaledBoundingBoxDimensions,
 } from 'features/controlLayers/util/getScaledBoundingBoxDimensions';
 import { simplifyFlatNumbersArray } from 'features/controlLayers/util/simplify';
-import type { MainModelBase } from 'features/nodes/types/common';
 import { isMainModelBase, zModelIdentifierField } from 'features/nodes/types/common';
 import { ASPECT_RATIO_MAP } from 'features/parameters/components/Bbox/constants';
 import { getGridSize, getIsSizeOptimal, getOptimalDimension } from 'features/parameters/util/optimalDimension';
@@ -770,11 +769,6 @@ export const canvasSlice = createSlice({
         state.bbox.rect.height = optimalDimension;
       }
 
-      syncScaledSize(state);
-    },
-    bboxModelBaseChanged: (state, action: PayloadAction<{ modelBase: MainModelBase }>) => {
-      const { modelBase } = action.payload;
-      state.bbox.modelBase = modelBase;
       syncScaledSize(state);
     },
     bboxSyncedToOptimalDimension: (state) => {

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewCanvasFromImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewCanvasFromImage.tsx
@@ -1,6 +1,7 @@
 import { MenuItem } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { useNewCanvasFromImage } from 'features/controlLayers/hooks/addLayerHooks';
+import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { toast } from 'features/toast/toast';
@@ -15,6 +16,7 @@ export const ImageMenuItemNewCanvasFromImage = memo(() => {
   const imageDTO = useImageDTOContext();
   const imageViewer = useImageViewer();
   const newCanvasFromImage = useNewCanvasFromImage();
+  const isBusy = useCanvasIsBusy();
 
   const onClick = useCallback(() => {
     newCanvasFromImage(imageDTO);
@@ -28,7 +30,7 @@ export const ImageMenuItemNewCanvasFromImage = memo(() => {
   }, [dispatch, imageDTO, imageViewer, newCanvasFromImage, t]);
 
   return (
-    <MenuItem icon={<PiFileBold />} onClickCapture={onClick}>
+    <MenuItem icon={<PiFileBold />} onClickCapture={onClick} isDisabled={isBusy}>
       {t('controlLayers.newCanvasFromImage')}
     </MenuItem>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewCanvasFromImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewCanvasFromImage.tsx
@@ -1,11 +1,6 @@
 import { MenuItem } from '@invoke-ai/ui-library';
-import { createSelector } from '@reduxjs/toolkit';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import { canvasReset } from 'features/controlLayers/store/actions';
-import { rasterLayerAdded } from 'features/controlLayers/store/canvasSlice';
-import { selectCanvasSlice } from 'features/controlLayers/store/selectors';
-import type { CanvasRasterLayerState } from 'features/controlLayers/store/types';
-import { imageDTOToImageObject } from 'features/controlLayers/store/util';
+import { useAppDispatch } from 'app/store/storeHooks';
+import { useNewCanvasFromImage } from 'features/controlLayers/hooks/addLayerHooks';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { toast } from 'features/toast/toast';
@@ -14,23 +9,15 @@ import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiFileBold } from 'react-icons/pi';
 
-const selectBboxRect = createSelector(selectCanvasSlice, (canvas) => canvas.bbox.rect);
-
 export const ImageMenuItemNewCanvasFromImage = memo(() => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const imageDTO = useImageDTOContext();
-  const bboxRect = useAppSelector(selectBboxRect);
   const imageViewer = useImageViewer();
+  const newCanvasFromImage = useNewCanvasFromImage();
 
-  const handleSendToCanvas = useCallback(() => {
-    const imageObject = imageDTOToImageObject(imageDTO);
-    const overrides: Partial<CanvasRasterLayerState> = {
-      position: { x: bboxRect.x, y: bboxRect.y },
-      objects: [imageObject],
-    };
-    dispatch(canvasReset());
-    dispatch(rasterLayerAdded({ overrides, isSelected: true }));
+  const onClick = useCallback(() => {
+    newCanvasFromImage(imageDTO);
     dispatch(setActiveTab('canvas'));
     imageViewer.close();
     toast({
@@ -38,10 +25,10 @@ export const ImageMenuItemNewCanvasFromImage = memo(() => {
       title: t('toast.sentToCanvas'),
       status: 'success',
     });
-  }, [bboxRect.x, bboxRect.y, dispatch, imageDTO, imageViewer, t]);
+  }, [dispatch, imageDTO, imageViewer, newCanvasFromImage, t]);
 
   return (
-    <MenuItem icon={<PiFileBold />} onClickCapture={handleSendToCanvas}>
+    <MenuItem icon={<PiFileBold />} onClickCapture={onClick}>
       {t('controlLayers.newCanvasFromImage')}
     </MenuItem>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewLayerFromImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewLayerFromImage.tsx
@@ -1,11 +1,7 @@
 import { MenuItem } from '@invoke-ai/ui-library';
-import { createSelector } from '@reduxjs/toolkit';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { useAppDispatch } from 'app/store/storeHooks';
 import { NewLayerIcon } from 'features/controlLayers/components/common/icons';
-import { rasterLayerAdded } from 'features/controlLayers/store/canvasSlice';
-import { selectCanvasSlice } from 'features/controlLayers/store/selectors';
-import type { CanvasRasterLayerState } from 'features/controlLayers/store/types';
-import { imageDTOToImageObject } from 'features/controlLayers/store/util';
+import { useNewRasterLayerFromImage } from 'features/controlLayers/hooks/addLayerHooks';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { sentImageToCanvas } from 'features/gallery/store/actions';
@@ -14,23 +10,16 @@ import { setActiveTab } from 'features/ui/store/uiSlice';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const selectBboxRect = createSelector(selectCanvasSlice, (canvas) => canvas.bbox.rect);
-
 export const ImageMenuItemNewLayerFromImage = memo(() => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const imageDTO = useImageDTOContext();
-  const bboxRect = useAppSelector(selectBboxRect);
   const imageViewer = useImageViewer();
+  const newRasterLayerFromImage = useNewRasterLayerFromImage();
 
-  const handleSendToCanvas = useCallback(() => {
-    const imageObject = imageDTOToImageObject(imageDTO);
-    const overrides: Partial<CanvasRasterLayerState> = {
-      position: { x: bboxRect.x, y: bboxRect.y },
-      objects: [imageObject],
-    };
+  const onClick = useCallback(() => {
     dispatch(sentImageToCanvas());
-    dispatch(rasterLayerAdded({ overrides, isSelected: true }));
+    newRasterLayerFromImage(imageDTO);
     dispatch(setActiveTab('canvas'));
     imageViewer.close();
     toast({
@@ -38,10 +27,10 @@ export const ImageMenuItemNewLayerFromImage = memo(() => {
       title: t('toast.sentToCanvas'),
       status: 'success',
     });
-  }, [bboxRect.x, bboxRect.y, dispatch, imageDTO, imageViewer, t]);
+  }, [dispatch, imageDTO, imageViewer, newRasterLayerFromImage, t]);
 
   return (
-    <MenuItem icon={<NewLayerIcon />} onClickCapture={handleSendToCanvas}>
+    <MenuItem icon={<NewLayerIcon />} onClickCapture={onClick}>
       {t('controlLayers.newLayerFromImage')}
     </MenuItem>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewLayerFromImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewLayerFromImage.tsx
@@ -2,6 +2,7 @@ import { MenuItem } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { NewLayerIcon } from 'features/controlLayers/components/common/icons';
 import { useNewRasterLayerFromImage } from 'features/controlLayers/hooks/addLayerHooks';
+import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { sentImageToCanvas } from 'features/gallery/store/actions';
@@ -16,6 +17,7 @@ export const ImageMenuItemNewLayerFromImage = memo(() => {
   const imageDTO = useImageDTOContext();
   const imageViewer = useImageViewer();
   const newRasterLayerFromImage = useNewRasterLayerFromImage();
+  const isBusy = useCanvasIsBusy();
 
   const onClick = useCallback(() => {
     dispatch(sentImageToCanvas());
@@ -30,7 +32,7 @@ export const ImageMenuItemNewLayerFromImage = memo(() => {
   }, [dispatch, imageDTO, imageViewer, newRasterLayerFromImage, t]);
 
   return (
-    <MenuItem icon={<NewLayerIcon />} onClickCapture={onClick}>
+    <MenuItem icon={<NewLayerIcon />} onClickCapture={onClick} isDisabled={isBusy}>
       {t('controlLayers.newLayerFromImage')}
     </MenuItem>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemsNewImg2ImgCanvasFromImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemsNewImg2ImgCanvasFromImage.tsx
@@ -1,6 +1,7 @@
 import { MenuItem } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { useNewImg2ImgCanvasFromImage } from 'features/controlLayers/hooks/addLayerHooks';
+import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
 import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
 import { toast } from 'features/toast/toast';
@@ -15,6 +16,7 @@ export const ImageMenuItemsNewImg2ImgCanvasFromImage = memo(() => {
   const imageDTO = useImageDTOContext();
   const imageViewer = useImageViewer();
   const newImg2ImgCanvasFromImage = useNewImg2ImgCanvasFromImage();
+  const isBusy = useCanvasIsBusy();
 
   const onClick = useCallback(() => {
     newImg2ImgCanvasFromImage(imageDTO);
@@ -28,7 +30,7 @@ export const ImageMenuItemsNewImg2ImgCanvasFromImage = memo(() => {
   }, [dispatch, imageDTO, imageViewer, newImg2ImgCanvasFromImage, t]);
 
   return (
-    <MenuItem icon={<PiFileImageBold />} onClickCapture={onClick}>
+    <MenuItem icon={<PiFileImageBold />} onClickCapture={onClick} isDisabled={isBusy}>
       {t('controlLayers.newImg2ImgCanvasFromImage')}
     </MenuItem>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemsNewImg2ImgCanvasFromImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemsNewImg2ImgCanvasFromImage.tsx
@@ -1,0 +1,37 @@
+import { MenuItem } from '@invoke-ai/ui-library';
+import { useAppDispatch } from 'app/store/storeHooks';
+import { useNewImg2ImgCanvasFromImage } from 'features/controlLayers/hooks/addLayerHooks';
+import { useImageViewer } from 'features/gallery/components/ImageViewer/useImageViewer';
+import { useImageDTOContext } from 'features/gallery/contexts/ImageDTOContext';
+import { toast } from 'features/toast/toast';
+import { setActiveTab } from 'features/ui/store/uiSlice';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiFileImageBold } from 'react-icons/pi';
+
+export const ImageMenuItemsNewImg2ImgCanvasFromImage = memo(() => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const imageDTO = useImageDTOContext();
+  const imageViewer = useImageViewer();
+  const newImg2ImgCanvasFromImage = useNewImg2ImgCanvasFromImage();
+
+  const onClick = useCallback(() => {
+    newImg2ImgCanvasFromImage(imageDTO);
+    dispatch(setActiveTab('canvas'));
+    imageViewer.close();
+    toast({
+      id: 'SENT_TO_CANVAS',
+      title: t('toast.sentToCanvas'),
+      status: 'success',
+    });
+  }, [dispatch, imageDTO, imageViewer, newImg2ImgCanvasFromImage, t]);
+
+  return (
+    <MenuItem icon={<PiFileImageBold />} onClickCapture={onClick}>
+      {t('controlLayers.newImg2ImgCanvasFromImage')}
+    </MenuItem>
+  );
+});
+
+ImageMenuItemsNewImg2ImgCanvasFromImage.displayName = 'ImageMenuItemsNewImg2ImgCanvasFromImage';

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/SingleSelectionMenuItems.tsx
@@ -1,5 +1,6 @@
 import { MenuDivider } from '@invoke-ai/ui-library';
 import { IconMenuItemGroup } from 'common/components/IconMenuItem';
+import { CanvasManagerProviderGate } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import { ImageMenuItemChangeBoard } from 'features/gallery/components/ImageContextMenu/ImageMenuItemChangeBoard';
 import { ImageMenuItemCopy } from 'features/gallery/components/ImageContextMenu/ImageMenuItemCopy';
 import { ImageMenuItemDelete } from 'features/gallery/components/ImageContextMenu/ImageMenuItemDelete';
@@ -12,6 +13,7 @@ import { ImageMenuItemOpenInNewTab } from 'features/gallery/components/ImageCont
 import { ImageMenuItemOpenInViewer } from 'features/gallery/components/ImageContextMenu/ImageMenuItemOpenInViewer';
 import { ImageMenuItemSelectForCompare } from 'features/gallery/components/ImageContextMenu/ImageMenuItemSelectForCompare';
 import { ImageMenuItemSendToUpscale } from 'features/gallery/components/ImageContextMenu/ImageMenuItemSendToUpscale';
+import { ImageMenuItemsNewImg2ImgCanvasFromImage } from 'features/gallery/components/ImageContextMenu/ImageMenuItemsNewImg2ImgCanvasFromImage';
 import { ImageMenuItemStarUnstar } from 'features/gallery/components/ImageContextMenu/ImageMenuItemStarUnstar';
 import { ImageDTOContextProvider } from 'features/gallery/contexts/ImageDTOContext';
 import { memo } from 'react';
@@ -37,8 +39,11 @@ const SingleSelectionMenuItems = ({ imageDTO }: SingleSelectionMenuItemsProps) =
       <ImageMenuItemMetadataRecallActions />
       <MenuDivider />
       <ImageMenuItemSendToUpscale />
-      <ImageMenuItemNewLayerFromImage />
-      <ImageMenuItemNewCanvasFromImage />
+      <CanvasManagerProviderGate>
+        <ImageMenuItemNewLayerFromImage />
+        <ImageMenuItemNewCanvasFromImage />
+        <ImageMenuItemsNewImg2ImgCanvasFromImage />
+      </CanvasManagerProviderGate>
       <MenuDivider />
       <ImageMenuItemChangeBoard />
       <ImageMenuItemStarUnstar />


### PR DESCRIPTION
## Summary

- Clean up canvas add layer hooks
- Add layer post-init callback system
- Add mutex to `CanvasEntityTransformer` to prevent concurrent operations
- Use new init callback and transform mutex to implement `New Img2Img from Image`
- Disable the "new X from image" actions when canvas is busy

## Related Issues / Discussions

Scattered discord & offline discussions

## QA Instructions

### To test the functionality

- Right click an image in gallery
- Click `New Img2Img from Image`, which should:
    - Reset the Canvas
    - Optimize the bbox size, retaining the image's aspect ratio
    - Fit the image exactly to the bbox
- You should be able to click Invoke immediately after this and it should do `img2img`.

### Discussion points

- I've left `New Canvas from Image` and `New Img2Img from Image` separate, but maybe it's better to not add a new button for img2img and instead update the behaviour of `New Canvas from Image`.

- Because the image can be of any size (e.g. not perfect multiples of 8/16), we will typically need to make a small concession with the image or bbox size. Two approaches:
    1. The image is fit to the bbox using the `fill` strategy, so its final aspect ratio may be _slightly_ different, but it will fit the bbox perfectly. This is the approach used in this PR. I think it's closer to what the user wants, and better replicates the old img2img flow.
    2. The image retains its aspect ratio _exactly_, and we do a conservative bbox fit. This would typically leave some edges of the image outside the bbox.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
