### PR TITLE
fix(ui): use non-icon version of delete menu item on canvas context menu

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerMenuItems.tsx
@@ -18,7 +18,7 @@ export const ControlLayerMenuItems = memo(() => {
       <IconMenuItemGroup>
         <CanvasEntityMenuItemsArrange />
         <CanvasEntityMenuItemsDuplicate />
-        <CanvasEntityMenuItemsDelete />
+        <CanvasEntityMenuItemsDelete asIcon />
       </IconMenuItemGroup>
       <MenuDivider />
       <CanvasEntityMenuItemsTransform />

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMenuItems.tsx
@@ -9,7 +9,7 @@ export const IPAdapterMenuItems = memo(() => {
     <IconMenuItemGroup>
       <CanvasEntityMenuItemsArrange />
       <CanvasEntityMenuItemsDuplicate />
-      <CanvasEntityMenuItemsDelete />
+      <CanvasEntityMenuItemsDelete asIcon />
     </IconMenuItemGroup>
   );
 });

--- a/invokeai/frontend/web/src/features/controlLayers/components/InpaintMask/InpaintMaskMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/InpaintMask/InpaintMaskMenuItems.tsx
@@ -13,7 +13,7 @@ export const InpaintMaskMenuItems = memo(() => {
       <IconMenuItemGroup>
         <CanvasEntityMenuItemsArrange />
         <CanvasEntityMenuItemsDuplicate />
-        <CanvasEntityMenuItemsDelete />
+        <CanvasEntityMenuItemsDelete asIcon />
       </IconMenuItemGroup>
       <MenuDivider />
       <CanvasEntityMenuItemsTransform />

--- a/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerMenuItems.tsx
@@ -17,7 +17,7 @@ export const RasterLayerMenuItems = memo(() => {
       <IconMenuItemGroup>
         <CanvasEntityMenuItemsArrange />
         <CanvasEntityMenuItemsDuplicate />
-        <CanvasEntityMenuItemsDelete />
+        <CanvasEntityMenuItemsDelete asIcon />
       </IconMenuItemGroup>
       <MenuDivider />
       <CanvasEntityMenuItemsTransform />

--- a/invokeai/frontend/web/src/features/controlLayers/components/RegionalGuidance/RegionalGuidanceMenuItems.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RegionalGuidance/RegionalGuidanceMenuItems.tsx
@@ -14,7 +14,7 @@ export const RegionalGuidanceMenuItems = memo(() => {
       <Flex gap={2}>
         <CanvasEntityMenuItemsArrange />
         <CanvasEntityMenuItemsDuplicate />
-        <CanvasEntityMenuItemsDelete />
+        <CanvasEntityMenuItemsDelete asIcon />
       </Flex>
       <MenuDivider />
       <RegionalGuidanceMenuItemsAddPromptsAndIPAdapter />

--- a/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityMenuItemsDelete.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityMenuItemsDelete.tsx
@@ -1,3 +1,4 @@
+import { MenuItem } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { IconMenuItem } from 'common/components/IconMenuItem';
 import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
@@ -7,7 +8,11 @@ import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiTrashSimpleBold } from 'react-icons/pi';
 
-export const CanvasEntityMenuItemsDelete = memo(() => {
+type Props = {
+  asIcon?: boolean;
+};
+
+export const CanvasEntityMenuItemsDelete = memo(({ asIcon = false }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const entityIdentifier = useEntityIdentifierContext();
@@ -17,15 +22,23 @@ export const CanvasEntityMenuItemsDelete = memo(() => {
     dispatch(entityDeleted({ entityIdentifier }));
   }, [dispatch, entityIdentifier]);
 
+  if (asIcon) {
+    return (
+      <IconMenuItem
+        aria-label={t('common.delete')}
+        tooltip={t('common.delete')}
+        onClick={deleteEntity}
+        icon={<PiTrashSimpleBold />}
+        isDestructive
+        isDisabled={!isInteractable}
+      />
+    );
+  }
+
   return (
-    <IconMenuItem
-      aria-label={t('common.delete')}
-      tooltip={t('common.delete')}
-      onClick={deleteEntity}
-      icon={<PiTrashSimpleBold />}
-      isDestructive
-      isDisabled={!isInteractable}
-    />
+    <MenuItem onClick={deleteEntity} icon={<PiTrashSimpleBold />} isDestructive isDisabled={!isInteractable}>
+      {t('common.delete')}
+    </MenuItem>
   );
 });
 


### PR DESCRIPTION
## Summary

fix(ui): use non-icon version of delete menu item on canvas context menu

## Related Issues / Discussions

UI issue discovered in https://discord.com/channels/1020123559063990373/1149506274971631688/1293901265322901515

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
