### PR TITLE
fix(ui): edge case where controladapters added counts could be off

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addControlAdapters.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addControlAdapters.ts
@@ -36,8 +36,6 @@ export const addControlNets = async (
   };
 
   for (const layer of validControlLayers) {
-    result.addedControlNets++;
-
     const getImageDTOResult = await withResultAsync(() => {
       const adapter = manager.adapters.controlLayers.get(layer.id);
       assert(adapter, 'Adapter not found');
@@ -50,6 +48,7 @@ export const addControlNets = async (
 
     const imageDTO = getImageDTOResult.value;
     addControlNetToGraph(g, layer, imageDTO, collector);
+    result.addedControlNets++;
   }
 
   return result;
@@ -77,8 +76,6 @@ export const addT2IAdapters = async (
   };
 
   for (const layer of validControlLayers) {
-    result.addedT2IAdapters++;
-
     const getImageDTOResult = await withResultAsync(() => {
       const adapter = manager.adapters.controlLayers.get(layer.id);
       assert(adapter, 'Adapter not found');
@@ -91,6 +88,7 @@ export const addT2IAdapters = async (
 
     const imageDTO = getImageDTOResult.value;
     addT2IAdapterToGraph(g, layer, imageDTO, collector);
+    result.addedT2IAdapters++;
   }
 
   return result;


### PR DESCRIPTION
## Summary

We were:
- Incrementing `addedControlNets` or `addedT2IAdapters`
- Attempting to add it, but maybe failing and skipping

Need to swap the order of operations to prevent misreporting of added cnet/t2i.

I don't think this would ever actually cause problems.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
