### PR TITLE
perf(ui): gallery / image perf

### DIFF
--- a/invokeai/frontend/web/src/app/components/App.tsx
+++ b/invokeai/frontend/web/src/app/components/App.tsx
@@ -20,6 +20,7 @@ import {
 import DeleteImageModal from 'features/deleteImageModal/components/DeleteImageModal';
 import { DynamicPromptsModal } from 'features/dynamicPrompts/components/DynamicPromptsPreviewModal';
 import DeleteBoardModal from 'features/gallery/components/Boards/DeleteBoardModal';
+import { ImageContextMenu } from 'features/gallery/components/ImageContextMenu/ImageContextMenu';
 import { useStarterModelsToast } from 'features/modelManagerV2/hooks/useStarterModelsToast';
 import { ShareWorkflowModal } from 'features/nodes/components/sidePanel/WorkflowListMenu/ShareWorkflowModal';
 import { ClearQueueConfirmationsAlertDialog } from 'features/queue/components/ClearQueueConfirmationAlertDialog';
@@ -120,6 +121,7 @@ const App = ({ config = DEFAULT_CONFIG, studioInitAction }: Props) => {
       <GlobalImageHotkeys />
       <NewGallerySessionDialog />
       <NewCanvasSessionDialog />
+      <ImageContextMenu />
     </ErrorBoundary>
   );
 };

--- a/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
@@ -109,8 +109,6 @@ const IAIDndImage = (props: IAIDndImageProps) => {
     useThumbailFallback,
     withHoverOverlay = false,
     children,
-    onMouseOver,
-    onMouseOut,
     dataTestId,
     ...rest
   } = props;
@@ -134,8 +132,6 @@ const IAIDndImage = (props: IAIDndImageProps) => {
   return (
     <Flex
       ref={ref}
-      onMouseOver={onMouseOver}
-      onMouseOut={onMouseOut}
       width="full"
       height="full"
       alignItems="center"

--- a/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
@@ -115,23 +115,6 @@ const IAIDndImage = (props: IAIDndImageProps) => {
     ...rest
   } = props;
 
-  const handleMouseOver = useCallback(
-    (e: MouseEvent<HTMLDivElement>) => {
-      if (onMouseOver) {
-        onMouseOver(e);
-      }
-    },
-    [onMouseOver]
-  );
-  const handleMouseOut = useCallback(
-    (e: MouseEvent<HTMLDivElement>) => {
-      if (onMouseOut) {
-        onMouseOut(e);
-      }
-    },
-    [onMouseOut]
-  );
-
   const openInNewTab = useCallback(
     (e: MouseEvent) => {
       if (!imageDTO) {
@@ -151,8 +134,8 @@ const IAIDndImage = (props: IAIDndImageProps) => {
   return (
     <Flex
       ref={ref}
-      onMouseOver={handleMouseOver}
-      onMouseOut={handleMouseOut}
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
       width="full"
       height="full"
       alignItems="center"

--- a/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
+++ b/invokeai/frontend/web/src/common/components/IAIDndImage.tsx
@@ -132,36 +132,6 @@ const IAIDndImage = (props: IAIDndImageProps) => {
     [onMouseOut]
   );
 
-  const { getUploadButtonProps, getUploadInputProps } = useImageUploadButton({
-    postUploadAction,
-    isDisabled: isUploadDisabled,
-  });
-
-  const uploadButtonStyles = useMemo<SystemStyleObject>(() => {
-    const styles: SystemStyleObject = {
-      minH: minSize,
-      w: 'full',
-      h: 'full',
-      alignItems: 'center',
-      justifyContent: 'center',
-      borderRadius: 'base',
-      transitionProperty: 'common',
-      transitionDuration: '0.1s',
-      color: 'base.500',
-    };
-    if (!isUploadDisabled) {
-      Object.assign(styles, {
-        cursor: 'pointer',
-        bg: 'base.700',
-        _hover: {
-          bg: 'base.650',
-          color: 'base.300',
-        },
-      });
-    }
-    return styles;
-  }, [isUploadDisabled, minSize]);
-
   const openInNewTab = useCallback(
     (e: MouseEvent) => {
       if (!imageDTO) {
@@ -224,12 +194,12 @@ const IAIDndImage = (props: IAIDndImageProps) => {
         </Flex>
       )}
       {!imageDTO && !isUploadDisabled && (
-        <>
-          <Flex sx={uploadButtonStyles} {...getUploadButtonProps()}>
-            <input {...getUploadInputProps()} />
-            {uploadElement}
-          </Flex>
-        </>
+        <UploadButton
+          isUploadDisabled={isUploadDisabled}
+          postUploadAction={postUploadAction}
+          uploadElement={uploadElement}
+          minSize={minSize}
+        />
       )}
       {!imageDTO && isUploadDisabled && noContentFallback}
       {imageDTO && !isDragDisabled && (
@@ -247,3 +217,56 @@ const IAIDndImage = (props: IAIDndImageProps) => {
 };
 
 export default memo(IAIDndImage);
+
+const UploadButton = memo(
+  ({
+    isUploadDisabled,
+    postUploadAction,
+    uploadElement,
+    minSize,
+  }: {
+    isUploadDisabled: boolean;
+    postUploadAction?: PostUploadAction;
+    uploadElement: ReactNode;
+    minSize: number;
+  }) => {
+    const { getUploadButtonProps, getUploadInputProps } = useImageUploadButton({
+      postUploadAction,
+      isDisabled: isUploadDisabled,
+    });
+
+    const uploadButtonStyles = useMemo<SystemStyleObject>(() => {
+      const styles: SystemStyleObject = {
+        minH: minSize,
+        w: 'full',
+        h: 'full',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 'base',
+        transitionProperty: 'common',
+        transitionDuration: '0.1s',
+        color: 'base.500',
+      };
+      if (!isUploadDisabled) {
+        Object.assign(styles, {
+          cursor: 'pointer',
+          bg: 'base.700',
+          _hover: {
+            bg: 'base.650',
+            color: 'base.300',
+          },
+        });
+      }
+      return styles;
+    }, [isUploadDisabled, minSize]);
+
+    return (
+      <Flex sx={uploadButtonStyles} {...getUploadButtonProps()}>
+        <input {...getUploadInputProps()} />
+        {uploadElement}
+      </Flex>
+    );
+  }
+);
+
+UploadButton.displayName = 'UploadButton';

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageContextMenu.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageContextMenu.tsx
@@ -34,21 +34,14 @@ export const useImageContextMenu = (imageDTO: ImageDTO | undefined, targetRef: R
   const longPressTimeoutRef = useRef(0);
   const animationTimeoutRef = useRef(0);
 
-  const activate = useCallback(
-    (x: number, y: number) => {
-      $imageContextMenuState.set({
-        isOpen: true,
-        position: { x, y },
-        imageDTO: imageDTO ?? null,
-      });
-    },
-    [imageDTO]
-  );
-
   const onContextMenu = useCallback(
     (e: MouseEvent | PointerEvent) => {
       if (e.shiftKey) {
         onClose();
+        return;
+      }
+
+      if (!imageDTO) {
         return;
       }
 
@@ -62,17 +55,25 @@ export const useImageContextMenu = (imageDTO: ImageDTO | undefined, targetRef: R
             onClose();
           }
           animationTimeoutRef.current = window.setTimeout(() => {
-            activate(e.pageX, e.pageY);
+            $imageContextMenuState.set({
+              isOpen: true,
+              position: { x: e.pageX, y: e.pageY },
+              imageDTO,
+            });
           }, 100);
         } else {
           // else we can just open the menu at the current position
-          activate(e.pageX, e.pageY);
+          $imageContextMenuState.set({
+            isOpen: true,
+            position: { x: e.pageX, y: e.pageY },
+            imageDTO,
+          });
         }
       }
 
       lastPositionRef.current = { x: e.pageX, y: e.pageY };
     },
-    [activate, targetRef]
+    [imageDTO, targetRef]
   );
 
   // Use a long press to open the context menu on touch devices

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageContextMenu.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageContextMenu.tsx
@@ -29,11 +29,10 @@ const onClose = () => {
   $imageContextMenuState.setKey('isOpen', false);
 };
 const elToImageMap = new Map<HTMLDivElement, ImageDTO>();
-const getImageDTOFromMap = (target: Node) => {
-  const parent = elToImageMap.keys().find((el) => el.contains(target));
-  return parent ? elToImageMap.get(parent) : undefined;
+const getImageDTOFromMap = (target: Node): ImageDTO | undefined => {
+  const entry = Array.from(elToImageMap.entries()).find((entry) => entry[0].contains(target));
+  return entry?.[1];
 };
-
 export const useImageContextMenu = (imageDTO: ImageDTO | undefined, targetRef: RefObject<HTMLDivElement>) => {
   useEffect(() => {
     if (!targetRef.current || !imageDTO) {

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageContextMenu.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageContextMenu.tsx
@@ -1,42 +1,216 @@
-import type { ContextMenuProps } from '@invoke-ai/ui-library';
-import { ContextMenu, MenuList } from '@invoke-ai/ui-library';
+import type { ChakraProps } from '@invoke-ai/ui-library';
+import { Menu, MenuButton, MenuList, Portal, useGlobalMenuClose } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
+import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
+import MultipleSelectionMenuItems from 'features/gallery/components/ImageContextMenu/MultipleSelectionMenuItems';
+import SingleSelectionMenuItems from 'features/gallery/components/ImageContextMenu/SingleSelectionMenuItems';
 import { selectSelectionCount } from 'features/gallery/store/gallerySelectors';
-import { memo, useCallback } from 'react';
+import { map } from 'nanostores';
+import type { RefObject } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import type { ImageDTO } from 'services/api/types';
 
-import MultipleSelectionMenuItems from './MultipleSelectionMenuItems';
-import SingleSelectionMenuItems from './SingleSelectionMenuItems';
+const LONGPRESS_DELAY_MS = 500;
+const LONGPRESS_MOVE_THRESHOLD_PX = 10;
 
-type Props = {
-  imageDTO: ImageDTO | undefined;
-  children: ContextMenuProps<HTMLDivElement>['children'];
+type ImageContextMenuState = {
+  isOpen: boolean;
+  imageDTO: ImageDTO | null;
+  position: { x: number; y: number };
 };
 
-const ImageContextMenu = ({ imageDTO, children }: Props) => {
+const $imageContextMenuState = map<ImageContextMenuState>({
+  isOpen: false,
+  imageDTO: null,
+  position: { x: -1, y: -1 },
+});
+const onClose = () => {
+  $imageContextMenuState.setKey('isOpen', false);
+};
+
+export const useImageContextMenu = (imageDTO: ImageDTO | undefined, targetRef: RefObject<HTMLDivElement>) => {
+  const lastPositionRef = useRef<{ x: number; y: number }>({ x: -1, y: -1 });
+  const longPressTimeoutRef = useRef(0);
+  const animationTimeoutRef = useRef(0);
+
+  const activate = useCallback(
+    (x: number, y: number) => {
+      $imageContextMenuState.set({
+        isOpen: true,
+        position: { x, y },
+        imageDTO: imageDTO ?? null,
+      });
+    },
+    [imageDTO]
+  );
+
+  const onContextMenu = useCallback(
+    (e: MouseEvent | PointerEvent) => {
+      if (e.shiftKey) {
+        onClose();
+        return;
+      }
+
+      if (targetRef.current?.contains(e.target as Node) || e.target === targetRef.current) {
+        // clear pending delayed open
+        window.clearTimeout(animationTimeoutRef.current);
+        e.preventDefault();
+        if (lastPositionRef.current.x !== e.pageX || lastPositionRef.current.y !== e.pageY) {
+          // if the mouse moved, we need to close, wait for animation and reopen the menu at the new position
+          if ($imageContextMenuState.get().isOpen) {
+            onClose();
+          }
+          animationTimeoutRef.current = window.setTimeout(() => {
+            activate(e.pageX, e.pageY);
+          }, 100);
+        } else {
+          // else we can just open the menu at the current position
+          activate(e.pageX, e.pageY);
+        }
+      }
+
+      lastPositionRef.current = { x: e.pageX, y: e.pageY };
+    },
+    [activate, targetRef]
+  );
+
+  // Use a long press to open the context menu on touch devices
+  const onPointerDown = useCallback(
+    (e: PointerEvent) => {
+      if (e.pointerType === 'mouse') {
+        // Bail out if it's a mouse event - this is for touch/pen only
+        return;
+      }
+
+      longPressTimeoutRef.current = window.setTimeout(() => {
+        onContextMenu(e);
+      }, LONGPRESS_DELAY_MS);
+
+      lastPositionRef.current = { x: e.pageX, y: e.pageY };
+    },
+    [onContextMenu]
+  );
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    if (e.pointerType === 'mouse') {
+      // Bail out if it's a mouse event - this is for touch/pen only
+      return;
+    }
+    if (longPressTimeoutRef.current === null) {
+      return;
+    }
+
+    const lastPosition = lastPositionRef.current;
+
+    const distanceFromLastPosition = Math.hypot(e.pageX - lastPosition.x, e.pageY - lastPosition.y);
+
+    if (distanceFromLastPosition > LONGPRESS_MOVE_THRESHOLD_PX) {
+      clearTimeout(longPressTimeoutRef.current);
+    }
+  }, []);
+
+  const onPointerUp = useCallback((e: PointerEvent) => {
+    if (e.pointerType === 'mouse') {
+      // Bail out if it's a mouse event - this is for touch/pen only
+      return;
+    }
+    if (longPressTimeoutRef.current) {
+      clearTimeout(longPressTimeoutRef.current);
+    }
+  }, []);
+
+  const onPointerCancel = useCallback((e: PointerEvent) => {
+    if (e.pointerType === 'mouse') {
+      // Bail out if it's a mouse event - this is for touch/pen only
+      return;
+    }
+    if (longPressTimeoutRef.current) {
+      clearTimeout(longPressTimeoutRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!targetRef.current) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    // Context menu events
+    window.addEventListener('contextmenu', onContextMenu, { signal: controller.signal });
+
+    // Long press events
+    targetRef.current.addEventListener('pointerdown', onPointerDown, { signal: controller.signal });
+    targetRef.current.addEventListener('pointerup', onPointerUp, { signal: controller.signal });
+    targetRef.current.addEventListener('pointercancel', onPointerCancel, { signal: controller.signal });
+    targetRef.current.addEventListener('pointermove', onPointerMove, { signal: controller.signal });
+
+    return () => {
+      controller.abort();
+    };
+  }, [onContextMenu, onPointerCancel, onPointerDown, onPointerMove, onPointerUp, targetRef]);
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(animationTimeoutRef.current);
+      window.clearTimeout(longPressTimeoutRef.current);
+    },
+    []
+  );
+};
+
+export const ImageContextMenu = memo(() => {
+  useAssertSingleton('ImageContextMenu');
+  const state = useStore($imageContextMenuState);
+  useGlobalMenuClose(onClose);
+
+  return (
+    <Portal>
+      <Menu isOpen={state.isOpen} gutter={0} placement="auto-end" onClose={onClose}>
+        <MenuButton
+          aria-hidden={true}
+          w={1}
+          h={1}
+          position="absolute"
+          left={state.position.x}
+          top={state.position.y}
+          cursor="default"
+          bg="transparent"
+          _hover={_hover}
+          pointerEvents="none"
+        />
+        <MenuContent />
+      </Menu>
+    </Portal>
+  );
+});
+
+ImageContextMenu.displayName = 'ImageContextMenu';
+
+const _hover: ChakraProps['_hover'] = { bg: 'transparent' };
+
+const MenuContent = memo(() => {
   const selectionCount = useAppSelector(selectSelectionCount);
+  const state = useStore($imageContextMenuState);
 
-  const renderMenuFunc = useCallback(() => {
-    if (!imageDTO) {
-      return null;
-    }
+  if (!state.imageDTO) {
+    return null;
+  }
 
-    if (selectionCount > 1) {
-      return (
-        <MenuList visibility="visible">
-          <MultipleSelectionMenuItems />
-        </MenuList>
-      );
-    }
-
+  if (selectionCount > 1) {
     return (
       <MenuList visibility="visible">
-        <SingleSelectionMenuItems imageDTO={imageDTO} />
+        <MultipleSelectionMenuItems />
       </MenuList>
     );
-  }, [imageDTO, selectionCount]);
+  }
 
-  return <ContextMenu renderMenu={renderMenuFunc}>{children}</ContextMenu>;
-};
+  return (
+    <MenuList visibility="visible">
+      <SingleSelectionMenuItems imageDTO={state.imageDTO} />
+    </MenuList>
+  );
+});
 
-export default memo(ImageContextMenu);
+MenuContent.displayName = 'MenuContent';

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
@@ -63,7 +63,6 @@ const GalleryImageContent = memo(({ index, imageDTO }: HoverableImageProps) => {
     () => createSelector(selectGallerySlice, (gallery) => gallery.imageToCompare?.image_name === imageDTO.image_name),
     [imageDTO.image_name]
   );
-  const alwaysShowImageSizeBadge = useAppSelector(selectAlwaysShouldImageSizeBadge);
   const isSelectedForCompare = useAppSelector(selectIsSelectedForCompare);
   const { handleClick, isSelected, areMultiplesSelected } = useMultiselect(imageDTO);
 
@@ -120,6 +119,8 @@ const GalleryImageContent = memo(({ index, imageDTO }: HoverableImageProps) => {
         justifyContent="center"
         alignItems="center"
         aspectRatio="1/1"
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
       >
         <IAIDndImage
           onClick={handleClick}
@@ -134,15 +135,8 @@ const GalleryImageContent = memo(({ index, imageDTO }: HoverableImageProps) => {
           isUploadDisabled={true}
           thumbnail={true}
           withHoverOverlay
-          onMouseOver={handleMouseOver}
-          onMouseOut={handleMouseOut}
         >
-          <>
-            {(isHovered || alwaysShowImageSizeBadge) && <SizeBadge imageDTO={imageDTO} />}
-            {(isHovered || imageDTO.starred) && <StarIcon imageDTO={imageDTO} />}
-            {isHovered && <DeleteIcon imageDTO={imageDTO} />}
-            {isHovered && <OpenInViewerIconButton imageDTO={imageDTO} />}
-          </>
+          <HoverIcons imageDTO={imageDTO} isHovered={isHovered} />
         </IAIDndImage>
       </Flex>
     </Box>
@@ -150,6 +144,20 @@ const GalleryImageContent = memo(({ index, imageDTO }: HoverableImageProps) => {
 });
 
 GalleryImageContent.displayName = 'GalleryImageContent';
+
+const HoverIcons = memo(({ imageDTO, isHovered }: { imageDTO: ImageDTO; isHovered: boolean }) => {
+  const alwaysShowImageSizeBadge = useAppSelector(selectAlwaysShouldImageSizeBadge);
+
+  return (
+    <>
+      {(isHovered || alwaysShowImageSizeBadge) && <SizeBadge imageDTO={imageDTO} />}
+      {(isHovered || imageDTO.starred) && <StarIcon imageDTO={imageDTO} />}
+      {isHovered && <DeleteIcon imageDTO={imageDTO} />}
+      {isHovered && <OpenInViewerIconButton imageDTO={imageDTO} />}
+    </>
+  );
+});
+HoverIcons.displayName = 'HoverIcons';
 
 const DeleteIcon = memo(({ imageDTO }: { imageDTO: ImageDTO }) => {
   const shift = useShiftModifier();

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryPagination.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryPagination.tsx
@@ -1,11 +1,11 @@
 import { Button, Flex, IconButton, Spacer } from '@invoke-ai/ui-library';
 import { ELLIPSIS, useGalleryPagination } from 'features/gallery/hooks/useGalleryPagination';
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import { PiCaretLeftBold, PiCaretRightBold } from 'react-icons/pi';
 
 import { JumpTo } from './JumpTo';
 
-export const GalleryPagination = () => {
+export const GalleryPagination = memo(() => {
   const { goPrev, goNext, isPrevEnabled, isNextEnabled, pageButtons, goToPage, currentPage, total } =
     useGalleryPagination();
 
@@ -47,7 +47,9 @@ export const GalleryPagination = () => {
       <JumpTo />
     </Flex>
   );
-};
+});
+
+GalleryPagination.displayName = 'GalleryPagination';
 
 type PageButtonProps = {
   page: number | typeof ELLIPSIS;
@@ -55,7 +57,7 @@ type PageButtonProps = {
   goToPage: (page: number) => void;
 };
 
-const PageButton = ({ page, currentPage, goToPage }: PageButtonProps) => {
+const PageButton = memo(({ page, currentPage, goToPage }: PageButtonProps) => {
   if (page === ELLIPSIS) {
     return (
       <Button size="sm" variant="link" isDisabled>
@@ -68,4 +70,6 @@ const PageButton = ({ page, currentPage, goToPage }: PageButtonProps) => {
       {page}
     </Button>
   );
-};
+});
+
+PageButton.displayName = 'PageButton';

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/JumpTo.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/JumpTo.tsx
@@ -11,11 +11,11 @@ import {
   useDisclosure,
 } from '@invoke-ai/ui-library';
 import { useGalleryPagination } from 'features/gallery/hooks/useGalleryPagination';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 
-export const JumpTo = () => {
+export const JumpTo = memo(() => {
   const { t } = useTranslation();
   const { goToPage, currentPage, pages } = useGalleryPagination();
   const [newPage, setNewPage] = useState(currentPage);
@@ -64,7 +64,7 @@ export const JumpTo = () => {
   }, [currentPage]);
 
   return (
-    <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
+    <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen} isLazy lazyBehavior="unmount">
       <PopoverTrigger>
         <Button aria-label={t('gallery.jump')} size="sm" onClick={onToggle} variant="outline">
           {t('gallery.jump')}
@@ -94,4 +94,6 @@ export const JumpTo = () => {
       </PopoverContent>
     </Popover>
   );
-};
+});
+
+JumpTo.displayName = 'JumpTo';


### PR DESCRIPTION
## Summary

The gallery was getting very slow.

On `main`, on FF in dev mode, after loading 2 pages of the gallery so the images are cached, switching between them took ~105ms across 7 renders.

With the changes in this PR, that's down to ~55ms across 3 renders.

This translates to the initial load of gallery pages and switching tabs in the app. Feels way better.

Specific changes:
- Refactor image context menu to be a singleton. Previously, we were creating a new context menu component for _every_ visible image. When changing pages in the gallery, we had to create new menu components, which was hugely wasteful. Now there is a single context menu and we just update the image it is for, as it is opened.
- Defer a lot of logic in `IAIDndImage` & `GalleryImage` (rendering components, calling hooks) until it's actually needed. We were spending a lot of time doing calculations or renders for things would likely never be used.
- Memoize a handful of components.

Tested on FF, Safari, Chrome and iOS Safari. Makes a really big difference on iOS.

## Related Issues / Discussions

n/a

## QA Instructions

Poke around the gallery. Should feel snappier.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
