### PR TITLE
fix: Pin onnx versions to builds that don't require rare dlls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ dependencies = [
   "invisible-watermark==0.2.0", # needed to install SDXL base and refiner using their repo_ids
   "mediapipe>=0.10.7",          # needed for "mediapipeface" controlnet model
   "numpy==1.26.4",              # >1.24.0 is needed to use the 'strict' argument to np.testing.assert_array_equal()
-  "onnx>=1.15.0",
-  "onnxruntime>=1.16.3",
+  "onnx==1.16.1",
+  "onnxruntime==1.19.2",
   "opencv-python==4.9.0.80",
   "pytorch-lightning==2.1.3",
   "safetensors==0.4.3",


### PR DESCRIPTION
## Summary

On current main, many users are experiencing the following error while trying to run the app.
```
ImportError: DLL load failed while importing onnx_cpp2py_export
```

According to this [issue on the onnx github](https://github.com/onnx/onnx/issues/6267), as well as various other issue reports, it seems like more recent versions of onnx require a dll that many users don't have on windows machines. I will call out that it does work on my personal windows machine with the latest onnx build, but I suspect it requires ddls received from the latest visual studio tools installation, which many users will not have installed.

To remedy this in the short term, this PR fixes the versions to versions of onnx that are known to work when receiving the above error.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1293975018082144287

## QA Instructions

If experiencing the above error on 5.1.1, attempt to start the app with these onnx packages installed

## Merge Plan

Can be merged when tested and approved.

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
