### PR TITLE
fix(ui): properly recall guidance value for flux images

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -664,6 +664,7 @@
         "cfgRescaleMultiplier": "$t(parameters.cfgRescaleMultiplier)",
         "createdBy": "Created By",
         "generationMode": "Generation Mode",
+        "guidance": "Guidance",
         "height": "Height",
         "imageDetails": "Image Details",
         "imageDimensions": "Image Dimensions",

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
@@ -33,6 +33,7 @@ const ImageMetadataActions = (props: Props) => {
       <MetadataItem metadata={metadata} handlers={handlers.scheduler} />
       <MetadataItem metadata={metadata} handlers={handlers.cfgScale} />
       <MetadataItem metadata={metadata} handlers={handlers.cfgRescaleMultiplier} />
+      <MetadataItem metadata={metadata} handlers={handlers.guidance} />
       {activeTabName !== 'canvas' && <MetadataItem metadata={metadata} handlers={handlers.strength} />}
       <MetadataItem metadata={metadata} handlers={handlers.hrfEnabled} />
       <MetadataItem metadata={metadata} handlers={handlers.hrfMethod} />

--- a/invokeai/frontend/web/src/features/metadata/util/handlers.ts
+++ b/invokeai/frontend/web/src/features/metadata/util/handlers.ts
@@ -168,6 +168,11 @@ export const handlers = {
     parser: parsers.cfgScale,
     recaller: recallers.cfgScale,
   }),
+  guidance: buildHandlers({
+    getLabel: () => t('metadata.guidance'),
+    parser: parsers.guidance,
+    recaller: recallers.guidance,
+  }),
   height: buildHandlers({ getLabel: () => t('metadata.height'), parser: parsers.height, recaller: recallers.height }),
   negativePrompt: buildHandlers({
     getLabel: () => t('metadata.negativePrompt'),

--- a/invokeai/frontend/web/src/features/metadata/util/parsers.ts
+++ b/invokeai/frontend/web/src/features/metadata/util/parsers.ts
@@ -27,6 +27,7 @@ import { zControlField, zIPAdapterField, zModelIdentifierField, zT2IAdapterField
 import type {
   ParameterCFGRescaleMultiplier,
   ParameterCFGScale,
+  ParameterGuidance,
   ParameterHeight,
   ParameterHRFEnabled,
   ParameterHRFMethod,
@@ -49,6 +50,7 @@ import type {
 import {
   isParameterCFGRescaleMultiplier,
   isParameterCFGScale,
+  isParameterGuidance,
   isParameterHeight,
   isParameterHRFEnabled,
   isParameterHRFMethod,
@@ -141,6 +143,9 @@ const parseCFGScale: MetadataParseFunc<ParameterCFGScale> = (metadata) =>
 
 const parseCFGRescaleMultiplier: MetadataParseFunc<ParameterCFGRescaleMultiplier> = (metadata) =>
   getProperty(metadata, 'cfg_rescale_multiplier', isParameterCFGRescaleMultiplier);
+
+const parseGuidance: MetadataParseFunc<ParameterGuidance> = (metadata) =>
+  getProperty(metadata, 'guidance', isParameterGuidance);
 
 const parseScheduler: MetadataParseFunc<ParameterScheduler> = (metadata) =>
   getProperty(metadata, 'scheduler', isParameterScheduler);
@@ -636,6 +641,7 @@ export const parsers = {
   seed: parseSeed,
   cfgScale: parseCFGScale,
   cfgRescaleMultiplier: parseCFGRescaleMultiplier,
+  guidance: parseGuidance,
   scheduler: parseScheduler,
   width: parseWidth,
   height: parseHeight,

--- a/invokeai/frontend/web/src/features/metadata/util/recallers.ts
+++ b/invokeai/frontend/web/src/features/metadata/util/recallers.ts
@@ -9,6 +9,7 @@ import {
   refinerModelChanged,
   setCfgRescaleMultiplier,
   setCfgScale,
+  setGuidance,
   setImg2imgStrength,
   setRefinerCFGScale,
   setRefinerNegativeAestheticScore,
@@ -29,6 +30,7 @@ import { modelSelected } from 'features/parameters/store/actions';
 import type {
   ParameterCFGRescaleMultiplier,
   ParameterCFGScale,
+  ParameterGuidance,
   ParameterHeight,
   ParameterHRFEnabled,
   ParameterHRFMethod,
@@ -72,6 +74,10 @@ const recallSeed: MetadataRecallFunc<ParameterSeed> = (seed) => {
 
 const recallCFGScale: MetadataRecallFunc<ParameterCFGScale> = (cfgScale) => {
   getStore().dispatch(setCfgScale(cfgScale));
+};
+
+const recallGuidance: MetadataRecallFunc<ParameterGuidance> = (guidance) => {
+  getStore().dispatch(setGuidance(guidance));
 };
 
 const recallCFGRescaleMultiplier: MetadataRecallFunc<ParameterCFGRescaleMultiplier> = (cfgRescaleMultiplier) => {
@@ -198,6 +204,7 @@ export const recallers = {
   sdxlNegativeStylePrompt: recallSDXLNegativeStylePrompt,
   seed: recallSeed,
   cfgScale: recallCFGScale,
+  guidance: recallGuidance,
   cfgRescaleMultiplier: recallCFGRescaleMultiplier,
   scheduler: recallScheduler,
   width: recallWidth,


### PR DESCRIPTION
## Summary

Properly set the "guidance" value for images created with flux models when using "Use All" from the context menu. Also display the "guidance" value in the metadata viewer.

## Related Changes

https://github.com/invoke-ai/InvokeAI/commit/ffbf4aba1f4018f92efd2e7b1247c5cf2aaac821
https://github.com/invoke-ai/InvokeAI/commit/c224971cb41affa73f94cd4479a905149201984f

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
