### PR TITLE
fix(api): update enum usage to work for python 3.11

### DIFF
--- a/invokeai/app/services/board_records/board_records_sqlite.py
+++ b/invokeai/app/services/board_records/board_records_sqlite.py
@@ -168,7 +168,9 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
             # Determine archived filter condition
             archived_filter = "" if include_archived else "WHERE archived = 0"
 
-            final_query = base_query.format(archived_filter=archived_filter, order_by=order_by, direction=direction)
+            final_query = base_query.format(
+                archived_filter=archived_filter, order_by=order_by.value, direction=direction.value
+            )
 
             # Execute query to fetch boards
             self._cursor.execute(final_query, (limit, offset))
@@ -208,7 +210,7 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
         try:
             self._lock.acquire()
 
-            if order_by == "board_name":
+            if order_by == BoardRecordOrderBy.Name:
                 base_query = """
                     SELECT *
                     FROM boards
@@ -225,7 +227,9 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
 
             archived_filter = "" if include_archived else "WHERE archived = 0"
 
-            final_query = base_query.format(archived_filter=archived_filter, order_by=order_by, direction=direction)
+            final_query = base_query.format(
+                archived_filter=archived_filter, order_by=order_by.value, direction=direction.value
+            )
 
             self._cursor.execute(final_query)
 


### PR DESCRIPTION
## Summary

Update enum usage in board service to work for python 3.11

## Related Issues / Discussions

Discord reported issue

## QA Instructions

Pull branch with a python 3.11 venv and try to load board list sorted in different ways

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
