### PR TITLE
Get flux working with MPS on torch 2.4.1, with GGUF support

### DIFF
--- a/invokeai/backend/flux/sampling_utils.py
+++ b/invokeai/backend/flux/sampling_utils.py
@@ -168,8 +168,17 @@ def generate_img_ids(h: int, w: int, batch_size: int, device: torch.device, dtyp
     Returns:
         torch.Tensor: Image position ids.
     """
+
+    if device.type == "mps":
+        orig_dtype = dtype
+        dtype = torch.float16
+
     img_ids = torch.zeros(h // 2, w // 2, 3, device=device, dtype=dtype)
     img_ids[..., 1] = img_ids[..., 1] + torch.arange(h // 2, device=device, dtype=dtype)[:, None]
     img_ids[..., 2] = img_ids[..., 2] + torch.arange(w // 2, device=device, dtype=dtype)[None, :]
     img_ids = repeat(img_ids, "h w c -> b (h w) c", b=batch_size)
+
+    if device.type == "mps":
+        img_ids.to(orig_dtype)
+
     return img_ids

--- a/invokeai/backend/quantization/gguf/ggml_tensor.py
+++ b/invokeai/backend/quantization/gguf/ggml_tensor.py
@@ -54,6 +54,11 @@ GGML_TENSOR_OP_TABLE = {
     torch.ops.aten.mul.Tensor: dequantize_and_run,  # pyright: ignore
 }
 
+if torch.backends.mps.is_available():
+    GGML_TENSOR_OP_TABLE.update(
+        {torch.ops.aten.linear.default: dequantize_and_run}  # pyright: ignore
+    )
+
 
 class GGMLTensor(torch.Tensor):
     """A torch.Tensor sub-class holding a quantized GGML tensor.


### PR DESCRIPTION
## Summary

builds on top of my last pull request, https://github.com/invoke-ai/InvokeAI/pull/7063, to get a subset of Flux working with Torch 2.4.1. so new installs can use it. With these change, fp16 Flux will work and GGUF quantised Flux will work.
bitandbytes quantised models will still not work.

## Related Issues / Discussions

https://github.com/invoke-ai/InvokeAI/issues/7060
https://discord.com/channels/1020123559063990373/1294664228757569587

## QA Instructions

It will need testing against none MacOS setups. Has been tested locally on MacOS using Flux Q8  and Q5.1 models
and is all wrapped in "if mps then"  code so it shouldn't have broke anything.

## Merge Plan

It's pretty straight forward to merge. Note I ran ruff against the directors these files are in but it made changes 
to other code and other files so I'm assuming ruff doesn't run against these. I have copied my code from the ruff formatted file to use in the repo.
