### PR TITLE
fix(mm): model names with periods may install to wrong location

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -184,7 +184,8 @@ class ModelInstallService(ModelInstallServiceBase):
         )  # type: ignore
 
         if preferred_name := config.name:
-            preferred_name = Path(preferred_name).with_suffix(model_path.suffix)
+            if model_path.suffix:
+                preferred_name = f"{preferred_name}.{model_path.suffix}"
 
         dest_path = (
             self.app_config.models_path / info.base.value / info.type.value / (preferred_name or model_path.name)


### PR DESCRIPTION
## Summary

When we provide a config object during a model install, the config can override individual fields that would otherwise be derived programmatically. We use this to install starter models w/ a given name, description, etc.

This logic used `pathlib` to append a suffix to the model's name. When we provide a model name that has a period in it, `pathlib` splits the name at the period and replaces everything after it with the suffix. This is then used to determine the output path of the model.

As a result, some starter model paths are incorrect. For example, `IP Adapter SD1.5 Image Encoder` gets installed to `sd-1/clip_vision/IP Adapter SD1`.

## Related Issues / Discussions

n/a

## QA Instructions

Delete the SD1.5 IP Adapter and its CLIP vision model. Reinstall them. Should work fine. I don't think there will be any other effects from this change but probably good to get a review from @lstein and @brandonrising .

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
