### PR TITLE
 fix(ui): fit to bbox just flashes transform handles 

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useEntityTransform.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useEntityTransform.ts
@@ -36,7 +36,7 @@ export const useEntityTransform = (entityIdentifier: CanvasEntityIdentifier | nu
     return false;
   }, [entityIdentifier, adapter, isBusy, isInteractable, isEmpty]);
 
-  const start = useCallback(() => {
+  const start = useCallback(async () => {
     if (isDisabled) {
       return;
     }
@@ -50,10 +50,10 @@ export const useEntityTransform = (entityIdentifier: CanvasEntityIdentifier | nu
     if (!adapter) {
       return;
     }
-    adapter.transformer.startTransform();
+    await adapter.transformer.startTransform();
   }, [isDisabled, entityIdentifier, canvasManager]);
 
-  const fitToBbox = useCallback(() => {
+  const fitToBbox = useCallback(async () => {
     if (isDisabled) {
       return;
     }
@@ -67,9 +67,9 @@ export const useEntityTransform = (entityIdentifier: CanvasEntityIdentifier | nu
     if (!adapter) {
       return;
     }
-    adapter.transformer.startTransform({ silent: true });
+    await adapter.transformer.startTransform({ silent: true });
     adapter.transformer.fitToBboxContain();
-    adapter.transformer.applyTransform();
+    await adapter.transformer.applyTransform();
   }, [canvasManager, entityIdentifier, isDisabled]);
 
   return { isDisabled, start, fitToBbox } as const;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -407,7 +407,9 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
    */
   fitToBboxFill = () => {
     if (!this.$isTransformEnabled.get()) {
-      this.log.warn('Cannot fit to bbox contain when transform is disabled');
+      this.log.warn(
+        'Cannot fit to bbox contain when transform is disabled. Did you forget to call `await adapter.transformer.startTransform()`?'
+      );
       return;
     }
     const { rect } = this.manager.stateApi.getBbox();
@@ -428,7 +430,9 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
    */
   fitToBboxContain = () => {
     if (!this.$isTransformEnabled.get()) {
-      this.log.warn('Cannot fit to bbox contain when transform is disabled');
+      this.log.warn(
+        'Cannot fit to bbox contain when transform is disabled. Did you forget to call `await adapter.transformer.startTransform()`?'
+      );
       return;
     }
     const { rect } = this.manager.stateApi.getBbox();
@@ -460,7 +464,9 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
    */
   fitToBboxCover = () => {
     if (!this.$isTransformEnabled.get()) {
-      this.log.warn('Cannot fit to bbox contain when transform is disabled');
+      this.log.warn(
+        'Cannot fit to bbox contain when transform is disabled. Did you forget to call `await adapter.transformer.startTransform()`?'
+      );
       return;
     }
     const { rect } = this.manager.stateApi.getBbox();
@@ -687,6 +693,12 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
    * Applies the transformation of the entity.
    */
   applyTransform = async () => {
+    if (!this.$isTransforming.get()) {
+      this.log.warn(
+        'Cannot apply transform when not transforming. Did you forget to call `await adapter.transformer.startTransform()`?'
+      );
+      return;
+    }
     this.log.debug('Applying transform');
     this.$isProcessing.set(true);
     this._setInteractionMode('off');

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -653,9 +653,20 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
 
   /**
    * Starts the transformation of the entity.
+   *
+   * This method will asynchronously acquire a mutex to prevent concurrent operations. If you need to perform an
+   * operation after the transformation is started, you should await this method.
+   *
    * @param arg Options for starting the transformation
    * @param arg.silent Whether the transformation should be silent. If silent, the transform controls will not be shown,
-   * so you _must_ immediately call `applyTransform` or `stopTransform` to complete the transformation.
+   * so you _must_ call `applyTransform` or `stopTransform` to complete the transformation.
+   *
+   * @example
+   * ```ts
+   * await adapter.transformer.startTransform({ silent: true });
+   * adapter.transformer.fitToBboxContain();
+   * await adapter.transformer.applyTransform();
+   * ```
    */
   startTransform = async (arg?: { silent: boolean }) => {
     const transformingAdapter = this.manager.stateApi.$transformingAdapter.get();


### PR DESCRIPTION
## Summary

Need to `await` the startTransform call so it can acquire the lock on concurrent transformation operations.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1020123559831539744/1295877271823060994

## QA Instructions

Right-click layer -> fit to bbox should work.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
