### PR TITLE
fix(ui): upload tooltip should only show plural if multiple upload is enabled

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/GalleryUploadButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryUploadButton.tsx
@@ -1,5 +1,7 @@
 import { IconButton } from '@invoke-ai/ui-library';
+import { useAppSelector } from 'app/store/storeHooks';
 import { useImageUploadButton } from 'common/hooks/useImageUploadButton';
+import { selectMaxImageUploadCount } from 'features/system/store/configSlice';
 import { t } from 'i18next';
 import { PiUploadBold } from 'react-icons/pi';
 
@@ -7,14 +9,23 @@ const options = { postUploadAction: { type: 'TOAST' }, allowMultiple: true } as 
 
 export const GalleryUploadButton = () => {
   const uploadApi = useImageUploadButton(options);
+  const maxImageUploadCount = useAppSelector(selectMaxImageUploadCount);
   return (
     <>
       <IconButton
         size="sm"
         alignSelf="stretch"
         variant="link"
-        aria-label={t('accessibility.uploadImages')}
-        tooltip={t('accessibility.uploadImages')}
+        aria-label={
+          maxImageUploadCount === undefined || maxImageUploadCount > 1
+            ? t('accessibility.uploadImages')
+            : t('accessibility.uploadImage')
+        }
+        tooltip={
+          maxImageUploadCount === undefined || maxImageUploadCount > 1
+            ? t('accessibility.uploadImages')
+            : t('accessibility.uploadImage')
+        }
         icon={<PiUploadBold />}
         {...uploadApi.getUploadButtonProps()}
       />


### PR DESCRIPTION
## Summary

fix(ui): upload tooltip should only show plural if multiple upload is enabled

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
