### PR TITLE
Fix AMD GPUs not being detected

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$TARGETPLATFORM" = "linux/arm64" ] || [ "$GPU_DRIVER" = "cpu" ]; then \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cpu"; \
     elif [ "$GPU_DRIVER" = "rocm" ]; then \
-        extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/rocm5.6"; \
+        extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/rocm6.1"; \
     else \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu124"; \
     fi &&\

--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -410,7 +410,7 @@ def get_torch_source() -> Tuple[str | None, str | None]:
     optional_modules: str | None = None
     if OS == "Linux":
         if device == GpuType.ROCM:
-            url = "https://download.pytorch.org/whl/rocm5.6"
+            url = "https://download.pytorch.org/whl/rocm6.1"
         elif device == GpuType.CPU:
             url = "https://download.pytorch.org/whl/cpu"
         elif device == GpuType.CUDA:


### PR DESCRIPTION
## Summary

Each version of torch is only available for specific versions of CUDA and ROCm. The Invoke installer tries to install torch 2.4.1 with ROCm 5.6 support, which does not exist. As a result, the installation falls back to the default CUDA version so AMD GPUs aren't detected. This commits fixes that by bumping the ROCm version to 6.1, as suggested by the PyTorch documentation.[^1] Torch 2.4.1 does not appear to be available for ROCm 6.2.

The specified CUDA version of 12.4 is still correct according to [^1] so it does need to be changed.

[^1]: https://pytorch.org/get-started/previous-versions/#v241

## Related Issues / Discussions

Closes #7006
Closes #7146

## QA Instructions

- Install Invoke 5.1.1 or later with ROCm support using the installer on a system with an AMD GPU.
- Start the server.
- Generate any image.

Without this fix, the  CPU is used to generate images. This can be seen in the log output. Image generation also takes forever.

I did not test the changes to the Dockerfile since I am not familiar with Docker.

## Merge Plan

n/a

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
