### PR TITLE
Small improvements for the installer text output

### DIFF
--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -12,7 +12,7 @@ MINIMUM_PYTHON_VERSION=3.10.0
 MAXIMUM_PYTHON_VERSION=3.11.100
 PYTHON=""
 for candidate in python3.11 python3.10 python3 python ; do
-    if ppath=`which $candidate`; then
+    if ppath=`which $candidate 2>/dev/null`; then
         # when using `pyenv`, the executable for an inactive Python version will exist but will not be operational
         # we check that this found executable can actually run
         if [ $($candidate --version &>/dev/null; echo ${PIPESTATUS}) -gt 0 ]; then continue; fi

--- a/installer/install.sh.in
+++ b/installer/install.sh.in
@@ -30,10 +30,11 @@ done
 if [ -z "$PYTHON" ]; then
     echo "A suitable Python interpreter could not be found"
     echo "Please install Python $MINIMUM_PYTHON_VERSION or higher (maximum $MAXIMUM_PYTHON_VERSION) before running this script. See instructions at $INSTRUCTIONS for help."
-    echo "For the best user experience we suggest enlarging or maximizing this window now."
     read -p "Press any key to exit"
     exit -1
 fi
+
+echo "For the best user experience we suggest enlarging or maximizing this window now."
 
 exec $PYTHON ./lib/main.py ${@}
 read -p "Press any key to exit"


### PR DESCRIPTION
## Summary

The installer needs to figure out if a compatible version of Python is installed and what its binary is called. On Linux, to do this, `which` is used to test possible candidates. However, `which` prints a message to stderr for every candidate that does not exist. To fix this, the error stream is simply routed to `/dev/null/`.

While working on this I also noticed that the installer is supposed to print a suggestion to maximize the window "for best user experience". However, the `echo` statement was put into an incorrect branch, so it only prints when no suitable Python version is found, just before exiting the installer. The fix is of course to move the statement out of the branch. Although telling the user to maximize the window so they can watch the script exit it full HD (maybe even 4k!) is pretty funny. Maybe it should be kept.

Since these are both small fixes to the installer's text output, I lumped them together into this merge request.

## Related Issues / Discussions

n/a

## QA Instructions

For the original bug, install Invoke on a Linux system that doesn't have an executable called `python3.11` on the system path.

For the unintended hint, run the installer on a Linux system with 3.10 <= python version <= 3.11.100.

## Merge Plan

n/a

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
