### PR TITLE
FLUX CFG support

### DIFF
--- a/invokeai/app/invocations/flux_denoise.py
+++ b/invokeai/app/invocations/flux_denoise.py
@@ -49,7 +49,7 @@ from invokeai.backend.util.devices import TorchDevice
     title="FLUX Denoise",
     tags=["image", "flux"],
     category="image",
-    version="3.1.0",
+    version="3.2.0",
     classification=Classification.Prototype,
 )
 class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
@@ -82,6 +82,12 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
     positive_text_conditioning: FluxConditioningField = InputField(
         description=FieldDescriptions.positive_cond, input=Input.Connection
     )
+    negative_text_conditioning: FluxConditioningField = InputField(
+        description=FieldDescriptions.negative_cond, input=Input.Connection
+    )
+    # TODO(ryand): Add support for cfg_scale to be a list of floats: one for each step.
+    # TODO(ryand): Add cfg_scale range validation.
+    cfg_scale: float = InputField(default=3.0, description=FieldDescriptions.cfg_scale, title="CFG Scale")
     width: int = InputField(default=1024, multiple_of=16, description="Width of the generated image.")
     height: int = InputField(default=1024, multiple_of=16, description="Height of the generated image.")
     num_steps: int = InputField(
@@ -109,6 +115,19 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         name = context.tensors.save(tensor=latents)
         return LatentsOutput.build(latents_name=name, latents=latents, seed=None)
 
+    def _load_text_conditioning(
+        self, context: InvocationContext, conditioning_name: str, dtype: torch.dtype
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Load the conditioning data.
+        cond_data = context.conditioning.load(conditioning_name)
+        assert len(cond_data.conditionings) == 1
+        flux_conditioning = cond_data.conditionings[0]
+        assert isinstance(flux_conditioning, FLUXConditioningInfo)
+        flux_conditioning = flux_conditioning.to(dtype=dtype)
+        t5_embeddings = flux_conditioning.t5_embeds
+        clip_embeddings = flux_conditioning.clip_embeds
+        return t5_embeddings, clip_embeddings
+
     def _run_diffusion(
         self,
         context: InvocationContext,
@@ -116,13 +135,12 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         inference_dtype = torch.bfloat16
 
         # Load the conditioning data.
-        cond_data = context.conditioning.load(self.positive_text_conditioning.conditioning_name)
-        assert len(cond_data.conditionings) == 1
-        flux_conditioning = cond_data.conditionings[0]
-        assert isinstance(flux_conditioning, FLUXConditioningInfo)
-        flux_conditioning = flux_conditioning.to(dtype=inference_dtype)
-        t5_embeddings = flux_conditioning.t5_embeds
-        clip_embeddings = flux_conditioning.clip_embeds
+        pos_t5_embeddings, pos_clip_embeddings = self._load_text_conditioning(
+            context, self.positive_text_conditioning.conditioning_name, inference_dtype
+        )
+        neg_t5_embeddings, neg_clip_embeddings = self._load_text_conditioning(
+            context, self.negative_text_conditioning.conditioning_name, inference_dtype
+        )
 
         # Load the input latents, if provided.
         init_latents = context.tensors.load(self.latents.latents_name) if self.latents else None
@@ -183,8 +201,14 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         b, _c, latent_h, latent_w = x.shape
         img_ids = generate_img_ids(h=latent_h, w=latent_w, batch_size=b, device=x.device, dtype=x.dtype)
 
-        bs, t5_seq_len, _ = t5_embeddings.shape
-        txt_ids = torch.zeros(bs, t5_seq_len, 3, dtype=inference_dtype, device=TorchDevice.choose_torch_device())
+        pos_bs, pos_t5_seq_len, _ = pos_t5_embeddings.shape
+        pos_txt_ids = torch.zeros(
+            pos_bs, pos_t5_seq_len, 3, dtype=inference_dtype, device=TorchDevice.choose_torch_device()
+        )
+        neg_bs, neg_t5_seq_len, _ = neg_t5_embeddings.shape
+        neg_txt_ids = torch.zeros(
+            neg_bs, neg_t5_seq_len, 3, dtype=inference_dtype, device=TorchDevice.choose_torch_device()
+        )
 
         # Pack all latent tensors.
         init_latents = pack(init_latents) if init_latents is not None else None
@@ -257,12 +281,16 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
                 model=transformer,
                 img=x,
                 img_ids=img_ids,
-                txt=t5_embeddings,
-                txt_ids=txt_ids,
-                vec=clip_embeddings,
+                txt=pos_t5_embeddings,
+                txt_ids=pos_txt_ids,
+                vec=pos_clip_embeddings,
+                neg_txt=neg_t5_embeddings,
+                neg_txt_ids=neg_txt_ids,
+                neg_vec=neg_clip_embeddings,
                 timesteps=timesteps,
                 step_callback=self._build_step_callback(context),
                 guidance=self.guidance,
+                cfg_scale=self.cfg_scale,
                 inpaint_extension=inpaint_extension,
                 controlnet_extensions=controlnet_extensions,
             )

--- a/invokeai/app/invocations/flux_denoise.py
+++ b/invokeai/app/invocations/flux_denoise.py
@@ -85,9 +85,8 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
     negative_text_conditioning: FluxConditioningField = InputField(
         description=FieldDescriptions.negative_cond, input=Input.Connection
     )
-    # TODO(ryand): Add support for cfg_scale to be a list of floats: one for each step.
     # TODO(ryand): Add cfg_scale range validation.
-    cfg_scale: float = InputField(default=3.0, description=FieldDescriptions.cfg_scale, title="CFG Scale")
+    cfg_scale: float | list[float] = InputField(default=1.0, description=FieldDescriptions.cfg_scale, title="CFG Scale")
     width: int = InputField(default=1024, multiple_of=16, description="Width of the generated image.")
     height: int = InputField(default=1024, multiple_of=16, description="Height of the generated image.")
     num_steps: int = InputField(

--- a/invokeai/app/invocations/flux_denoise.py
+++ b/invokeai/app/invocations/flux_denoise.py
@@ -82,8 +82,10 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
     positive_text_conditioning: FluxConditioningField = InputField(
         description=FieldDescriptions.positive_cond, input=Input.Connection
     )
-    negative_text_conditioning: FluxConditioningField = InputField(
-        description=FieldDescriptions.negative_cond, input=Input.Connection
+    negative_text_conditioning: FluxConditioningField | None = InputField(
+        default=None,
+        description="Negative conditioning tensor. Can be None if cfg_scale is 1.0.",
+        input=Input.Connection,
     )
     # TODO(ryand): Add cfg_scale range validation.
     cfg_scale: float | list[float] = InputField(default=1.0, description=FieldDescriptions.cfg_scale, title="CFG Scale")
@@ -137,9 +139,12 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         pos_t5_embeddings, pos_clip_embeddings = self._load_text_conditioning(
             context, self.positive_text_conditioning.conditioning_name, inference_dtype
         )
-        neg_t5_embeddings, neg_clip_embeddings = self._load_text_conditioning(
-            context, self.negative_text_conditioning.conditioning_name, inference_dtype
-        )
+        neg_t5_embeddings: torch.Tensor | None = None
+        neg_clip_embeddings: torch.Tensor | None = None
+        if self.negative_text_conditioning is not None:
+            neg_t5_embeddings, neg_clip_embeddings = self._load_text_conditioning(
+                context, self.negative_text_conditioning.conditioning_name, inference_dtype
+            )
 
         # Load the input latents, if provided.
         init_latents = context.tensors.load(self.latents.latents_name) if self.latents else None
@@ -204,10 +209,12 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         pos_txt_ids = torch.zeros(
             pos_bs, pos_t5_seq_len, 3, dtype=inference_dtype, device=TorchDevice.choose_torch_device()
         )
-        neg_bs, neg_t5_seq_len, _ = neg_t5_embeddings.shape
-        neg_txt_ids = torch.zeros(
-            neg_bs, neg_t5_seq_len, 3, dtype=inference_dtype, device=TorchDevice.choose_torch_device()
-        )
+        neg_txt_ids: torch.Tensor | None = None
+        if neg_t5_embeddings is not None:
+            neg_bs, neg_t5_seq_len, _ = neg_t5_embeddings.shape
+            neg_txt_ids = torch.zeros(
+                neg_bs, neg_t5_seq_len, 3, dtype=inference_dtype, device=TorchDevice.choose_torch_device()
+            )
 
         # Pack all latent tensors.
         init_latents = pack(init_latents) if init_latents is not None else None

--- a/invokeai/backend/flux/denoise.py
+++ b/invokeai/backend/flux/denoise.py
@@ -1,3 +1,4 @@
+import math
 from typing import Callable
 
 import torch
@@ -28,7 +29,7 @@ def denoise(
     timesteps: list[float],
     step_callback: Callable[[PipelineIntermediateState], None],
     guidance: float,
-    cfg_scale: float,
+    cfg_scale: float | list[float],
     inpaint_extension: InpaintExtension | None,
     controlnet_extensions: list[XLabsControlNetExtension | InstantXControlNetExtension],
 ):
@@ -43,10 +44,9 @@ def denoise(
             latents=img,
         ),
     )
-    step = 1
     # guidance_vec is ignored for schnell.
     guidance_vec = torch.full((img.shape[0],), guidance, device=img.device, dtype=img.dtype)
-    for t_curr, t_prev in tqdm(list(zip(timesteps[:-1], timesteps[1:], strict=True))):
+    for step_index, (t_curr, t_prev) in tqdm(list(enumerate(zip(timesteps[:-1], timesteps[1:], strict=True)))):
         t_vec = torch.full((img.shape[0],), t_curr, dtype=img.dtype, device=img.device)
 
         # Run ControlNet models.
@@ -54,7 +54,7 @@ def denoise(
         for controlnet_extension in controlnet_extensions:
             controlnet_residuals.append(
                 controlnet_extension.run_controlnet(
-                    timestep_index=step - 1,
+                    timestep_index=step_index,
                     total_num_timesteps=total_steps,
                     img=img,
                     img_ids=img_ids,
@@ -84,21 +84,24 @@ def denoise(
             controlnet_single_block_residuals=merged_controlnet_residuals.single_block_residuals,
         )
 
-        # TODO(ryand): Add option to apply controlnet to negative conditioning as well.
-        # TODO(ryand): Add option to run positive and negative predictions in a single batch for better performance on
-        # systems with sufficient VRAM.
-        neg_pred = model(
-            img=img,
-            img_ids=img_ids,
-            txt=neg_txt,
-            txt_ids=neg_txt_ids,
-            y=neg_vec,
-            timesteps=t_vec,
-            guidance=guidance_vec,
-            controlnet_double_block_residuals=None,
-            controlnet_single_block_residuals=None,
-        )
-        pred = neg_pred + cfg_scale * (pred - neg_pred)
+        step_cfg_scale = cfg_scale[step_index] if isinstance(cfg_scale, list) else cfg_scale
+
+        # If step_cfg_scale, is 1.0, then we don't need to run the negative prediction.
+        if not math.isclose(step_cfg_scale, 1.0):
+            # TODO(ryand): Add option to run positive and negative predictions in a single batch for better performance on
+            # systems with sufficient VRAM.
+            neg_pred = model(
+                img=img,
+                img_ids=img_ids,
+                txt=neg_txt,
+                txt_ids=neg_txt_ids,
+                y=neg_vec,
+                timesteps=t_vec,
+                guidance=guidance_vec,
+                controlnet_double_block_residuals=None,
+                controlnet_single_block_residuals=None,
+            )
+            pred = neg_pred + step_cfg_scale * (pred - neg_pred)
 
         preview_img = img - t_curr * pred
         img = img + (t_prev - t_curr) * pred
@@ -109,13 +112,12 @@ def denoise(
 
         step_callback(
             PipelineIntermediateState(
-                step=step,
+                step=step_index + 1,
                 order=1,
                 total_steps=total_steps,
                 timestep=int(t_curr),
                 latents=preview_img,
             ),
         )
-        step += 1
 
     return img

--- a/invokeai/backend/flux/denoise.py
+++ b/invokeai/backend/flux/denoise.py
@@ -16,13 +16,19 @@ def denoise(
     # model input
     img: torch.Tensor,
     img_ids: torch.Tensor,
+    # positive text conditioning
     txt: torch.Tensor,
     txt_ids: torch.Tensor,
     vec: torch.Tensor,
+    # negative text conditioning
+    neg_txt: torch.Tensor,
+    neg_txt_ids: torch.Tensor,
+    neg_vec: torch.Tensor,
     # sampling parameters
     timesteps: list[float],
     step_callback: Callable[[PipelineIntermediateState], None],
     guidance: float,
+    cfg_scale: float,
     inpaint_extension: InpaintExtension | None,
     controlnet_extensions: list[XLabsControlNetExtension | InstantXControlNetExtension],
 ):
@@ -77,6 +83,22 @@ def denoise(
             controlnet_double_block_residuals=merged_controlnet_residuals.double_block_residuals,
             controlnet_single_block_residuals=merged_controlnet_residuals.single_block_residuals,
         )
+
+        # TODO(ryand): Add option to apply controlnet to negative conditioning as well.
+        # TODO(ryand): Add option to run positive and negative predictions in a single batch for better performance on
+        # systems with sufficient VRAM.
+        neg_pred = model(
+            img=img,
+            img_ids=img_ids,
+            txt=neg_txt,
+            txt_ids=neg_txt_ids,
+            y=neg_vec,
+            timesteps=t_vec,
+            guidance=guidance_vec,
+            controlnet_double_block_residuals=None,
+            controlnet_single_block_residuals=None,
+        )
+        pred = neg_pred + cfg_scale * (pred - neg_pred)
 
         preview_img = img - t_curr * pred
         img = img + (t_prev - t_curr) * pred

--- a/invokeai/backend/flux/denoise.py
+++ b/invokeai/backend/flux/denoise.py
@@ -22,9 +22,9 @@ def denoise(
     txt_ids: torch.Tensor,
     vec: torch.Tensor,
     # negative text conditioning
-    neg_txt: torch.Tensor,
-    neg_txt_ids: torch.Tensor,
-    neg_vec: torch.Tensor,
+    neg_txt: torch.Tensor | None,
+    neg_txt_ids: torch.Tensor | None,
+    neg_vec: torch.Tensor | None,
     # sampling parameters
     timesteps: list[float],
     step_callback: Callable[[PipelineIntermediateState], None],
@@ -90,6 +90,10 @@ def denoise(
         if not math.isclose(step_cfg_scale, 1.0):
             # TODO(ryand): Add option to run positive and negative predictions in a single batch for better performance on
             # systems with sufficient VRAM.
+
+            if neg_txt is None or neg_txt_ids is None or neg_vec is None:
+                raise ValueError("Negative text conditioning is required when cfg_scale is not 1.0.")
+
             neg_pred = model(
                 img=img,
                 img_ids=img_ids,

--- a/invokeai/backend/flux/denoise.py
+++ b/invokeai/backend/flux/denoise.py
@@ -29,7 +29,7 @@ def denoise(
     timesteps: list[float],
     step_callback: Callable[[PipelineIntermediateState], None],
     guidance: float,
-    cfg_scale: float | list[float],
+    cfg_scale: list[float],
     inpaint_extension: InpaintExtension | None,
     controlnet_extensions: list[XLabsControlNetExtension | InstantXControlNetExtension],
 ):
@@ -84,7 +84,7 @@ def denoise(
             controlnet_single_block_residuals=merged_controlnet_residuals.single_block_residuals,
         )
 
-        step_cfg_scale = cfg_scale[step_index] if isinstance(cfg_scale, list) else cfg_scale
+        step_cfg_scale = cfg_scale[step_index]
 
         # If step_cfg_scale, is 1.0, then we don't need to run the negative prediction.
         if not math.isclose(step_cfg_scale, 1.0):

--- a/tests/app/invocations/test_flux_denoise.py
+++ b/tests/app/invocations/test_flux_denoise.py
@@ -1,0 +1,62 @@
+import pytest
+
+from invokeai.app.invocations.flux_denoise import FluxDenoiseInvocation
+
+TIMESTEPS = [1.0, 0.75, 0.5, 0.25, 0.0]
+
+
+@pytest.mark.parametrize(
+    ["cfg_scale", "timesteps", "cfg_scale_start_step", "cfg_scale_end_step", "expected"],
+    [
+        # Test scalar cfg_scale.
+        (2.0, TIMESTEPS, 0, -1, [2.0, 2.0, 2.0, 2.0]),
+        # Test list cfg_scale.
+        ([1.0, 2.0, 3.0, 4.0], TIMESTEPS, 0, -1, [1.0, 2.0, 3.0, 4.0]),
+        # Test positive cfg_scale_start_step.
+        (2.0, TIMESTEPS, 1, -1, [1.0, 2.0, 2.0, 2.0]),
+        # Test positive cfg_scale_end_step.
+        (2.0, TIMESTEPS, 0, 2, [2.0, 2.0, 2.0, 1.0]),
+        # Test negative cfg_scale_start_step.
+        (2.0, TIMESTEPS, -3, -1, [1.0, 2.0, 2.0, 2.0]),
+        # Test negative cfg_scale_end_step.
+        (2.0, TIMESTEPS, 0, -2, [2.0, 2.0, 2.0, 1.0]),
+        # Test single step application.
+        (2.0, TIMESTEPS, 2, 2, [1.0, 1.0, 2.0, 1.0]),
+    ],
+)
+def test_prep_cfg_scale(
+    cfg_scale: float | list[float],
+    timesteps: list[float],
+    cfg_scale_start_step: int,
+    cfg_scale_end_step: int,
+    expected: list[float],
+):
+    result = FluxDenoiseInvocation.prep_cfg_scale(cfg_scale, timesteps, cfg_scale_start_step, cfg_scale_end_step)
+    assert result == expected
+
+
+def test_prep_cfg_scale_invalid_type():
+    with pytest.raises(ValueError, match="Unsupported cfg_scale type"):
+        FluxDenoiseInvocation.prep_cfg_scale("invalid", [1.0, 0.5], 0, -1)  # type: ignore
+
+
+@pytest.mark.parametrize("cfg_scale_start_step", [4, -5])
+def test_prep_cfg_scale_invalid_start_step(cfg_scale_start_step: int):
+    with pytest.raises(ValueError, match="Invalid cfg_scale_start_step"):
+        FluxDenoiseInvocation.prep_cfg_scale(2.0, TIMESTEPS, cfg_scale_start_step, -1)
+
+
+@pytest.mark.parametrize("cfg_scale_end_step", [4, -5])
+def test_prep_cfg_scale_invalid_end_step(cfg_scale_end_step: int):
+    with pytest.raises(ValueError, match="Invalid cfg_scale_end_step"):
+        FluxDenoiseInvocation.prep_cfg_scale(2.0, TIMESTEPS, 0, cfg_scale_end_step)
+
+
+def test_prep_cfg_scale_start_after_end():
+    with pytest.raises(ValueError, match="cfg_scale_start_step .* must be before cfg_scale_end_step"):
+        FluxDenoiseInvocation.prep_cfg_scale(2.0, TIMESTEPS, 3, 2)
+
+
+def test_prep_cfg_scale_list_length_mismatch():
+    with pytest.raises(AssertionError):
+        FluxDenoiseInvocation.prep_cfg_scale([1.0, 2.0, 3.0], TIMESTEPS, 0, -1)


### PR DESCRIPTION
## Summary

Add support for Classifier-Free Guidance with FLUX.

- Using CFG doubles the time for the denoising process. Running both the positive and negative conditioning in a single batch is left for future work, because most users are already VRAM-constrained (this would probably be faster at the cost of higher peak VRAM).
- Negative text conditioning is optional and only required if `cfg_scale != 1.0`
- CFG is skipped if `cfg_scale == 1.0` (i.e. no compute overhead in this case)
- `cfg_scale_start_step` and `cfg_scale_end_step` can be used to easily control the range of steps that CFG is applied for.
- CFG is a prerequisite for IP-Adapter support.

## Example

Positive Caption: `Professional photography of a luxury hotel in the Nevada desert`
CFG: 1.0
![image](https://github.com/user-attachments/assets/f25ff832-d69b-4c5f-88f4-9429ce96d598)

Positive Caption: `Professional photography of a luxury hotel in the Nevada desert`
Negative Caption: `Swimming pool`
CFG: 2.0
Same seed
![image](https://github.com/user-attachments/assets/27e3b952-2795-469f-bb24-b7fddb726ba1)


## QA Instructions

- [ ] Test interactions with ControlNet
- [ ] Verify that peak RAM/VRAM utilization has not increased significantly
- [ ] Test that CFG is skipped when cfg_scale == 1.0
- [ ] Test that negative text conditioning can be omitted when cfg_scale == 1.0
- [ ] Test that a clear error message is returned when negative text conditioning is omitted when cfg_scale != 1.0
- [ ] Test that the negative text prompt gets applied when cfg_scale >1.0
- [ ] Test that a collection of cfg_scale values can be provided for per-step control.
- [ ] Test that `cfg_scale_start_step` and `cfg_scale_end_step` control the range of steps that CFG is applied

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
