### PR TITLE
fix(nodes): `FluxDenoiseInvocation.controlnet_vae` missing `default=None`

### DIFF
--- a/invokeai/app/invocations/flux_denoise.py
+++ b/invokeai/app/invocations/flux_denoise.py
@@ -96,6 +96,7 @@ class FluxDenoiseInvocation(BaseInvocation, WithMetadata, WithBoard):
         default=None, input=Input.Connection, description="ControlNet models."
     )
     controlnet_vae: VAEField | None = InputField(
+        default=None,
         description=FieldDescriptions.vae,
         input=Input.Connection,
     )


### PR DESCRIPTION
## Summary

Fixes an issue where the workflow editor erroneously requires a connection for the field

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149510134058471514/1297983406440972464

## QA Instructions

You should be able to omit the connection.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
