### PR TITLE
Remove xformers before installation

### DIFF
--- a/installer/lib/installer.py
+++ b/installer/lib/installer.py
@@ -245,6 +245,9 @@ class InvokeAiInstance:
 
         pip = local[self.pip]
 
+        # Uninstall xformers if it is present; the correct version of it will be reinstalled if needed
+        _ = pip["uninstall", "-yqq", "xformers"] & FG
+
         pipeline = pip[
             "install",
             "--require-virtualenv",


### PR DESCRIPTION
## Summary

Try to remove `xformers` before installing or upgrading Invoke. This fixes the issue for users of newer GPUs where a lingering `xformers` installation would break `torch` compatibility.

If `xformers` is still needed (older GPU / option 2 selected for install), it will simply be reinstalled.

## Related Issues / Discussions

Closes #7142

## QA Instructions

1. Make a fresh install selecting *InvokeAI v5.0.0* and Option 2 in the installer (`CUDA+xFormers`)
2. After the installation completes, activate the virtual environment and confirm that `xformers` is installed: `pip freeze | grep xformers` should return `xformers==0.0.25.post1`
3. Upgrade the same install to the latest release using Option 1 in the installer (no xFormers)
4. Check the virtual environment once again and confirm that `xformers` is no longer present (there should be no output from `pip freeze | grep xformers`
5. Run the application to confirm that it launches and works.

## Merge Plan
Merge at will

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_

