### PR TITLE
feat(ui): canvas auto mask followups 1

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -527,6 +527,9 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     if (segmentResult.isErr()) {
       this.log.error({ error: serializeError(segmentResult.error) }, 'Error segmenting');
       this.$isProcessing.set(false);
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort();
+      }
       this.abortController = null;
       return;
     }
@@ -549,6 +552,9 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
 
     this.$isProcessing.set(false);
     this.$hasProcessed.set(true);
+    if (!this.abortController.signal.aborted) {
+      this.abortController.abort();
+    }
     this.abortController = null;
   };
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -779,6 +779,10 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
 
   destroy = () => {
     this.log.debug('Destroying module');
+    if (this.abortController && !this.abortController.signal.aborted) {
+      this.abortController.abort();
+    }
+    this.abortController = null;
     this.unsubscribe();
     this.konva.group.destroy();
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -316,7 +316,11 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
       e.cancelBubble = true;
       circle.destroy();
       this.$points.set(this.$points.get().filter((point) => point.id !== id));
-      this.$hasProcessed.set(false);
+      if (this.$points.get().length === 0) {
+        this.resetEphemeralState();
+      } else {
+        this.$hasProcessed.set(false);
+      }
     });
 
     circle.on('dragstart', () => {


### PR DESCRIPTION
## Summary

- Fix an issue where deleting the last point didn't reset the mask
- Only subscribe listeners when actually segmenting (filter module gets same treatment)
- Clean up abort controllers more thoroughly (filter module gets same treatment)
- Update comments throughout SAM module

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Documentation added / updated (if applicable)_
