### PR TITLE
 fix(ui): normalize infill alpha to 0-255 when building infill nodes

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/graphBuilderUtils.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/graphBuilderUtils.ts
@@ -106,10 +106,12 @@ export const getInfill = (
   }
 
   if (infillMethod === 'color') {
+    const { a, ...rgb } = infillColorValue;
+    const color = { ...rgb, a: Math.round(a * 255) };
     return g.addNode({
       id: 'infill_rgba',
       type: 'infill_rgba',
-      color: infillColorValue,
+      color,
     });
   }
 


### PR DESCRIPTION
## Summary

The browser/UI uses float 0-1 for alpha, while backend uses 0-255. We need to normalize the value when building the infill nodes for outpaint.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1298593181348265984

## QA Instructions

Change the infill alpha in Canvas compositing settings when outpainting. The transparency for the infill should work as expected.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
