### PR TITLE
tweak(ui): prevent show/hide boards button cutoff

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/GalleryHeader.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Link, Spacer, Text } from '@invoke-ai/ui-library';
+import { Link } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { $projectName, $projectUrl } from 'app/store/nanostores/projectId';
 import { memo } from 'react';
@@ -9,15 +9,13 @@ export const GalleryHeader = memo(() => {
 
   if (projectName && projectUrl) {
     return (
-      <Flex gap={2} alignItems="center" justifyContent="space-evenly" pe={2} w="50%">
-        <Text fontSize="md" fontWeight="semibold" noOfLines={1} wordBreak="break-all" w="full" textAlign="center">
-          <Link href={projectUrl}>{projectName}</Link>
-        </Text>
-      </Flex>
+      <Link fontSize="md" fontWeight="semibold" noOfLines={1} wordBreak="break-all" href={projectUrl}>
+        {projectName}
+      </Link>
     );
   }
 
-  return <Spacer />;
+  return null;
 });
 
 GalleryHeader.displayName = 'GalleryHeader';

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -51,8 +51,8 @@ const GalleryPanelContent = () => {
 
   return (
     <Flex ref={galleryPanelFocusRef} position="relative" flexDirection="column" h="full" w="full" tabIndex={-1}>
-      <Flex alignItems="center" w="full">
-        <Flex w="25%">
+      <Flex alignItems="center" justifyContent="space-between" w="full">
+        <Flex flexGrow={1} flexBasis={0}>
           <Button
             size="sm"
             variant="ghost"
@@ -62,8 +62,10 @@ const GalleryPanelContent = () => {
             {boardsListPanel.isCollapsed ? t('boards.viewBoards') : t('boards.hideBoards')}
           </Button>
         </Flex>
-        <GalleryHeader />
-        <Flex h="full" w="25%" justifyContent="flex-end">
+        <Flex>
+          <GalleryHeader />
+        </Flex>
+        <Flex flexGrow={1} flexBasis={0} justifyContent="flex-end">
           <BoardsSettingsPopover />
           <IconButton
             size="sm"


### PR DESCRIPTION
## Summary

The use of hard 25% widths caused issues for some translations. Adjusted styling to not rely on any hard numbers. Tested with a project name and URL.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1054129386447716433/1298960174400409681

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
