### PR TITLE
Pin python-multipart to v0.0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
   "pypatchmatch",
   'pyperclip',
   "pyreadline3",
-  "python-multipart",
+  "python-multipart==0.0.12",
   "requests~=2.28.2",
   "rich~=13.3",
   "scikit-image~=0.21.0",


### PR DESCRIPTION
## Summary

Just-released version of `python-multipart` v0.0.14 breaks the FastAPI router.

See https://github.com/Kludex/python-multipart/issues/173

## QA Instructions

- `pip install` from `main` without this commit
- try to run `invokeai-web`, observe failure to launch
- `pip install` from this commit, or `pip install python-multipart==0.0.12`
- run the app, observe success

## Merge Plan

Merge ASAP

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
