### PR TITLE
feat(ui): canvas auto-mask followups 4

### DIFF
--- a/invokeai/app/services/shared/invocation_context.py
+++ b/invokeai/app/services/shared/invocation_context.py
@@ -221,7 +221,7 @@ class ImagesInterface(InvocationContextInterface):
         )
 
     def get_pil(self, image_name: str, mode: IMAGE_MODES | None = None) -> Image:
-        """Gets an image as a PIL Image object.
+        """Gets an image as a PIL Image object. This method returns a copy of the image.
 
         Args:
             image_name: The name of the image to get.
@@ -233,11 +233,15 @@ class ImagesInterface(InvocationContextInterface):
         image = self._services.images.get_pil_image(image_name)
         if mode and mode != image.mode:
             try:
+                # convert makes a copy!
                 image = image.convert(mode)
             except ValueError:
                 self._services.logger.warning(
                     f"Could not convert image from {image.mode} to {mode}. Using original mode instead."
                 )
+        else:
+            # copy the image to prevent the user from modifying the original
+            image = image.copy()
         return image
 
     def get_metadata(self, image_name: str) -> Optional[MetadataField]:

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasDropArea.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasDropArea.tsx
@@ -41,7 +41,7 @@ export const CanvasDropArea = memo(() => {
   return (
     <>
       <Grid
-        gridTemplateRows="1fr 1fr 1fr"
+        gridTemplateRows="1fr 1fr"
         gridTemplateColumns="1fr 1fr"
         position="absolute"
         top={0}

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -293,6 +293,9 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
       if (this.$isDraggingPoint.get()) {
         return;
       }
+      if (e.evt.button !== 0) {
+        return;
+      }
       // This event should not bubble up to the parent, stage or any other nodes
       e.cancelBubble = true;
       circle.destroy();


### PR DESCRIPTION
## Summary

- Canvas drop area layout fix
- Do not delete SAM point on right click (which opens the menu)
- Fixed image cache issue that could cause all sorts of problems (not the invocation cache! that still has a perfect track record)

## Related Issues / Discussions

- Drop area: https://discord.com/channels/1020123559063990373/1149506274971631688/1299123024125235210
- Right click: https://discord.com/channels/1020123559063990373/1149506274971631688/1299129130041999371
- Cache issue: https://discord.com/channels/1020123559063990373/1149506274971631688/1298593181348265984

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
