### PR TITLE
Fix SDXL t2i adapters expect BGR instead of RGB

### DIFF
--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -522,7 +522,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
 
         for t2i_adapter_field in t2i_adapters:
             image = context.images.get_pil(t2i_adapter_field.image.image_name)
-            if bgr_mode:#SDXL t2i trained on cv2's BGR outputs, but PIL won't convert straight to BGR
+            if bgr_mode:  # SDXL t2i trained on cv2's BGR outputs, but PIL won't convert straight to BGR
                 r, g, b = image.split()
                 image = Image.merge("RGB", (b, g, r))
             ext_manager.add_extension(
@@ -623,7 +623,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
             t2i_adapter_model_config = context.models.get_config(t2i_adapter_field.t2i_adapter_model.key)
             t2i_adapter_loaded_model = context.models.load(t2i_adapter_field.t2i_adapter_model)
             image = context.images.get_pil(t2i_adapter_field.image.image_name)
-                
+
             # The max_unet_downscale is the maximum amount that the UNet model downscales the latent image internally.
             if t2i_adapter_model_config.base == BaseModelType.StableDiffusion1:
                 max_unet_downscale = 8

--- a/invokeai/backend/stable_diffusion/extensions/preview.py
+++ b/invokeai/backend/stable_diffusion/extensions/preview.py
@@ -33,7 +33,7 @@ class PreviewExt(ExtensionBase):
     def initial_preview(self, ctx: DenoiseContext):
         self.callback(
             PipelineIntermediateState(
-                step=-1,
+                step=0,
                 order=ctx.scheduler.order,
                 total_steps=len(ctx.inputs.timesteps),
                 timestep=int(ctx.scheduler.config.num_train_timesteps),  # TODO: is there any code which uses it?


### PR DESCRIPTION
## Summary

Added conversions that trigger on SDXL to change the color order for t2i image inputs, which is required for OpenPose to work correctly. TencentARC t2i adapters were trained on cv2 preprocessor outputs in BGR format. As far as I can tell, those are the only publicly available SDXL-T2I available at this time, and OpenPose is the only one that is not greyscale. Changing the image order has no effect on canny/depth/etc.

Fix is applied for both main backend and the as-of-yet-unused modular backend. Also I snuck in a fix for the progress bar so the modular backend doesn't crash before denoising begins.

## Related Issues / Discussions

https://www.reddit.com/r/StableDiffusion/comments/1f854k3/psa_fixing_sdxl_t2iadapter_openpose/

## QA Instructions

Before:
![image](https://github.com/user-attachments/assets/b4e0c733-94d5-4fdd-9984-2b52f6225854)

After:  
![image](https://github.com/user-attachments/assets/3de9c251-7fec-491d-96e6-8f30e9d9aa85)


## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
