### PR TITLE
fix(ui): canvas filter and SAM module fixes

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
@@ -36,7 +36,7 @@ const FilterContent = memo(
     const config = useStore(adapter.filterer.$filterConfig);
     const isCanvasFocused = useIsRegionFocused('canvas');
     const isProcessing = useStore(adapter.filterer.$isProcessing);
-    const hasProcessed = useStore(adapter.filterer.$hasProcessed);
+    const hasImageState = useStore(adapter.filterer.$hasImageState);
     const autoProcess = useAppSelector(selectAutoProcess);
 
     const onChangeFilterConfig = useCallback(
@@ -118,7 +118,7 @@ const FilterContent = memo(
             variant="ghost"
             onClick={adapter.filterer.processImmediate}
             loadingText={t('controlLayers.filter.process')}
-            isDisabled={isProcessing || !isValid || autoProcess}
+            isDisabled={isProcessing || !isValid || (autoProcess && hasImageState)}
           >
             {t('controlLayers.filter.process')}
             {isProcessing && <Spinner ms={3} boxSize={5} color="base.600" />}
@@ -136,7 +136,7 @@ const FilterContent = memo(
             onClick={adapter.filterer.apply}
             loadingText={t('controlLayers.filter.apply')}
             variant="ghost"
-            isDisabled={isProcessing || !isValid || !hasProcessed}
+            isDisabled={isProcessing || !isValid || !hasImageState}
           >
             {t('controlLayers.filter.apply')}
           </Button>
@@ -145,22 +145,22 @@ const FilterContent = memo(
               as={Button}
               loadingText={t('controlLayers.selectObject.saveAs')}
               variant="ghost"
-              isDisabled={isProcessing || !isValid || !hasProcessed}
+              isDisabled={isProcessing || !isValid || !hasImageState}
               rightIcon={<PiCaretDownBold />}
             >
               {t('controlLayers.selectObject.saveAs')}
             </MenuButton>
             <MenuList>
-              <MenuItem isDisabled={!isValid || !hasProcessed} onClick={saveAsInpaintMask}>
+              <MenuItem isDisabled={isProcessing || !isValid || !hasImageState} onClick={saveAsInpaintMask}>
                 {t('controlLayers.newInpaintMask')}
               </MenuItem>
-              <MenuItem isDisabled={!isValid || !hasProcessed} onClick={saveAsRegionalGuidance}>
+              <MenuItem isDisabled={isProcessing || !isValid || !hasImageState} onClick={saveAsRegionalGuidance}>
                 {t('controlLayers.newRegionalGuidance')}
               </MenuItem>
-              <MenuItem isDisabled={!isValid || !hasProcessed} onClick={saveAsControlLayer}>
+              <MenuItem isDisabled={isProcessing || !isValid || !hasImageState} onClick={saveAsControlLayer}>
                 {t('controlLayers.newControlLayer')}
               </MenuItem>
-              <MenuItem isDisabled={!isValid || !hasProcessed} onClick={saveAsRasterLayer}>
+              <MenuItem isDisabled={isProcessing || !isValid || !hasImageState} onClick={saveAsRasterLayer}>
                 {t('controlLayers.newRasterLayer')}
               </MenuItem>
             </MenuList>

--- a/invokeai/frontend/web/src/features/controlLayers/components/SelectObject/SelectObject.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/SelectObject/SelectObject.tsx
@@ -115,7 +115,7 @@ const SelectObjectContent = memo(
             onClick={adapter.segmentAnything.processImmediate}
             loadingText={t('controlLayers.selectObject.process')}
             variant="ghost"
-            isDisabled={isProcessing || !hasPoints || autoProcess}
+            isDisabled={isProcessing || !hasPoints || (autoProcess && hasImageState)}
           >
             {t('controlLayers.selectObject.process')}
             {isProcessing && <Spinner ms={3} boxSize={5} color="base.600" />}

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -228,8 +228,11 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       this.log.warn('No image state to apply filter to');
       return;
     }
-    this.log.trace('Applying filter');
-    this.parent.bufferRenderer.commitBuffer();
+    this.log.trace(`Saving as ${type}`);
+
+    // Clear the buffer - we are creating a new entity, so we don't want to keep the old one
+    this.parent.bufferRenderer.clearBuffer();
+
     const rect = this.parent.transformer.getRelativeRect();
     const arg = {
       overrides: {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -323,6 +323,12 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     }
     this.log.trace('Applying');
 
+    // Have the parent adopt the image module - this prevents a flash of the original layer content before the filtered
+    // image is rendered
+    if (this.imageModule) {
+      this.parent.renderer.adoptObjectRenderer(this.imageModule);
+    }
+
     // Rasterize the entity, replacing the objects with the masked image
     const rect = this.parent.transformer.getRelativeRect();
     this.manager.stateApi.rasterizeEntity({
@@ -392,7 +398,10 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       this.abortController.abort();
     }
     this.abortController = null;
-    if (this.imageModule) {
+
+    // If the image module exists, and is a child of the group, destroy it. It might not be a child of the group if
+    // the user has applied the filter and the image has been adopted by the parent entity.
+    if (this.imageModule && this.imageModule.konva.group.parent === this.konva.group) {
       this.imageModule.destroy();
       this.imageModule = null;
     }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -416,6 +416,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     this.$initialFilterConfig.set(null);
     this.konva.group.remove();
     this.unsubscribe();
+    this.$isFiltering.set(false);
     this.manager.stateApi.$filteringAdapter.set(null);
   };
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -1,29 +1,36 @@
+import { deepClone } from 'common/util/deepClone';
 import { withResult, withResultAsync } from 'common/util/result';
 import type { CanvasEntityAdapterControlLayer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterControlLayer';
 import type { CanvasEntityAdapterRasterLayer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRasterLayer';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
 import { CanvasModuleBase } from 'features/controlLayers/konva/CanvasModuleBase';
-import { getPrefixedId } from 'features/controlLayers/konva/util';
+import { CanvasObjectImage } from 'features/controlLayers/konva/CanvasObject/CanvasObjectImage';
+import { addCoords, getKonvaNodeDebugAttrs, getPrefixedId } from 'features/controlLayers/konva/util';
 import { selectAutoProcess } from 'features/controlLayers/store/canvasSettingsSlice';
 import type { FilterConfig } from 'features/controlLayers/store/filters';
 import { getFilterForModel, IMAGE_FILTERS } from 'features/controlLayers/store/filters';
 import type { CanvasEntityType, CanvasImageState } from 'features/controlLayers/store/types';
 import { imageDTOToImageObject } from 'features/controlLayers/store/util';
+import Konva from 'konva';
 import { debounce } from 'lodash-es';
-import { atom } from 'nanostores';
+import { atom, computed } from 'nanostores';
 import type { Logger } from 'roarr';
 import { serializeError } from 'serialize-error';
 import { buildSelectModelConfig } from 'services/api/hooks/modelsByType';
 import { isControlNetOrT2IAdapterModelConfig } from 'services/api/types';
+import stableHash from 'stable-hash';
 import type { Equals } from 'tsafe';
 import { assert } from 'tsafe';
 
 type CanvasEntityFiltererConfig = {
-  processDebounceMs: number;
+  /**
+   * The debounce time in milliseconds for processing the filter.
+   */
+  PROCESS_DEBOUNCE_MS: number;
 };
 
 const DEFAULT_CONFIG: CanvasEntityFiltererConfig = {
-  processDebounceMs: 1000,
+  PROCESS_DEBOUNCE_MS: 1000,
 };
 
 export class CanvasEntityFilterer extends CanvasModuleBase {
@@ -34,19 +41,64 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
   readonly manager: CanvasManager;
   readonly log: Logger;
 
-  imageState: CanvasImageState | null = null;
-  subscriptions = new Set<() => void>();
   config: CanvasEntityFiltererConfig = DEFAULT_CONFIG;
+
+  subscriptions = new Set<() => void>();
 
   /**
    * The AbortController used to cancel the filter processing.
    */
   abortController: AbortController | null = null;
 
+  /**
+   * Whether the module is currently filtering an image.
+   */
   $isFiltering = atom<boolean>(false);
-  $hasProcessed = atom<boolean>(false);
+  /**
+   * The hash of the last processed config. This is used to prevent re-processing the same config.
+   */
+  $lastProcessedHash = atom<string>('');
+
+  /**
+   * Whether the module is currently processing the filter.
+   */
   $isProcessing = atom<boolean>(false);
+
+  /**
+   * The config for the filter.
+   */
   $filterConfig = atom<FilterConfig>(IMAGE_FILTERS.canny_edge_detection.buildDefaults());
+
+  /**
+   * The initial filter config, used to reset the filter config.
+   */
+  $initialFilterConfig = atom<FilterConfig | null>(null);
+
+  /**
+   * The ephemeral image state of the filtered image.
+   */
+  $imageState = atom<CanvasImageState | null>(null);
+
+  /**
+   * Whether the module has an image state. This is a computed value based on $imageState.
+   */
+  $hasImageState = computed(this.$imageState, (imageState) => imageState !== null);
+  /**
+   * The filtered image object module, if it exists.
+   */
+  imageModule: CanvasObjectImage | null = null;
+
+  /**
+   * The Konva nodes for the module.
+   */
+  konva: {
+    /**
+     * The main Konva group node for the module. This is added to the parent layer on start, and removed on teardown.
+     */
+    group: Konva.Group;
+  };
+
+  KONVA_GROUP_NAME = `${this.type}:group`;
 
   constructor(parent: CanvasEntityAdapterRasterLayer | CanvasEntityAdapterControlLayer) {
     super();
@@ -57,9 +109,17 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     this.log = this.manager.buildLogger(this);
 
     this.log.debug('Creating filter module');
+
+    this.konva = {
+      group: new Konva.Group({ name: this.KONVA_GROUP_NAME }),
+    };
   }
 
+  /**
+   * Adds event listeners needed while filtering the entity.
+   */
   subscribe = () => {
+    // As the filter config changes, process the filter
     this.subscriptions.add(
       this.$filterConfig.listen(() => {
         if (this.manager.stateApi.getSettings().autoProcess && this.$isFiltering.get()) {
@@ -67,6 +127,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
         }
       })
     );
+    // When auto-process is enabled, process the filter
     this.subscriptions.add(
       this.manager.stateApi.createStoreSubscription(selectAutoProcess, (autoProcess) => {
         if (autoProcess && this.$isFiltering.get()) {
@@ -76,11 +137,18 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     );
   };
 
+  /**
+   * Removes event listeners used while filtering the entity.
+   */
   unsubscribe = () => {
     this.subscriptions.forEach((unsubscribe) => unsubscribe());
     this.subscriptions.clear();
   };
 
+  /**
+   * Starts the filter module.
+   * @param config The filter config to start with. If omitted, the default filter config is used.
+   */
   start = (config?: FilterConfig) => {
     const filteringAdapter = this.manager.stateApi.$filteringAdapter.get();
     if (filteringAdapter) {
@@ -90,30 +158,57 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
 
     this.log.trace('Initializing filter');
 
-    this.subscribe();
+    // Reset any previous state
+    this.resetEphemeralState();
+    this.$isFiltering.set(true);
+
+    // Update the konva group's position to match the parent entity
+    const pixelRect = this.parent.transformer.$pixelRect.get();
+    const position = addCoords(this.parent.state.position, pixelRect);
+    this.konva.group.setAttrs(position);
+
+    // Add the group to the parent layer
+    this.parent.konva.layer.add(this.konva.group);
 
     if (config) {
+      // If a config is provided, use it
       this.$filterConfig.set(config);
-    } else if (this.parent.type === 'control_layer_adapter' && this.parent.state.controlAdapter.model) {
+      this.$initialFilterConfig.set(config);
+    } else {
+      this.$filterConfig.set(this.createInitialFilterConfig());
+    }
+
+    this.$initialFilterConfig.set(this.$filterConfig.get());
+
+    this.subscribe();
+
+    this.manager.stateApi.$filteringAdapter.set(this.parent);
+
+    if (this.manager.stateApi.getSettings().autoProcess) {
+      this.processImmediate();
+    }
+  };
+
+  createInitialFilterConfig = (): FilterConfig => {
+    if (this.parent.type === 'control_layer_adapter' && this.parent.state.controlAdapter.model) {
       // If the parent is a control layer adapter, we should check if the model has a default filter and set it if so
       const selectModelConfig = buildSelectModelConfig(
         this.parent.state.controlAdapter.model.key,
         isControlNetOrT2IAdapterModelConfig
       );
       const modelConfig = this.manager.stateApi.runSelector(selectModelConfig);
+      // This always returns a filter
       const filter = getFilterForModel(modelConfig);
-      this.$filterConfig.set(filter.buildDefaults());
+      return filter.buildDefaults();
     } else {
-      // Otherwise, set the default filter
-      this.$filterConfig.set(IMAGE_FILTERS.canny_edge_detection.buildDefaults());
-    }
-    this.$isFiltering.set(true);
-    this.manager.stateApi.$filteringAdapter.set(this.parent);
-    if (this.manager.stateApi.getSettings().autoProcess) {
-      this.processImmediate();
+      // Otherwise, used the default filter
+      return IMAGE_FILTERS.canny_edge_detection.buildDefaults();
     }
   };
 
+  /**
+   * Processes the filter, updating the module's state and rendering the filtered image.
+   */
   processImmediate = async () => {
     const config = this.$filterConfig.get();
     const filterData = IMAGE_FILTERS[config.type];
@@ -122,6 +217,12 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     const isValid = filterData.validateConfig?.(config as never) ?? true;
     if (!isValid) {
       this.log.error({ config }, 'Invalid filter config');
+      return;
+    }
+
+    const hash = stableHash({ config });
+    if (hash === this.$lastProcessedHash.get()) {
+      this.log.trace('Already processed config');
       return;
     }
 
@@ -158,80 +259,98 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       this.manager.stateApi.runGraphAndReturnImageOutput({
         graph,
         outputNodeId,
-        // The filter graph should always be prepended to the queue so it's processed ASAP.
         prepend: true,
-        /**
-         * The filter node may need to download a large model. Currently, the models required by the filter nodes are
-         * downloaded just-in-time, as required by the filter. If we use a timeout here, we might get into a catch-22
-         * where the filter node is waiting for the model to download, but the download gets canceled if the filter
-         * node times out.
-         *
-         * (I suspect the model download will actually _not_ be canceled if the graph is canceled, but let's not chance it!)
-         *
-         * TODO(psyche): Figure out a better way to handle this. Probably need to download the models ahead of time.
-         */
-        // timeout: 5000,
-        /**
-         * The filter node should be able to cancel the request if it's taking too long. This will cancel the graph's
-         * queue item and clear any event listeners on the request.
-         */
         signal: controller.signal,
       })
     );
+
+    // If there is an error, log it and bail out of this processing run
     if (filterResult.isErr()) {
-      this.log.error({ error: serializeError(filterResult.error) }, 'Error processing filter');
+      this.log.error({ error: serializeError(filterResult.error) }, 'Error filtering');
       this.$isProcessing.set(false);
+      // Clean up the abort controller as needed
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort();
+      }
       this.abortController = null;
       return;
     }
 
-    this.log.trace({ imageDTO: filterResult.value }, 'Filter processed');
-    this.imageState = imageDTOToImageObject(filterResult.value);
+    this.log.trace({ imageDTO: filterResult.value }, 'Filtered');
 
-    await this.parent.bufferRenderer.setBuffer(this.imageState, true);
+    // Prepare the ephemeral image state
+    const imageState = imageDTOToImageObject(filterResult.value);
+    this.$imageState.set(imageState);
+
+    // Destroy any existing masked image and create a new one
+    if (this.imageModule) {
+      this.imageModule.destroy();
+    }
+
+    this.imageModule = new CanvasObjectImage(imageState, this);
+
+    // Force update the masked image - after awaiting, the image will be rendered (in memory)
+    await this.imageModule.update(imageState, true);
+
+    this.konva.group.add(this.imageModule.konva.group);
+
+    // The porcessing is complete, set can set the last processed hash and isProcessing to false
+    this.$lastProcessedHash.set(hash);
 
     this.$isProcessing.set(false);
-    this.$hasProcessed.set(true);
+
+    // Clean up the abort controller as needed
+    if (!this.abortController.signal.aborted) {
+      this.abortController.abort();
+    }
+
     this.abortController = null;
   };
 
-  process = debounce(this.processImmediate, this.config.processDebounceMs);
+  /**
+   * Debounced version of processImmediate.
+   */
+  process = debounce(this.processImmediate, this.config.PROCESS_DEBOUNCE_MS);
 
+  /**
+   * Applies the filter image to the entity, replacing the entity's objects with the filtered image.
+   */
   apply = () => {
-    const imageState = this.imageState;
-    if (!imageState) {
+    const filteredImageObjectState = this.$imageState.get();
+    if (!filteredImageObjectState) {
       this.log.warn('No image state to apply filter to');
       return;
     }
-    this.log.trace('Applying filter');
-    this.parent.bufferRenderer.commitBuffer();
+    this.log.trace('Applying');
+
+    // Rasterize the entity, replacing the objects with the masked image
     const rect = this.parent.transformer.getRelativeRect();
     this.manager.stateApi.rasterizeEntity({
       entityIdentifier: this.parent.entityIdentifier,
-      imageObject: imageState,
+      imageObject: filteredImageObjectState,
       position: {
         x: Math.round(rect.x),
         y: Math.round(rect.y),
       },
       replaceObjects: true,
     });
-    this.imageState = null;
-    this.unsubscribe();
-    this.$isFiltering.set(false);
-    this.$hasProcessed.set(false);
-    this.manager.stateApi.$filteringAdapter.set(null);
+
+    // Final cleanup and teardown, returning user to main canvas UI
+    this.resetEphemeralState();
+    this.teardown();
   };
 
+  /**
+   * Saves the filtered image as a new entity of the given type.
+   * @param type The type of entity to save the filtered image as.
+   */
   saveAs = (type: Exclude<CanvasEntityType, 'reference_image'>) => {
-    const imageState = this.imageState;
+    const imageState = this.$imageState.get();
     if (!imageState) {
       this.log.warn('No image state to apply filter to');
       return;
     }
     this.log.trace(`Saving as ${type}`);
-
-    // Clear the buffer - we are creating a new entity, so we don't want to keep the old one
-    this.parent.bufferRenderer.clearBuffer();
 
     const rect = this.parent.transformer.getRelativeRect();
     const arg = {
@@ -262,34 +381,49 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
         assert<Equals<typeof type, never>>(false);
     }
 
-    this.imageState = null;
+    // Final cleanup and teardown, returning user to main canvas UI
+    this.resetEphemeralState();
+    this.teardown();
+  };
+
+  resetEphemeralState = () => {
+    // First we need to bail out of any processing
+    if (this.abortController && !this.abortController.signal.aborted) {
+      this.abortController.abort();
+    }
+    this.abortController = null;
+    if (this.imageModule) {
+      this.imageModule.destroy();
+      this.imageModule = null;
+    }
+    const initialFilterConfig = this.$initialFilterConfig.get() ?? this.createInitialFilterConfig();
+    this.$filterConfig.set(initialFilterConfig);
+    this.$imageState.set(null);
+    this.$lastProcessedHash.set('');
+    this.$isProcessing.set(false);
+  };
+
+  teardown = () => {
+    this.$initialFilterConfig.set(null);
+    this.konva.group.remove();
     this.unsubscribe();
-    this.$isFiltering.set(false);
-    this.$hasProcessed.set(false);
     this.manager.stateApi.$filteringAdapter.set(null);
   };
 
+  /**
+   * Resets the module (e.g. remove all points and the mask image).
+   *
+   * Does not cancel or otherwise complete the segmenting process.
+   */
   reset = () => {
-    this.log.trace('Resetting filter');
-
-    this.abortController?.abort();
-    this.abortController = null;
-    this.parent.bufferRenderer.clearBuffer();
-    this.parent.transformer.updatePosition();
-    this.parent.renderer.syncKonvaCache(true);
-    this.imageState = null;
-    this.$hasProcessed.set(false);
+    this.log.trace('Resetting');
+    this.resetEphemeralState();
   };
 
   cancel = () => {
-    this.log.trace('Cancelling filter');
-
-    this.reset();
-    this.unsubscribe();
-    this.$isProcessing.set(false);
-    this.$isFiltering.set(false);
-    this.$hasProcessed.set(false);
-    this.manager.stateApi.$filteringAdapter.set(null);
+    this.log.trace('Canceling');
+    this.resetEphemeralState();
+    this.teardown();
   };
 
   repr = () => {
@@ -297,11 +431,14 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       id: this.id,
       type: this.type,
       path: this.path,
+      parent: this.parent.id,
       config: this.config,
+      imageState: deepClone(this.$imageState.get()),
       $isFiltering: this.$isFiltering.get(),
-      $hasProcessed: this.$hasProcessed.get(),
+      $lastProcessedHash: this.$lastProcessedHash.get(),
       $isProcessing: this.$isProcessing.get(),
       $filterConfig: this.$filterConfig.get(),
+      konva: { group: getKonvaNodeDebugAttrs(this.konva.group) },
     };
   };
 
@@ -312,5 +449,6 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
     }
     this.abortController = null;
     this.unsubscribe();
+    this.konva.group.destroy();
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
@@ -1,6 +1,7 @@
 import { Mutex } from 'async-mutex';
 import { deepClone } from 'common/util/deepClone';
 import type { CanvasEntityBufferObjectRenderer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityBufferObjectRenderer';
+import type { CanvasEntityFilterer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer';
 import type { CanvasEntityObjectRenderer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
 import { CanvasModuleBase } from 'features/controlLayers/konva/CanvasModuleBase';
@@ -21,7 +22,8 @@ export class CanvasObjectImage extends CanvasModuleBase {
     | CanvasEntityObjectRenderer
     | CanvasEntityBufferObjectRenderer
     | CanvasStagingAreaModule
-    | CanvasSegmentAnythingModule;
+    | CanvasSegmentAnythingModule
+    | CanvasEntityFilterer;
   readonly manager: CanvasManager;
   readonly log: Logger;
 
@@ -43,6 +45,7 @@ export class CanvasObjectImage extends CanvasModuleBase {
       | CanvasEntityBufferObjectRenderer
       | CanvasStagingAreaModule
       | CanvasSegmentAnythingModule
+      | CanvasEntityFilterer
   ) {
     super();
     this.id = state.id;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -705,6 +705,12 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     }
     this.log.trace(`Saving as ${type}`);
 
+    // Have the parent adopt the image module - this prevents a flash of the original layer content before the
+    // segmented image is rendered
+    if (this.imageModule) {
+      this.parent.renderer.adoptObjectRenderer(this.imageModule);
+    }
+
     // Create the new entity with the masked image as its only object
     const rect = this.parent.transformer.getRelativeRect();
     const arg = {
@@ -796,7 +802,10 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     for (const point of this.$points.get()) {
       point.konva.circle.destroy();
     }
-    if (this.imageModule) {
+
+    // If the image module exists, and is a child of the group, destroy it. It might not be a child of the group if
+    // the user has applied the segmented image and the image has been adopted by the parent entity.
+    if (this.imageModule && this.imageModule.konva.group.parent === this.konva.group) {
       this.imageModule.destroy();
       this.imageModule = null;
     }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -114,7 +114,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
   subscriptions = new Set<() => void>();
 
   /**
-   * The AbortController used to cancel the filter processing.
+   * The AbortController used to cancel the segment processing.
    */
   abortController: AbortController | null = null;
 
@@ -178,16 +178,16 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
   $invert = atom<boolean>(false);
 
   /**
-   * The masked image object, if it exists.
+   * The masked image object module, if it exists.
    */
-  maskedImage: CanvasObjectImage | null = null;
+  imageModule: CanvasObjectImage | null = null;
 
   /**
    * The Konva nodes for the module.
    */
   konva: {
     /**
-     * The main Konva group node for the module.
+     * The main Konva group node for the module. This is added to the parent layer on start, and removed on teardown.
      */
     group: Konva.Group;
     /**
@@ -488,7 +488,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
   };
 
   /**
-   * Adds event listeners needed while segmenting the entity.
+   * Removes event listeners used while segmenting the entity.
    */
   unsubscribe = () => {
     this.subscriptions.forEach((unsubscribe) => unsubscribe());
@@ -607,18 +607,18 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     this.$imageState.set(imageState);
 
     // Destroy any existing masked image and create a new one
-    if (this.maskedImage) {
-      this.maskedImage.destroy();
+    if (this.imageModule) {
+      this.imageModule.destroy();
     }
     if (this.konva.maskTween) {
       this.konva.maskTween.destroy();
       this.konva.maskTween = null;
     }
 
-    this.maskedImage = new CanvasObjectImage(imageState, this);
+    this.imageModule = new CanvasObjectImage(imageState, this);
 
     // Force update the masked image - after awaiting, the image will be rendered (in memory)
-    await this.maskedImage.update(imageState, true);
+    await this.imageModule.update(imageState, true);
 
     // Update the compositing rect to match the image size
     this.konva.compositingRect.setAttrs({
@@ -629,7 +629,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
 
     // Now we can add the masked image to the mask group. It will be rendered above the compositing rect, but should be
     // under it, so we will move the compositing rect to the top
-    this.konva.maskGroup.add(this.maskedImage.konva.group);
+    this.konva.maskGroup.add(this.imageModule.konva.group);
     this.konva.compositingRect.moveToTop();
 
     // Cache the group to ensure the mask is rendered correctly w/ opacity
@@ -666,7 +666,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
   process = debounce(this.processImmediate, this.config.PROCESS_DEBOUNCE_MS);
 
   /**
-   * Applies the segmented image to the entity.
+   * Applies the segmented image to the entity, replacing the entity's objects with the masked image.
    */
   apply = () => {
     const imageState = this.$imageState.get();
@@ -676,7 +676,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     }
     this.log.trace('Applying');
 
-    // Rasterize the entity, this time replacing the objects with the masked image
+    // Rasterize the entity, replacing the objects with the masked image
     const rect = this.parent.transformer.getRelativeRect();
     this.manager.stateApi.rasterizeEntity({
       entityIdentifier: this.parent.entityIdentifier,
@@ -694,7 +694,8 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
   };
 
   /**
-   * Applies the segmented image to the entity.
+   * Saves the segmented image as a new entity of the given type.
+   * @param type The type of entity to save the segmented image as.
    */
   saveAs = (type: Exclude<CanvasEntityType, 'reference_image'>) => {
     const imageState = this.$imageState.get();
@@ -795,8 +796,9 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     for (const point of this.$points.get()) {
       point.konva.circle.destroy();
     }
-    if (this.maskedImage) {
-      this.maskedImage.destroy();
+    if (this.imageModule) {
+      this.imageModule.destroy();
+      this.imageModule = null;
     }
     if (this.konva.maskTween) {
       this.konva.maskTween.destroy();
@@ -878,7 +880,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
         circle: getKonvaNodeDebugAttrs(konva.circle),
       })),
       imageState: deepClone(this.$imageState.get()),
-      maskedImage: this.maskedImage?.repr(),
+      imageModule: this.imageModule?.repr(),
       config: deepClone(this.config),
       $isSegmenting: this.$isSegmenting.get(),
       $lastProcessedHash: this.$lastProcessedHash.get(),

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -676,9 +676,6 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     }
     this.log.trace('Applying');
 
-    // Commit the buffer, which will move the buffer to from the layers' buffer renderer to its main renderer
-    this.parent.bufferRenderer.commitBuffer();
-
     // Rasterize the entity, this time replacing the objects with the masked image
     const rect = this.parent.transformer.getRelativeRect();
     this.manager.stateApi.rasterizeEntity({
@@ -706,9 +703,6 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
       return;
     }
     this.log.trace(`Saving as ${type}`);
-
-    // Clear the buffer - we are creating a new entity, so we don't want to keep the old one
-    this.parent.bufferRenderer.clearBuffer();
 
     // Create the new entity with the masked image as its only object
     const rect = this.parent.transformer.getRelativeRect();
@@ -820,10 +814,6 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     // Reset non-ephemeral konva nodes
     this.konva.compositingRect.visible(false);
     this.konva.maskGroup.clearCache();
-
-    // The parent module's buffer should be reset & forcibly sync the cache
-    this.parent.bufferRenderer.clearBuffer();
-    this.parent.renderer.syncKonvaCache(true);
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStateApiModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStateApiModule.ts
@@ -293,6 +293,8 @@ export class CanvasStateApiModule extends CanvasModuleBase {
       },
     };
 
+    let didSuceed = false;
+
     /**
      * If a timeout is provided, we will cancel the graph if it takes too long - but we need a way to clear the timeout
      * if the graph completes or errors before the timeout.
@@ -343,6 +345,8 @@ export class CanvasStateApiModule extends CanvasModuleBase {
           reject(getImageDTOResult.error);
           return;
         }
+
+        didSuceed = true;
 
         // Ok!
         resolve(getImageDTOResult.value);
@@ -434,6 +438,10 @@ export class CanvasStateApiModule extends CanvasModuleBase {
 
       if (timeout) {
         timeoutId = window.setTimeout(() => {
+          if (didSuceed) {
+            // If we already succeeded, we don't need to do anything
+            return;
+          }
           this.log.trace('Graph canceled by timeout');
           clearListeners();
           cancelGraph();
@@ -443,6 +451,10 @@ export class CanvasStateApiModule extends CanvasModuleBase {
 
       if (signal) {
         signal.addEventListener('abort', () => {
+          if (didSuceed) {
+            // If we already succeeded, we don't need to do anything
+            return;
+          }
           this.log.trace('Graph canceled by signal');
           _clearTimeout();
           clearListeners();


### PR DESCRIPTION
## Summary

- When filtering, we used the parent entity's buffer renderer to render the filter preview. An sloppy copy-paste resulted in the filter committing the buffer when it should have been cleared when saving-as. This fixes the only cause I can imagine for [this issue](https://discord.com/channels/1020123559063990373/1149506274971631688/1300882469658169377) reported by @skunkworxdark.
- But akshually, there's no need to use the buffer renderer at all. The canvas SAM module renders its canvas objects directly to the parent layer, without using the parent's object renderers. This better separates the logic. Updated the filter module to use this pattern instead.
- Update the filter module with the more resilient and clearer logic from the SAM module. Namely, using a hash to determine if we've already processed the given points, and explicit methods to reset the module's ephemeral state and do a teardown once we finish filtering. 
     - These two modules are very similar. It makes sense to share the same overall logic between them, but there are enough differences that they can't share a class or inherit from each other.
- Update the filter and select object UIs to handle an edge case where you reset them, but they don't auto-process.
- Use node "adoption" to prevent the original layer from briefly appearing while applying a filter or segment operation.
- Update the comments in the filter module to match the documentation quality of the SAM module.

## Related Issues / Discussions

[this issue](https://discord.com/channels/1020123559063990373/1149506274971631688/1300882469658169377) reported by @skunkworxdark

## QA Instructions

Try out filtering and segmenting, just kinda fuzz-test it.

I don't know how to reliably repro @skunkworxdark's issue but it there should be no way it can happen now, because a filtered image is now _never_ rendered outside the safe confines of the filter module.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_