### PR TITLE
Adjust pins for torch, numpy, other dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "gguf==0.10.0",
   "invisible-watermark==0.2.0", # needed to install SDXL base and refiner using their repo_ids
   "mediapipe>=0.10.7",          # needed for "mediapipeface" controlnet model
-  "numpy==1.26.4",              # >1.24.0 is needed to use the 'strict' argument to np.testing.assert_array_equal()
+  "numpy<2.0.0",
   "onnx==1.16.1",
   "onnxruntime==1.19.2",
   "opencv-python==4.9.0.80",
@@ -52,10 +52,10 @@ dependencies = [
   "sentencepiece==0.2.0",
   "spandrel==0.3.4",
   "timm==0.6.13",               # needed to override timm latest in controlnet_aux, see  https://github.com/isl-org/ZoeDepth/issues/26
-  "torch==2.4.1",
-  "torchmetrics==0.11.4",
-  "torchsde==0.2.6",
-  "torchvision==0.19.1",
+  "torch",                      # torch and related dependencies are not pinned, resolved as dependency of `diffusers[torch]` and so forth
+  "torchmetrics",
+  "torchsde",
+  "torchvision",
   "transformers==4.41.1",
 
   # Core application dependencies, pinned for reproducible builds.
@@ -73,7 +73,7 @@ dependencies = [
   "click",
   "datasets",
   "Deprecated",
-  "dnspython~=2.4.0",
+  "dnspython",
   "dynamicprompts",
   "easing-functions",
   "einops",
@@ -85,23 +85,23 @@ dependencies = [
   "picklescan",
   "pillow",
   "prompt-toolkit",
-  "pympler~=1.0.1",
+  "pympler",
   "pypatchmatch",
-  'pyperclip',
+  "pyperclip",
   "pyreadline3",
   "python-multipart",
-  "requests~=2.28.2",
+  "requests",
   "rich~=13.3",
-  "scikit-image~=0.21.0",
+  "scikit-image",
   "semver~=3.0.1",
-  "test-tube~=0.7.5",
+  "test-tube",
   "windows-curses; sys_platform=='win32'",
 ]
 
 [project.optional-dependencies]
 "xformers" = [
   # Core generation dependencies, pinned for reproducible builds.
-  "xformers==0.0.28.post1; sys_platform!='darwin'",
+  "xformers>=0.0.28.post1; sys_platform!='darwin'",
   # Auxiliary dependencies, pinned only if necessary.
   "triton; sys_platform=='linux'",
 ]


### PR DESCRIPTION
## Summary

Dependency resolution by `pip` is fairly lax, and allows fallback to the main PyPi index in case a matching distribution cannot be found. As we're working on an improved installation experience, this is becoming a blocker for installing Invoke using other tools, such as `uv`. Also, this work exposed some spots where some transitive dependencies might be overridden in spite of different version requirements by direct dependencies (e.g. `requests` was pinned to a version that is no longer valid).

This PR makes the minimal adjustments to the dependency pins, just to satisfy all direct dependencies and allow the package to be installed.

## QA Instructions

This is best tested using a tool that has follows strict dependency resolution rules, such as Astral's `uv`: https://github.com/astral-sh/uv. Install it prior to testing, then run the following, adjusting paths as necessary:

```
# breaking test

mkdir -p /tmp/invokeai
uv venv /tmp/invokeai/.venv --python 3.11
cd /tmp/invokeai
. .venv/bin/activate
uv pip install invokeai==5.3.0 --extra-index-url https://download.pytorch.org/whl/cu124

# the above will produce an error to the effect of not being able to find the requested version of numpy

# reset
deactivate; rm -rf /tmp/invokeai/.venv

# repeat with this PR
uv venv /tmp/invokeai/.venv --python 3.11
cd /tmp/invokeai
. .venv/bin/activate
uv pip install git+https://github.com/invoke-ai/InvokeAI.git@ebr/unpin-numpy --extra-index-url https://download.pytorch.org/whl/cu124

# this should work without an issue
```

## Merge Plan

Merge when sufficiently tested on the following platforms / pytorch indices:  

windows
- [x] `--extra-index-url https://download.pytorch.org/whl/cu124` 
- [x] `--extra-index-url https://download.pytorch.org/whl/cpu`

linux
- [x] `--extra-index-url https://download.pytorch.org/whl/cu124` 
- [x] `--extra-index-url https://download.pytorch.org/whl/cpu`

macOS
- [ ] `--extra-index-url https://download.pytorch.org/whl/cpu`
- [x] no extra index

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
