### PR TITLE
feat(ui): filter/select-object do not exit on save-as

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -529,6 +529,22 @@ export abstract class CanvasEntityAdapterBase<
     }
     this.log.trace(isVisible ? 'Showing' : 'Hiding');
     this.konva.layer.visible(isVisible);
+    if (isVisible) {
+      /**
+       * When a layer is created and initially not visible, its compositing rect won't be set up properly. Then, when
+       * we show it in this method, it the layer will not render as it should.
+       *
+       * For example, if an inpaint mask is created via select-object while the isolated layer preview feature is
+       * enabled, it will be hidden on its first render, and the compositing rect will not be sized/positioned/filled.
+       * When next show the layer, the its underlying objects will be rendered directly, without the compositing rect
+       * providing the correct fill.
+       *
+       * The simplest way to ensure this doesn't happen is to always update the compositing rect when showing the layer.
+       */
+      this.renderer.updateCompositingRectSize();
+      this.renderer.updateCompositingRectPosition();
+      this.renderer.updateCompositingRectFill();
+    }
     this.renderer.syncKonvaCache();
   };
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -386,10 +386,6 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       default:
         assert<Equals<typeof type, never>>(false);
     }
-
-    // Final cleanup and teardown, returning user to main canvas UI
-    this.resetEphemeralState();
-    this.teardown();
   };
 
   resetEphemeralState = () => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -223,10 +223,14 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
       return;
     }
 
-    this.log.trace('Updating compositing rect fill');
+    if (
+      !this.konva.compositing ||
+      (this.parent.state.type !== 'inpaint_mask' && this.parent.state.type !== 'regional_guidance')
+    ) {
+      return;
+    }
 
-    assert(this.konva.compositing, 'Missing compositing rect');
-    assert(this.parent.state.type === 'inpaint_mask' || this.parent.state.type === 'regional_guidance');
+    this.log.trace('Updating compositing rect fill');
 
     const fill = this.parent.state.fill;
 
@@ -252,9 +256,14 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
       return;
     }
 
-    this.log.trace('Updating compositing rect size');
+    if (
+      !this.konva.compositing ||
+      (this.parent.state.type !== 'inpaint_mask' && this.parent.state.type !== 'regional_guidance')
+    ) {
+      return;
+    }
 
-    assert(this.konva.compositing, 'Missing compositing rect');
+    this.log.trace('Updating compositing rect size');
 
     const scale = this.manager.stage.unscale(1);
 
@@ -274,9 +283,14 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
       return;
     }
 
-    this.log.trace('Updating compositing rect position');
+    if (
+      !this.konva.compositing ||
+      (this.parent.state.type !== 'inpaint_mask' && this.parent.state.type !== 'regional_guidance')
+    ) {
+      return;
+    }
 
-    assert(this.konva.compositing, 'Missing compositing rect');
+    this.log.trace('Updating compositing rect position');
 
     this.konva.compositing.rect.setAttrs({
       ...this.manager.stage.getScaledStageRect(),

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -740,10 +740,6 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
       default:
         assert<Equals<typeof type, never>>(false);
     }
-
-    // Final cleanup and teardown, returning user to main canvas UI
-    this.resetEphemeralState();
-    this.teardown();
   };
 
   /**


### PR DESCRIPTION
## Summary

- When using save-as with filter/select-object, do not exit the filter/select-object. This facilitates common workflows that want to use the output of these features for multiple layers.
- Fix a bug that is exacerbated by this change that causes inpaint mask and regional guidance layers not rendering correctly.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1020123559831539744/1301301721565233172

## QA Instructions

Try save-as when filtering/select-object-ing. Mask layers should render as expected when you exit filter or select-object.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
