### PR TITLE
Pin torch to <2.5.0 to prevent unnecessary downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "sentencepiece==0.2.0",
   "spandrel==0.3.4",
   "timm==0.6.13",               # needed to override timm latest in controlnet_aux, see  https://github.com/isl-org/ZoeDepth/issues/26
-  "torch",                      # torch and related dependencies are not pinned, resolved as dependency of `diffusers[torch]` and so forth
+  "torch<2.5.0",                # torch and related dependencies are loosely pinned, will respect requirement of `diffusers[torch]`
   "torchmetrics",
   "torchsde",
   "torchvision",


### PR DESCRIPTION
## Summary

pip's dependency resolution doesn't take into account transitive dependencies when choosing package versions for download. Even though `torch=~2.4.1` is required by `diffusers`, pip will download 2.5.0 and higher, but only install 2.4.1. Pinning torch to <2.5.0 prevents this behaviour.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1301766243237494855

## QA Instructions

Failing test:
```
pip install --require-virtualenv --force-reinstall --use-pep517 invokeai==5.3.1 --extra-index-url https://download.pytorch.org/whl/cu124
```

This will download torch 2.5.1, but only install 2.4.1 (as expected)

Passing test:
```
pip install --require-virtualenv --force-reinstall --use-pep517 git+https://github.com/invoke-ai/InvokeAI.git@ebr/max-pin-torch --extra-index-url https://download.pytorch.org/whl/cu124
```

torch 2.5.1 will not be downloaded



## Merge Plan

Merge anytime

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
