### PR TITLE
fix(ui): load workflow from file

### DIFF
--- a/invokeai/frontend/web/src/features/workflowLibrary/components/WorkflowLibraryMenu/WorkflowLibraryMenu.tsx
+++ b/invokeai/frontend/web/src/features/workflowLibrary/components/WorkflowLibraryMenu/WorkflowLibraryMenu.tsx
@@ -25,7 +25,7 @@ const WorkflowLibraryMenu = () => {
   const shift = useShiftModifier();
   useGlobalMenuClose(onClose);
   return (
-    <Menu isOpen={isOpen} onOpen={onOpen} onClose={onClose} isLazy>
+    <Menu isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
       <MenuButton
         as={IconButton}
         aria-label={t('workflows.workflowEditorMenu')}


### PR DESCRIPTION
## Summary

In a8de6406c5e12e8fae7a6aef97c4fb606880b67f a change was made to many menus in an effort to improve performance. The menus were made to be lazy, so that they are mounted only while open.

This causes unexpected behaviour when there is some logic in the menu that may need to execute after the user selects a menu item.

In this case, when you click to load a workflow from file, the file picker opens but then the menuitem unmounts, taking the input element and all uploading logic with it. When you select a file, nothing happens because we've nuked the handlers by unmounting everything.

Easy fix - un-lazy-fy the menu.

## Related Issues / Discussions

Closes #7240

## QA Instructions

Loading workflow from the three-dots menu should work.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
