### PR TITLE
fix(deps): pin mediapipe strictly to a known working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "diffusers[torch]==0.31.0",
   "gguf==0.10.0",
   "invisible-watermark==0.2.0", # needed to install SDXL base and refiner using their repo_ids
-  "mediapipe>=0.10.7",          # needed for "mediapipeface" controlnet model
+  "mediapipe==0.10.14",         # needed for "mediapipeface" controlnet model
   "numpy<2.0.0",
   "onnx==1.16.1",
   "onnxruntime==1.19.2",


### PR DESCRIPTION
## Summary

We have received some reports of `mediapipe` failing to install on Windows. Version `0.0.18` was released on 2024-11-01, and is published to pypi, but not released in their Github repo.

Pinning it to the known working `v0.0.14` for now.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1020123559831539744/1302911486066163712

## QA Instructions

Install Invoke on windows and confirm that `mediapipe` is present.

## Merge Plan

Merge anytime

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
