### PR TITLE
fix: Never throw an exception when finding the clip variant type

### DIFF
--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -169,17 +169,20 @@ def convert_bundle_to_flux_transformer_checkpoint(
 
 
 def get_clip_variant_type(location: str) -> Optional[ClipVariantType]:
-    path = Path(location)
-    config_path = path / "config.json"
-    if not config_path.exists():
+    try:
+        path = Path(location)
+        config_path = path / "config.json"
+        if not config_path.exists():
+            return None
+        with open(config_path) as file:
+            clip_conf = json.load(file)
+            hidden_size = clip_conf.get("hidden_size", -1)
+            match hidden_size:
+                case 1280:
+                    return ClipVariantType.G
+                case 768:
+                    return ClipVariantType.L
+                case _:
+                    return None
+    except Exception:
         return None
-    with open(config_path) as file:
-        clip_conf = json.load(file)
-        hidden_size = clip_conf.get("hidden_size", -1)
-        match hidden_size:
-            case 1280:
-                return ClipVariantType.G
-            case 768:
-                return ClipVariantType.L
-            case _:
-                return None

--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -183,6 +183,6 @@ def get_clip_variant_type(location: str) -> Optional[ClipVariantType]:
                 case 768:
                     return ClipVariantType.L
                 case _:
-                    return None
+                    return ClipVariantType.L
     except Exception:
-        return None
+        return ClipVariantType.L


### PR DESCRIPTION
## Summary

This can fail if the folder isn't formatted how we expect it to be. This should never cause a model to fail so I wrapped it in a try catch.

## QA Instructions

Attempt to install any flux main model bundle in starter models and confirm InvokeAI/clip-vit-large-patch14-text-encoder::bfloat16 installs correctly

## Merge Plan

Can be merged when tested/approved
