### PR TITLE
fix(ui): add some feedback while layers are merging

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1662,6 +1662,7 @@
         "mergeDown": "Merge Down",
         "mergeVisibleOk": "Merged layers",
         "mergeVisibleError": "Error merging layers",
+        "mergingLayers": "Merging layers",
         "clearHistory": "Clear History",
         "bboxOverlay": "Show Bbox Overlay",
         "resetCanvas": "Reset Canvas",

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
@@ -329,6 +329,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
     entityIdentifiers: T[],
     deleteMergedEntities: boolean
   ): Promise<ImageDTO | null> => {
+    toast({ id: 'MERGE_LAYERS_TOAST', title: t('controlLayers.mergingLayers'), withCount: false });
     if (entityIdentifiers.length <= 1) {
       this.log.warn({ entityIdentifiers }, 'Cannot merge less than 2 entities');
       return null;
@@ -351,7 +352,12 @@ export class CanvasCompositorModule extends CanvasModuleBase {
 
     if (result.isErr()) {
       this.log.error({ error: serializeError(result.error) }, 'Failed to merge selected entities');
-      toast({ title: t('controlLayers.mergeVisibleError'), status: 'error' });
+      toast({
+        id: 'MERGE_LAYERS_TOAST',
+        title: t('controlLayers.mergeVisibleError'),
+        status: 'error',
+        withCount: false,
+      });
       return null;
     }
 
@@ -383,7 +389,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
         assert<Equals<typeof type, never>>(false, 'Unsupported type for merge');
     }
 
-    toast({ title: t('controlLayers.mergeVisibleOk') });
+    toast({ id: 'MERGE_LAYERS_TOAST', title: t('controlLayers.mergeVisibleOk'), status: 'success', withCount: false });
 
     return result.value;
   };


### PR DESCRIPTION
## Summary

Adds a "Merging layers" toast while waiting for the network request to come back that merges layers

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

Either "merge visible" or "merge down". Should see an info-level toast that transitions to success toast when layers are merging and then merged

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
