### PR TITLE
feat(api,ui): allow Whats New module to get content from back-end

### DIFF
--- a/invokeai/app/api/routers/app_info.py
+++ b/invokeai/app/api/routers/app_info.py
@@ -40,6 +40,8 @@ class AppVersion(BaseModel):
 
     version: str = Field(description="App version")
 
+    highlights: Optional[list[str]] = Field(default=None, description="Highlights of release")
+
 
 class AppDependencyVersions(BaseModel):
     """App depencency Versions Response"""

--- a/invokeai/frontend/web/src/features/ui/components/WhatsNew.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/WhatsNew.tsx
@@ -2,27 +2,38 @@ import { ExternalLink, Flex, ListItem, Text, UnorderedList } from '@invoke-ai/ui
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from 'app/store/storeHooks';
 import { selectConfigSlice } from 'features/system/store/configSlice';
+import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useGetAppVersionQuery } from 'services/api/endpoints/appInfo';
 
 const selectIsLocal = createSelector(selectConfigSlice, (config) => config.isLocal);
 
 export const WhatsNew = () => {
   const { t } = useTranslation();
+  const { data } = useGetAppVersionQuery();
   const isLocal = useAppSelector(selectIsLocal);
+
+  const highlights = useMemo(() => (data?.highlights ? data.highlights : []), [data]);
 
   return (
     <Flex gap={4} flexDir="column">
       <UnorderedList fontSize="sm">
-        <ListItem>
-          <Trans
-            i18nKey="whatsNew.line1"
-            components={{
-              ItalicComponent: <Text as="span" color="white" fontSize="sm" fontStyle="italic" />,
-            }}
-          />
-        </ListItem>
-        <ListItem>{t('whatsNew.line2')}</ListItem>
-        <ListItem>{t('whatsNew.line3')}</ListItem>
+        {highlights.length ? (
+          highlights.map((highlight, index) => <ListItem key={index}>{highlight}</ListItem>)
+        ) : (
+          <>
+            <ListItem>
+              <Trans
+                i18nKey="whatsNew.line1"
+                components={{
+                  ItalicComponent: <Text as="span" color="white" fontSize="sm" fontStyle="italic" />,
+                }}
+              />
+            </ListItem>
+            <ListItem>{t('whatsNew.line2')}</ListItem>
+            <ListItem>{t('whatsNew.line3')}</ListItem>
+          </>
+        )}
       </UnorderedList>
       <Flex flexDir="column" gap={1}>
         <ExternalLink
@@ -31,7 +42,7 @@ export const WhatsNew = () => {
           label={t('whatsNew.readReleaseNotes')}
           href={
             isLocal
-              ? 'https://github.com/invoke-ai/InvokeAI/releases/tag/v5.0.0'
+              ? `https://github.com/invoke-ai/InvokeAI/releases/tag/v${data.version}`
               : 'https://support.invoke.ai/support/solutions/articles/151000178246'
           }
         />

--- a/invokeai/frontend/web/src/features/ui/components/WhatsNew.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/WhatsNew.tsx
@@ -42,7 +42,7 @@ export const WhatsNew = () => {
           label={t('whatsNew.readReleaseNotes')}
           href={
             isLocal
-              ? `https://github.com/invoke-ai/InvokeAI/releases/tag/v${data.version}`
+              ? `https://github.com/invoke-ai/InvokeAI/releases/tag/v${data?.version}`
               : 'https://support.invoke.ai/support/solutions/articles/151000178246'
           }
         />

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -1687,6 +1687,11 @@ export type components = {
              * @description App version
              */
             version: string;
+            /**
+             * Highlights
+             * @description Highlights of release
+             */
+            highlights?: string[] | null;
         };
         /**
          * Apply Tensor Mask to Image


### PR DESCRIPTION
## Summary

* Updates app_info router to have optional highlights list so that Whats New module can get data from back-end instead of being hard-coded in UI
* Updates release notes URL to be dynamic based on current version

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
