### PR TITLE
fix: get_clip_variant_type should never return None

### DIFF
--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -173,7 +173,7 @@ def get_clip_variant_type(location: str) -> Optional[ClipVariantType]:
         path = Path(location)
         config_path = path / "config.json"
         if not config_path.exists():
-            return None
+            return ClipVariantType.L
         with open(config_path) as file:
             clip_conf = json.load(file)
             hidden_size = clip_conf.get("hidden_size", -1)


### PR DESCRIPTION
## Summary

Missed one spot in an earlier bugfix PR where get_clip_variant_type is returning None

## Merge Plan

Can be merged when approved

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
