### PR TITLE
feat(ui): new user ux improvements

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1777,6 +1777,7 @@
         "newCanvasSession": "New Canvas Session",
         "newCanvasSessionDesc": "This will clear the canvas and all settings except for your model selection. Generations will be staged on the canvas.",
         "replaceCurrent": "Replace Current",
+        "controlLayerEmptyState": "<UploadButton>Upload an image</UploadButton>, drag an image from the <GalleryButton>gallery</GalleryButton> onto this layer, or draw on the canvas to get started.",
         "controlMode": {
             "controlMode": "Control Mode",
             "balanced": "Balanced (recommended)",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1779,7 +1779,7 @@
         "replaceCurrent": "Replace Current",
         "controlMode": {
             "controlMode": "Control Mode",
-            "balanced": "Balanced",
+            "balanced": "Balanced (recommended)",
             "prompt": "Prompt",
             "control": "Control",
             "megaControl": "Mega Control"

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1819,6 +1819,9 @@
             "process": "Process",
             "apply": "Apply",
             "cancel": "Cancel",
+            "advanced": "Advanced",
+            "processingLayerWith": "Processing layer with the {{type}} filter.",
+            "forMoreControl": "For more control, click Advanced below.",
             "spandrel_filter": {
                 "label": "Image-to-Image Model",
                 "description": "Run an image-to-image model on the selected layer.",

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDropped.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageDropped.ts
@@ -2,7 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import { deepClone } from 'common/util/deepClone';
-import { selectDefaultControlAdapter, selectDefaultIPAdapter } from 'features/controlLayers/hooks/addLayerHooks';
+import { selectDefaultIPAdapter } from 'features/controlLayers/hooks/addLayerHooks';
 import { getPrefixedId } from 'features/controlLayers/konva/util';
 import {
   controlLayerAdded,
@@ -23,7 +23,7 @@ import type {
   CanvasReferenceImageState,
   CanvasRegionalGuidanceState,
 } from 'features/controlLayers/store/types';
-import { imageDTOToImageObject, imageDTOToImageWithDims } from 'features/controlLayers/store/util';
+import { imageDTOToImageObject, imageDTOToImageWithDims, initialControlNet } from 'features/controlLayers/store/util';
 import type { TypesafeDraggableData, TypesafeDroppableData } from 'features/dnd/types';
 import { isValidDrop } from 'features/dnd/util/isValidDrop';
 import { imageToCompareChanged, selectionChanged } from 'features/gallery/store/gallerySlice';
@@ -163,11 +163,10 @@ export const addImageDroppedListener = (startAppListening: AppStartListening) =>
         const state = getState();
         const imageObject = imageDTOToImageObject(activeData.payload.imageDTO);
         const { x, y } = selectCanvasSlice(state).bbox.rect;
-        const defaultControlAdapter = selectDefaultControlAdapter(state);
         const overrides: Partial<CanvasControlLayerState> = {
           objects: [imageObject],
           position: { x, y },
-          controlAdapter: defaultControlAdapter,
+          controlAdapter: deepClone(initialControlNet),
         };
         dispatch(controlLayerAdded({ overrides, isSelected: true }));
         return;

--- a/invokeai/frontend/web/src/app/store/nanostores/util.ts
+++ b/invokeai/frontend/web/src/app/store/nanostores/util.ts
@@ -4,6 +4,8 @@ import { atom } from 'nanostores';
 /**
  * A fallback non-writable atom that always returns `false`, used when a nanostores atom is only conditionally available
  * in a hook or component.
+ *
+ * @knipignore
  */
 export const $false: ReadableAtom<boolean> = atom(false);
 /**

--- a/invokeai/frontend/web/src/app/store/nanostores/util.ts
+++ b/invokeai/frontend/web/src/app/store/nanostores/util.ts
@@ -5,7 +5,7 @@ import { atom } from 'nanostores';
  * A fallback non-writable atom that always returns `false`, used when a nanostores atom is only conditionally available
  * in a hook or component.
  */
-// export const $false: ReadableAtom<boolean> = atom(false);
+export const $false: ReadableAtom<boolean> = atom(false);
 /**
  * A fallback non-writable atom that always returns `true`, used when a nanostores atom is only conditionally available
  * in a hook or component.

--- a/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayer.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayer.tsx
@@ -7,7 +7,7 @@ import { CanvasEntityPreviewImage } from 'features/controlLayers/components/comm
 import { CanvasEntitySettingsWrapper } from 'features/controlLayers/components/common/CanvasEntitySettingsWrapper';
 import { CanvasEntityEditableTitle } from 'features/controlLayers/components/common/CanvasEntityTitleEdit';
 import { ControlLayerBadges } from 'features/controlLayers/components/ControlLayer/ControlLayerBadges';
-import { ControlLayerControlAdapter } from 'features/controlLayers/components/ControlLayer/ControlLayerControlAdapter';
+import { ControlLayerSettings } from 'features/controlLayers/components/ControlLayer/ControlLayerSettings';
 import { ControlLayerAdapterGate } from 'features/controlLayers/contexts/EntityAdapterContext';
 import { EntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
 import type { CanvasEntityIdentifier } from 'features/controlLayers/store/types';
@@ -41,7 +41,7 @@ export const ControlLayer = memo(({ id }: Props) => {
             <CanvasEntityHeaderCommonActions />
           </CanvasEntityHeader>
           <CanvasEntitySettingsWrapper>
-            <ControlLayerControlAdapter />
+            <ControlLayerSettings />
           </CanvasEntitySettingsWrapper>
           <IAIDroppable data={dropData} dropLabel={t('controlLayers.replaceLayer')} />
         </CanvasEntityContainer>

--- a/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerSettings.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerSettings.tsx
@@ -1,0 +1,18 @@
+import { ControlLayerControlAdapter } from 'features/controlLayers/components/ControlLayer/ControlLayerControlAdapter';
+import { ControlLayerSettingsEmptyState } from 'features/controlLayers/components/ControlLayer/ControlLayerSettingsEmptyState';
+import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
+import { useEntityIsEmpty } from 'features/controlLayers/hooks/useEntityIsEmpty';
+import { memo } from 'react';
+
+export const ControlLayerSettings = memo(() => {
+  const entityIdentifier = useEntityIdentifierContext();
+  const isEmpty = useEntityIsEmpty(entityIdentifier);
+
+  if (isEmpty) {
+    return <ControlLayerSettingsEmptyState />;
+  }
+
+  return <ControlLayerControlAdapter />;
+});
+
+ControlLayerSettings.displayName = 'ControlLayerSettings';

--- a/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerSettingsEmptyState.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerSettingsEmptyState.tsx
@@ -1,0 +1,50 @@
+import { Button, Flex, Text } from '@invoke-ai/ui-library';
+import { useAppDispatch } from 'app/store/storeHooks';
+import { useImageUploadButton } from 'common/hooks/useImageUploadButton';
+import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
+import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
+import { activeTabCanvasRightPanelChanged } from 'features/ui/store/uiSlice';
+import { memo, useCallback, useMemo } from 'react';
+import { Trans } from 'react-i18next';
+import type { PostUploadAction } from 'services/api/types';
+
+export const ControlLayerSettingsEmptyState = memo(() => {
+  const entityIdentifier = useEntityIdentifierContext('control_layer');
+  const dispatch = useAppDispatch();
+  const isBusy = useCanvasIsBusy();
+  const postUploadAction = useMemo<PostUploadAction>(
+    () => ({ type: 'REPLACE_LAYER_WITH_IMAGE', entityIdentifier }),
+    [entityIdentifier]
+  );
+  const uploadApi = useImageUploadButton({ postUploadAction });
+  const onClickGalleryButton = useCallback(() => {
+    dispatch(activeTabCanvasRightPanelChanged('gallery'));
+  }, [dispatch]);
+
+  return (
+    <Flex flexDir="column" gap={3} position="relative" w="full" p={4}>
+      <Text textAlign="center" color="base.300">
+        <Trans
+          i18nKey="controlLayers.controlLayerEmptyState"
+          components={{
+            UploadButton: (
+              <Button
+                isDisabled={isBusy}
+                size="sm"
+                variant="link"
+                color="base.300"
+                {...uploadApi.getUploadButtonProps()}
+              />
+            ),
+            GalleryButton: (
+              <Button onClick={onClickGalleryButton} isDisabled={isBusy} size="sm" variant="link" color="base.300" />
+            ),
+          }}
+        />
+      </Text>
+      <input {...uploadApi.getUploadInputProps()} />
+    </Flex>
+  );
+});
+
+ControlLayerSettingsEmptyState.displayName = 'ControlLayerSettingsEmptyState';

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/Filter.tsx
@@ -9,6 +9,7 @@ import {
   MenuList,
   Spacer,
   Spinner,
+  Text,
 } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
@@ -28,13 +29,10 @@ import { memo, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiCaretDownBold } from 'react-icons/pi';
 
-const FilterContent = memo(
+const FilterContentAdvanced = memo(
   ({ adapter }: { adapter: CanvasEntityAdapterRasterLayer | CanvasEntityAdapterControlLayer }) => {
     const { t } = useTranslation();
-    const ref = useRef<HTMLDivElement>(null);
-    useFocusRegion('canvas', ref, { focusOnMount: true });
     const config = useStore(adapter.filterer.$filterConfig);
-    const isCanvasFocused = useIsRegionFocused('canvas');
     const isProcessing = useStore(adapter.filterer.$isProcessing);
     const hasImageState = useStore(adapter.filterer.$hasImageState);
     const autoProcess = useAppSelector(selectAutoProcess);
@@ -73,36 +71,8 @@ const FilterContent = memo(
       adapter.filterer.saveAs('control_layer');
     }, [adapter.filterer]);
 
-    useRegisteredHotkeys({
-      id: 'applyFilter',
-      category: 'canvas',
-      callback: adapter.filterer.apply,
-      options: { enabled: !isProcessing && isCanvasFocused },
-      dependencies: [adapter.filterer, isProcessing, isCanvasFocused],
-    });
-
-    useRegisteredHotkeys({
-      id: 'cancelFilter',
-      category: 'canvas',
-      callback: adapter.filterer.cancel,
-      options: { enabled: !isProcessing && isCanvasFocused },
-      dependencies: [adapter.filterer, isProcessing, isCanvasFocused],
-    });
-
     return (
-      <Flex
-        ref={ref}
-        bg="base.800"
-        borderRadius="base"
-        p={4}
-        flexDir="column"
-        gap={4}
-        w={420}
-        h="auto"
-        shadow="dark-lg"
-        transitionProperty="height"
-        transitionDuration="normal"
-      >
+      <>
         <Flex w="full" gap={4}>
           <Heading size="md" color="base.300" userSelect="none">
             {t('controlLayers.filter.filter')}
@@ -169,12 +139,67 @@ const FilterContent = memo(
             {t('controlLayers.filter.cancel')}
           </Button>
         </ButtonGroup>
-      </Flex>
+      </>
     );
   }
 );
 
-FilterContent.displayName = 'FilterContent';
+FilterContentAdvanced.displayName = 'FilterContentAdvanced';
+
+const FilterContentSimple = memo(
+  ({ adapter }: { adapter: CanvasEntityAdapterRasterLayer | CanvasEntityAdapterControlLayer }) => {
+    const { t } = useTranslation();
+    const config = useStore(adapter.filterer.$filterConfig);
+    const isProcessing = useStore(adapter.filterer.$isProcessing);
+    const hasImageState = useStore(adapter.filterer.$hasImageState);
+
+    const isValid = useMemo(() => {
+      return IMAGE_FILTERS[config.type].validateConfig?.(config as never) ?? true;
+    }, [config]);
+
+    const onClickAdvanced = useCallback(() => {
+      adapter.filterer.$simple.set(false);
+    }, [adapter.filterer.$simple]);
+
+    return (
+      <>
+        <Flex w="full" gap={4}>
+          <Heading size="md" color="base.300" userSelect="none">
+            {t('controlLayers.filter.filter')}
+          </Heading>
+          <Spacer />
+        </Flex>
+        <Flex flexDir="column" w="full" gap={2} pb={2}>
+          <Text color="base.500" textAlign="center">
+            {t('controlLayers.filter.processingLayerWith', { type: t(`controlLayers.filter.${config.type}.label`) })}
+          </Text>
+          <Text color="base.500" textAlign="center">
+            {t('controlLayers.filter.forMoreControl')}
+          </Text>
+        </Flex>
+        <ButtonGroup isAttached={false} size="sm" w="full">
+          <Button variant="ghost" onClick={onClickAdvanced}>
+            {t('controlLayers.filter.advanced')}
+          </Button>
+          <Spacer />
+          <Button
+            onClick={adapter.filterer.apply}
+            loadingText={t('controlLayers.filter.apply')}
+            variant="ghost"
+            isDisabled={isProcessing || !isValid || !hasImageState}
+          >
+            {t('controlLayers.filter.apply')}
+          </Button>
+          <Button variant="ghost" onClick={adapter.filterer.cancel} loadingText={t('controlLayers.filter.cancel')}>
+            {t('controlLayers.filter.cancel')}
+          </Button>
+        </ButtonGroup>
+      </>
+    );
+  }
+);
+
+FilterContentSimple.displayName = 'FilterContentSimple';
 
 export const Filter = () => {
   const canvasManager = useCanvasManager();
@@ -182,8 +207,54 @@ export const Filter = () => {
   if (!adapter) {
     return null;
   }
-
   return <FilterContent adapter={adapter} />;
 };
 
 Filter.displayName = 'Filter';
+
+const FilterContent = memo(
+  ({ adapter }: { adapter: CanvasEntityAdapterRasterLayer | CanvasEntityAdapterControlLayer }) => {
+    const simplified = useStore(adapter.filterer.$simple);
+    const isCanvasFocused = useIsRegionFocused('canvas');
+    const isProcessing = useStore(adapter.filterer.$isProcessing);
+    const ref = useRef<HTMLDivElement>(null);
+    useFocusRegion('canvas', ref, { focusOnMount: true });
+
+    useRegisteredHotkeys({
+      id: 'applyFilter',
+      category: 'canvas',
+      callback: adapter.filterer.apply,
+      options: { enabled: !isProcessing && isCanvasFocused, enableOnFormTags: true },
+      dependencies: [adapter.filterer, isProcessing, isCanvasFocused],
+    });
+
+    useRegisteredHotkeys({
+      id: 'cancelFilter',
+      category: 'canvas',
+      callback: adapter.filterer.cancel,
+      options: { enabled: !isProcessing && isCanvasFocused, enableOnFormTags: true },
+      dependencies: [adapter.filterer, isProcessing, isCanvasFocused],
+    });
+
+    return (
+      <Flex
+        ref={ref}
+        bg="base.800"
+        borderRadius="base"
+        p={4}
+        flexDir="column"
+        gap={4}
+        w={420}
+        h="auto"
+        shadow="dark-lg"
+        transitionProperty="height"
+        transitionDuration="normal"
+      >
+        {simplified && <FilterContentSimple adapter={adapter} />}
+        {!simplified && <FilterContentAdvanced adapter={adapter} />}
+      </Flex>
+    );
+  }
+);
+
+FilterContent.displayName = 'FilterContent';

--- a/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerMenuItemsConvertToSubMenu.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerMenuItemsConvertToSubMenu.tsx
@@ -1,8 +1,8 @@
 import { Menu, MenuButton, MenuItem, MenuList } from '@invoke-ai/ui-library';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { useAppDispatch } from 'app/store/storeHooks';
 import { SubMenuButtonContent, useSubMenu } from 'common/hooks/useSubMenu';
+import { deepClone } from 'common/util/deepClone';
 import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
-import { selectDefaultControlAdapter } from 'features/controlLayers/hooks/addLayerHooks';
 import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useEntityIsLocked } from 'features/controlLayers/hooks/useEntityIsLocked';
 import {
@@ -10,6 +10,7 @@ import {
   rasterLayerConvertedToInpaintMask,
   rasterLayerConvertedToRegionalGuidance,
 } from 'features/controlLayers/store/canvasSlice';
+import { initialControlNet } from 'features/controlLayers/store/util';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiSwapBold } from 'react-icons/pi';
@@ -20,7 +21,6 @@ export const RasterLayerMenuItemsConvertToSubMenu = memo(() => {
 
   const dispatch = useAppDispatch();
   const entityIdentifier = useEntityIdentifierContext('raster_layer');
-  const defaultControlAdapter = useAppSelector(selectDefaultControlAdapter);
   const isBusy = useCanvasIsBusy();
   const isLocked = useEntityIsLocked(entityIdentifier);
 
@@ -37,10 +37,10 @@ export const RasterLayerMenuItemsConvertToSubMenu = memo(() => {
       rasterLayerConvertedToControlLayer({
         entityIdentifier,
         replace: true,
-        overrides: { controlAdapter: defaultControlAdapter },
+        overrides: { controlAdapter: deepClone(initialControlNet) },
       })
     );
-  }, [defaultControlAdapter, dispatch, entityIdentifier]);
+  }, [dispatch, entityIdentifier]);
 
   return (
     <MenuItem {...subMenu.parentMenuItemProps} icon={<PiSwapBold />} isDisabled={isBusy || isLocked}>

--- a/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerMenuItemsCopyToSubMenu.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerMenuItemsCopyToSubMenu.tsx
@@ -1,15 +1,16 @@
 import { Menu, MenuButton, MenuItem, MenuList } from '@invoke-ai/ui-library';
-import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { useAppDispatch } from 'app/store/storeHooks';
 import { SubMenuButtonContent, useSubMenu } from 'common/hooks/useSubMenu';
+import { deepClone } from 'common/util/deepClone';
 import { CanvasEntityMenuItemsCopyToClipboard } from 'features/controlLayers/components/common/CanvasEntityMenuItemsCopyToClipboard';
 import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
-import { selectDefaultControlAdapter } from 'features/controlLayers/hooks/addLayerHooks';
 import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import {
   rasterLayerConvertedToControlLayer,
   rasterLayerConvertedToInpaintMask,
   rasterLayerConvertedToRegionalGuidance,
 } from 'features/controlLayers/store/canvasSlice';
+import { initialControlNet } from 'features/controlLayers/store/util';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiCopyBold } from 'react-icons/pi';
@@ -20,7 +21,6 @@ export const RasterLayerMenuItemsCopyToSubMenu = memo(() => {
 
   const dispatch = useAppDispatch();
   const entityIdentifier = useEntityIdentifierContext('raster_layer');
-  const defaultControlAdapter = useAppSelector(selectDefaultControlAdapter);
   const isBusy = useCanvasIsBusy();
 
   const copyToInpaintMask = useCallback(() => {
@@ -35,10 +35,10 @@ export const RasterLayerMenuItemsCopyToSubMenu = memo(() => {
     dispatch(
       rasterLayerConvertedToControlLayer({
         entityIdentifier,
-        overrides: { controlAdapter: defaultControlAdapter },
+        overrides: { controlAdapter: deepClone(initialControlNet) },
       })
     );
-  }, [defaultControlAdapter, dispatch, entityIdentifier]);
+  }, [dispatch, entityIdentifier]);
 
   return (
     <MenuItem {...subMenu.parentMenuItemProps} icon={<PiCopyBold />} isDisabled={isBusy}>

--- a/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityGroupList.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityGroupList.tsx
@@ -2,6 +2,7 @@ import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { Button, Collapse, Flex, Icon, Spacer, Text } from '@invoke-ai/ui-library';
 import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
 import { useBoolean } from 'common/hooks/useBoolean';
+import { fixTooltipCloseOnScrollStyles } from 'common/util/fixTooltipCloseOnScrollStyles';
 import { CanvasEntityAddOfTypeButton } from 'features/controlLayers/components/common/CanvasEntityAddOfTypeButton';
 import { CanvasEntityMergeVisibleButton } from 'features/controlLayers/components/common/CanvasEntityMergeVisibleButton';
 import { CanvasEntityTypeIsHiddenToggle } from 'features/controlLayers/components/common/CanvasEntityTypeIsHiddenToggle';
@@ -78,7 +79,7 @@ export const CanvasEntityGroupList = memo(({ isSelected, type, children }: Props
         {isRenderableEntityType(type) && <CanvasEntityTypeIsHiddenToggle type={type} />}
         <CanvasEntityAddOfTypeButton type={type} />
       </Flex>
-      <Collapse in={collapse.isTrue}>
+      <Collapse in={collapse.isTrue} style={fixTooltipCloseOnScrollStyles}>
         <Flex flexDir="column" gap={2} pt={2}>
           {children}
         </Flex>

--- a/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityPreviewImage.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityPreviewImage.tsx
@@ -1,4 +1,4 @@
-import { Box, chakra, Flex } from '@invoke-ai/ui-library';
+import { Box, chakra, Flex, Tooltip } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { createSelector } from '@reduxjs/toolkit';
 import { rgbColorToString } from 'common/util/colorCodeTransformers';
@@ -87,12 +87,62 @@ export const CanvasEntityPreviewImage = memo(() => {
   useEffect(updatePreview, [updatePreview, canvasCache, nodeRect, pixelRect]);
 
   return (
+    <Tooltip label={<TooltipContent canvasRef={canvasRef} />} p={2} closeOnScroll>
+      <Flex
+        position="relative"
+        alignItems="center"
+        justifyContent="center"
+        w={CONTAINER_WIDTH_PX}
+        h={CONTAINER_WIDTH_PX}
+        borderRadius="sm"
+        borderWidth={1}
+        bg="base.900"
+        flexShrink={0}
+      >
+        <Box
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          left={0}
+          bgImage={TRANSPARENCY_CHECKERBOARD_PATTERN_DARK_DATAURL}
+          bgSize="5px"
+        />
+        <ChakraCanvas position="relative" ref={canvasRef} objectFit="contain" maxW="full" maxH="full" />
+      </Flex>
+    </Tooltip>
+  );
+});
+
+CanvasEntityPreviewImage.displayName = 'CanvasEntityPreviewImage';
+
+const TooltipContent = ({ canvasRef }: { canvasRef: React.RefObject<HTMLCanvasElement> }) => {
+  const canvasRef2 = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!canvasRef2.current || !canvasRef.current) {
+      return;
+    }
+
+    const ctx = canvasRef2.current.getContext('2d');
+
+    if (!ctx) {
+      return;
+    }
+
+    canvasRef2.current.width = canvasRef.current.width;
+    canvasRef2.current.height = canvasRef.current.height;
+    ctx.clearRect(0, 0, canvasRef2.current.width, canvasRef2.current.height);
+    ctx.drawImage(canvasRef.current, 0, 0);
+  }, [canvasRef]);
+
+  return (
     <Flex
       position="relative"
       alignItems="center"
       justifyContent="center"
-      w={CONTAINER_WIDTH_PX}
-      h={CONTAINER_WIDTH_PX}
+      w={150}
+      h={150}
       borderRadius="sm"
       borderWidth={1}
       bg="base.900"
@@ -105,11 +155,9 @@ export const CanvasEntityPreviewImage = memo(() => {
         bottom={0}
         left={0}
         bgImage={TRANSPARENCY_CHECKERBOARD_PATTERN_DARK_DATAURL}
-        bgSize="5px"
+        bgSize="8px"
       />
-      <ChakraCanvas position="relative" ref={canvasRef} objectFit="contain" maxW="full" maxH="full" />
+      <ChakraCanvas position="relative" ref={canvasRef2} objectFit="contain" maxW="full" maxH="full" />
     </Flex>
   );
-});
-
-CanvasEntityPreviewImage.displayName = 'CanvasEntityPreviewImage';
+};

--- a/invokeai/frontend/web/src/features/controlLayers/contexts/EntityAdapterContext.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/contexts/EntityAdapterContext.tsx
@@ -4,9 +4,13 @@ import type { CanvasEntityAdapterControlLayer } from 'features/controlLayers/kon
 import type { CanvasEntityAdapterInpaintMask } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterInpaintMask';
 import type { CanvasEntityAdapterRasterLayer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRasterLayer';
 import type { CanvasEntityAdapterRegionalGuidance } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance';
-import type { CanvasEntityIdentifier } from 'features/controlLayers/store/types';
+import type { CanvasEntityAdapterFromType } from 'features/controlLayers/konva/CanvasEntity/types';
+import type {
+  CanvasEntityIdentifier,
+  CanvasRenderableEntityType,
+} from 'features/controlLayers/store/types';
 import type { PropsWithChildren } from 'react';
-import { createContext, memo, useMemo, useSyncExternalStore } from 'react';
+import { createContext, memo, useContext, useMemo, useSyncExternalStore } from 'react';
 import { assert } from 'tsafe';
 
 const EntityAdapterContext = createContext<
@@ -94,6 +98,17 @@ export const RegionalGuidanceAdapterGate = memo(({ children }: PropsWithChildren
 
   return <EntityAdapterContext.Provider value={adapter}>{children}</EntityAdapterContext.Provider>;
 });
+
+export const useEntityAdapterContext = <T extends CanvasRenderableEntityType | undefined = CanvasRenderableEntityType>(
+  type?: T
+): CanvasEntityAdapterFromType<T extends undefined ? CanvasRenderableEntityType : T> => {
+  const adapter = useContext(EntityAdapterContext);
+  assert(adapter, 'useEntityIdentifier must be used within a EntityIdentifierProvider');
+  if (type) {
+    assert(adapter.entityIdentifier.type === type, 'useEntityIdentifier must be used with the correct type');
+  }
+  return adapter as CanvasEntityAdapterFromType<T extends undefined ? CanvasRenderableEntityType : T>;
+};
 
 RegionalGuidanceAdapterGate.displayName = 'RegionalGuidanceAdapterGate';
 

--- a/invokeai/frontend/web/src/features/controlLayers/contexts/EntityAdapterContext.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/contexts/EntityAdapterContext.tsx
@@ -5,10 +5,7 @@ import type { CanvasEntityAdapterInpaintMask } from 'features/controlLayers/konv
 import type { CanvasEntityAdapterRasterLayer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRasterLayer';
 import type { CanvasEntityAdapterRegionalGuidance } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance';
 import type { CanvasEntityAdapterFromType } from 'features/controlLayers/konva/CanvasEntity/types';
-import type {
-  CanvasEntityIdentifier,
-  CanvasRenderableEntityType,
-} from 'features/controlLayers/store/types';
+import type { CanvasEntityIdentifier, CanvasRenderableEntityType } from 'features/controlLayers/store/types';
 import type { PropsWithChildren } from 'react';
 import { createContext, memo, useContext, useMemo, useSyncExternalStore } from 'react';
 import { assert } from 'tsafe';

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
@@ -49,6 +49,7 @@ import { isControlNetOrT2IAdapterModelConfig, isIPAdapterModelConfig } from 'ser
 import type { Equals } from 'tsafe';
 import { assert } from 'tsafe';
 
+/** @knipignore */
 export const selectDefaultControlAdapter = createSelector(
   selectModelConfigsQuery,
   selectBase,

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
@@ -92,11 +92,10 @@ export const selectDefaultIPAdapter = createSelector(
 
 export const useAddControlLayer = () => {
   const dispatch = useAppDispatch();
-  const defaultControlAdapter = useAppSelector(selectDefaultControlAdapter);
   const func = useCallback(() => {
-    const overrides = { controlAdapter: defaultControlAdapter };
+    const overrides = { controlAdapter: deepClone(initialControlNet) };
     dispatch(controlLayerAdded({ isSelected: true, overrides }));
-  }, [defaultControlAdapter, dispatch]);
+  }, [dispatch]);
 
   return func;
 };

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/saveCanvasHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/saveCanvasHooks.ts
@@ -4,7 +4,7 @@ import type { SerializableObject } from 'common/types';
 import { deepClone } from 'common/util/deepClone';
 import { withResultAsync } from 'common/util/result';
 import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
-import { selectDefaultControlAdapter, selectDefaultIPAdapter } from 'features/controlLayers/hooks/addLayerHooks';
+import { selectDefaultIPAdapter } from 'features/controlLayers/hooks/addLayerHooks';
 import { getPrefixedId } from 'features/controlLayers/konva/util';
 import {
   controlLayerAdded,
@@ -25,7 +25,7 @@ import type {
   Rect,
   RegionalGuidanceReferenceImageState,
 } from 'features/controlLayers/store/types';
-import { imageDTOToImageObject, imageDTOToImageWithDims } from 'features/controlLayers/store/util';
+import { imageDTOToImageObject, imageDTOToImageWithDims, initialControlNet } from 'features/controlLayers/store/util';
 import { toast } from 'features/toast/toast';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -229,13 +229,12 @@ export const useNewRasterLayerFromBbox = () => {
 export const useNewControlLayerFromBbox = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const defaultControlAdapter = useAppSelector(selectDefaultControlAdapter);
 
   const arg = useMemo<UseSaveCanvasArg>(() => {
     const onSave = (imageDTO: ImageDTO, rect: Rect) => {
       const overrides: Partial<CanvasControlLayerState> = {
         objects: [imageDTOToImageObject(imageDTO)],
-        controlAdapter: deepClone(defaultControlAdapter),
+        controlAdapter: deepClone(initialControlNet),
         position: { x: rect.x, y: rect.y },
       };
       dispatch(controlLayerAdded({ overrides, isSelected: true }));
@@ -248,7 +247,7 @@ export const useNewControlLayerFromBbox = () => {
       toastOk: t('controlLayers.newControlLayerOk'),
       toastError: t('controlLayers.newControlLayerError'),
     };
-  }, [defaultControlAdapter, dispatch, t]);
+  }, [dispatch, t]);
   const func = useSaveCanvas(arg);
   return func;
 };

--- a/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
@@ -456,14 +456,14 @@ const PROCESSOR_TO_FILTER_MAP: Record<string, FilterType> = {
  */
 export const getFilterForModel = (modelConfig: ControlNetModelConfig | T2IAdapterModelConfig | null) => {
   if (!modelConfig) {
-    // No model, use the default filter
-    return IMAGE_FILTERS.canny_edge_detection;
+    // No model
+    return null;
   }
 
   const preprocessor = modelConfig?.default_settings?.preprocessor;
   if (!preprocessor) {
-    // No preprocessor, use the default filter
-    return IMAGE_FILTERS.canny_edge_detection;
+    // No preprocessor
+    return null;
   }
 
   if (isFilterType(preprocessor)) {
@@ -473,8 +473,8 @@ export const getFilterForModel = (modelConfig: ControlNetModelConfig | T2IAdapte
 
   const filterName = PROCESSOR_TO_FILTER_MAP[preprocessor];
   if (!filterName) {
-    // No filter found, use the default filter
-    return IMAGE_FILTERS.canny_edge_detection;
+    // No filter found
+    return null;
   }
 
   // Found a filter, use it

--- a/invokeai/frontend/web/src/features/controlLayers/store/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/util.ts
@@ -78,7 +78,7 @@ export const initialT2IAdapter: T2IAdapterConfig = {
 export const initialControlNet: ControlNetConfig = {
   type: 'controlnet',
   model: null,
-  weight: 1,
+  weight: 0.75,
   beginEndStepPct: [0, 1],
   controlMode: 'balanced',
 };

--- a/invokeai/frontend/web/src/features/controlLayers/store/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/util.ts
@@ -79,7 +79,7 @@ export const initialControlNet: ControlNetConfig = {
   type: 'controlnet',
   model: null,
   weight: 0.75,
-  beginEndStepPct: [0, 1],
+  beginEndStepPct: [0, 0.75],
   controlMode: 'balanced',
 };
 

--- a/invokeai/frontend/web/src/features/deleteImageModal/components/DeleteImageButton.tsx
+++ b/invokeai/frontend/web/src/features/deleteImageModal/components/DeleteImageButton.tsx
@@ -27,6 +27,8 @@ export const DeleteImageButton = memo((props: DeleteImageButtonProps) => {
       aria-label={labelMessage}
       isDisabled={isDisabled || !isConnected}
       colorScheme="error"
+      variant="link"
+      alignSelf="stretch"
     />
   );
 });

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CompareToolbar.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CompareToolbar.tsx
@@ -22,7 +22,7 @@ import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/us
 import { memo, useCallback } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { Trans, useTranslation } from 'react-i18next';
-import { PiArrowsOutBold, PiQuestion, PiSwapBold } from 'react-icons/pi';
+import { PiArrowsLeftRightBold, PiArrowsOutBold, PiQuestion } from 'react-icons/pi';
 
 export const CompareToolbar = memo(() => {
   const { t } = useTranslation();
@@ -60,14 +60,16 @@ export const CompareToolbar = memo(() => {
   useRegisteredHotkeys({ id: 'nextComparisonMode', category: 'viewer', callback: nextMode, dependencies: [nextMode] });
 
   return (
-    <Flex w="full" gap={2}>
+    <Flex w="full" px={2} gap={2} bg="base.750" borderTopRadius="base" h={12}>
       <Flex flex={1} justifyContent="center">
-        <Flex gap={2} marginInlineEnd="auto">
+        <Flex marginInlineEnd="auto" alignItems="center">
           <IconButton
-            icon={<PiSwapBold />}
+            icon={<PiArrowsLeftRightBold />}
             aria-label={`${t('gallery.swapImages')} (C)`}
             tooltip={`${t('gallery.swapImages')} (C)`}
             onClick={swapImages}
+            variant="link"
+            alignSelf="stretch"
           />
           {comparisonMode !== 'side-by-side' && (
             <IconButton
@@ -75,14 +77,15 @@ export const CompareToolbar = memo(() => {
               tooltip={t('gallery.stretchToFit')}
               onClick={toggleComparisonFit}
               colorScheme={comparisonFit === 'fill' ? 'invokeBlue' : 'base'}
-              variant="outline"
+              variant="link"
+              alignSelf="stretch"
               icon={<PiArrowsOutBold />}
             />
           )}
         </Flex>
       </Flex>
-      <Flex flex={1} gap={4} justifyContent="center">
-        <ButtonGroup variant="outline">
+      <Flex flex={1} justifyContent="center">
+        <ButtonGroup variant="outline" alignItems="center">
           <Button
             flexShrink={0}
             onClick={setComparisonModeSlider}
@@ -110,11 +113,13 @@ export const CompareToolbar = memo(() => {
         <Flex gap={2} marginInlineStart="auto" alignItems="center">
           <Tooltip label={<CompareHelp />}>
             <Flex alignItems="center">
-              <Icon boxSize={6} color="base.500" as={PiQuestion} lineHeight={0} />
+              <Icon boxSize={6} color="base.300" as={PiQuestion} lineHeight={0} />
             </Flex>
           </Tooltip>
           <Button
-            variant="ghost"
+            variant="link"
+            alignSelf="stretch"
+            px={2}
             aria-label={`${t('gallery.exitCompare')} (Esc)`}
             tooltip={`${t('gallery.exitCompare')} (Esc)`}
             onClick={exitCompare}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImageButtons.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImageButtons.tsx
@@ -1,4 +1,4 @@
-import { ButtonGroup, IconButton, Menu, MenuButton, MenuList } from '@invoke-ai/ui-library';
+import { Divider, IconButton, Menu, MenuButton, MenuList } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useAppSelector } from 'app/store/storeHooks';
@@ -46,73 +46,81 @@ const CurrentImageButtonsContent = memo(({ imageDTO }: { imageDTO: ImageDTO }) =
 
   return (
     <>
-      <ButtonGroup>
-        <Menu isLazy>
-          <MenuButton
-            as={IconButton}
-            aria-label={t('parameters.imageActions')}
-            tooltip={t('parameters.imageActions')}
-            isDisabled={!imageDTO}
-            icon={<PiDotsThreeOutlineFill />}
-          />
-          <MenuList>{imageDTO && <SingleSelectionMenuItems imageDTO={imageDTO} />}</MenuList>
-        </Menu>
-      </ButtonGroup>
+      <Menu isLazy>
+        <MenuButton
+          as={IconButton}
+          aria-label={t('parameters.imageActions')}
+          tooltip={t('parameters.imageActions')}
+          isDisabled={!imageDTO}
+          variant="link"
+          alignSelf="stretch"
+          icon={<PiDotsThreeOutlineFill />}
+        />
+        <MenuList>{imageDTO && <SingleSelectionMenuItems imageDTO={imageDTO} />}</MenuList>
+      </Menu>
 
-      <ButtonGroup>
-        <IconButton
-          icon={<PiFlowArrowBold />}
-          tooltip={`${t('nodes.loadWorkflow')} (W)`}
-          aria-label={`${t('nodes.loadWorkflow')} (W)`}
-          isDisabled={!imageActions.hasWorkflow || !hasTemplates}
-          onClick={imageActions.loadWorkflow}
-        />
-        <IconButton
-          icon={<PiArrowsCounterClockwiseBold />}
-          tooltip={`${t('parameters.remixImage')} (R)`}
-          aria-label={`${t('parameters.remixImage')} (R)`}
-          isDisabled={!imageActions.hasMetadata}
-          onClick={imageActions.remix}
-        />
-        <IconButton
-          icon={<PiQuotesBold />}
-          tooltip={`${t('parameters.usePrompt')} (P)`}
-          aria-label={`${t('parameters.usePrompt')} (P)`}
-          isDisabled={!imageActions.hasPrompts}
-          onClick={imageActions.recallPrompts}
-        />
-        <IconButton
-          icon={<PiPlantBold />}
-          tooltip={`${t('parameters.useSeed')} (S)`}
-          aria-label={`${t('parameters.useSeed')} (S)`}
-          isDisabled={!imageActions.hasSeed}
-          onClick={imageActions.recallSeed}
-        />
-        <IconButton
-          icon={<PiRulerBold />}
-          tooltip={`${t('parameters.useSize')} (D)`}
-          aria-label={`${t('parameters.useSize')} (D)`}
-          onClick={imageActions.recallSize}
-          isDisabled={isStaging}
-        />
-        <IconButton
-          icon={<PiAsteriskBold />}
-          tooltip={`${t('parameters.useAll')} (A)`}
-          aria-label={`${t('parameters.useAll')} (A)`}
-          isDisabled={!imageActions.hasMetadata}
-          onClick={imageActions.recallAll}
-        />
-      </ButtonGroup>
+      <Divider orientation="vertical" h={8} mx={2} />
 
-      {isUpscalingEnabled && (
-        <ButtonGroup>
-          <PostProcessingPopover imageDTO={imageDTO} />
-        </ButtonGroup>
-      )}
+      <IconButton
+        icon={<PiFlowArrowBold />}
+        tooltip={`${t('nodes.loadWorkflow')} (W)`}
+        aria-label={`${t('nodes.loadWorkflow')} (W)`}
+        isDisabled={!imageActions.hasWorkflow || !hasTemplates}
+        variant="link"
+        alignSelf="stretch"
+        onClick={imageActions.loadWorkflow}
+      />
+      <IconButton
+        icon={<PiArrowsCounterClockwiseBold />}
+        tooltip={`${t('parameters.remixImage')} (R)`}
+        aria-label={`${t('parameters.remixImage')} (R)`}
+        isDisabled={!imageActions.hasMetadata}
+        variant="link"
+        alignSelf="stretch"
+        onClick={imageActions.remix}
+      />
+      <IconButton
+        icon={<PiQuotesBold />}
+        tooltip={`${t('parameters.usePrompt')} (P)`}
+        aria-label={`${t('parameters.usePrompt')} (P)`}
+        isDisabled={!imageActions.hasPrompts}
+        variant="link"
+        alignSelf="stretch"
+        onClick={imageActions.recallPrompts}
+      />
+      <IconButton
+        icon={<PiPlantBold />}
+        tooltip={`${t('parameters.useSeed')} (S)`}
+        aria-label={`${t('parameters.useSeed')} (S)`}
+        isDisabled={!imageActions.hasSeed}
+        variant="link"
+        alignSelf="stretch"
+        onClick={imageActions.recallSeed}
+      />
+      <IconButton
+        icon={<PiRulerBold />}
+        tooltip={`${t('parameters.useSize')} (D)`}
+        aria-label={`${t('parameters.useSize')} (D)`}
+        variant="link"
+        alignSelf="stretch"
+        onClick={imageActions.recallSize}
+        isDisabled={isStaging}
+      />
+      <IconButton
+        icon={<PiAsteriskBold />}
+        tooltip={`${t('parameters.useAll')} (A)`}
+        aria-label={`${t('parameters.useAll')} (A)`}
+        isDisabled={!imageActions.hasMetadata}
+        variant="link"
+        alignSelf="stretch"
+        onClick={imageActions.recallAll}
+      />
 
-      <ButtonGroup>
-        <DeleteImageButton onClick={imageActions.delete} />
-      </ButtonGroup>
+      {isUpscalingEnabled && <PostProcessingPopover imageDTO={imageDTO} />}
+
+      <Divider orientation="vertical" h={8} mx={2} />
+
+      <DeleteImageButton onClick={imageActions.delete} />
     </>
   );
 });

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
@@ -37,7 +37,6 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
       ref={ref}
       tabIndex={-1}
       layerStyle="first"
-      p={2}
       borderRadius="base"
       position="absolute"
       flexDirection="column"
@@ -51,7 +50,7 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
     >
       {hasImageToCompare && <CompareToolbar />}
       {!hasImageToCompare && <ViewerToolbar closeButton={closeButton} />}
-      <Box ref={containerRef} w="full" h="full">
+      <Box ref={containerRef} w="full" h="full" p={2}>
         {!hasImageToCompare && <CurrentImagePreview />}
         {hasImageToCompare && <ImageComparison containerDims={containerDims} />}
       </Box>
@@ -84,7 +83,8 @@ const ImageViewerCloseButton = memo(() => {
       tooltip={t('gallery.closeViewer')}
       aria-label={t('gallery.closeViewer')}
       icon={<PiXBold />}
-      variant="ghost"
+      variant="link"
+      alignSelf="stretch"
       onClick={imageViewer.close}
     />
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ToggleMetadataViewerButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ToggleMetadataViewerButton.tsx
@@ -38,7 +38,8 @@ export const ToggleMetadataViewerButton = memo(() => {
       aria-label={`${t('parameters.info')} (I)`}
       onClick={toggleMetadataViewer}
       isDisabled={!imageDTO}
-      variant="outline"
+      variant="link"
+      alignSelf="stretch"
       colorScheme={shouldShowImageDetails ? 'invokeBlue' : 'base'}
       data-testid="toggle-show-metadata-button"
     />

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ToggleProgressButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ToggleProgressButton.tsx
@@ -21,7 +21,8 @@ export const ToggleProgressButton = memo(() => {
       tooltip={t('settings.displayInProgress')}
       icon={<PiHourglassHighBold />}
       onClick={onClick}
-      variant="outline"
+      variant="link"
+      alignSelf="stretch"
       colorScheme={shouldShowProgressInViewer ? 'invokeBlue' : 'base'}
       data-testid="toggle-show-progress-button"
     />

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToolbar.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToolbar.tsx
@@ -12,20 +12,18 @@ type Props = {
 
 export const ViewerToolbar = memo(({ closeButton }: Props) => {
   return (
-    <Flex w="full" gap={2}>
+    <Flex w="full" px={2} gap={2} bg="base.750" borderTopRadius="base" h={12}>
       <Flex flex={1} justifyContent="center">
-        <Flex gap={2} marginInlineEnd="auto">
+        <Flex marginInlineEnd="auto" alignItems="center">
           <ToggleProgressButton />
           <ToggleMetadataViewerButton />
         </Flex>
       </Flex>
-      <Flex flex={1} gap={2} justifyContent="center">
+      <Flex flex={1} justifyContent="center" alignItems="center">
         <CurrentImageButtons />
       </Flex>
-      <Flex flex={1} justifyContent="center">
-        <Flex gap={2} marginInlineStart="auto">
-          {closeButton}
-        </Flex>
+      <Flex flex={1} justifyContent="center" alignItems="center">
+        <Flex marginInlineStart="auto">{closeButton}</Flex>
       </Flex>
     </Flex>
   );

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToolbar.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ViewerToolbar.tsx
@@ -22,8 +22,10 @@ export const ViewerToolbar = memo(({ closeButton }: Props) => {
       <Flex flex={1} justifyContent="center" alignItems="center">
         <CurrentImageButtons />
       </Flex>
-      <Flex flex={1} justifyContent="center" alignItems="center">
-        <Flex marginInlineStart="auto">{closeButton}</Flex>
+      <Flex flex={1} justifyContent="center">
+        <Flex marginInlineStart="auto" alignItems="center">
+          {closeButton}
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/invokeai/frontend/web/src/features/parameters/components/PostProcessing/PostProcessingPopover.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/PostProcessing/PostProcessingPopover.tsx
@@ -47,6 +47,8 @@ export const PostProcessingPopover = memo((props: Props) => {
           onClick={onOpen}
           icon={<PiFrameCornersBold />}
           aria-label={t('parameters.postProcessing')}
+          variant="link"
+          alignSelf="stretch"
         />
       </PopoverTrigger>
       <PopoverContent>


### PR DESCRIPTION
## Summary

- Update viewer styling to have a menubar-ish header. Also used for image comparison.
- Set default control weight & end step % to 0.75.
- Add " (recommended)" to the "Balanced" control mode label.
- Add tooltip to layer preview image showing the layer at the same size as the boards/style presets image preview tooltips.
- Add empty state for control layers guiding user to upload an image, drag an image from gallery or start drawing.
- Add "simple" mode for control layers filtering, triggered when you select a control model. This automatically selects and processes the default filter for that model, if a default exists. If the user clicks `Advanced`, they get the full filter settings UI.
- Default control layers to no model selection.

## Related Issues / Discussions

Offline discussion.

## QA Instructions

Try the changes out.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_