### PR TITLE
feat(ui): simplify parameter schema declaration

### DIFF
--- a/invokeai/frontend/web/knip.ts
+++ b/invokeai/frontend/web/knip.ts
@@ -9,6 +9,7 @@ const config: KnipConfig = {
     'src/services/api/schema.ts',
     'src/features/nodes/types/v1/**',
     'src/features/nodes/types/v2/**',
+    'src/features/parameters/types/parameterSchemas.ts',
     // TODO(psyche): maybe we can clean up these utils after canvas v2 release
     'src/features/controlLayers/konva/util.ts',
     // TODO(psyche): restore HRF functionality?

--- a/invokeai/frontend/web/src/features/parameters/types/parameterSchemas.ts
+++ b/invokeai/frontend/web/src/features/parameters/types/parameterSchemas.ts
@@ -15,88 +15,87 @@ import { z } from 'zod';
  * simply be the zod schema's safeParse function
  */
 
+/**
+ * Helper to create a type guard from a zod schema. The type guard will infer the schema's TS type.
+ * @param schema The zod schema to create a type guard from.
+ * @returns A type guard function for the schema.
+ */
+const buildTypeGuard = <T extends z.ZodTypeAny>(schema: T) => {
+  return (val: unknown): val is z.infer<T> => schema.safeParse(val).success;
+};
+
+/**
+ * Helper to create a zod schema and a type guard from it.
+ * @param schema The zod schema to create a type guard from.
+ * @returns A tuple containing the zod schema and the type guard function.
+ */
+const buildParameter = <T extends z.ZodTypeAny>(schema: T) => [schema, buildTypeGuard(schema)] as const;
+
 // #region Positive prompt
-export const zParameterPositivePrompt = z.string();
+export const [zParameterPositivePrompt, isParameterPositivePrompt] = buildParameter(z.string());
 export type ParameterPositivePrompt = z.infer<typeof zParameterPositivePrompt>;
-export const isParameterPositivePrompt = (val: unknown): val is ParameterPositivePrompt =>
-  zParameterPositivePrompt.safeParse(val).success;
 // #endregion
 
 // #region Negative prompt
-export const zParameterNegativePrompt = z.string();
+export const [zParameterNegativePrompt, isParameterNegativePrompt] = buildParameter(z.string());
 export type ParameterNegativePrompt = z.infer<typeof zParameterNegativePrompt>;
-export const isParameterNegativePrompt = (val: unknown): val is ParameterNegativePrompt =>
-  zParameterNegativePrompt.safeParse(val).success;
 // #endregion
 
 // #region Positive style prompt (SDXL)
-const zParameterPositiveStylePromptSDXL = z.string();
+export const [zParameterPositiveStylePromptSDXL, isParameterPositiveStylePromptSDXL] = buildParameter(z.string());
 export type ParameterPositiveStylePromptSDXL = z.infer<typeof zParameterPositiveStylePromptSDXL>;
-export const isParameterPositiveStylePromptSDXL = (val: unknown): val is ParameterPositiveStylePromptSDXL =>
-  zParameterPositiveStylePromptSDXL.safeParse(val).success;
 // #endregion
 
 // #region Positive style prompt (SDXL)
-const zParameterNegativeStylePromptSDXL = z.string();
+export const [zParameterNegativeStylePromptSDXL, isParameterNegativeStylePromptSDXL] = buildParameter(z.string());
 export type ParameterNegativeStylePromptSDXL = z.infer<typeof zParameterNegativeStylePromptSDXL>;
-export const isParameterNegativeStylePromptSDXL = (val: unknown): val is ParameterNegativeStylePromptSDXL =>
-  zParameterNegativeStylePromptSDXL.safeParse(val).success;
 // #endregion
 
 // #region Steps
-const zParameterSteps = z.number().int().min(1);
+export const [zParameterSteps, isParameterSteps] = buildParameter(z.number().int().min(1));
 export type ParameterSteps = z.infer<typeof zParameterSteps>;
-export const isParameterSteps = (val: unknown): val is ParameterSteps => zParameterSteps.safeParse(val).success;
 // #endregion
 
 // #region CFG scale parameter
-const zParameterCFGScale = z.number().min(1);
+export const [zParameterCFGScale, isParameterCFGScale] = buildParameter(z.number().min(1));
 export type ParameterCFGScale = z.infer<typeof zParameterCFGScale>;
-export const isParameterCFGScale = (val: unknown): val is ParameterCFGScale =>
-  zParameterCFGScale.safeParse(val).success;
 // #endregion
 
 // #region Guidance parameter
-const zParameterGuidance = z.number().min(1);
+export const [zParameterGuidance, isParameterGuidance] = buildParameter(z.number().min(1));
 export type ParameterGuidance = z.infer<typeof zParameterGuidance>;
-export const isParameterGuidance = (val: unknown): val is ParameterGuidance =>
-  zParameterGuidance.safeParse(val).success;
 // #endregion
 
 // #region CFG Rescale Multiplier
-const zParameterCFGRescaleMultiplier = z.number().gte(0).lt(1);
+export const [zParameterCFGRescaleMultiplier, isParameterCFGRescaleMultiplier] = buildParameter(
+  z.number().gte(0).lt(1)
+);
 export type ParameterCFGRescaleMultiplier = z.infer<typeof zParameterCFGRescaleMultiplier>;
-export const isParameterCFGRescaleMultiplier = (val: unknown): val is ParameterCFGRescaleMultiplier =>
-  zParameterCFGRescaleMultiplier.safeParse(val).success;
 // #endregion
 
 // #region Scheduler
-const zParameterScheduler = zSchedulerField;
+export const [zParameterScheduler, isParameterScheduler] = buildParameter(zSchedulerField);
 export type ParameterScheduler = z.infer<typeof zParameterScheduler>;
-export const isParameterScheduler = (val: unknown): val is ParameterScheduler =>
-  zParameterScheduler.safeParse(val).success;
 // #endregion
 
 // #region seed
-const zParameterSeed = z.number().int().min(0).max(NUMPY_RAND_MAX);
+export const [zParameterSeed, isParameterSeed] = buildParameter(z.number().int().min(0).max(NUMPY_RAND_MAX));
 export type ParameterSeed = z.infer<typeof zParameterSeed>;
-export const isParameterSeed = (val: unknown): val is ParameterSeed => zParameterSeed.safeParse(val).success;
 // #endregion
 
 // #region Width
-export const zParameterImageDimension = z
-  .number()
-  .min(64)
-  .transform((val) => roundToMultiple(val, 8));
+export const [zParameterImageDimension, isParameterImageDimension] = buildParameter(
+  z
+    .number()
+    .min(64)
+    .transform((val) => roundToMultiple(val, 8))
+);
 export type ParameterWidth = z.infer<typeof zParameterImageDimension>;
-export const isParameterWidth = (val: unknown): val is ParameterWidth =>
-  zParameterImageDimension.safeParse(val).success;
-// #endregion
+export const isParameterWidth = isParameterImageDimension;
 
 // #region Height
 export type ParameterHeight = z.infer<typeof zParameterImageDimension>;
-export const isParameterHeight = (val: unknown): val is ParameterHeight =>
-  zParameterImageDimension.safeParse(val).success;
+export const isParameterHeight = isParameterImageDimension;
 // #endregion
 
 // #region Model
@@ -135,70 +134,50 @@ export type ParameterSpandrelImageToImageModel = z.infer<typeof zParameterSpandr
 // #endregion
 
 // #region Strength (l2l strength)
-const zParameterStrength = z.number().min(0).max(1);
+export const [zParameterStrength, isParameterStrength] = buildParameter(z.number().min(0).max(1));
 export type ParameterStrength = z.infer<typeof zParameterStrength>;
-export const isParameterStrength = (val: unknown): val is ParameterStrength =>
-  zParameterStrength.safeParse(val).success;
 // #endregion
 
 // #region SeamlessX
-const zParameterSeamlessX = z.boolean();
+export const [zParameterSeamlessX, isParameterSeamlessX] = buildParameter(z.boolean());
 export type ParameterSeamlessX = z.infer<typeof zParameterSeamlessX>;
-export const isParameterSeamlessX = (val: unknown): val is ParameterSeamlessX =>
-  zParameterSeamlessX.safeParse(val).success;
 // #endregion
 
 // #region SeamlessY
-const zParameterSeamlessY = z.boolean();
+export const [zParameterSeamlessY, isParameterSeamlessY] = buildParameter(z.boolean());
 export type ParameterSeamlessY = z.infer<typeof zParameterSeamlessY>;
-export const isParameterSeamlessY = (val: unknown): val is ParameterSeamlessY =>
-  zParameterSeamlessY.safeParse(val).success;
 // #endregion
 
 // #region Precision
-const zParameterPrecision = z.enum(['fp16', 'fp32']);
+export const [zParameterPrecision, isParameterPrecision] = buildParameter(z.enum(['fp16', 'fp32']));
 export type ParameterPrecision = z.infer<typeof zParameterPrecision>;
-export const isParameterPrecision = (val: unknown): val is ParameterPrecision =>
-  zParameterPrecision.safeParse(val).success;
 // #endregion
 
 // #region HRF Method
-const zParameterHRFMethod = z.enum(['ESRGAN', 'bilinear']);
+export const [zParameterHRFMethod, isParameterHRFMethod] = buildParameter(z.enum(['ESRGAN', 'bilinear']));
 export type ParameterHRFMethod = z.infer<typeof zParameterHRFMethod>;
-export const isParameterHRFMethod = (val: unknown): val is ParameterHRFMethod =>
-  zParameterHRFMethod.safeParse(val).success;
 // #endregion
 
 // #region HRF Enabled
-const zParameterHRFEnabled = z.boolean();
+export const [zParameterHRFEnabled, isParameterHRFEnabled] = buildParameter(z.boolean());
 export type ParameterHRFEnabled = z.infer<typeof zParameterHRFEnabled>;
-export const isParameterHRFEnabled = (val: unknown): val is boolean =>
-  zParameterHRFEnabled.safeParse(val).success && val !== null && val !== undefined;
 // #endregion
 
 // #region SDXL Refiner Positive Aesthetic Score
-const zParameterSDXLRefinerPositiveAestheticScore = z.number().min(1).max(10);
+export const [zParameterSDXLRefinerPositiveAestheticScore, isParameterSDXLRefinerPositiveAestheticScore] =
+  buildParameter(z.number().min(1).max(10));
 export type ParameterSDXLRefinerPositiveAestheticScore = z.infer<typeof zParameterSDXLRefinerPositiveAestheticScore>;
-export const isParameterSDXLRefinerPositiveAestheticScore = (
-  val: unknown
-): val is ParameterSDXLRefinerPositiveAestheticScore =>
-  zParameterSDXLRefinerPositiveAestheticScore.safeParse(val).success;
 // #endregion
 
 // #region SDXL Refiner Negative Aesthetic Score
-const zParameterSDXLRefinerNegativeAestheticScore = zParameterSDXLRefinerPositiveAestheticScore;
+export const [zParameterSDXLRefinerNegativeAestheticScore, isParameterSDXLRefinerNegativeAestheticScore] =
+  buildParameter(zParameterSDXLRefinerPositiveAestheticScore);
 export type ParameterSDXLRefinerNegativeAestheticScore = z.infer<typeof zParameterSDXLRefinerNegativeAestheticScore>;
-export const isParameterSDXLRefinerNegativeAestheticScore = (
-  val: unknown
-): val is ParameterSDXLRefinerNegativeAestheticScore =>
-  zParameterSDXLRefinerNegativeAestheticScore.safeParse(val).success;
 // #endregion
 
 // #region SDXL Refiner Start
-const zParameterSDXLRefinerStart = z.number().min(0).max(1);
+export const [zParameterSDXLRefinerStart, isParameterSDXLRefinerStart] = buildParameter(z.number().min(0).max(1));
 export type ParameterSDXLRefinerStart = z.infer<typeof zParameterSDXLRefinerStart>;
-export const isParameterSDXLRefinerStart = (val: unknown): val is ParameterSDXLRefinerStart =>
-  zParameterSDXLRefinerStart.safeParse(val).success;
 // #endregion
 
 // #region Mask Blur Method
@@ -207,14 +186,13 @@ export type ParameterMaskBlurMethod = z.infer<typeof zParameterMaskBlurMethod>;
 // #endregion
 
 // #region Canvas Coherence Mode
-const zParameterCanvasCoherenceMode = z.enum(['Gaussian Blur', 'Box Blur', 'Staged']);
+export const [zParameterCanvasCoherenceMode, isParameterCanvasCoherenceMode] = buildParameter(
+  z.enum(['Gaussian Blur', 'Box Blur', 'Staged'])
+);
 export type ParameterCanvasCoherenceMode = z.infer<typeof zParameterCanvasCoherenceMode>;
-export const isParameterCanvasCoherenceMode = (val: unknown): val is ParameterCanvasCoherenceMode =>
-  zParameterCanvasCoherenceMode.safeParse(val).success;
 // #endregion
 
 // #region LoRA weight
-const zLoRAWeight = z.number();
-type ParameterLoRAWeight = z.infer<typeof zLoRAWeight>;
-export const isParameterLoRAWeight = (val: unknown): val is ParameterLoRAWeight => zLoRAWeight.safeParse(val).success;
+export const [zLoRAWeight, isParameterLoRAWeight] = buildParameter(z.number());
+export type ParameterLoRAWeight = z.infer<typeof zLoRAWeight>;
 // #endregion


### PR DESCRIPTION
## Summary 

- Simplify parameter schema declaration.
- Export some unused `zParameter` variables.
- Exclude the schema file in `invokeai/frontend/web/knip.ts`.

I prefer this concise version as it’s the most readable. In my opinion, more selective exports add unnecessary verbosity again.

## Related Issues / Discussions

https://github.com/invoke-ai/InvokeAI/pull/7217#discussion_r1820027840

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
