### PR TITLE
fix: Look in known subfolders for configs for clip variants

### DIFF
--- a/invokeai/backend/model_manager/util/model_util.py
+++ b/invokeai/backend/model_manager/util/model_util.py
@@ -173,6 +173,8 @@ def get_clip_variant_type(location: str) -> Optional[ClipVariantType]:
         path = Path(location)
         config_path = path / "config.json"
         if not config_path.exists():
+            config_path = path / "text_encoder" / "config.json"
+        if not config_path.exists():
             return ClipVariantType.L
         with open(config_path) as file:
             clip_conf = json.load(file)


### PR DESCRIPTION
## Summary

Currently if a text encoder is in a subfolder of a climpembed, we have no way of determining its variant. This enables our probe to search deeper than the root directory.

## QA Instructions

Install InvokeAI/clip-vit-large-patch14-text-encoder::bfloat16 and validate it checks the text_encoder via debugger

## Merge Plan

Can be merged when approved

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
