### PR TITLE
fix(ui): FLUX IP adapter clip vision model error

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedLinear.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedLinear.ts
@@ -1,6 +1,7 @@
 import { logger } from 'app/logging/logger';
 import { enqueueRequested } from 'app/store/actions';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
+import { extractMessageFromAssertionError } from 'common/util/extractMessageFromAssertionError';
 import type { Result } from 'common/util/result';
 import { withResult, withResultAsync } from 'common/util/result';
 import { $canvasManager } from 'features/controlLayers/store/ephemeral';
@@ -9,10 +10,11 @@ import { buildFLUXGraph } from 'features/nodes/util/graph/generation/buildFLUXGr
 import { buildSD1Graph } from 'features/nodes/util/graph/generation/buildSD1Graph';
 import { buildSDXLGraph } from 'features/nodes/util/graph/generation/buildSDXLGraph';
 import type { Graph } from 'features/nodes/util/graph/generation/Graph';
+import { toast } from 'features/toast/toast';
 import { serializeError } from 'serialize-error';
 import { queueApi } from 'services/api/endpoints/queue';
 import type { Invocation } from 'services/api/types';
-import { assert } from 'tsafe';
+import { assert, AssertionError } from 'tsafe';
 import type { JsonObject } from 'type-fest';
 
 const log = logger('generation');
@@ -57,7 +59,17 @@ export const addEnqueueRequestedLinear = (startAppListening: AppStartListening) 
       }
 
       if (buildGraphResult.isErr()) {
-        log.error({ error: serializeError(buildGraphResult.error) }, 'Failed to build graph');
+        let description: string | null = null;
+        if (buildGraphResult.error instanceof AssertionError) {
+          description = extractMessageFromAssertionError(buildGraphResult.error);
+        }
+        const error = serializeError(buildGraphResult.error);
+        log.error({ error }, 'Failed to build graph');
+        toast({
+          status: 'error',
+          title: 'Failed to build graph',
+          description,
+        });
         return;
       }
 

--- a/invokeai/frontend/web/src/common/util/extractMessageFromAssertionError.ts
+++ b/invokeai/frontend/web/src/common/util/extractMessageFromAssertionError.ts
@@ -1,0 +1,6 @@
+import type { AssertionError } from 'tsafe';
+
+export function extractMessageFromAssertionError(error: AssertionError): string | null {
+  const match = error.message.match(/Wrong assertion encountered: "(.*)"/);
+  return match ? (match[1] ?? null) : null;
+}

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
@@ -66,6 +66,9 @@ export const selectDefaultIPAdapter = createSelector(
     const ipAdapter = deepClone(initialIPAdapter);
     if (model) {
       ipAdapter.model = zModelIdentifierField.parse(model);
+      if (model.base === 'flux') {
+        ipAdapter.clipVisionModel = 'ViT-L';
+      }
     }
     return ipAdapter;
   }

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addIPAdapters.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addIPAdapters.ts
@@ -37,7 +37,10 @@ const addIPAdapter = (entity: CanvasReferenceImageState, g: Graph, collector: In
   let ipAdapterNode: Invocation<'flux_ip_adapter' | 'ip_adapter'>;
 
   if (model.base === 'flux') {
-    assert(clipVisionModel === 'ViT-L', 'ViT-L is the only supported CLIP Vision model for FLUX IP adapter');
+    assert(
+      clipVisionModel === 'ViT-L',
+      `ViT-L is the only supported CLIP Vision model for FLUX IP adapter, got ${clipVisionModel}`
+    );
     ipAdapterNode = g.addNode({
       id: `ip_adapter_${id}`,
       type: 'flux_ip_adapter',


### PR DESCRIPTION
## Summary

When creating a reference image (global or regional) we were not setting the CLIP vision model correctly. As a result, FLUX IP Adapters, which require the `ViT-L` model, were causing errors. 

This situation is now handled.

Also, when graph building fails, we now display an error toast. Previously, there was no feedback at all, so it felt like the invoke button just did nothing.

## Related Issues / Discussions

offline discussion

## QA Instructions

This won't fix existing misconfigured IP Adapters, but it does prevent new ones from ending up with the wrong CLIP vision model selection.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
