### PR TITLE
feat(ui): tweak image selection/hover styling

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
@@ -66,7 +66,7 @@ const galleryImageContainerSX = {
     },
     '&:hover::before': {
       boxShadow:
-        'inset 0px 0px 0px 2px var(--invoke-colors-invokeBlue-300), inset 0px 0px 0px 3px var(--invoke-colors-invokeBlue-800)',
+        'inset 0px 0px 0px 1px var(--invoke-colors-invokeBlue-300), inset 0px 0px 0px 2px var(--invoke-colors-invokeBlue-800)',
     },
     '&:hover[data-selected=true]::before': {
       boxShadow:


### PR DESCRIPTION
## Summary

The styling in gallery for selected vs hovered was very similar, leading users to think that the hovered image was also selected.

Reducing the borders for hovered images to a single pixel makes it easier to distinquich between selected and hovered.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1304457546563584011

## QA Instructions

Before:
<video src="https://github.com/user-attachments/assets/8c5a3afd-a86b-470c-b166-faab74e169b3"></video>

After:
<video src="https://github.com/user-attachments/assets/c8a9a5b4-bce7-4b6f-9fcf-d1d21fd5fc81"></video>

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_