### PR TITLE
fix(ui): image uploading handling

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageUploaded.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageUploaded.ts
@@ -41,29 +41,33 @@ export const addImageUploadedFulfilledListener = (startAppListening: AppStartLis
 
       log.debug({ imageDTO }, 'Image uploaded');
 
+      if (action.meta.arg.originalArgs.silent || imageDTO.is_intermediate) {
+        // When a "silent" upload is requested, or the image is intermediate, we can skip all post-upload actions,
+        // like toasts and switching the gallery view
+        return;
+      }
+
       const boardId = imageDTO.board_id ?? 'none';
 
-      if (action.meta.arg.originalArgs.withToast) {
-        const DEFAULT_UPLOADED_TOAST = {
-          id: 'IMAGE_UPLOADED',
-          title: t('toast.imageUploaded'),
-          status: 'success',
-        } as const;
+      const DEFAULT_UPLOADED_TOAST = {
+        id: 'IMAGE_UPLOADED',
+        title: t('toast.imageUploaded'),
+        status: 'success',
+      } as const;
 
-        // default action - just upload and alert user
-        if (lastUploadedToastTimeout !== null) {
-          window.clearTimeout(lastUploadedToastTimeout);
-        }
-        const toastApi = toast({
-          ...DEFAULT_UPLOADED_TOAST,
-          title: DEFAULT_UPLOADED_TOAST.title,
-          description: getUploadedToastDescription(boardId, state),
-          duration: null, // we will close the toast manually
-        });
-        lastUploadedToastTimeout = window.setTimeout(() => {
-          toastApi.close();
-        }, 3000);
+      // default action - just upload and alert user
+      if (lastUploadedToastTimeout !== null) {
+        window.clearTimeout(lastUploadedToastTimeout);
       }
+      const toastApi = toast({
+        ...DEFAULT_UPLOADED_TOAST,
+        title: DEFAULT_UPLOADED_TOAST.title,
+        description: getUploadedToastDescription(boardId, state),
+        duration: null, // we will close the toast manually
+      });
+      lastUploadedToastTimeout = window.setTimeout(() => {
+        toastApi.close();
+      }, 3000);
 
       /**
        * We only want to change the board and view if this is the first upload of a batch, else we end up hijacking

--- a/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
+++ b/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
@@ -75,11 +75,13 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
       } else {
         //
         const imageDTOs = await uploadImages(
-          files.map((file) => ({
+          files.map((file, i) => ({
             file,
             image_category: 'user',
             is_intermediate: false,
             board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+            silent: false,
+            isFirstUploadOfBatch: i === 0,
           }))
         );
         if (onUpload) {

--- a/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
+++ b/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
@@ -61,6 +61,11 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
           log.warn('Multiple files dropped but only one allowed');
           return;
         }
+        if (files.length === 0) {
+          // Should never happen
+          log.warn('No files dropped');
+          return;
+        }
         const file = files[0];
         assert(file !== undefined); // should never happen
         const imageDTO = await uploadImage({
@@ -68,12 +73,12 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
           image_category: 'user',
           is_intermediate: false,
           board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+          silent: true,
         }).unwrap();
         if (onUpload) {
           onUpload(imageDTO);
         }
       } else {
-        //
         const imageDTOs = await uploadImages(
           files.map((file, i) => ({
             file,

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/saveCanvasHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/saveCanvasHooks.ts
@@ -25,6 +25,8 @@ import type {
   RegionalGuidanceReferenceImageState,
 } from 'features/controlLayers/store/types';
 import { imageDTOToImageObject, imageDTOToImageWithDims, initialControlNet } from 'features/controlLayers/store/util';
+import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
+import type { BoardId } from 'features/gallery/store/types';
 import { toast } from 'features/toast/toast';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -70,6 +72,11 @@ const useSaveCanvas = ({ region, saveToGallery, toastOk, toastError, onSave, wit
       metadata = selectCanvasMetadata(store.getState());
     }
 
+    let boardId: BoardId | undefined = undefined;
+    if (saveToGallery) {
+      boardId = selectAutoAddBoardId(store.getState());
+    }
+
     const result = await withResultAsync(() => {
       const rasterAdapters = canvasManager.compositor.getVisibleAdaptersOfType('raster_layer');
       return canvasManager.compositor.getCompositeImageDTO(
@@ -78,6 +85,8 @@ const useSaveCanvas = ({ region, saveToGallery, toastOk, toastError, onSave, wit
         {
           is_intermediate: !saveToGallery,
           metadata,
+          board_id: boardId,
+          silent: true,
         },
         undefined,
         true // force upload the image to ensure it gets added to the gallery
@@ -222,8 +231,8 @@ export const useNewRasterLayerFromBbox = () => {
       toastError: t('controlLayers.newRasterLayerError'),
     };
   }, [dispatch, t]);
-  const newRasterLayerFromBbox = useSaveCanvas(arg);
-  return newRasterLayerFromBbox;
+  const func = useSaveCanvas(arg);
+  return func;
 };
 
 export const useNewControlLayerFromBbox = () => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
@@ -28,19 +28,17 @@ import type {
 } from 'features/controlLayers/store/types';
 import { getEntityIdentifier } from 'features/controlLayers/store/types';
 import { imageDTOToImageObject } from 'features/controlLayers/store/util';
-import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
 import { toast } from 'features/toast/toast';
 import { t } from 'i18next';
 import { atom, computed } from 'nanostores';
 import type { Logger } from 'roarr';
 import { serializeError } from 'serialize-error';
-import type { UploadImageArg } from 'services/api/endpoints/images';
 import { getImageDTOSafe, uploadImage } from 'services/api/endpoints/images';
-import type { ImageDTO } from 'services/api/types';
+import type { ImageDTO, UploadImageArg } from 'services/api/types';
 import stableHash from 'stable-hash';
 import type { Equals } from 'tsafe';
 import { assert } from 'tsafe';
-import type { JsonObject } from 'type-fest';
+import type { JsonObject, SetOptional } from 'type-fest';
 
 type CompositingOptions = {
   /**
@@ -259,7 +257,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
   getCompositeImageDTO = async (
     adapters: CanvasEntityAdapter[],
     rect: Rect,
-    uploadOptions: Pick<UploadImageArg, 'is_intermediate' | 'metadata'>,
+    uploadOptions: SetOptional<Omit<UploadImageArg, 'file'>, 'image_category'>,
     compositingOptions?: CompositingOptions,
     forceUpload?: boolean
   ): Promise<ImageDTO> => {
@@ -299,10 +297,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
       uploadImage({
         file: new File([blob], 'canvas-composite.png', { type: 'image/png' }),
         image_category: 'general',
-        is_intermediate: uploadOptions.is_intermediate,
-        board_id: uploadOptions.is_intermediate ? undefined : selectAutoAddBoardId(this.manager.store.getState()),
-        metadata: uploadOptions.metadata,
-        withToast: false,
+        ...uploadOptions,
       })
     );
     this.$isUploading.set(false);

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -493,7 +493,7 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
       file: new File([blob], `${this.id}_rasterized.png`, { type: 'image/png' }),
       image_category: 'other',
       is_intermediate: true,
-      withToast: false,
+      silent: true,
     });
     const imageObject = imageDTOToImageObject(imageDTO);
     if (replaceObjects) {

--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -13,8 +13,9 @@ import { selectMaxImageUploadCount } from 'features/system/store/configSlice';
 import { toast } from 'features/toast/toast';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type UploadImageArg, uploadImages } from 'services/api/endpoints/images';
+import { uploadImages } from 'services/api/endpoints/images';
 import { useBoardName } from 'services/api/hooks/useBoardName';
+import type { UploadImageArg } from 'services/api/types';
 import { z } from 'zod';
 
 const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -94,11 +95,12 @@ export const FullscreenDropzone = memo(() => {
       }
       const autoAddBoardId = selectAutoAddBoardId(getState());
 
-      const uploadArgs: UploadImageArg[] = files.map((file) => ({
+      const uploadArgs: UploadImageArg[] = files.map((file, i) => ({
         file,
         image_category: 'user',
         is_intermediate: false,
         board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+        isFirstUploadOfBatch: i === 0,
       }));
 
       uploadImages(uploadArgs);

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addImageToImage.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addImageToImage.ts
@@ -36,7 +36,10 @@ export const addImageToImage = async ({
 }: AddImageToImageArg): Promise<Invocation<'img_resize' | 'l2i' | 'flux_vae_decode' | 'sd3_l2i'>> => {
   denoise.denoising_start = denoising_start;
   const adapters = manager.compositor.getVisibleAdaptersOfType('raster_layer');
-  const { image_name } = await manager.compositor.getCompositeImageDTO(adapters, bbox.rect, { is_intermediate: true });
+  const { image_name } = await manager.compositor.getCompositeImageDTO(adapters, bbox.rect, {
+    is_intermediate: true,
+    silent: true,
+  });
 
   if (!isEqual(scaledSize, originalSize)) {
     // Resize the initial image to the scaled size, denoise, then resize back to the original size

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
@@ -51,11 +51,13 @@ export const addInpaint = async ({
   const rasterAdapters = manager.compositor.getVisibleAdaptersOfType('raster_layer');
   const initialImage = await manager.compositor.getCompositeImageDTO(rasterAdapters, bbox.rect, {
     is_intermediate: true,
+    silent: true,
   });
 
   const inpaintMaskAdapters = manager.compositor.getVisibleAdaptersOfType('inpaint_mask');
   const maskImage = await manager.compositor.getCompositeImageDTO(inpaintMaskAdapters, bbox.rect, {
     is_intermediate: true,
+    silent: true,
   });
 
   if (!isEqual(scaledSize, originalSize)) {

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addOutpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addOutpaint.ts
@@ -52,11 +52,13 @@ export const addOutpaint = async ({
   const rasterAdapters = manager.compositor.getVisibleAdaptersOfType('raster_layer');
   const initialImage = await manager.compositor.getCompositeImageDTO(rasterAdapters, bbox.rect, {
     is_intermediate: true,
+    silent: true,
   });
 
   const inpaintMaskAdapters = manager.compositor.getVisibleAdaptersOfType('inpaint_mask');
   const maskImage = await manager.compositor.getCompositeImageDTO(inpaintMaskAdapters, bbox.rect, {
     is_intermediate: true,
+    silent: true,
   });
 
   const infill = getInfill(g, params);

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -545,7 +545,6 @@ export const {
   useClearIntermediatesMutation,
   useAddImagesToBoardMutation,
   useRemoveImagesFromBoardMutation,
-  useChangeImageIsIntermediateMutation,
   useDeleteBoardAndImagesMutation,
   useDeleteBoardMutation,
   useStarImagesMutation,

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -1,5 +1,5 @@
 import type { components, paths } from 'services/api/schema';
-import type { SetRequired } from 'type-fest';
+import type { JsonObject, SetRequired } from 'type-fest';
 
 export type S = components['schemas'];
 
@@ -287,3 +287,42 @@ export type SetHFTokenResponse = NonNullable<
 export type SetHFTokenArg = NonNullable<
   paths['/api/v2/models/hf_login']['post']['requestBody']['content']['application/json']
 >;
+
+export type UploadImageArg = {
+  /**
+   * The file object to upload
+   */
+  file: File;
+  /**
+   * THe category of image to upload
+   */
+  image_category: ImageCategory;
+  /**
+   * Whether the uploaded image is an intermediate image (intermediate images are not shown int he gallery)
+   */
+  is_intermediate: boolean;
+  /**
+   * The session with which to associate the uploaded image
+   */
+  session_id?: string;
+  /**
+   * The board id to add the image to
+   */
+  board_id?: string;
+  /**
+   * Whether or not to crop the image to its bounding box before saving
+   */
+  crop_visible?: boolean;
+  /**
+   * Metadata to embed in the image when saving it
+   */
+  metadata?: JsonObject;
+  /**
+   * Whether this upload should be "silent" (no toast on upload, no changing of gallery view)
+   */
+  silent?: boolean;
+  /**
+   * Whether this is the first upload of a batch (used when displaying user feedback with toasts - ignored if the upload is silent)
+   */
+  isFirstUploadOfBatch?: boolean;
+};


### PR DESCRIPTION
## Summary

Rework uploadImage and uploadImages helpers and the RTK listener, ensuring gallery view isn't changed unexpectedly and preventing extraneous toasts.

Fix staging area save to gallery button to essentially make a copy of the image, instead of changing its intermediate status.

## Related Issues / Discussions

Multiple threads on discord

## QA Instructions

Test functionality that uploads an image:
- Generating on canvas, which uploads images for each layer type
- Clicking save to gallery on the canvas toolbar
- Clicking save to gallery on the staging area toolbar
- Uploading an image using a button (e.g. upscale initial image, node image field, control layer, ref image)

## Merge Plan

Probably bout time for a release.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_