### PR TITLE
fix(ui): unable to use text inputs within draggable

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasEntityList/useCanvasEntityListDnd.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasEntityList/useCanvasEntityListDnd.ts
@@ -4,6 +4,7 @@ import { attachClosestEdge, extractClosestEdge } from '@atlaskit/pragmatic-drag-
 import type { CanvasEntityIdentifier } from 'features/controlLayers/store/types';
 import { singleCanvasEntityDndSource } from 'features/dnd/dnd';
 import { type DndListTargetState, idle } from 'features/dnd/types';
+import { firefoxDndFix } from 'features/dnd/util';
 import type { RefObject } from 'react';
 import { useEffect, useState } from 'react';
 
@@ -17,6 +18,7 @@ export const useCanvasEntityListDnd = (ref: RefObject<HTMLElement>, entityIdenti
       return;
     }
     return combine(
+      firefoxDndFix(element),
       draggable({
         element,
         getInitialData() {

--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
@@ -12,6 +12,7 @@ import type { DndDragPreviewMultipleImageState } from 'features/dnd/DndDragPrevi
 import { createMultipleImageDragPreview, setMultipleImageDragPreview } from 'features/dnd/DndDragPreviewMultipleImage';
 import type { DndDragPreviewSingleImageState } from 'features/dnd/DndDragPreviewSingleImage';
 import { createSingleImageDragPreview, setSingleImageDragPreview } from 'features/dnd/DndDragPreviewSingleImage';
+import { firefoxDndFix } from 'features/dnd/util';
 import { useImageContextMenu } from 'features/gallery/components/ImageContextMenu/ImageContextMenu';
 import { GalleryImageHoverIcons } from 'features/gallery/components/ImageGrid/GalleryImageHoverIcons';
 import { getGalleryImageDataTestId } from 'features/gallery/components/ImageGrid/getGalleryImageDataTestId';
@@ -115,6 +116,7 @@ export const GalleryImage = memo(({ imageDTO }: Props) => {
       return;
     }
     return combine(
+      firefoxDndFix(element),
       draggable({
         element,
         getInitialData: () => {

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/useLinearViewFieldDnd.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/useLinearViewFieldDnd.ts
@@ -4,6 +4,7 @@ import { attachClosestEdge, extractClosestEdge } from '@atlaskit/pragmatic-drag-
 import { singleWorkflowFieldDndSource } from 'features/dnd/dnd';
 import type { DndListTargetState } from 'features/dnd/types';
 import { idle } from 'features/dnd/types';
+import { firefoxDndFix } from 'features/dnd/util';
 import type { FieldIdentifier } from 'features/nodes/types/field';
 import type { RefObject } from 'react';
 import { useEffect, useState } from 'react';
@@ -18,6 +19,7 @@ export const useLinearViewFieldDnd = (ref: RefObject<HTMLElement>, fieldIdentifi
       return;
     }
     return combine(
+      firefoxDndFix(element),
       draggable({
         element,
         getInitialData() {


### PR DESCRIPTION
## Summary

Fixes a Firefox-only bug that prevents text selection for `input` and `textarea` elements within draggables. This made it tricky to use linear view workflow fields and control layers.

## Related Issues / Discussions

Discord discussion

## QA Instructions

- Edit a prompt in a regional guidance layer
- Edit the name of a layer
- Edit any text field in a linear view workflow field

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_