### PR TITLE
fix(ui): multiple selection dnd sometimes doesn't get full selection

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
@@ -123,7 +123,10 @@ export const GalleryImage = memo(({ imageDTO }: Props) => {
           const { gallery } = store.getState();
           // When we have multiple images selected, and the dragged image is part of the selection, initiate a
           // multi-image drag.
-          if (gallery.selection.length > 1 && gallery.selection.includes(imageDTO)) {
+          if (
+            gallery.selection.length > 1 &&
+            gallery.selection.find(({ image_name }) => image_name === imageDTO.image_name) !== undefined
+          ) {
             return multipleImageDndSource.getData({
               imageDTOs: gallery.selection,
               boardId: gallery.selectedBoardId,


### PR DESCRIPTION
## Summary

fix(ui): multiple selection dnd sometimes doesn't get full selection

## Related Issues / Discussions

Discord: https://discord.com/channels/1020123559063990373/1149506274971631688/1306665643898175490

## QA Instructions

- Click the first image in a board.
- Hold shift and click a different image to get a multi-selection going on.
- Click and drag the first image in the board. You should get a multi-image drag.


## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_