### PR TITLE
fix(ui): remove progress message condition for canvas destinations

### DIFF
--- a/invokeai/frontend/web/src/services/events/stores.ts
+++ b/invokeai/frontend/web/src/services/events/stores.ts
@@ -15,9 +15,6 @@ export const $invocationProgressMessage = computed($lastProgressEvent, (val) => 
   if (!val) {
     return null;
   }
-  if (val.destination !== 'canvas') {
-    return null;
-  }
   let message = val.message;
   if (val.percentage) {
     message += ` (${round(val.percentage * 100)}%)`;


### PR DESCRIPTION
## Summary

Remove extraneous condition that would hide the progress message if the generation's destination was not canvas (this was left in from an earlier iteration of the feature)

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_