### PR TITLE
fix(ui): add padding to the metadata recall section so buttons are not blocked

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/ImageMetadataActions.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import { MetadataItem } from 'features/metadata/components/MetadataItem';
 import { MetadataLoRAs } from 'features/metadata/components/MetadataLoRAs';
@@ -18,7 +19,7 @@ const ImageMetadataActions = (props: Props) => {
   }
 
   return (
-    <>
+    <Flex flexDir="column" pl={8}>
       <MetadataItem metadata={metadata} handlers={handlers.generationMode} />
       <MetadataItem metadata={metadata} handlers={handlers.positivePrompt} direction="column" />
       <MetadataItem metadata={metadata} handlers={handlers.negativePrompt} direction="column" />
@@ -48,7 +49,7 @@ const ImageMetadataActions = (props: Props) => {
       <MetadataItem metadata={metadata} handlers={handlers.refinerStart} />
       <MetadataItem metadata={metadata} handlers={handlers.refinerSteps} />
       <MetadataLoRAs metadata={metadata} />
-    </>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
## Summary

add padding to the metadata recall section so buttons are not blocked

## Related Issues / Discussions

Closes https://github.com/invoke-ai/InvokeAI/issues/7325

## QA Instructions

<img width="293" alt="Screenshot 2024-11-15 at 9 09 36 AM" src="https://github.com/user-attachments/assets/f9ae0e9e-9080-43d6-b3a8-768432ad6c78">

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
