### PR TITLE
XLabs FLUX IP-Adapter v2

### DIFF
--- a/invokeai/backend/flux/ip_adapter/state_dict_utils.py
+++ b/invokeai/backend/flux/ip_adapter/state_dict_utils.py
@@ -41,10 +41,12 @@ def infer_xlabs_ip_adapter_params_from_state_dict(state_dict: dict[str, torch.Te
     hidden_dim = state_dict["double_blocks.0.processor.ip_adapter_double_stream_k_proj.weight"].shape[0]
     context_dim = state_dict["double_blocks.0.processor.ip_adapter_double_stream_k_proj.weight"].shape[1]
     clip_embeddings_dim = state_dict["ip_adapter_proj_model.proj.weight"].shape[1]
+    clip_extra_context_tokens = state_dict["ip_adapter_proj_model.proj.weight"].shape[0] // context_dim
 
     return XlabsIpAdapterParams(
         num_double_blocks=num_double_blocks,
         context_dim=context_dim,
         hidden_dim=hidden_dim,
         clip_embeddings_dim=clip_embeddings_dim,
+        clip_extra_context_tokens=clip_extra_context_tokens,
     )

--- a/invokeai/backend/flux/ip_adapter/xlabs_ip_adapter_flux.py
+++ b/invokeai/backend/flux/ip_adapter/xlabs_ip_adapter_flux.py
@@ -31,13 +31,16 @@ class XlabsIpAdapterParams:
     hidden_dim: int
 
     clip_embeddings_dim: int
+    clip_extra_context_tokens: int
 
 
 class XlabsIpAdapterFlux(torch.nn.Module):
     def __init__(self, params: XlabsIpAdapterParams):
         super().__init__()
         self.image_proj = ImageProjModel(
-            cross_attention_dim=params.context_dim, clip_embeddings_dim=params.clip_embeddings_dim
+            cross_attention_dim=params.context_dim,
+            clip_embeddings_dim=params.clip_embeddings_dim,
+            clip_extra_context_tokens=params.clip_extra_context_tokens,
         )
         self.ip_adapter_double_blocks = IPAdapterDoubleBlocks(
             num_double_blocks=params.num_double_blocks, context_dim=params.context_dim, hidden_dim=params.hidden_dim

--- a/invokeai/backend/model_manager/starter_models.py
+++ b/invokeai/backend/model_manager/starter_models.py
@@ -298,13 +298,12 @@ ip_adapter_sdxl = StarterModel(
     previous_names=["IP Adapter SDXL"],
 )
 ip_adapter_flux = StarterModel(
-    name="Standard Reference (XLabs FLUX IP-Adapter)",
+    name="Standard Reference (XLabs FLUX IP-Adapter v2)",
     base=BaseModelType.Flux,
-    source="https://huggingface.co/XLabs-AI/flux-ip-adapter/resolve/main/ip_adapter.safetensors",
+    source="https://huggingface.co/XLabs-AI/flux-ip-adapter-v2/resolve/main/ip_adapter.safetensors",
     description="References images with a more generalized/looser degree of precision.",
     type=ModelType.IPAdapter,
     dependencies=[clip_vit_l_image_encoder],
-    previous_names=["XLabs FLUX IP-Adapter"],
 )
 # endregion
 # region ControlNet

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
@@ -218,27 +218,6 @@ export const buildFLUXGraph = async (
 
   const totalIPAdaptersAdded = ipAdapterResult.addedIPAdapters;
   if (totalIPAdaptersAdded > 0) {
-    assert(steps > 2);
-    const cfg_scale_start_step = 1;
-    const cfg_scale_end_step = Math.ceil(steps / 2);
-    assert(cfg_scale_end_step > cfg_scale_start_step);
-
-    const negCond = g.addNode({
-      type: 'flux_text_encoder',
-      id: getPrefixedId('flux_text_encoder'),
-      prompt: '',
-    });
-
-    g.addEdge(modelLoader, 'clip', negCond, 'clip');
-    g.addEdge(modelLoader, 't5_encoder', negCond, 't5_encoder');
-    g.addEdge(modelLoader, 'max_seq_len', negCond, 't5_max_seq_len');
-    g.addEdge(negCond, 'conditioning', denoise, 'negative_text_conditioning');
-
-    g.updateNode(denoise, {
-      cfg_scale: 3,
-      cfg_scale_start_step,
-      cfg_scale_end_step,
-    });
     g.addEdge(ipAdapterCollector, 'collection', denoise, 'ip_adapter');
   } else {
     g.deleteNode(ipAdapterCollector.id);

--- a/tests/backend/flux/ip_adapter/test_xlabs_ip_adapter_flux.py
+++ b/tests/backend/flux/ip_adapter/test_xlabs_ip_adapter_flux.py
@@ -10,36 +10,51 @@ from invokeai.backend.flux.ip_adapter.state_dict_utils import (
 )
 from invokeai.backend.flux.ip_adapter.xlabs_ip_adapter_flux import (
     XlabsIpAdapterFlux,
+    XlabsIpAdapterParams,
 )
-from tests.backend.flux.ip_adapter.xlabs_flux_ip_adapter_state_dict import xlabs_sd_shapes
+from tests.backend.flux.ip_adapter.xlabs_flux_ip_adapter_state_dict import xlabs_flux_ip_adapter_sd_shapes
+from tests.backend.flux.ip_adapter.xlabs_flux_ip_adapter_v2_state_dict import xlabs_flux_ip_adapter_v2_sd_shapes
 
 
-def test_is_state_dict_xlabs_ip_adapter():
+@pytest.mark.parametrize("sd_shapes", [xlabs_flux_ip_adapter_sd_shapes, xlabs_flux_ip_adapter_v2_sd_shapes])
+def test_is_state_dict_xlabs_ip_adapter(sd_shapes: dict[str, list[int]]):
     # Construct a dummy state_dict.
-    sd = {k: None for k in xlabs_sd_shapes}
+    sd = {k: None for k in sd_shapes}
 
     assert is_state_dict_xlabs_ip_adapter(sd)
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Skipping on macOS")
-def test_infer_xlabs_ip_adapter_params_from_state_dict():
+@pytest.mark.parametrize(
+    ["sd_shapes", "expected_params"],
+    [
+        (
+            xlabs_flux_ip_adapter_sd_shapes,
+            XlabsIpAdapterParams(num_double_blocks=19, context_dim=4096, hidden_dim=3072, clip_embeddings_dim=768),
+        ),
+        (
+            xlabs_flux_ip_adapter_v2_sd_shapes,
+            XlabsIpAdapterParams(num_double_blocks=19, context_dim=4096, hidden_dim=3072, clip_embeddings_dim=768),
+        ),
+    ],
+)
+def test_infer_xlabs_ip_adapter_params_from_state_dict(
+    sd_shapes: dict[str, list[int]], expected_params: XlabsIpAdapterParams
+):
     # Construct a dummy state_dict with tensors of the correct shape on the meta device.
     with torch.device("meta"):
-        sd = {k: torch.zeros(v) for k, v in xlabs_sd_shapes.items()}
+        sd = {k: torch.zeros(v) for k, v in sd_shapes.items()}
 
     params = infer_xlabs_ip_adapter_params_from_state_dict(sd)
-
-    assert params.num_double_blocks == 19
-    assert params.context_dim == 4096
-    assert params.hidden_dim == 3072
-    assert params.clip_embeddings_dim == 768
+    assert params == expected_params
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Skipping on macOS")
-def test_initialize_xlabs_ip_adapter_flux_from_state_dict():
+@pytest.mark.parametrize("sd_shapes", [xlabs_flux_ip_adapter_sd_shapes, xlabs_flux_ip_adapter_v2_sd_shapes])
+def test_initialize_xlabs_ip_adapter_flux_from_state_dict(sd_shapes: dict[str, list[int]]):
     # Construct a dummy state_dict with tensors of the correct shape on the meta device.
     with torch.device("meta"):
-        sd = {k: torch.zeros(v) for k, v in xlabs_sd_shapes.items()}
+        sd = {k: torch.zeros(v) for k, v in sd_shapes.items()}
 
     # Initialize the XLabs IP-Adapter from the state_dict.
     params = infer_xlabs_ip_adapter_params_from_state_dict(sd)

--- a/tests/backend/flux/ip_adapter/test_xlabs_ip_adapter_flux.py
+++ b/tests/backend/flux/ip_adapter/test_xlabs_ip_adapter_flux.py
@@ -30,11 +30,23 @@ def test_is_state_dict_xlabs_ip_adapter(sd_shapes: dict[str, list[int]]):
     [
         (
             xlabs_flux_ip_adapter_sd_shapes,
-            XlabsIpAdapterParams(num_double_blocks=19, context_dim=4096, hidden_dim=3072, clip_embeddings_dim=768),
+            XlabsIpAdapterParams(
+                num_double_blocks=19,
+                context_dim=4096,
+                hidden_dim=3072,
+                clip_embeddings_dim=768,
+                clip_extra_context_tokens=4,
+            ),
         ),
         (
             xlabs_flux_ip_adapter_v2_sd_shapes,
-            XlabsIpAdapterParams(num_double_blocks=19, context_dim=4096, hidden_dim=3072, clip_embeddings_dim=768),
+            XlabsIpAdapterParams(
+                num_double_blocks=19,
+                context_dim=4096,
+                hidden_dim=3072,
+                clip_embeddings_dim=768,
+                clip_extra_context_tokens=16,
+            ),
         ),
     ],
 )

--- a/tests/backend/flux/ip_adapter/xlabs_flux_ip_adapter_v2_state_dict.py
+++ b/tests/backend/flux/ip_adapter/xlabs_flux_ip_adapter_v2_state_dict.py
@@ -1,7 +1,7 @@
-# State dict keys and shapes for an XLabs FLUX IP-Adapter model. Intended to be used for unit tests.
+# State dict keys and shapes for an XLabs FLUX IP-Adapter V2 model. Intended to be used for unit tests.
 # These keys were extracted from:
-# https://huggingface.co/XLabs-AI/flux-ip-adapter/resolve/main/ip_adapter.safetensors
-xlabs_flux_ip_adapter_sd_shapes = {
+# https://huggingface.co/XLabs-AI/flux-ip-adapter-v2/blob/main/ip_adapter.safetensors
+xlabs_flux_ip_adapter_v2_sd_shapes = {
     "double_blocks.0.processor.ip_adapter_double_stream_k_proj.bias": [3072],
     "double_blocks.0.processor.ip_adapter_double_stream_k_proj.weight": [3072, 4096],
     "double_blocks.0.processor.ip_adapter_double_stream_v_proj.bias": [3072],
@@ -80,6 +80,6 @@ xlabs_flux_ip_adapter_sd_shapes = {
     "double_blocks.9.processor.ip_adapter_double_stream_v_proj.weight": [3072, 4096],
     "ip_adapter_proj_model.norm.bias": [4096],
     "ip_adapter_proj_model.norm.weight": [4096],
-    "ip_adapter_proj_model.proj.bias": [16384],
-    "ip_adapter_proj_model.proj.weight": [16384, 768],
+    "ip_adapter_proj_model.proj.bias": [65536],
+    "ip_adapter_proj_model.proj.weight": [65536, 768],
 }


### PR DESCRIPTION
## Summary

This PR adds support for the XLabs FLUX IP-Adapter v2 model (https://huggingface.co/XLabs-AI/flux-ip-adapter-v2).

### Known v1 regression

The recommended inference configuration for XLabs IP v2 is different than that for v1:
- v1 works well with cfg_start_step=1 and cfg_scale=3
- v2 works well with cfg_scale=1 (i.e. no CFG)

This PR updates the Linear UI behavior to optimize for v2. As a result, the performance of v1 models in the Linear UI will be significantly degraded.

It is still possible to use the v1 models by manually constructing a workflow like the one shown on the original IP-Adapter v1 PR: https://github.com/invoke-ai/InvokeAI/pull/7157

**Example 1:**
- Promp: `a statue wearing sunglasses`
- ip-adapter weight: 0.8
- In order (left to right, top to bottom):
  - Original
  - IP-Adapter v2
  - IP-Adapter v1 degraded after this PR
  - IP-Adapter v1 before this PR

 <div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/ca1cb395-458b-4091-88e7-6ccf7fdba096" alt="Image 1" width="300">
  <img src="https://github.com/user-attachments/assets/67e57bf1-6413-4fd5-a53f-f815fea5bb00" alt="Image 2" width="300">
  <img src="https://github.com/user-attachments/assets/75a4d118-4921-4a73-81be-dd93400c7d30" alt="Image 3" width="300">
  <img src="https://github.com/user-attachments/assets/a12f9e73-2db9-4e4b-8ee5-0b8386e211e5" alt="Image 4" width="300">
</div>


**Example 2:**
- Prompt: `A hooded warrior shown from behind overlooking a vibrant underwater sea world. There are sea turtles and colorful fish swimming around.`
- ip-adapter weight: 0.8
- In order (left to right, top to bottom):
  - Original
  - IP-Adapter v2
  - IP-Adapter v1 degraded after this PR
  - IP-Adapter v1 before this PR

 <div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/ab15927f-aa69-4cc3-ab4a-8e6dd35c3de1" alt="Image 1" width="300">
  <img src="https://github.com/user-attachments/assets/a2438b8c-1947-42ed-b17e-95302e357830" alt="Image 2" width="300">
  <img src="https://github.com/user-attachments/assets/bee08a63-086f-4f5f-ace8-083a520c2df4" alt="Image 3" width="300">
  <img src="https://github.com/user-attachments/assets/73535c41-5a15-4e87-817e-ef87334c5d4f" alt="Image 4" width="300">
</div>

## QA Instructions

- [x] Install XLabs IP-Adapter v2 from the Starter Models tab.
- [x] Run the XLabs IP-Adapter v2 model from the Linear UI.
- [x] The XLabs IP-Adapter v1 model can still be used in the Linear UI, but with severely degraded performance.
- [x] Smoke test SD-1 and SDXL IP-Adapters

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
