### PR TITLE
feat(ui): change reset canvas icon to "empty"

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbarResetCanvasButton.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbarResetCanvasButton.tsx
@@ -4,7 +4,7 @@ import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerP
 import { canvasReset } from 'features/controlLayers/store/actions';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiTrashBold } from 'react-icons/pi';
+import { PiEmptyBold } from 'react-icons/pi';
 
 export const CanvasToolbarResetCanvasButton = memo(() => {
   const { t } = useTranslation();
@@ -20,7 +20,7 @@ export const CanvasToolbarResetCanvasButton = memo(() => {
       tooltip={t('controlLayers.resetCanvas')}
       onClick={onClick}
       colorScheme="error"
-      icon={<PiTrashBold />}
+      icon={<PiEmptyBold />}
       variant="link"
       alignSelf="stretch"
     />


### PR DESCRIPTION
## Summary

feat(ui): change reset canvas icon to "empty"

<img width="323" alt="image" src="https://github.com/user-attachments/assets/4c952fa9-ac11-4624-81e0-0c537d3d2c48">

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1308084638023028807/1308084638023028807

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_