### PR TITLE
fix(ui): make sure schema has loaded before trying to load any workflows

### DIFF
--- a/invokeai/frontend/web/src/app/components/App.tsx
+++ b/invokeai/frontend/web/src/app/components/App.tsx
@@ -59,7 +59,7 @@ const App = ({ config = DEFAULT_CONFIG, studioInitAction }: Props) => {
   useSocketIO();
   useGlobalModifiersInit();
   useGlobalHotkeys();
-  const { data: openApiData } = useGetOpenAPISchemaQuery();
+  useGetOpenAPISchemaQuery();
   useSyncLoggingConfig();
 
   const handleReset = useCallback(() => {
@@ -83,7 +83,7 @@ const App = ({ config = DEFAULT_CONFIG, studioInitAction }: Props) => {
     dispatch(appStarted());
   }, [dispatch]);
 
-  useStudioInitAction(studioInitAction, !!openApiData);
+  useStudioInitAction(studioInitAction);
   useStarterModelsToast();
   useSyncQueueStatus();
   useFocusRegionWatcher();

--- a/invokeai/frontend/web/src/app/components/App.tsx
+++ b/invokeai/frontend/web/src/app/components/App.tsx
@@ -59,7 +59,7 @@ const App = ({ config = DEFAULT_CONFIG, studioInitAction }: Props) => {
   useSocketIO();
   useGlobalModifiersInit();
   useGlobalHotkeys();
-  useGetOpenAPISchemaQuery();
+  const { data: openApiData } = useGetOpenAPISchemaQuery();
   useSyncLoggingConfig();
 
   const handleReset = useCallback(() => {
@@ -83,7 +83,7 @@ const App = ({ config = DEFAULT_CONFIG, studioInitAction }: Props) => {
     dispatch(appStarted());
   }, [dispatch]);
 
-  useStudioInitAction(studioInitAction);
+  useStudioInitAction(studioInitAction, !!openApiData);
   useStarterModelsToast();
   useSyncQueueStatus();
   useFocusRegionWatcher();

--- a/invokeai/frontend/web/src/app/hooks/useStudioInitAction.ts
+++ b/invokeai/frontend/web/src/app/hooks/useStudioInitAction.ts
@@ -178,35 +178,44 @@ export const useStudioInitAction = (action?: StudioInitAction, schemaLoaded?: bo
       return;
     }
 
-    didInit.current = true;
-
     switch (action.type) {
+      case 'loadWorkflow':
+        if (schemaLoaded) {
+          handleLoadWorkflow(action.data.workflowId);
+          didInit.current = true;
+        }
+        break;
+
       case 'selectStylePreset':
         handleSelectStylePreset(action.data.stylePresetId);
+        didInit.current = true;
         break;
+
       case 'sendToCanvas':
         handleSendToCanvas(action.data.imageName);
+        didInit.current = true;
         break;
+
       case 'useAllParameters':
         handleUseAllMetadata(action.data.imageName);
+        didInit.current = true;
         break;
+
       case 'goToDestination':
         handleGoToDestination(action.data.destination);
+        didInit.current = true;
         break;
+
       default:
         break;
     }
-  }, [handleSendToCanvas, handleUseAllMetadata, action, handleSelectStylePreset, handleGoToDestination]);
-
-  useEffect(() => {
-    if (didInit.current || !action || !schemaLoaded) {
-      return;
-    }
-
-    didInit.current = true;
-
-    if (action.type === 'loadWorkflow') {
-      handleLoadWorkflow(action.data.workflowId);
-    }
-  }, [action, handleLoadWorkflow, schemaLoaded]);
+  }, [
+    handleSendToCanvas,
+    handleUseAllMetadata,
+    action,
+    handleSelectStylePreset,
+    handleGoToDestination,
+    handleLoadWorkflow,
+    schemaLoaded,
+  ]);
 };

--- a/invokeai/frontend/web/src/app/hooks/useStudioInitAction.ts
+++ b/invokeai/frontend/web/src/app/hooks/useStudioInitAction.ts
@@ -46,7 +46,7 @@ export type StudioInitAction =
  * - Use `getImageDTO` helper instead of `useGetImageDTO`
  * - Usee the `$imageViewer` atom instead of `useImageViewer`
  */
-export const useStudioInitAction = (action?: StudioInitAction) => {
+export const useStudioInitAction = (action?: StudioInitAction, schemaLoaded?: boolean) => {
   useAssertSingleton('useStudioInitAction');
   const { t } = useTranslation();
   // Use a ref to ensure that we only perform the action once
@@ -181,9 +181,6 @@ export const useStudioInitAction = (action?: StudioInitAction) => {
     didInit.current = true;
 
     switch (action.type) {
-      case 'loadWorkflow':
-        handleLoadWorkflow(action.data.workflowId);
-        break;
       case 'selectStylePreset':
         handleSelectStylePreset(action.data.stylePresetId);
         break;
@@ -196,13 +193,20 @@ export const useStudioInitAction = (action?: StudioInitAction) => {
       case 'goToDestination':
         handleGoToDestination(action.data.destination);
         break;
+      default:
+        break;
     }
-  }, [
-    handleSendToCanvas,
-    handleUseAllMetadata,
-    action,
-    handleLoadWorkflow,
-    handleSelectStylePreset,
-    handleGoToDestination,
-  ]);
+  }, [handleSendToCanvas, handleUseAllMetadata, action, handleSelectStylePreset, handleGoToDestination]);
+
+  useEffect(() => {
+    if (didInit.current || !action || !schemaLoaded) {
+      return;
+    }
+
+    didInit.current = true;
+
+    if (action.type === 'loadWorkflow') {
+      handleLoadWorkflow(action.data.workflowId);
+    }
+  }, [action, handleLoadWorkflow, schemaLoaded]);
 };


### PR DESCRIPTION
## Summary

Makes sure that the schema has been loaded and parsed before the UI tries to load any workflows. Solves a race conditions where edges didn't appear for workflows passed in a studio init action

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
