### PR TITLE
feat(ui): nudge on canvas

### DIFF
--- a/invokeai/frontend/web/src/common/hooks/focus.ts
+++ b/invokeai/frontend/web/src/common/hooks/focus.ts
@@ -46,7 +46,7 @@ const REGION_TARGETS: Record<FocusRegionName, Set<HTMLElement>> = {
 /**
  * The currently-focused region or `null` if no region is focused.
  */
-const $focusedRegion = atom<FocusRegionName | null>(null);
+export const $focusedRegion = atom<FocusRegionName | null>(null);
 
 /**
  * A map of focus regions to atoms that indicate if that region is focused.

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -9,6 +9,7 @@ import {
   getEmptyRect,
   getKonvaNodeDebugAttrs,
   getPrefixedId,
+  offsetCoord,
 } from 'features/controlLayers/konva/util';
 import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
 import type { Coordinate, Rect, RectWithRotation } from 'features/controlLayers/store/types';
@@ -548,18 +549,33 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
     }
 
     const pixelRect = this.$pixelRect.get();
-    this.nudgePosition(-pixelRect.x, -pixelRect.y);
+
+    const position = {
+      x: this.konva.proxyRect.x() - pixelRect.x,
+      y: this.konva.proxyRect.y() - pixelRect.y,
+    };
+
+    this.log.trace({ position }, 'Position changed');
+    this.manager.stateApi.setEntityPosition({ entityIdentifier: this.parent.entityIdentifier, position });
   };
 
-  nudgePosition = (x: number, y: number) => {
-    // Nudge the position by (x, y) pixels
-    const position = {
-      x: this.konva.proxyRect.x() + x,
-      y: this.konva.proxyRect.y() + y,
-    };
-    // Push state to redux
-    this.manager.stateApi.setEntityPosition({ entityIdentifier: this.parent.entityIdentifier, position });
-    this.log.trace({ position }, 'Position changed');
+  nudgeBy = (offset: Coordinate) => {
+    // We can immediately move both the proxy rect and layer objects so we don't have to wait for a redux round-trip,
+    // which can take up to 2ms in my testing. This is optional, but can make the interaction feel more responsive,
+    // especially on lower-end devices.
+    // Get the relative position of the layer's objects, according to konva
+    const position = this.konva.proxyRect.position();
+    // Offset the position by the nudge amount
+    const newPosition = offsetCoord(position, offset);
+    // Set the new position of the proxy rect - this doesn't move the layer objects - only the outline rect
+    this.konva.proxyRect.setAttrs(newPosition);
+    // Sync the layer objects with the proxy rect - moves them to the new position
+    this.syncObjectGroupWithProxyRect();
+
+    // Push to redux. The state change will do a round-trip, and eventually make it back to the canvas classes, at
+    // which point the layer will be moved to the new position.
+    this.manager.stateApi.moveEntityBy({ entityIdentifier: this.parent.entityIdentifier, offset });
+    this.log.trace({ offset }, 'Nudged');
   };
 
   syncObjectGroupWithProxyRect = () => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -548,14 +548,18 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
     }
 
     const pixelRect = this.$pixelRect.get();
+    this.nudgePosition(-pixelRect.x, -pixelRect.y);
+  };
 
+  nudgePosition = (x: number, y: number) => {
+    // Nudge the position by (x, y) pixels
     const position = {
-      x: this.konva.proxyRect.x() - pixelRect.x,
-      y: this.konva.proxyRect.y() - pixelRect.y,
+      x: this.konva.proxyRect.x() + x,
+      y: this.konva.proxyRect.y() + y,
     };
-
-    this.log.trace({ position }, 'Position changed');
+    // Push state to redux
     this.manager.stateApi.setEntityPosition({ entityIdentifier: this.parent.entityIdentifier, position });
+    this.log.trace({ position }, 'Position changed');
   };
 
   syncObjectGroupWithProxyRect = () => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStateApiModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStateApiModule.ts
@@ -20,7 +20,8 @@ import {
   controlLayerAdded,
   entityBrushLineAdded,
   entityEraserLineAdded,
-  entityMoved,
+  entityMovedBy,
+  entityMovedTo,
   entityRasterized,
   entityRectAdded,
   entityReset,
@@ -40,7 +41,8 @@ import type {
   EntityBrushLineAddedPayload,
   EntityEraserLineAddedPayload,
   EntityIdentifierPayload,
-  EntityMovedPayload,
+  EntityMovedByPayload,
+  EntityMovedToPayload,
   EntityRasterizedPayload,
   EntityRectAddedPayload,
   Rect,
@@ -139,8 +141,15 @@ export class CanvasStateApiModule extends CanvasModuleBase {
   /**
    * Updates an entity's position, pushing state to redux.
    */
-  setEntityPosition = (arg: EntityMovedPayload) => {
-    this.store.dispatch(entityMoved(arg));
+  setEntityPosition = (arg: EntityMovedToPayload) => {
+    this.store.dispatch(entityMovedTo(arg));
+  };
+
+  /**
+   * Moves an entity by the give offset, pushing state to redux.
+   */
+  moveEntityBy = (arg: EntityMovedByPayload) => {
+    this.store.dispatch(entityMovedBy(arg));
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -20,7 +20,6 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
     this.manager = this.parent.manager;
     this.path = this.manager.buildPath(this);
     this.log = this.manager.buildLogger(this);
-
     this.log.debug('Creating module');
   }
 
@@ -45,18 +44,15 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
     };
     const { key } = e;
     const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
+    const { x: offsetX = 0, y: offsetY = 0 } = offsets[key] || {};
 
-    if (!(selectedEntity && selectedEntity.$isInteractable.get() && $focusedRegion.get() === 'canvas')) {
+    if (
+      !(selectedEntity && selectedEntity.$isInteractable.get() && $focusedRegion.get() === 'canvas') ||
+      (offsetX === 0 && offsetY === 0)
+    ) {
       return; // Early return if no entity is selected or it is disabled or canvas is not focused
     }
 
-    const { x: offsetX = 0, y: offsetY = 0 } = offsets[key] || {};
-
-    if (offsetX) {
-      selectedEntity.konva.layer.x(selectedEntity.konva.layer.x() + offsetX);
-    }
-    if (offsetY) {
-      selectedEntity.konva.layer.y(selectedEntity.konva.layer.y() + offsetY);
-    }
+    selectedEntity.transformer.nudgePosition(offsetX, offsetY);
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -41,7 +41,6 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
 
   onKeyDown = (e: KeyboardEvent) => {
     // Support moving via arrow keys
-    const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
     let offset_x;
     let offset_y;
     switch (e.key) {
@@ -58,11 +57,15 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
         offset_y = 1;
         break;
     }
-    if (offset_x !== undefined) {
-      selectedEntity?.konva.layer.x(selectedEntity?.konva.layer.x() + offset_x);
-    }
-    if (offset_y !== undefined) {
-      selectedEntity?.konva.layer.y(selectedEntity?.konva.layer.y() + offset_y);
+    const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
+    this.log.debug(`XX ${selectedEntity} YY ${selectedEntity?.$isDisabled.get()}`);
+    if (selectedEntity && !selectedEntity.$isDisabled.get()) {
+      if (offset_x !== undefined) {
+        selectedEntity.konva.layer.x(selectedEntity.konva.layer.x() + offset_x);
+      }
+      if (offset_y !== undefined) {
+        selectedEntity.konva.layer.y(selectedEntity.konva.layer.y() + offset_y);
+      }
     }
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -1,3 +1,4 @@
+import { $focusedRegion } from 'common/hooks/focus';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
 import { CanvasModuleBase } from 'features/controlLayers/konva/CanvasModuleBase';
 import type { CanvasToolModule } from 'features/controlLayers/konva/CanvasTool/CanvasToolModule';
@@ -35,7 +36,7 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
 
   onKeyDown = (e: KeyboardEvent) => {
     // Support moving via arrow keys
-    const OFFSET = 1; // Define a constant for the movement offset
+    const OFFSET = 1; // How much to move, in px
     const offsets: Record<string, { x: number; y: number }> = {
       ArrowLeft: { x: -OFFSET, y: 0 },
       ArrowRight: { x: OFFSET, y: 0 },
@@ -45,8 +46,8 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
     const { key } = e;
     const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
 
-    if (!(selectedEntity && selectedEntity.$isInteractable.get())) {
-      return; // Early return if no entity is selected or it is disabled
+    if (!(selectedEntity && selectedEntity.$isInteractable.get() && $focusedRegion.get() === 'canvas')) {
+      return; // Early return if no entity is selected or it is disabled or canvas is not focused
     }
 
     const { x: offsetX = 0, y: offsetY = 0 } = offsets[key] || {};

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -4,6 +4,12 @@ import type { CanvasToolModule } from 'features/controlLayers/konva/CanvasTool/C
 import { getPrefixedId } from 'features/controlLayers/konva/util';
 import type { Logger } from 'roarr';
 
+// Typo insurance
+const KEY_LEFT = 'ArrowLeft';
+const KEY_RIGHT = 'ArrowRight';
+const KEY_UP = 'ArrowUp';
+const KEY_DOWN = 'ArrowDown';
+
 export class CanvasMoveToolModule extends CanvasModuleBase {
   readonly type = 'move_tool';
   readonly id: string;
@@ -30,6 +36,33 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
     } else {
       // The cursor is on an entity, defer to transformer to handle the cursor
       selectedEntity.transformer.syncCursorStyle();
+    }
+  };
+
+  onKeyDown = (e: KeyboardEvent) => {
+    // Support moving via arrow keys
+    const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
+    let offset_x;
+    let offset_y;
+    switch (e.key) {
+      case KEY_LEFT:
+        offset_x = -1;
+        break;
+      case KEY_RIGHT:
+        offset_x = 1;
+        break;
+      case KEY_UP:
+        offset_y = -1;
+        break;
+      case KEY_DOWN:
+        offset_y = 1;
+        break;
+    }
+    if (offset_x !== undefined) {
+      selectedEntity?.konva.layer.x(selectedEntity?.konva.layer.x() + offset_x);
+    }
+    if (offset_y !== undefined) {
+      selectedEntity?.konva.layer.y(selectedEntity?.konva.layer.y() + offset_y);
     }
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -45,7 +45,7 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
     const { key } = e;
     const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
 
-    if (!selectedEntity || selectedEntity.$isDisabled.get()) {
+    if (! (selectedEntity && selectedEntity.$isInteractable.get())) {
       return; // Early return if no entity is selected or it is disabled
     }
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -4,12 +4,6 @@ import type { CanvasToolModule } from 'features/controlLayers/konva/CanvasTool/C
 import { getPrefixedId } from 'features/controlLayers/konva/util';
 import type { Logger } from 'roarr';
 
-// Typo insurance
-const KEY_LEFT = 'ArrowLeft';
-const KEY_RIGHT = 'ArrowRight';
-const KEY_UP = 'ArrowUp';
-const KEY_DOWN = 'ArrowDown';
-
 export class CanvasMoveToolModule extends CanvasModuleBase {
   readonly type = 'move_tool';
   readonly id: string;
@@ -41,31 +35,27 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
 
   onKeyDown = (e: KeyboardEvent) => {
     // Support moving via arrow keys
-    let offset_x;
-    let offset_y;
-    switch (e.key) {
-      case KEY_LEFT:
-        offset_x = -1;
-        break;
-      case KEY_RIGHT:
-        offset_x = 1;
-        break;
-      case KEY_UP:
-        offset_y = -1;
-        break;
-      case KEY_DOWN:
-        offset_y = 1;
-        break;
-    }
+    const OFFSET = 1; // Define a constant for the movement offset
+    const offsets: Record<string, { x: number; y: number }> = {
+      ArrowLeft: { x: -OFFSET, y: 0 },
+      ArrowRight: { x: OFFSET, y: 0 },
+      ArrowUp: { x: 0, y: -OFFSET },
+      ArrowDown: { x: 0, y: OFFSET },
+    };
+    const { key } = e;
     const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
-    this.log.debug(`XX ${selectedEntity} YY ${selectedEntity?.$isDisabled.get()}`);
-    if (selectedEntity && !selectedEntity.$isDisabled.get()) {
-      if (offset_x !== undefined) {
-        selectedEntity.konva.layer.x(selectedEntity.konva.layer.x() + offset_x);
-      }
-      if (offset_y !== undefined) {
-        selectedEntity.konva.layer.y(selectedEntity.konva.layer.y() + offset_y);
-      }
+
+    if (!selectedEntity || selectedEntity.$isDisabled.get()) {
+      return; // Early return if no entity is selected or it is disabled
+    }
+
+    const { x: offsetX = 0, y: offsetY = 0 } = offsets[key] || {};
+
+    if (offsetX) {
+      selectedEntity.konva.layer.x(selectedEntity.konva.layer.x() + offsetX);
+    }
+    if (offsetY) {
+      selectedEntity.konva.layer.y(selectedEntity.konva.layer.y() + offsetY);
     }
   };
 }

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasMoveToolModule.ts
@@ -45,7 +45,7 @@ export class CanvasMoveToolModule extends CanvasModuleBase {
     const { key } = e;
     const selectedEntity = this.manager.stateApi.getSelectedEntityAdapter();
 
-    if (! (selectedEntity && selectedEntity.$isInteractable.get())) {
+    if (!(selectedEntity && selectedEntity.$isInteractable.get())) {
       return; // Early return if no entity is selected or it is disabled
     }
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
@@ -532,10 +532,12 @@ export class CanvasToolModule extends CanvasModuleBase {
       return;
     }
 
-    switch (this.$tool.get()) { // before repeat, as we may want to catch repeating keys
+    switch (
+      this.$tool.get() // before repeat, as we may want to catch repeating keys
+    ) {
       case 'move':
         this.tools.move.onKeyDown(e);
-        break
+        break;
     }
 
     if (e.repeat) {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
@@ -532,12 +532,9 @@ export class CanvasToolModule extends CanvasModuleBase {
       return;
     }
 
-    switch (
-      this.$tool.get() // before repeat, as we may want to catch repeating keys
-    ) {
-      case 'move':
-        this.tools.move.onKeyDown(e);
-        break;
+    // Handle nudging - must be before repeat, as we may want to catch repeating keys
+    if (this.tools.move.isNudgeKey(e.key)) {
+      this.tools.move.nudge(e.key);
     }
 
     if (e.repeat) {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasToolModule.ts
@@ -528,11 +528,17 @@ export class CanvasToolModule extends CanvasModuleBase {
   };
 
   onKeyDown = (e: KeyboardEvent) => {
-    if (e.repeat) {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
       return;
     }
 
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+    switch (this.$tool.get()) { // before repeat, as we may want to catch repeating keys
+      case 'move':
+        this.tools.move.onKeyDown(e);
+        break
+    }
+
+    if (e.repeat) {
       return;
     }
 

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -18,6 +18,7 @@ import type {
   CanvasEntityType,
   CanvasInpaintMaskState,
   CanvasMetadata,
+  EntityMovedByPayload,
   FillStyle,
   RegionalGuidanceReferenceImageState,
   RgbColor,
@@ -51,7 +52,7 @@ import type {
   EntityBrushLineAddedPayload,
   EntityEraserLineAddedPayload,
   EntityIdentifierPayload,
-  EntityMovedPayload,
+  EntityMovedToPayload,
   EntityRasterizedPayload,
   EntityRectAddedPayload,
   IPMethodV2,
@@ -1201,7 +1202,7 @@ export const canvasSlice = createSlice({
       }
       entity.fill.style = style;
     },
-    entityMoved: (state, action: PayloadAction<EntityMovedPayload>) => {
+    entityMovedTo: (state, action: PayloadAction<EntityMovedToPayload>) => {
       const { entityIdentifier, position } = action.payload;
       const entity = selectEntity(state, entityIdentifier);
       if (!entity) {
@@ -1211,6 +1212,20 @@ export const canvasSlice = createSlice({
       if (isRenderableEntity(entity)) {
         entity.position = position;
       }
+    },
+    entityMovedBy: (state, action: PayloadAction<EntityMovedByPayload>) => {
+      const { entityIdentifier, offset } = action.payload;
+      const entity = selectEntity(state, entityIdentifier);
+      if (!entity) {
+        return;
+      }
+
+      if (!isRenderableEntity(entity)) {
+        return;
+      }
+
+      entity.position.x += offset.x;
+      entity.position.y += offset.y;
     },
     entityRasterized: (state, action: PayloadAction<EntityRasterizedPayload>) => {
       const { entityIdentifier, imageObject, position, replaceObjects, isSelected } = action.payload;
@@ -1505,7 +1520,8 @@ export const {
   entityIsLockedToggled,
   entityFillColorChanged,
   entityFillStyleChanged,
-  entityMoved,
+  entityMovedTo,
+  entityMovedBy,
   entityDuplicated,
   entityRasterized,
   entityBrushLineAdded,

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -439,7 +439,8 @@ export type EntityIdentifierPayload<
       entityIdentifier: CanvasEntityIdentifier<U>;
     } & T;
 
-export type EntityMovedPayload = EntityIdentifierPayload<{ position: Coordinate }>;
+export type EntityMovedToPayload = EntityIdentifierPayload<{ position: Coordinate }>;
+export type EntityMovedByPayload = EntityIdentifierPayload<{ offset: Coordinate }>;
 export type EntityBrushLineAddedPayload = EntityIdentifierPayload<{
   brushLine: CanvasBrushLineState | CanvasBrushLineWithPressureState;
 }>;


### PR DESCRIPTION
## Summary

Adds the ability to nudge layers by a single pixel on canvas. Nudging is allowed when the move tool is selected, or when the selected entity is being transformed.

## Related Issues / Discussions

- This PR picks up on #7202, which had stalled. I didn't have permission to push to the contributor's fork, so I needed to create this new branch to address my feedback from that PR.

## QA Instructions

Should do what it says on the tin.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_