### PR TITLE
Add `ImagePanelLayoutInvocation` utility to facilitate In-Context LoRA workflows

### DIFF
--- a/invokeai/app/invocations/flux_text_encoder.py
+++ b/invokeai/app/invocations/flux_text_encoder.py
@@ -5,7 +5,7 @@ import torch
 from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokenizer
 
 from invokeai.app.invocations.baseinvocation import BaseInvocation, Classification, invocation
-from invokeai.app.invocations.fields import FieldDescriptions, Input, InputField
+from invokeai.app.invocations.fields import FieldDescriptions, Input, InputField, UIComponent
 from invokeai.app.invocations.model import CLIPField, T5EncoderField
 from invokeai.app.invocations.primitives import FluxConditioningOutput
 from invokeai.app.services.shared.invocation_context import InvocationContext
@@ -41,7 +41,10 @@ class FluxTextEncoderInvocation(BaseInvocation):
     t5_max_seq_len: Literal[256, 512] = InputField(
         description="Max sequence length for the T5 encoder. Expected to be 256 for FLUX schnell models and 512 for FLUX dev models."
     )
-    prompt: str = InputField(description="Text prompt to encode.")
+    prompt: str = InputField(
+        description="Text prompt to encode.",
+        ui_component=UIComponent.Textarea,
+    )
 
     @torch.no_grad()
     def invoke(self, context: InvocationContext) -> FluxConditioningOutput:

--- a/invokeai/app/invocations/image_panels.py
+++ b/invokeai/app/invocations/image_panels.py
@@ -1,0 +1,59 @@
+from pydantic import ValidationInfo, field_validator
+
+from invokeai.app.invocations.baseinvocation import (
+    BaseInvocation,
+    BaseInvocationOutput,
+    Classification,
+    invocation,
+    invocation_output,
+)
+from invokeai.app.invocations.fields import InputField, OutputField
+from invokeai.app.services.shared.invocation_context import InvocationContext
+
+
+@invocation_output("image_panel_coordinate_output")
+class ImagePanelCoordinateOutput(BaseInvocationOutput):
+    x_left: int = OutputField(description="The left x-coordinate of the panel.")
+    y_top: int = OutputField(description="The top y-coordinate of the panel.")
+    width: int = OutputField(description="The width of the panel.")
+    height: int = OutputField(description="The height of the panel.")
+
+
+@invocation(
+    "image_panel_layout",
+    title="Image Panel Layout",
+    tags=["image", "panel", "layout"],
+    category="image",
+    version="1.0.0",
+    classification=Classification.Prototype,
+)
+class ImagePanelLayoutInvocation(BaseInvocation):
+    """Get the coordinates of a single panel in a grid. (If the full image shape cannot be divided evenly into panels,
+    then the grid may not cover the entire image.)
+    """
+
+    width: int = InputField(description="The width of the entire grid.")
+    height: int = InputField(description="The height of the entire grid.")
+    num_cols: int = InputField(ge=1, default=1, description="The number of columns in the grid.")
+    num_rows: int = InputField(ge=1, default=1, description="The number of rows in the grid.")
+    panel_col_idx: int = InputField(ge=0, default=0, description="The column index of the panel to be processed.")
+    panel_row_idx: int = InputField(ge=0, default=0, description="The row index of the panel to be processed.")
+
+    @field_validator("panel_col_idx")
+    def validate_panel_col_idx(cls, v: int, info: ValidationInfo) -> int:
+        if v < 0 or v >= info.data["num_cols"]:
+            raise ValueError(f"panel_col_idx must be between 0 and {info.data['num_cols'] - 1}")
+        return v
+
+    @field_validator("panel_row_idx")
+    def validate_panel_row_idx(cls, v: int, info: ValidationInfo) -> int:
+        if v < 0 or v >= info.data["num_rows"]:
+            raise ValueError(f"panel_row_idx must be between 0 and {info.data['num_rows'] - 1}")
+        return v
+
+    def invoke(self, context: InvocationContext) -> ImagePanelCoordinateOutput:
+        x_left = self.panel_col_idx * (self.width // self.num_cols)
+        y_top = self.panel_row_idx * (self.height // self.num_rows)
+        width = self.width // self.num_cols
+        height = self.height // self.num_rows
+        return ImagePanelCoordinateOutput(x_left=x_left, y_top=y_top, width=width, height=height)


### PR DESCRIPTION
## Summary

This PR adds a `ImagePanelLayoutInvocation` that makes it easy to calculate the coordinates of panels within an image grid. This utility invocation is intended to make it easier to experiment with In-Context LoRA workflows.

### Example 1: Reference-Based In-Context LoRA - Reference Logo Consistency

Instructions:
1. Install this LoRA: https://huggingface.co/ali-vilab/In-Context-LoRA/blob/main/visual-identity-design.safetensors
2. Load the sample workflow: [flux_icl_single_reference_image.json](https://github.com/user-attachments/files/17873610/flux_icl_single_reference_image.json)
3. Run.

Workflow
<img width="2320" alt="image" src="https://github.com/user-attachments/assets/d68e66c5-2d7c-43a2-bfb7-323415a00f59">

Sample output (cherry-picked, full grid):
![image](https://github.com/user-attachments/assets/067a804c-2bfd-4ce2-bce3-2604cc2d056f)

Sample output (cherry-picked, cropped):
![image](https://github.com/user-attachments/assets/ddc25cb2-a36d-46f7-a3e6-88e5a8170f1d)


### Example 2: Reference-Free In-Context LoRA - Character Consistency

Instructions:
1. Install this LoRA: https://huggingface.co/ali-vilab/In-Context-LoRA/blob/main/film-storyboard.safetensors
2. Load the sample workflow: [flux_icl_reference_free.json](https://github.com/user-attachments/files/17873644/flux_icl_reference_free.json)
3. Run.

Sample output:
![image](https://github.com/user-attachments/assets/dc494945-0ce7-4347-b389-5e0bd7a053dc)

## QA Instructions

Tested via the example workflows shown above.

## Merge Plan

No special instructions.

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
