### PR TITLE
Bump transformers to ingest a DepthAnything post-processing fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "torchmetrics",
   "torchsde",
   "torchvision",
-  "transformers==4.41.1",
+  "transformers==4.46.3",
 
   # Core application dependencies, pinned for reproducible builds.
   "fastapi-events==0.11.1",


### PR DESCRIPTION
## Summary

This PR bumps the `transformers` dependency to address a DepthAnything post-processing bug.

Closes #7358 

### Example

Before:
![image](https://github.com/user-attachments/assets/e5d41a13-9310-4ba0-bb73-e9b3854f9fca)

After:
![image](https://github.com/user-attachments/assets/2b27765d-44fb-4652-8624-8b6b7f2f9b8c)

## Related Issues / Discussions

- Description of the DepthAnything artifact bug: https://github.com/invoke-ai/InvokeAI/issues/7358
- Relevant fix upstream in transformers: https://github.com/huggingface/transformers/pull/32550
- Related issues / discussions:
  - https://github.com/huggingface/transformers/issues/34300
  - https://github.com/huggingface/transformers/pull/34413

## QA Instructions

- [x] Test DepthAnything
- [x] Smoke test Grounding Dino and Segment Anything.
- [x] Smoke test SD3 text-to-image

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
