### PR TITLE
feat(ui): add `New Layer from Image` menu to staging area toolbar

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/StagingAreaToolbar.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/StagingAreaToolbar.tsx
@@ -5,6 +5,7 @@ import { StagingAreaToolbarDiscardSelectedButton } from 'features/controlLayers/
 import { StagingAreaToolbarImageCountButton } from 'features/controlLayers/components/StagingArea/StagingAreaToolbarImageCountButton';
 import { StagingAreaToolbarNextButton } from 'features/controlLayers/components/StagingArea/StagingAreaToolbarNextButton';
 import { StagingAreaToolbarPrevButton } from 'features/controlLayers/components/StagingArea/StagingAreaToolbarPrevButton';
+import { StagingAreaToolbarSaveAsMenu } from 'features/controlLayers/components/StagingArea/StagingAreaToolbarSaveAsMenu';
 import { StagingAreaToolbarSaveSelectedToGalleryButton } from 'features/controlLayers/components/StagingArea/StagingAreaToolbarSaveSelectedToGalleryButton';
 import { StagingAreaToolbarToggleShowResultsButton } from 'features/controlLayers/components/StagingArea/StagingAreaToolbarToggleShowResultsButton';
 import { memo } from 'react';
@@ -21,6 +22,7 @@ export const StagingAreaToolbar = memo(() => {
         <StagingAreaToolbarAcceptButton />
         <StagingAreaToolbarToggleShowResultsButton />
         <StagingAreaToolbarSaveSelectedToGalleryButton />
+        <StagingAreaToolbarSaveAsMenu />
         <StagingAreaToolbarDiscardSelectedButton />
         <StagingAreaToolbarDiscardAllButton />
       </ButtonGroup>

--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/StagingAreaToolbarSaveAsMenu.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/StagingAreaToolbarSaveAsMenu.tsx
@@ -1,0 +1,136 @@
+import { IconButton, Menu, MenuButton, MenuItem, MenuList } from '@invoke-ai/ui-library';
+import { useAppStore } from 'app/store/nanostores/store';
+import { useAppSelector } from 'app/store/storeHooks';
+import { NewLayerIcon } from 'features/controlLayers/components/common/icons';
+import { selectSelectedImage } from 'features/controlLayers/store/canvasStagingAreaSlice';
+import { createNewCanvasEntityFromImage } from 'features/imageActions/actions';
+import { toast } from 'features/toast/toast';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiDotsThreeBold } from 'react-icons/pi';
+import { imageDTOToFile, uploadImage } from 'services/api/endpoints/images';
+
+const uploadImageArg = { image_category: 'general', is_intermediate: true, silent: true } as const;
+
+export const StagingAreaToolbarSaveAsMenu = memo(() => {
+  const { t } = useTranslation();
+  const selectedImage = useAppSelector(selectSelectedImage);
+  const store = useAppStore();
+
+  const onClickNewRasterLayerFromImage = useCallback(async () => {
+    if (!selectedImage) {
+      return;
+    }
+    const { dispatch, getState } = store;
+    const file = await imageDTOToFile(selectedImage.imageDTO);
+    const imageDTO = await uploadImage({ file, ...uploadImageArg });
+    createNewCanvasEntityFromImage({
+      imageDTO,
+      type: 'raster_layer',
+      dispatch,
+      getState,
+      overrides: { isEnabled: false }, // We are adding the layer while staging, it should be disabled by default
+    });
+    toast({
+      id: 'SENT_TO_CANVAS',
+      title: t('toast.sentToCanvas'),
+      status: 'success',
+    });
+  }, [selectedImage, store, t]);
+
+  const onClickNewControlLayerFromImage = useCallback(async () => {
+    if (!selectedImage) {
+      return;
+    }
+    const { dispatch, getState } = store;
+    const file = await imageDTOToFile(selectedImage.imageDTO);
+    const imageDTO = await uploadImage({ file, ...uploadImageArg });
+    createNewCanvasEntityFromImage({
+      imageDTO,
+      type: 'control_layer',
+      dispatch,
+      getState,
+      overrides: { isEnabled: false }, // We are adding the layer while staging, it should be disabled by default
+    });
+    toast({
+      id: 'SENT_TO_CANVAS',
+      title: t('toast.sentToCanvas'),
+      status: 'success',
+    });
+  }, [selectedImage, store, t]);
+
+  const onClickNewInpaintMaskFromImage = useCallback(async () => {
+    if (!selectedImage) {
+      return;
+    }
+    const { dispatch, getState } = store;
+    const file = await imageDTOToFile(selectedImage.imageDTO);
+    const imageDTO = await uploadImage({ file, ...uploadImageArg });
+    createNewCanvasEntityFromImage({
+      imageDTO,
+      type: 'inpaint_mask',
+      dispatch,
+      getState,
+      overrides: { isEnabled: false }, // We are adding the layer while staging, it should be disabled by default
+    });
+    toast({
+      id: 'SENT_TO_CANVAS',
+      title: t('toast.sentToCanvas'),
+      status: 'success',
+    });
+  }, [selectedImage, store, t]);
+
+  const onClickNewRegionalGuidanceFromImage = useCallback(async () => {
+    if (!selectedImage) {
+      return;
+    }
+    const { dispatch, getState } = store;
+    const file = await imageDTOToFile(selectedImage.imageDTO);
+    const imageDTO = await uploadImage({ file, ...uploadImageArg });
+    createNewCanvasEntityFromImage({
+      imageDTO,
+      type: 'regional_guidance',
+      dispatch,
+      getState,
+      overrides: { isEnabled: false }, // We are adding the layer while staging, it should be disabled by default
+    });
+    toast({
+      id: 'SENT_TO_CANVAS',
+      title: t('toast.sentToCanvas'),
+      status: 'success',
+    });
+  }, [selectedImage, store, t]);
+
+  return (
+    <Menu>
+      <MenuButton
+        as={IconButton}
+        aria-label={t('controlLayers.newLayerFromImage')}
+        tooltip={t('controlLayers.newLayerFromImage')}
+        icon={<PiDotsThreeBold />}
+        colorScheme="invokeBlue"
+        isDisabled={!selectedImage}
+      />
+      <MenuList>
+        <MenuItem icon={<NewLayerIcon />} onClickCapture={onClickNewInpaintMaskFromImage} isDisabled={!selectedImage}>
+          {t('controlLayers.inpaintMask')}
+        </MenuItem>
+        <MenuItem
+          icon={<NewLayerIcon />}
+          onClickCapture={onClickNewRegionalGuidanceFromImage}
+          isDisabled={!selectedImage}
+        >
+          {t('controlLayers.regionalGuidance')}
+        </MenuItem>
+        <MenuItem icon={<NewLayerIcon />} onClickCapture={onClickNewControlLayerFromImage} isDisabled={!selectedImage}>
+          {t('controlLayers.controlLayer')}
+        </MenuItem>
+        <MenuItem icon={<NewLayerIcon />} onClickCapture={onClickNewRasterLayerFromImage} isDisabled={!selectedImage}>
+          {t('controlLayers.rasterLayer')}
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+});
+
+StagingAreaToolbarSaveAsMenu.displayName = 'StagingAreaToolbarSaveAsMenu';

--- a/invokeai/frontend/web/src/features/imageActions/actions.ts
+++ b/invokeai/frontend/web/src/features/imageActions/actions.ts
@@ -20,6 +20,7 @@ import { selectBboxModelBase, selectBboxRect } from 'features/controlLayers/stor
 import type {
   CanvasControlLayerState,
   CanvasEntityIdentifier,
+  CanvasEntityState,
   CanvasEntityType,
   CanvasInpaintMaskState,
   CanvasRasterLayerState,
@@ -134,14 +135,16 @@ export const createNewCanvasEntityFromImage = (arg: {
   type: CanvasEntityType | 'regional_guidance_with_reference_image';
   dispatch: AppDispatch;
   getState: () => RootState;
+  overrides?: Partial<Pick<CanvasEntityState, 'isEnabled' | 'isLocked' | 'name'>>;
 }) => {
-  const { type, imageDTO, dispatch, getState } = arg;
+  const { type, imageDTO, dispatch, getState, overrides: _overrides } = arg;
   const state = getState();
   const imageObject = imageDTOToImageObject(imageDTO);
   const { x, y } = selectBboxRect(state);
   const overrides = {
     objects: [imageObject],
     position: { x, y },
+    ..._overrides,
   };
   switch (type) {
     case 'raster_layer': {

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -1,4 +1,5 @@
 import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/dist/query/core/buildInitiate';
+import { $authToken } from 'app/store/nanostores/authToken';
 import { getStore } from 'app/store/nanostores/store';
 import type { BoardId } from 'features/gallery/store/types';
 import { ASSETS_CATEGORIES, IMAGE_CATEGORIES } from 'features/gallery/store/types';
@@ -623,4 +624,21 @@ export const uploadImages = async (args: UploadImageArg[]): Promise<ImageDTO[]> 
     })
   );
   return results.filter((r): r is PromiseFulfilledResult<ImageDTO> => r.status === 'fulfilled').map((r) => r.value);
+};
+
+/**
+ * Convert an ImageDTO to a File by downloading the image from the server.
+ * @param imageDTO The image to download and convert to a File
+ */
+export const imageDTOToFile = async (imageDTO: ImageDTO): Promise<File> => {
+  const init: RequestInit = {};
+  const authToken = $authToken.get();
+  if (authToken) {
+    init.headers = { Authorization: `Bearer ${authToken}` };
+  }
+  const res = await fetch(imageDTO.image_url, init);
+  const blob = await res.blob();
+  // Create a new file with the same name, which we will upload
+  const file = new File([blob], `copy_of_${imageDTO.image_name}`, { type: 'image/png' });
+  return file;
 };


### PR DESCRIPTION
## Summary

When staging images, users may now save the current image as a new layer without accepting the current image or needing to do the round-trip of saving to gallery and then creating the layer.

The layers are created in a disabled state, to not interfere with the current canvas setup. All layer types are supported. Images are duplicated when creating the layer

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_