### PR TITLE
Fix docker deployment for ubuntu 23 EOL.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 ## Builder stage
 
-FROM library/ubuntu:22.04 AS builder
+FROM library/ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -66,7 +66,7 @@ RUN npx vite build
 
 #### Runtime stage ---------------------------------------
 
-FROM library/ubuntu:22.04 AS runtime
+FROM library/ubuntu:24.04 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 ## Builder stage
 
-FROM library/ubuntu:23.04 AS builder
+FROM library/ubuntu:22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -41,9 +41,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/rocm6.1"; \
     else \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu124"; \
-    fi &&\
-
-    # xformers + triton fails to install on arm64
+    fi && \
+          \
+    # xformers + triton fails to install on arm64 \
     if [ "$GPU_DRIVER" = "cuda" ] && [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         pip install $extra_index_url_arg -e ".[xformers]"; \
     else \
@@ -66,7 +66,7 @@ RUN npx vite build
 
 #### Runtime stage ---------------------------------------
 
-FROM library/ubuntu:23.04 AS runtime
+FROM library/ubuntu:22.04 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -83,7 +83,8 @@ RUN apt update && apt install -y --no-install-recommends \
         gosu \
         magic-wormhole \
         libglib2.0-0 \
-        libgl1-mesa-glx \
+        libgl1 \
+        libglx-mesa0 \
         python3-venv \
         python3-pip \
         build-essential \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,7 @@ set -e -o pipefail
 
 USER_ID=${CONTAINER_UID:-1000}
 USER=ubuntu
+_=$(id ${USER} 2>&1) || useradd -u ${USER_ID} ${USER}
 usermod -u ${USER_ID} ${USER} 1>/dev/null
 
 ### Set the $PUBLIC_KEY env var to enable SSH access.
@@ -36,6 +37,8 @@ fi
 mkdir -p "${INVOKEAI_ROOT}"
 chown --recursive ${USER} "${INVOKEAI_ROOT}" || true
 cd "${INVOKEAI_ROOT}"
+export HF_HOME=${HF_HOME-$INVOKEAI_ROOT/cache}
+export MPLCONFIGDIR=${MPLCONFIGDIR-$INVOKEAI_ROOT/matplotlib}
 
 # Run the CMD as the Container User (not root).
 exec gosu ${USER} "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "InvokeAI"
 description = "An implementation of Stable Diffusion which provides various new features and options to aid the image generation process"
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.13"
 readme = { content-type = "text/markdown", file = "README.md" }
 keywords = ["stable-diffusion", "AI"]
 dynamic = ["version"]


### PR DESCRIPTION
## Summary

Ubuntu 23 has EOL'd and the docker image fails to build.  Updates to Ubuntu 24 LTS and replaces libgl1-mesa-glx which is no longer available.   Also fixes a broken continuation in the Dockerfile, does a sanity check of the passwd file, and sets some environment variables so that caching is done in $INVOKEAI_ROOT.

## Related Issues / Discussions

Closes: #7387

## QA Instructions



## Merge Plan


## Checklist

- [ x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
