### PR TITLE
Use dynamic FLUX T5 seq len (small speed / mem improvement)

### DIFF
--- a/invokeai/app/invocations/flux_text_encoder.py
+++ b/invokeai/app/invocations/flux_text_encoder.py
@@ -81,7 +81,9 @@ class FluxTextEncoderInvocation(BaseInvocation):
 
         valid_seq_lens = [self.t5_max_seq_len]
         if self.use_short_t5_seq_len:
-            valid_seq_lens = [128, 256, 512]
+            # We allow a minimum sequence length of 128. Going too short results in more significant image chagnes.
+            valid_seq_lens = list(range(128, self.t5_max_seq_len, 128))
+            valid_seq_lens.append(self.t5_max_seq_len)
 
         with (
             t5_text_encoder_info as t5_text_encoder,

--- a/invokeai/backend/flux/modules/conditioner.py
+++ b/invokeai/backend/flux/modules/conditioner.py
@@ -1,32 +1,43 @@
 # Initially pulled from https://github.com/black-forest-labs/flux
 
+
 from torch import Tensor, nn
 from transformers import PreTrainedModel, PreTrainedTokenizer
 
 
 class HFEncoder(nn.Module):
-    def __init__(self, encoder: PreTrainedModel, tokenizer: PreTrainedTokenizer, is_clip: bool, max_length: int):
+    def __init__(self, encoder: PreTrainedModel, tokenizer: PreTrainedTokenizer, is_clip: bool):
         super().__init__()
-        self.max_length = max_length
         self.is_clip = is_clip
         self.output_key = "pooler_output" if self.is_clip else "last_hidden_state"
         self.tokenizer = tokenizer
         self.hf_module = encoder
         self.hf_module = self.hf_module.eval().requires_grad_(False)
 
-    def forward(self, text: list[str]) -> Tensor:
+    def forward(self, text: list[str], valid_seq_lens: list[int]) -> Tensor:
+        valid_seq_lens = sorted(valid_seq_lens)
         batch_encoding = self.tokenizer(
             text,
             truncation=True,
-            max_length=self.max_length,
-            return_length=False,
+            max_length=max(valid_seq_lens),
+            return_length=True,
             return_overflowing_tokens=False,
             padding="max_length",
             return_tensors="pt",
         )
 
+        seq_len: int = batch_encoding["length"][0].item()
+        # Find selected_seq_len, the minimum valid sequence length that can contain all of the input tokens.
+        selected_seq_len = valid_seq_lens[-1]
+        for len in valid_seq_lens:
+            if len >= seq_len:
+                selected_seq_len = len
+                break
+
+        input_ids = batch_encoding["input_ids"][..., :selected_seq_len]
+
         outputs = self.hf_module(
-            input_ids=batch_encoding["input_ids"].to(self.hf_module.device),
+            input_ids=input_ids.to(self.hf_module.device),
             attention_mask=None,
             output_hidden_states=False,
         )

--- a/invokeai/backend/flux/modules/conditioner.py
+++ b/invokeai/backend/flux/modules/conditioner.py
@@ -15,7 +15,17 @@ class HFEncoder(nn.Module):
         self.hf_module = self.hf_module.eval().requires_grad_(False)
 
     def forward(self, text: list[str], valid_seq_lens: list[int]) -> Tensor:
+        """Encode text into a tensor.
+
+        Args:
+            text: A list of text prompts to encode.
+            valid_seq_lens: A list of valid sequence lengths. The shortest valid sequence length that can contain the
+                text will be used. If the largest valid sequence length cannot contain the text, the encoding will be
+                truncated.
+        """
         valid_seq_lens = sorted(valid_seq_lens)
+
+        # Perform initial encoding with the maximum valid sequence length.
         batch_encoding = self.tokenizer(
             text,
             truncation=True,
@@ -26,8 +36,8 @@ class HFEncoder(nn.Module):
             return_tensors="pt",
         )
 
-        seq_len: int = batch_encoding["length"][0].item()
         # Find selected_seq_len, the minimum valid sequence length that can contain all of the input tokens.
+        seq_len: int = batch_encoding["length"][0].item()
         selected_seq_len = valid_seq_lens[-1]
         for len in valid_seq_lens:
             if len >= seq_len:


### PR DESCRIPTION
## Summary

This PR adds the option to dynamically select a T5 sequence length based on the length of the input prompt.

Using a smaller sequence length can improve inference speed and reduce peak memory, but will produce slightly different outputs.

### Speed Improvement

Config: 1024x1024, bf16

T5 seq len = 512: 0.481 secs / it
T5 seq len = 128: 0.461 secs / it (4.1% speedup)

### Memory improvement

Config: 1024x1024, bf16

T5 seq len = 512: 23355.16 MB peak VRAM
T5 seq len = 128: 23292.12 MB peak VRAM (63 MB saved)

### Image difference

TODO: Add sample images showing the difference in output as T5 sequence len is varied.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

- Test varied prompt lengths:
  - [ ] ~50 (t5 seq len of 128)
  - [ ] 127 (t5 seq len of 128)
  - [ ] 128 (t5 seq len of 128)
  - [ ] 129 (t5 seq len of 256)
  - [ ] ~250 (t5 seq len of 256)
  - [ ] ~500 (t5 seq len of 512)
- [ ] Test with regional prompts of varied lengths
- Test compatibility with:
  - [ ] ControlNet
  - [ ] IP-Adapter
  - [ ] LoRA

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
