### PR TITLE
[docker] upgrade to ubuntu 24.04 + use uv for package management

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,22 +9,35 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt update && apt-get install -y \
-        git \
-        python3-venv \
-        python3-pip \
-        build-essential
+        build-essential \
+        git
 
-ENV INVOKEAI_SRC=/opt/invokeai
-ENV VIRTUAL_ENV=/opt/venv/invokeai
+# Install `uv` for package management
+COPY --from=ghcr.io/astral-sh/uv:0.5.5 /uv /uvx /bin/
 
+ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV INVOKEAI_SRC=/opt/invokeai
+ENV PYTHON_VERSION=3.11
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
 ARG GPU_DRIVER=cuda
 ARG TARGETPLATFORM="linux/amd64"
 # unused but available
 ARG BUILDPLATFORM
 
-WORKDIR ${INVOKEAI_SRC}
+# Switch to the `ubuntu` user to work around dependency issues with uv-installed python
+RUN mkdir -p ${VIRTUAL_ENV} && \
+    mkdir -p ${INVOKEAI_SRC} && \
+    chmod -R a+w /opt
+USER ubuntu
 
+# Install python and create the venv
+RUN uv python install ${PYTHON_VERSION} && \
+    uv venv --relocatable --prompt "invoke" --python ${PYTHON_VERSION} ${VIRTUAL_ENV}
+
+WORKDIR ${INVOKEAI_SRC}
 COPY invokeai ./invokeai
 COPY pyproject.toml ./
 
@@ -32,9 +45,8 @@ COPY pyproject.toml ./
 # the local working copy can be bind-mounted into the image
 # at path defined by ${INVOKEAI_SRC}
 # NOTE: there are no pytorch builds for arm64 + cuda, only cpu
-# x86_64/CUDA is default
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m venv ${VIRTUAL_ENV} &&\
+# x86_64/CUDA is the default
+RUN --mount=type=cache,target=/home/ubuntu/.cache/uv,uid=1000,gid=1000 \
     if [ "$TARGETPLATFORM" = "linux/arm64" ] || [ "$GPU_DRIVER" = "cpu" ]; then \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cpu"; \
     elif [ "$GPU_DRIVER" = "rocm" ]; then \
@@ -42,15 +54,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     else \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu124"; \
     fi && \
-          \
-    # xformers + triton fails to install on arm64 \
-    if [ "$GPU_DRIVER" = "cuda" ] && [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        pip install $extra_index_url_arg -e ".[xformers]"; \
-    else \
-        pip install $extra_index_url_arg -e "."; \
-    fi
+    uv pip install --python ${PYTHON_VERSION} $extra_index_url_arg -e "."
 
-# #### Build the Web UI ------------------------------------
+#### Build the Web UI ------------------------------------
 
 FROM node:20-slim AS web-builder
 ENV PNPM_HOME="/pnpm"
@@ -85,22 +91,28 @@ RUN apt update && apt install -y --no-install-recommends \
         libglib2.0-0 \
         libgl1 \
         libglx-mesa0 \
-        python3-venv \
-        python3-pip \
         build-essential \
         libopencv-dev \
         libstdc++-10-dev &&\
     apt-get clean && apt-get autoclean
 
-
 ENV INVOKEAI_SRC=/opt/invokeai
-ENV VIRTUAL_ENV=/opt/venv/invokeai
+ENV VIRTUAL_ENV=/opt/venv
+ENV PYTHON_VERSION=3.11
 ENV INVOKEAI_ROOT=/invokeai
 ENV INVOKEAI_HOST=0.0.0.0
 ENV INVOKEAI_PORT=9090
 ENV PATH="$VIRTUAL_ENV/bin:$INVOKEAI_SRC:$PATH"
 ENV CONTAINER_UID=${CONTAINER_UID:-1000}
 ENV CONTAINER_GID=${CONTAINER_GID:-1000}
+
+# Install `uv` for package management
+# and install python for the ubuntu user (expected to exist on ubuntu >=24.x)
+# this is too tiny to optimize with multi-stage builds, but maybe we'll come back to it
+COPY --from=ghcr.io/astral-sh/uv:0.5.5 /uv /uvx /bin/
+USER ubuntu
+RUN uv python install ${PYTHON_VERSION}
+USER root
 
 # --link requires buldkit w/ dockerfile syntax 1.4
 COPY --link --from=builder ${INVOKEAI_SRC} ${INVOKEAI_SRC}
@@ -116,7 +128,7 @@ WORKDIR ${INVOKEAI_SRC}
 
 # build patchmatch
 RUN cd /usr/lib/$(uname -p)-linux-gnu/pkgconfig/ && ln -sf opencv4.pc opencv.pc
-RUN python3 -c "from patchmatch import patch_match"
+RUN python -c "from patchmatch import patch_match"
 
 RUN mkdir -p ${INVOKEAI_ROOT} && chown -R ${CONTAINER_UID}:${CONTAINER_GID} ${INVOKEAI_ROOT}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 ## Builder stage
 
-FROM library/ubuntu:22.04 AS builder
+FROM library/ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -66,7 +66,7 @@ RUN npx vite build
 
 #### Runtime stage ---------------------------------------
 
-FROM library/ubuntu:22.04 AS runtime
+FROM library/ubuntu:24.04 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 ## Builder stage
 
-FROM library/ubuntu:23.04 AS builder
+FROM library/ubuntu:22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -41,9 +41,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/rocm6.1"; \
     else \
         extra_index_url_arg="--extra-index-url https://download.pytorch.org/whl/cu124"; \
-    fi &&\
-
-    # xformers + triton fails to install on arm64
+    fi && \
+          \
+    # xformers + triton fails to install on arm64 \
     if [ "$GPU_DRIVER" = "cuda" ] && [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         pip install $extra_index_url_arg -e ".[xformers]"; \
     else \
@@ -66,7 +66,7 @@ RUN npx vite build
 
 #### Runtime stage ---------------------------------------
 
-FROM library/ubuntu:23.04 AS runtime
+FROM library/ubuntu:22.04 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -83,7 +83,8 @@ RUN apt update && apt install -y --no-install-recommends \
         gosu \
         magic-wormhole \
         libglib2.0-0 \
-        libgl1-mesa-glx \
+        libgl1 \
+        libglx-mesa0 \
         python3-venv \
         python3-pip \
         build-essential \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,7 +16,9 @@ set -e -o pipefail
 
 USER_ID=${CONTAINER_UID:-1000}
 USER=ubuntu
+# if the user does not exist, create it. It is expected to be present on ubuntu >=24.x
 _=$(id ${USER} 2>&1) || useradd -u ${USER_ID} ${USER}
+# ensure the UID is correct
 usermod -u ${USER_ID} ${USER} 1>/dev/null
 
 ### Set the $PUBLIC_KEY env var to enable SSH access.
@@ -37,8 +39,8 @@ fi
 mkdir -p "${INVOKEAI_ROOT}"
 chown --recursive ${USER} "${INVOKEAI_ROOT}" || true
 cd "${INVOKEAI_ROOT}"
-export HF_HOME=${HF_HOME-$INVOKEAI_ROOT/cache}
-export MPLCONFIGDIR=${MPLCONFIGDIR-$INVOKEAI_ROOT/matplotlib}
+export HF_HOME=${HF_HOME:-$INVOKEAI_ROOT/.cache/huggingface}
+export MPLCONFIGDIR=${MPLCONFIGDIR:-$INVOKEAI_ROOT/.matplotlib}
 
 # Run the CMD as the Container User (not root).
 exec gosu ${USER} "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,7 @@ set -e -o pipefail
 
 USER_ID=${CONTAINER_UID:-1000}
 USER=ubuntu
+_=$(id ${USER} 2>&1) || useradd -u ${USER_ID} ${USER}
 usermod -u ${USER_ID} ${USER} 1>/dev/null
 
 ### Set the $PUBLIC_KEY env var to enable SSH access.
@@ -36,6 +37,8 @@ fi
 mkdir -p "${INVOKEAI_ROOT}"
 chown --recursive ${USER} "${INVOKEAI_ROOT}" || true
 cd "${INVOKEAI_ROOT}"
+export HF_HOME=${HF_HOME-$INVOKEAI_ROOT/cache}
+export MPLCONFIGDIR=${MPLCONFIGDIR-$INVOKEAI_ROOT/matplotlib}
 
 # Run the CMD as the Container User (not root).
 exec gosu ${USER} "$@"

--- a/invokeai/app/invocations/__init__.py
+++ b/invokeai/app/invocations/__init__.py
@@ -15,6 +15,11 @@ custom_nodes_readme_path = str(custom_nodes_path / "README.md")
 shutil.copy(Path(__file__).parent / "custom_nodes/init.py", custom_nodes_init_path)
 shutil.copy(Path(__file__).parent / "custom_nodes/README.md", custom_nodes_readme_path)
 
+# set the same permissions as the destination directory, in case our source is read-only,
+# so that the files are user-writable
+for p in custom_nodes_path.glob("**/*"):
+    p.chmod(custom_nodes_path.stat().st_mode)
+
 # Import custom nodes, see https://docs.python.org/3/library/importlib.html#importing-programmatically
 spec = spec_from_file_location("custom_nodes", custom_nodes_init_path)
 if spec is None or spec.loader is None:

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -536,11 +536,13 @@ def get_config() -> InvokeAIAppConfig:
 
     # Compare directories recursively
     comparison = filecmp.dircmp(configs_src, dest_path)
-    need_copy = any([
-        comparison.left_only,  # Files exist only in source
-        comparison.diff_files, # Files that differ
-        comparison.common_funny # Files that couldn't be compared
-    ])
+    need_copy = any(
+        [
+            comparison.left_only,  # Files exist only in source
+            comparison.diff_files,  # Files that differ
+            comparison.common_funny,  # Files that couldn't be compared
+        ]
+    )
 
     if need_copy:
         # Get permissions from destination directory

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import filecmp
 import locale
 import os
 import re
@@ -525,9 +526,33 @@ def get_config() -> InvokeAIAppConfig:
     ]
     example_config.write_file(config.config_file_path.with_suffix(".example.yaml"), as_example=True)
 
-    # Copy all legacy configs - We know `__path__[0]` is correct here
+    # Copy all legacy configs only if needed
+    # We know `__path__[0]` is correct here
     configs_src = Path(model_configs.__path__[0])  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType, reportAttributeAccessIssue]
-    shutil.copytree(configs_src, config.legacy_conf_path, dirs_exist_ok=True)
+    dest_path = config.legacy_conf_path
+
+    # Create destination (we don't need to check for existence)
+    dest_path.mkdir(parents=True, exist_ok=True)
+
+    # Compare directories recursively
+    comparison = filecmp.dircmp(configs_src, dest_path)
+    need_copy = any([
+        comparison.left_only,  # Files exist only in source
+        comparison.diff_files, # Files that differ
+        comparison.common_funny # Files that couldn't be compared
+    ])
+
+    if need_copy:
+        # Get permissions from destination directory
+        dest_mode = dest_path.stat().st_mode
+
+        # Copy directory tree
+        shutil.copytree(configs_src, dest_path, dirs_exist_ok=True)
+
+        # Set permissions on copied files to match destination directory
+        dest_path.chmod(dest_mode)
+        for p in dest_path.glob("**/*"):
+            p.chmod(dest_mode)
 
     if config.config_file_path.exists():
         config_from_file = load_and_migrate_config(config.config_file_path)

--- a/invokeai/app/services/shared/sqlite_migrator/migrations/migration_11.py
+++ b/invokeai/app/services/shared/sqlite_migrator/migrations/migration_11.py
@@ -35,7 +35,7 @@ class Migration11Callback:
 
     def _remove_convert_cache(self) -> None:
         """Rename models/.cache to models/.convert_cache."""
-        self._logger.info("Removing .cache directory. Converted models will now be cached in .convert_cache.")
+        self._logger.info("Removing models/.cache directory. Converted models will now be cached in .convert_cache.")
         legacy_convert_path = self._app_config.root_path / "models" / ".cache"
         shutil.rmtree(legacy_convert_path, ignore_errors=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "InvokeAI"
 description = "An implementation of Stable Diffusion which provides various new features and options to aid the image generation process"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.12"
 readme = { content-type = "text/markdown", file = "README.md" }
 keywords = ["stable-diffusion", "AI"]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "InvokeAI"
 description = "An implementation of Stable Diffusion which provides various new features and options to aid the image generation process"
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.13"
 readme = { content-type = "text/markdown", file = "README.md" }
 keywords = ["stable-diffusion", "AI"]
 dynamic = ["version"]


### PR DESCRIPTION
## Summary

- upgrades docker image to ubuntu 24.04 (contributed by @rick-github)
- adds support in docker entrypoint for keeping HF cache in the invoke runtime directory, unless specified otherwise - this should help avoid unnecessary redownloads from HF (contributed by @rick-github)
- ubuntu 24.04 ships with python 3.12, so this PR changes our package management backend to use `uv`, including the installation of python itself. This will both improve performance when using docker cache, and decouple python versioning from the underlying OS.
- fixes: legacy model configs were being copied with their permissions intact. Because we're trying to copy them on every startup, this would cause the application to fail to start when the source code directory is read-only, because it could not overwrite the read-only copies of the configs. This PR checks whether the files already exist and are identical, and if copying is needed, it changes permissions on the copied files.
- same for custom nodes dir

## Related Issues / Discussions

Closes #7387
Supercedes https://github.com/invoke-ai/InvokeAI/pull/7396

## QA Instructions

Build and run the container locally as usual: `docker compose up --build`, and test the application.

## Merge Plan

Community testing might be useful, but can be merged anytime otherwise.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
