### PR TITLE
fix(ui): remove "adding to" text on Invoke tooltip on Workflows/Upscaling tabs

### DIFF
--- a/invokeai/frontend/web/src/features/queue/components/InvokeButtonTooltip/InvokeButtonTooltip.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/InvokeButtonTooltip/InvokeButtonTooltip.tsx
@@ -147,8 +147,6 @@ const UpscaleTabTooltipContent = memo(({ prepend = false }: { prepend?: boolean 
           <ReasonsList reasons={reasons} />
         </>
       )}
-      <StyledDivider />
-      <AddingToText />
     </Flex>
   );
 });
@@ -180,8 +178,6 @@ const WorkflowsTabTooltipContent = memo(({ prepend = false }: { prepend?: boolea
           <ReasonsList reasons={reasons} />
         </>
       )}
-      <StyledDivider />
-      <AddingToText />
     </Flex>
   );
 });


### PR DESCRIPTION
## Summary

The "adding to" text indicates if images are going to the gallery or staging area. This info is relevant only to the canvas tab, but was displayed on Upscaling and Workflows tabs. Removed it from those tabs.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_