### PR TITLE
fix(worker): only apply processor cancel logic if cancel event is for current item

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -378,6 +378,9 @@ class DefaultSessionProcessor(SessionProcessorBase):
         self._poll_now()
 
     async def _on_queue_item_status_changed(self, event: FastAPIEvent[QueueItemStatusChangedEvent]) -> None:
+        # Make sure the cancel event is for the currently processing queue item
+        if self._queue_item and self._queue_item.item_id is not event[1].item_id:
+            return
         if self._queue_item and event[1].status in ["completed", "failed", "canceled"]:
             # When the queue item is canceled via HTTP, the queue item status is set to `"canceled"` and this event is
             # emitted. We need to respond to this event and stop graph execution. This is done by setting the cancel


### PR DESCRIPTION
## Summary

Fixes a bug in the session processor where a cancel event for any queue item was triggering the processor to cancel the current queue item.

## Related Issues / Discussions

Closes https://github.com/invoke-ai/InvokeAI/issues/7414

## QA Instructions

Queue up a batch of generations and cancel some at the end. The currently processing queue item should still finish and have expected output appear.

## Merge Plan

Should be reviewed by @psychedelicious before merge

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
