### PR TITLE
fix(ui): skip disabled global reference image

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addIPAdapters.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addIPAdapters.ts
@@ -17,7 +17,9 @@ type AddIPAdaptersArg = {
 };
 
 export const addIPAdapters = ({ entities, g, collector, model }: AddIPAdaptersArg): AddIPAdaptersResult => {
-  const validIPAdapters = entities.filter((entity) => getGlobalReferenceImageWarnings(entity, model).length === 0);
+  const validIPAdapters = entities
+    .filter((entity) => entity.isEnabled)
+    .filter((entity) => getGlobalReferenceImageWarnings(entity, model).length === 0);
 
   const result: AddIPAdaptersResult = {
     addedIPAdapters: 0,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addRegions.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addRegions.ts
@@ -63,12 +63,9 @@ export const addRegions = async ({
   const isSDXL = model.base === 'sdxl';
   const isFLUX = model.base === 'flux';
 
-  const validRegions = regions.filter((rg) => {
-    if (!rg.isEnabled) {
-      return false;
-    }
-    return getRegionalGuidanceWarnings(rg, model).length === 0;
-  });
+  const validRegions = regions
+    .filter((entity) => entity.isEnabled)
+    .filter((entity) => getRegionalGuidanceWarnings(entity, model).length === 0);
 
   const results: AddedRegionResult[] = [];
 


### PR DESCRIPTION
## Summary

I missed a spot in #7388.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1313348384693813298

## QA Instructions

Global Reference Images should be skipped when disabled.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_