### PR TITLE
fix(app): processor cancelation weirdness

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -379,7 +379,7 @@ class DefaultSessionProcessor(SessionProcessorBase):
 
     async def _on_queue_item_status_changed(self, event: FastAPIEvent[QueueItemStatusChangedEvent]) -> None:
         # Make sure the cancel event is for the currently processing queue item
-        if self._queue_item and self._queue_item.item_id is not event[1].item_id:
+        if self._queue_item and self._queue_item.item_id != event[1].item_id:
             return
         if self._queue_item and event[1].status in ["completed", "failed", "canceled"]:
             # When the queue item is canceled via HTTP, the queue item status is set to `"canceled"` and this event is


### PR DESCRIPTION
## Summary

The `is` operator compares references, not values. Thanks to a wonderfully unintuitive quirk of python, `is` works on integers from `-5` to `256`, inclusive.

Whenever integers in this range are used for a value, internally python returns a reference to a stable object in memory. When integers outside this range are used as a value, python creates a new object in memory for that integer.

See `PyLong_FromLong` documentation here: https://docs.python.org/3/c-api/long.html

Tying this back to our session processor, we were using `is` to compare the queue item ids for equality. Our queue item ids start at 0, and each queue item created increments this by one. So this comparison works only for the first 256 queue items on the machine.

Starting with the 257th queue item, the comparison starts returning `False`, and cancelation gets weird.

Easy fix - use `!=` instead of `is not`.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1313343197262385162

## QA Instructions

Cancel button should work and not be really weird.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_