### PR TITLE
Fix error message when adding a local path with quotes (issue #6517)

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -438,9 +438,10 @@ class ModelInstallService(ModelInstallServiceBase):
         variants = "|".join(ModelRepoVariant.__members__.values())
         hf_repoid_re = f"^([^/:]+/[^/:]+)(?::({variants})?(?::/?([^:]+))?)?$"
         source_obj: Optional[StringLikeSource] = None
+        source_stripped = source.strip('\"') # Strip possible quotes from source string to avoid later errors with local files or directories
 
-        if Path(source).exists():  # A local file or directory
-            source_obj = LocalModelSource(path=Path(source))
+        if Path(source_stripped).exists():  # A local file or directory
+            source_obj = LocalModelSource(path=Path(source_stripped))
         elif match := re.match(hf_repoid_re, source):
             source_obj = HFModelSource(
                 repo_id=match.group(1),

--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -438,7 +438,7 @@ class ModelInstallService(ModelInstallServiceBase):
         variants = "|".join(ModelRepoVariant.__members__.values())
         hf_repoid_re = f"^([^/:]+/[^/:]+)(?::({variants})?(?::/?([^:]+))?)?$"
         source_obj: Optional[StringLikeSource] = None
-        source_stripped = source.strip('\"') # Strip possible quotes from source string to avoid later errors with local files or directories
+        source_stripped = source.strip('"')
 
         if Path(source_stripped).exists():  # A local file or directory
             source_obj = LocalModelSource(path=Path(source_stripped))


### PR DESCRIPTION
This is just a small fix for this minor but annoying issue: https://github.com/invoke-ai/InvokeAI/issues/6517
It just strips quotes from the local path string before it's used.  It should only affect local paths.

Not sure if this is the best place to apply the fix or cleanest approach, but it seems to work.