### PR TITLE
Fix for DEIS / DPM++ config clash by setting algorithm type -  fixes #6368

### DIFF
--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -10,9 +10,9 @@ import torchvision.transforms as T
 from diffusers.configuration_utils import ConfigMixin
 from diffusers.models.adapter import T2IAdapter
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
+from diffusers.schedulers.scheduling_dpmsolver_multistep import DPMSolverMultistepScheduler
 from diffusers.schedulers.scheduling_dpmsolver_sde import DPMSolverSDEScheduler
 from diffusers.schedulers.scheduling_dpmsolver_singlestep import DPMSolverSinglestepScheduler
-from diffusers.schedulers.scheduling_dpmsolver_multistep import DPMSolverMultistepScheduler
 from diffusers.schedulers.scheduling_tcd import TCDScheduler
 from diffusers.schedulers.scheduling_utils import SchedulerMixin as Scheduler
 from PIL import Image

--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -108,8 +108,8 @@ def get_scheduler(
         scheduler_config["noise_sampler_seed"] = seed
 
     if scheduler_class is DPMSolverMultistepScheduler or scheduler_class is DPMSolverSinglestepScheduler:
-      if scheduler_config['_class_name'] == 'DEISMultistepScheduler' and scheduler_config["algorithm_type"] == 'deis':
-          scheduler_config["algorithm_type"] = 'dpmsolver++'
+        if scheduler_config["_class_name"] == "DEISMultistepScheduler" and scheduler_config["algorithm_type"] == "deis":
+            scheduler_config["algorithm_type"] = "dpmsolver++"
 
     scheduler = scheduler_class.from_config(scheduler_config)
 


### PR DESCRIPTION
## Summary

If a model defaults to DEIS scheduler and the user attempts to use DPM++ schedulers with it, the inherited config parameters clash giving #6368, this fixes it by changing the config to use DPM's default alogorythm type, which I
believe is was a user attempt to using the DPM++ would expect.

## Related Issues / Discussions

Closes #6368

## QA Instructions

Run a Dreamshaper 8 render using any of the following schedulers

DPM++ 2M
DPM++ 2M Karras
DPM++ 2S
DPM++ 2S Karras

It will fail without the pull request, and will work with the pull request.

## Merge Plan

N/A simple merge
