### PR TITLE
docs: add redirect for patchmatch docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ plugins:
         'installation/INSTALL_DOCKER.md': 'installation/docker.md'
         'installation/INSTALLING_MODELS.md': 'installation/models.md'
         'installation/INSTALL_PATCHMATCH.md': 'installation/patchmatch.md'
+        'installation/060_INSTALL_PATCHMATCH.md': 'installation/patchmatch.md'
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
## Summary

The patchmatch lib links directly to our docs: https://invoke-ai.github.io/InvokeAI/installation/060_INSTALL_PATCHMATCH/

That URL doesn't exist any more. Added a redirect to the new URL.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_