### PR TITLE
feat(ui): improved canvas/queue error handling

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketConnected.ts
@@ -17,8 +17,6 @@ export const addSocketConnectedEventListener = (startAppListening: AppStartListe
   startAppListening({
     actionCreator: socketConnected,
     effect: async (action, { dispatch, getState, cancelActiveListeners, delay }) => {
-      log.debug('Connected');
-
       /**
        * The rest of this listener has recovery logic for when the socket disconnects and reconnects.
        *

--- a/invokeai/frontend/web/src/common/util/result.ts
+++ b/invokeai/frontend/web/src/common/util/result.ts
@@ -57,7 +57,7 @@ export class Err<E> {
  * @template T The type of the value in the `Ok` case.
  * @template E The type of the error in the `Err` case.
  */
-export type Result<T, E = Error> = Ok<T> | Err<E>;
+type Result<T, E = Error> = Ok<T> | Err<E>;
 
 /**
  * Creates a successful result.

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -11,6 +11,7 @@ import type { FilterConfig } from 'features/controlLayers/store/filters';
 import { getFilterForModel, IMAGE_FILTERS } from 'features/controlLayers/store/filters';
 import type { CanvasImageState, CanvasRenderableEntityType } from 'features/controlLayers/store/types';
 import { imageDTOToImageObject } from 'features/controlLayers/store/util';
+import { toast } from 'features/toast/toast';
 import Konva from 'konva';
 import { debounce } from 'lodash-es';
 import { atom, computed } from 'nanostores';
@@ -246,6 +247,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       this.parent.renderer.rasterize({ rect, attrs: { filters: [], opacity: 1 } })
     );
     if (rasterizeResult.isErr()) {
+      toast({ status: 'error', title: 'Failed to process filter' });
       this.log.error({ error: serializeError(rasterizeResult.error) }, 'Error rasterizing entity');
       this.$isProcessing.set(false);
       return;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -13,6 +13,7 @@ import {
 } from 'features/controlLayers/konva/util';
 import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
 import type { Coordinate, Rect, RectWithRotation } from 'features/controlLayers/store/types';
+import { toast } from 'features/toast/toast';
 import Konva from 'konva';
 import type { GroupConfig } from 'konva/lib/Group';
 import { clamp, debounce, get } from 'lodash-es';
@@ -779,6 +780,7 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
       })
     );
     if (rasterizeResult.isErr()) {
+      toast({ status: 'error', title: 'Failed to apply transform' });
       this.log.error({ error: serializeError(rasterizeResult.error) }, 'Failed to rasterize entity');
     }
     this.requestRectCalculation();

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasSegmentAnythingModule.ts
@@ -26,6 +26,7 @@ import type {
 import { SAM_POINT_LABEL_NUMBER_TO_STRING } from 'features/controlLayers/store/types';
 import { imageDTOToImageObject } from 'features/controlLayers/store/util';
 import { Graph } from 'features/nodes/util/graph/generation/Graph';
+import { toast } from 'features/toast/toast';
 import Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
 import { debounce } from 'lodash-es';
@@ -571,6 +572,7 @@ export class CanvasSegmentAnythingModule extends CanvasModuleBase {
     );
 
     if (rasterizeResult.isErr()) {
+      toast({ status: 'error', title: 'Failed to select object' });
       this.log.error({ error: serializeError(rasterizeResult.error) }, 'Error rasterizing entity');
       this.$isProcessing.set(false);
       return;


### PR DESCRIPTION
## Summary

Improve error handling and logging for:
- Canvas layer rasterization, which occurs during transform, filter, select and crop operations
- Canvas layer compositing, which occurs during graph building
- Canvas generation mode calculations, which occurs during graph building

Minor additional changes:
- Remove duplicate log message when socket connects
- Simplify the handling of the `enqueueRequested` graph building RTK Q listener

## Related Issues / Discussions

offline discussion

## QA Instructions

These improvements should prevent canvas from getting stuck in a various processing states when an operation fails.

To test this, you could try this diff, which makes most uploads from within the app fail. This (hopefully) replicates a spotty/dropped network connection. There are other ways that canvas operations could fail, but this is the easiest way to induce this class of error.

```diff
diff --git a/invokeai/frontend/web/src/services/api/endpoints/images.ts b/invokeai/frontend/web/src/services/api/endpoints/images.ts
index 40b14201eb..8cbe368874 100644
--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -611,6 +611,7 @@ export const getImageMetadata = (
 
 export const uploadImage = (arg: UploadImageArg): Promise<ImageDTO> => {
   const { dispatch } = getStore();
+  throw new Error('Bork');
   const req = dispatch(imagesApi.endpoints.uploadImage.initiate(arg, { track: false }));
   return req.unwrap();
 };
 ```

Then try a transform & apply, filter, select object or crop to bbox.

- Before this PR: the canvas will get stuck with a grey-ed out Invoke button. The Invoke button tooltip will show a message like `Canvas is busy (rasterizing)` (maybe others if you were filtering or select-objecting).
- After this PR: you should see a toast saying which operation failed, then the canvas recovers gracefully, leaving you back in the state you were in before you started the failed operation.
    
    So for example, if it was applying a transform that failed, you should get a toast saying `Failed to apply transform` and the layer you were transforming should revert to the state it was in before you started the transform.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_