### PR TITLE
fix(ui): fix double filter on slow networks

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerControlAdapter.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/ControlLayer/ControlLayerControlAdapter.tsx
@@ -102,12 +102,12 @@ export const ControlLayerControlAdapter = memo(() => {
       const filterConfig = defaultFilterForNewModel.buildDefaults();
       if (isFiltering) {
         adapter.filterer.$filterConfig.set(filterConfig);
+        // The user may have disabled auto-processing, so we should process the filter manually. This is essentially a
+        // no-op if auto-processing is already enabled, because the process method is debounced.
+        adapter.filterer.process();
       } else {
         adapter.filterer.start(filterConfig);
       }
-      // The user may have disabled auto-processing, so we should process the filter manually. This is essentially a
-      // no-op if auto-processing is already enabled, because the process method is debounced.
-      adapter.filterer.process();
     },
     [adapter.filterer, dispatch, entityIdentifier]
   );


### PR DESCRIPTION
## Summary

Depending on network latency, there was a race condition where filters would run twice and improved error handling showed a toast to user that previously was swallowed. This solves the root issue.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
