### PR TITLE
feat(ci): add typegen check workflow

### DIFF
--- a/.github/workflows/typegen-checks.yml
+++ b/.github/workflows/typegen-checks.yml
@@ -1,0 +1,85 @@
+# Runs typegen schema quality checks.
+# Frontend types should match the server.
+#
+# Checks for changes to files before running the checks.
+# If always_run is true, always runs the checks.
+
+name: 'typegen checks'
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types:
+      - 'ready_for_review'
+      - 'opened'
+      - 'synchronize'
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      always_run:
+        description: 'Always run the checks'
+        required: true
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      always_run:
+        description: 'Always run the checks'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  typegen-checks:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15 # expected run time: <5 min
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: check for changed files
+        if: ${{ inputs.always_run != true }}
+        id: changed-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files_yaml: |
+            src:
+              - 'pyproject.toml'
+              - 'invokeai/**'
+
+      - name: setup python
+        if: ${{ steps.changed-files.outputs.src_any_changed == 'true' || inputs.always_run == true }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: install python dependencies
+        if: ${{ steps.changed-files.outputs.src_any_changed == 'true' || inputs.always_run == true }}
+        run: pip3 install --use-pep517 --editable="."
+
+      - name: install frontend dependencies
+        if: ${{ steps.changed-files.outputs.src_any_changed == 'true' || inputs.always_run == true }}
+        uses: ./.github/actions/install-frontend-deps
+
+      - name: copy schema
+        if: ${{ steps.changed-files.outputs.src_any_changed == 'true' || inputs.always_run == true }}
+        run: cp invokeai/frontend/web/src/services/api/schema.ts invokeai/frontend/web/src/services/api/schema_orig.ts
+        shell: bash
+
+      - name: generate schema
+        if: ${{ steps.changed-files.outputs.src_any_changed == 'true' || inputs.always_run == true }}
+        run: make frontend-typegen
+        shell: bash
+
+      - name: compare files
+        if: ${{ steps.changed-files.outputs.src_any_changed == 'true' || inputs.always_run == true }}
+        run: |
+          if ! diff invokeai/frontend/web/src/services/api/schema.ts invokeai/frontend/web/src/services/api/schema_orig.ts; then
+            echo "Files are different!";
+            exit 1;
+          fi
+        shell: bash


### PR DESCRIPTION
## Summary

Workflow to check whether the generated frontend types in `invokeai/frontend/web/src/services/api/schema.ts` match those on the server.

## Notes

There still appears to be some non-determinism in the typegen creation process. Depending on the Torch installation (CPU, GPU, etc.), the default value of an InputField may change.

Example: https://github.com/invoke-ai/InvokeAI/blob/main/invokeai/app/invocations/create_denoise_mask.py#L33
```py
DEFAULT_PRECISION = TorchDevice.choose_torch_dtype()

fp32: bool = InputField(
    default=DEFAULT_PRECISION == torch.float32,
    description=FieldDescriptions.fp32,
    ui_order=4,
)
```

## Merge Plan 

- Address non-determinism (my suggestion: use a fixed default value) https://github.com/invoke-ai/InvokeAI/pull/7464
- Ensure schema is up-to-date: https://github.com/invoke-ai/InvokeAI/pull/7462

## Related Issues / Discussions

https://github.com/invoke-ai/InvokeAI/pull/7394#issuecomment-2522328756

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
