### PR TITLE
feat(api): less verbose uvicorn logs

### DIFF
--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -97,6 +97,7 @@ class InvokeAIAppConfig(BaseSettings):
         log_format: Log format. Use "plain" for text-only, "color" for colorized output, "legacy" for 2.3-style logging and "syslog" for syslog-style.<br>Valid values: `plain`, `color`, `syslog`, `legacy`
         log_level: Emit logging messages at this level or higher.<br>Valid values: `debug`, `info`, `warning`, `error`, `critical`
         log_sql: Log SQL queries. `log_level` must be `debug` for this to do anything. Extremely verbose.
+        log_level_network: Log level for network-related messages. 'info' and 'debug' are very verbose.<br>Valid values: `debug`, `info`, `warning`, `error`, `critical`
         use_memory_db: Use in-memory database. Useful for development.
         dev_reload: Automatically reload when Python sources are changed. Does not reload node definitions.
         profile_graphs: Enable graph profiling using `cProfile`.
@@ -163,6 +164,7 @@ class InvokeAIAppConfig(BaseSettings):
     log_format:              LOG_FORMAT = Field(default="color",            description='Log format. Use "plain" for text-only, "color" for colorized output, "legacy" for 2.3-style logging and "syslog" for syslog-style.')
     log_level:                LOG_LEVEL = Field(default="info",             description="Emit logging messages at this level or higher.")
     log_sql:                       bool = Field(default=False,              description="Log SQL queries. `log_level` must be `debug` for this to do anything. Extremely verbose.")
+    log_level_network:        LOG_LEVEL = Field(default='warning',          description="Log level for network-related messages. 'info' and 'debug' are very verbose.")
 
     # Development
     use_memory_db:                 bool = Field(default=False,              description="Use in-memory database. Useful for development.")

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -439,7 +439,9 @@ class DefaultSessionProcessor(SessionProcessorBase):
                         poll_now_event.wait(self._polling_interval)
                         continue
 
-                    self._invoker.services.logger.debug(f"Executing queue item {self._queue_item.item_id}")
+                    self._invoker.services.logger.info(
+                        f"Executing queue item {self._queue_item.item_id}, session {self._queue_item.session_id}"
+                    )
                     cancel_event.clear()
 
                     # Run the graph


### PR DESCRIPTION
## Summary

[feat(api): less verbose uvicorn logs](https://github.com/invoke-ai/InvokeAI/commit/97857430cb6b783759b5076bd8c7fa0b58596cba)

Uvicorn's logging is rather verbose. This change adds a `log_level_network` config setting to independently control uvicorn's log outputs. The setting defaults to warning.

The change hides this helpful startup message that says the host and port we are running on:

```
Uvicorn running on http://0.0.0.0:9090/ (Press CTRL+C to quit)
```

The ASGI lifespan handler is updated to log a similar message on startup, regardless of log level settings:

```
Invoke running on http://0.0.0.0:9090 (Press CTRL+C to quit)
```

Besides being helpful, the launcher relies on a message like this to launch the app. So, previously, if the user set their log level to anything above info (e.g. warning or error), the launcher would fail to open the app. This change prevents that edge case. The launcher will be updated to handle the altered format ("Uvicorn" -> "Invoke").

[feat(app): change queue item execution log from debug to info](https://github.com/invoke-ai/InvokeAI/commit/7ca51e441e31133d8347f2ad2d6c56cdb8349e15)

This provides useful context for subsequent logs during queue item execution.

## Related Issues / Discussions

n/a

## QA Instructions

- Start the app. You should see far fewer spurious logs.
- Generate. You should see logs for each queue item / session being executed.
- Set `log_level: error` in `invokeai.yaml`. You should still see a message like `[2024-12-20 08:04:04,928]::[InvokeAI]::INFO --> Invoke running on http://0.0.0.0:9090 (Press CTRL+C to quit)` on startup.
- Set `log_level_network: info` in `invokeai.yaml`. You should see the traditional invoke logsplosion.

## Merge Plan

I'll do a release.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_