### PR TITLE
Support v-prediction checkpoint models when set in the model manager

### DIFF
--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -40,6 +40,7 @@ from invokeai.app.services.shared.invocation_context import InvocationContext
 from invokeai.app.util.controlnet_utils import prepare_control_image
 from invokeai.backend.ip_adapter.ip_adapter import IPAdapter
 from invokeai.backend.model_manager import BaseModelType, ModelVariantType
+from invokeai.backend.model_manager.config import AnyModelConfig
 from invokeai.backend.model_patcher import ModelPatcher
 from invokeai.backend.patches.layer_patcher import LayerPatcher
 from invokeai.backend.patches.model_patch_raw import ModelPatchRaw
@@ -85,6 +86,7 @@ def get_scheduler(
     scheduler_info: ModelIdentifierField,
     scheduler_name: str,
     seed: int,
+    unet_config: AnyModelConfig | None = None,
 ) -> Scheduler:
     """Load a scheduler and apply some scheduler-specific overrides."""
     # TODO(ryand): Silently falling back to ddim seems like a bad idea. Look into why this was added and remove if
@@ -102,6 +104,9 @@ def get_scheduler(
         **scheduler_extra_config,  # FIXME
         "_backup": scheduler_config,
     }
+
+    if unet_config is not None:
+        scheduler_config["prediction_type"] = unet_config.prediction_type
 
     # make dpmpp_sde reproducable(seed can be passed only in initializer)
     if scheduler_class is DPMSolverSDEScheduler:
@@ -829,6 +834,9 @@ class DenoiseLatentsInvocation(BaseInvocation):
         seed, noise, latents = self.prepare_noise_and_latents(context, self.noise, self.latents)
         _, _, latent_height, latent_width = latents.shape
 
+        # get the unet's config so that we can pass the base to sd_step_callback()
+        unet_config = context.models.get_config(self.unet.unet.key)
+
         conditioning_data = self.get_conditioning_data(
             context=context,
             positive_conditioning_field=self.positive_conditioning,
@@ -848,6 +856,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
             scheduler_info=self.unet.scheduler,
             scheduler_name=self.scheduler,
             seed=seed,
+            unet_config=unet_config,
         )
 
         timesteps, init_timestep, scheduler_step_kwargs = self.init_scheduler(
@@ -858,9 +867,6 @@ class DenoiseLatentsInvocation(BaseInvocation):
             denoising_start=self.denoising_start,
             denoising_end=self.denoising_end,
         )
-
-        # get the unet's config so that we can pass the base to sd_step_callback()
-        unet_config = context.models.get_config(self.unet.unet.key)
 
         ### preview
         def step_callback(state: PipelineIntermediateState) -> None:
@@ -1030,6 +1036,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
                 scheduler_info=self.unet.scheduler,
                 scheduler_name=self.scheduler,
                 seed=seed,
+                unet_config=unet_config,
             )
 
             pipeline = self.create_pipeline(unet, scheduler)

--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -86,7 +86,7 @@ def get_scheduler(
     scheduler_info: ModelIdentifierField,
     scheduler_name: str,
     seed: int,
-    unet_config: AnyModelConfig | None = None,
+    unet_config: AnyModelConfig,
 ) -> Scheduler:
     """Load a scheduler and apply some scheduler-specific overrides."""
     # TODO(ryand): Silently falling back to ddim seems like a bad idea. Look into why this was added and remove if
@@ -105,7 +105,7 @@ def get_scheduler(
         "_backup": scheduler_config,
     }
 
-    if unet_config is not None:
+    if hasattr(unet_config, "prediction_type"):
         scheduler_config["prediction_type"] = unet_config.prediction_type
 
     # make dpmpp_sde reproducable(seed can be passed only in initializer)

--- a/invokeai/app/invocations/tiled_multi_diffusion_denoise_latents.py
+++ b/invokeai/app/invocations/tiled_multi_diffusion_denoise_latents.py
@@ -218,6 +218,7 @@ class TiledMultiDiffusionDenoiseLatents(BaseInvocation):
                 scheduler_info=self.unet.scheduler,
                 scheduler_name=self.scheduler,
                 seed=seed,
+                unet_config=unet_config,
             )
             pipeline = self.create_pipeline(unet=unet, scheduler=scheduler)
 


### PR DESCRIPTION
## Summary

Capture prediction type from model settings and pass it to the scheduler to enable v_prediction checkpoints to work again.

## Related Issues / Discussions

I'm certain there is a more correct way to handle this in the model manager that would also allow automatic detection from checkpoint files, but this at least gets vpred models working again before we go make sweeping changes to the model probe code.

Since our conversion code does not check the settings on the checkpoint, attempting to convert a v_prediction model to Diffusers will still default over to epsilon prediction and it will forever fail afterwards. It is not currently possible for users to change a diffusers model to v_prediction in Invoke without editing the local json files. User Mewt on discord has found that huggingface repos with correct scheduler_config.json are able to work without issues, but I have found others online that still specify epsilon. 

Closes #7495 
Closes #6268 (edit by @psychedelicious to get GH to pick up that this PR closes this issue)

## QA Instructions

Before:
![image](https://github.com/user-attachments/assets/b2f43537-2546-44e9-9535-010042a5d108)

After:
![image](https://github.com/user-attachments/assets/6b727e79-a551-4302-ab8d-600763aff701)

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
