### PR TITLE
docs: install guides

### DIFF
--- a/docs/contributing/dev-environment.md
+++ b/docs/contributing/dev-environment.md
@@ -1,12 +1,10 @@
 # Dev Environment
 
-To make changes to Invoke's backend, frontend, or documentation, you'll need to set up a dev environment.
+To make changes to Invoke's backend, frontend or documentation, you'll need to set up a dev environment.
 
-If you just want to use Invoke, you should use the [installer][installer link].
+If you only want to make changes to the docs site, you can skip the frontend dev environment setup as described in the below guide.
 
-!!! info "Why do I need the frontend toolchain?"
-
-    The repo doesn't contain a build of the frontend. You'll be responsible for rebuilding it every time you pull in new changes, or run it in dev mode (which incurs a substantial performance penalty).
+If you just want to use Invoke, you should use the [launcher][launcher link].
 
 !!! warning
 
@@ -17,84 +15,66 @@ If you just want to use Invoke, you should use the [installer][installer link].
 ## Setup
 
 1. Run through the [requirements][requirements link].
+
 2. [Fork and clone][forking link] the [InvokeAI repo][repo link].
+
 3. Create an directory for user data (images, models, db, etc). This is typically at `~/invokeai`, but if you already have a non-dev install, you may want to create a separate directory for the dev install.
-4. Create a python virtual environment inside the directory you just created:
+
+4. Follow the [manual install][manual install link] guide, with some modifications to the install command:
+
+      - Use `.` instead of `invokeai` to install from the current directory.
+
+      - Add `-e` after the `install` operation to make this an [editable install][editable install link]. That means your changes to the python code will be reflected when you restart the Invoke server.
+
+      - When installing the `invokeai` package, add the `dev`, `test` and `docs` package options to the package specifier. You may or may not need the `xformers` option - follow the manual install guide to figure that out. So, your package specifier will be either `".[dev,test,docs]"` or `".[dev,test,docs,xformers]"`. Note the quotes!
+
+     With the modifications made, the install command should look something like this:
 
       ```sh
-      python3 -m venv .venv --prompt InvokeAI-Dev
+      uv pip install -e ".[dev,test,docs,xformers]"=5.5.0 --python 3.11 --python-preference only-managed --index=https://download.pytorch.org/whl/cu124 --reinstall
       ```
 
-5. Activate the venv (you'll need to do this every time you want to run the app):
+5. At this point, you should have Invoke installed, a venv set up and activated, and the server running. But you will see a warning in the terminal that no UI was found. If you go to the URL for the server, you won't get a UI.
+
+      This is because the UI build is not distributed with the source code. You need to build it manually. End the running server instance.
+
+      If you only want to edit the docs, you can stop here and skip to the **Documentation** section below.
+
+6. Install the frontend dev toolchain:
+
+      - [`nodejs`](https://nodejs.org/) (v20+)
+
+      - [`pnpm`](https://pnpm.io/8.x/installation) (must be v8 - not v9!)
+
+7. Do a production build of the frontend:
 
       ```sh
-      source .venv/bin/activate
-      ```
-
-6. Install the repo as an [editable install][editable install link]:
-
-      ```sh
-      pip install -e ".[dev,test,xformers]" --use-pep517 --extra-index-url https://download.pytorch.org/whl/cu121
-      ```
-
-      Refer to the [manual installation][manual install link] instructions for more determining the correct install options. `xformers` is optional, but `dev` and `test` are not.
-
-7. Install the frontend dev toolchain:
-
-   - [`nodejs`](https://nodejs.org/) (recommend v20 LTS)
-   - [`pnpm`](https://pnpm.io/8.x/installation) (must be v8 - not v9!)
-
-8. Do a production build of the frontend:
-
-      ```sh
-      cd PATH_TO_INVOKEAI_REPO/invokeai/frontend/web
+      cd <PATH_TO_INVOKEAI_REPO>/invokeai/frontend/web
       pnpm i
       pnpm build
       ```
 
-9. Start the application:
-
-      ```sh
-      cd PATH_TO_INVOKEAI_REPO
-      python scripts/invokeai-web.py
-      ```
-
-10. Access the UI at `localhost:9090`.
+8. Restart the server and navigate to the URL. You should get a UI. After making changes to the python code, restart the server to see those changes.
 
 ## Updating the UI
 
-You'll need to run `pnpm build` every time you pull in new changes. Another option is to skip the build and instead run the app in dev mode:
+You'll need to run `pnpm build` every time you pull in new changes.
+
+Another option is to skip the build and instead run the UI in dev mode:
 
 ```sh
 pnpm dev
 ```
 
-This starts a dev server at `localhost:5173`, which you will use instead of `localhost:9090`.
+This starts a vite dev server for the UI at `127.0.0.1:5173`, which you will use instead of `127.0.0.1:9090`.
 
-The dev mode is substantially slower than the production build but may be more convenient if you just need to test things out.
+The dev mode is substantially slower than the production build but may be more convenient if you just need to test things out. It will hot-reload the UI as you make changes to the frontend code. Sometimes the hot-reload doesn't work, and you need to manually refresh the browser tab.
 
 ## Documentation
 
-The documentation is built with `mkdocs`. To preview it locally, you need a additional set of packages installed.
+The documentation is built with `mkdocs`. It provides a hot-reload dev server for the docs. Start it with `mkdocs serve`.
 
-```sh
-# after activating the venv
-pip install -e ".[docs]"
-```
-
-Then, you can start a live docs dev server, which will auto-refresh when you edit the docs:
-
-```sh
-mkdocs serve
-```
-
-On macOS and Linux, there is a `make` target for this:
-
-```sh
-make docs
-```
-
-[installer link]: ../installation/installer.md
+[launcher link]: ../installation/quick_start.md
 [forking link]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
 [requirements link]: ../installation/requirements.md
 [repo link]: https://github.com/invoke-ai/InvokeAI


### PR DESCRIPTION
## Summary

- Update the manual install and dev environment docs to use `uv` and the same logic we use in the launcher.
- Add a blurb to the manual install docs hinting at how to create your own install and launch scripts, since we are focusing our dev resources on the GUI launcher moving forward.

## Related Issues / Discussions

n/a

## QA Instructions

Fire up the docs and see how they look.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Documentation added / updated (if applicable)_
