### PR TITLE
feat(ui): reset canvas layers only resets the layers

### DIFF
--- a/invokeai/frontend/web/src/common/components/SessionMenuItems.tsx
+++ b/invokeai/frontend/web/src/common/components/SessionMenuItems.tsx
@@ -4,7 +4,7 @@ import {
   useNewCanvasSession,
   useNewGallerySession,
 } from 'features/controlLayers/components/NewSessionConfirmationAlertDialog';
-import { canvasReset } from 'features/controlLayers/store/actions';
+import { allEntitiesDeleted } from 'features/controlLayers/store/canvasSlice';
 import { paramsReset } from 'features/controlLayers/store/paramsSlice';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +16,7 @@ export const SessionMenuItems = memo(() => {
   const { newGallerySessionWithDialog } = useNewGallerySession();
   const { newCanvasSessionWithDialog } = useNewCanvasSession();
   const resetCanvasLayers = useCallback(() => {
-    dispatch(canvasReset());
+    dispatch(allEntitiesDeleted());
   }, [dispatch]);
   const resetGenerationSettings = useCallback(() => {
     dispatch(paramsReset());

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -80,6 +80,9 @@ import {
   initialT2IAdapter,
 } from './util';
 
+/**
+ * Gets a fresh canvas initial state with no references in memory to existing objects.
+ */
 const getInitialState = (): CanvasState => {
   const initialInpaintMaskState = getInpaintMaskState(getPrefixedId('inpaint_mask'));
   const initialState: CanvasState = {
@@ -1497,6 +1500,15 @@ export const canvasSlice = createSlice({
           break;
       }
     },
+    allEntitiesDeleted: (state) => {
+      // Deleting all entities is equivalent to resetting the state for each entity type
+      const initialState = getInitialState();
+      state.rasterLayers = initialState.rasterLayers;
+      state.controlLayers = initialState.controlLayers;
+      state.inpaintMasks = initialState.inpaintMasks;
+      state.regionalGuidance = initialState.regionalGuidance;
+      state.referenceImages = initialState.referenceImages;
+    },
     canvasMetadataRecalled: (state, action: PayloadAction<CanvasMetadata>) => {
       const { controlLayers, inpaintMasks, rasterLayers, referenceImages, regionalGuidance } = action.payload;
       state.controlLayers.entities = controlLayers;
@@ -1593,7 +1605,7 @@ export const {
   entityArrangedToBack,
   entityOpacityChanged,
   entitiesReordered,
-  // allEntitiesDeleted, // currently unused
+  allEntitiesDeleted,
   allEntitiesOfTypeIsHiddenToggled,
   // bbox
   bboxChangedFromCanvas,


### PR DESCRIPTION
## Summary

This button now only resets the canvas layers - not the bbox.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/43025f68-ca64-4343-b14b-a2ddae5d14bd" />


One thing I'm unsure of. `Reset Generation Settings` _also_ does not reset the bbox. 

@skunkworxdark Do you think `Reset Generation Settings` should reset the bbox? In other words, should the fix instead be to move the bbox-resetting functionality from `Reset Canvas Layers` to `Reset Generation Settings`? Thanks for your input.

## Related Issues / Discussions

This was reported as unexpected behaviour by @skunkworxdark : https://discord.com/channels/1020123559063990373/1149506274971631688/1309557626476040253


## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_