### PR TITLE
fix(api): add max len for BoardChanges

### DIFF
--- a/invokeai/app/services/board_records/board_records_common.py
+++ b/invokeai/app/services/board_records/board_records_common.py
@@ -57,8 +57,10 @@ def deserialize_board_record(board_dict: dict) -> BoardRecord:
 
 
 class BoardChanges(BaseModel, extra="forbid"):
-    board_name: Optional[str] = Field(default=None, description="The board's new name.")
-    cover_image_name: Optional[str] = Field(default=None, description="The name of the board's new cover image.")
+    board_name: Optional[str] = Field(default=None, description="The board's new name.", max_length=255)
+    cover_image_name: Optional[str] = Field(
+        default=None, description="The name of the board's new cover image.", max_length=255
+    )
     archived: Optional[bool] = Field(default=None, description="Whether or not the board is archived")
 
 


### PR DESCRIPTION
## Summary

Add a max length to the `BoardChanges.board_name` and `BoardChanges.cover_image_name` to prevent massive payloads from causing slowdowns or crashes.

## Related Issues / Discussions

n/a

## QA Instructions

Try to set a long board name or cover image name. It should fail quickly and without impacting the application.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_