### PR TITLE
docs: fix pypi indices for manual install for AMD

### DIFF
--- a/docs/contributing/dev-environment.md
+++ b/docs/contributing/dev-environment.md
@@ -22,7 +22,7 @@ If you just want to use Invoke, you should use the [launcher][launcher link].
 
 4. Follow the [manual install][manual install link] guide, with some modifications to the install command:
 
-      - Use `.` instead of `invokeai` to install from the current directory.
+      - Use `.` instead of `invokeai` to install from the current directory. You don't need to specify the version.
 
       - Add `-e` after the `install` operation to make this an [editable install][editable install link]. That means your changes to the python code will be reflected when you restart the Invoke server.
 

--- a/docs/installation/manual.md
+++ b/docs/installation/manual.md
@@ -75,14 +75,14 @@ The following commands vary depending on the version of Invoke being installed a
 
         - If you are on Windows with an Nvidia GPU, use `https://download.pytorch.org/whl/cu124`.
         - If you are on Linux with no GPU, use `https://download.pytorch.org/whl/cpu`.
-        - If you are on Linux with an AMD GPU, use `https://download.pytorch.org/whl/rocm62`.
+        - If you are on Linux with an AMD GPU, use `https://download.pytorch.org/whl/rocm6.1`.
         - **In all other cases, do not use an index.**
 
     === "Invoke v4"
 
         - If you are on Windows with an Nvidia GPU, use `https://download.pytorch.org/whl/cu124`.
         - If you are on Linux with no GPU, use `https://download.pytorch.org/whl/cpu`.
-        - If you are on Linux with an AMD GPU, use `https://download.pytorch.org/whl/rocm52`.
+        - If you are on Linux with an AMD GPU, use `https://download.pytorch.org/whl/rocm5.2`.
         - **In all other cases, do not use an index.**
 
 8. Install the `invokeai` package. Substitute the package specifier and version.


### PR DESCRIPTION
## Summary

Fix a typo in the docs. Was just fixed in the launcher in https://github.com/invoke-ai/launcher/pull/33. Hopefully this will resolve the AMD issue on Linux.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Documentation added / updated (if applicable)_