### PR TITLE
fix(ui): prevent canvas & main panel content from scrolling

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
@@ -57,6 +57,7 @@ export const CanvasMainPanelContent = memo(() => {
       gap={2}
       alignItems="center"
       justifyContent="center"
+      overflow="hidden"
     >
       <CanvasManagerProviderGate>
         <CanvasToolbar />
@@ -70,6 +71,7 @@ export const CanvasMainPanelContent = memo(() => {
             h="full"
             bg={dynamicGrid ? 'base.850' : 'base.900'}
             borderRadius="base"
+            overflow="hidden"
           >
             <InvokeCanvasComponent />
             <CanvasManagerProviderGate>

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
@@ -46,6 +46,7 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
       left={0}
       alignItems="center"
       justifyContent="center"
+      overflow="hidden"
     >
       {hasImageToCompare && <CompareToolbar />}
       {!hasImageToCompare && <ViewerToolbar closeButton={closeButton} />}

--- a/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
@@ -117,7 +117,7 @@ export const AppContent = memo(() => {
   });
 
   return (
-    <Flex id="invoke-app-tabs" w="full" h="full" gap={4} p={4}>
+    <Flex id="invoke-app-tabs" w="full" h="full" gap={4} p={4} overflow="hidden">
       <VerticalNavBar />
       <PanelGroup
         ref={imperativePanelGroupRef}


### PR DESCRIPTION
## Summary

Hopefully fixes issues where, when run via the launcher, the main panel kinda just scrolls out of bounds.

Just adding `overflow: hidden` to all divs from the top level down to canvas and viewer. I did all sorts of stuff on canvas on Windows and macOS in an attempt to repro the issue but couldn't, so we'll just need to get this fix released to see if it works.

## Related Issues / Discussions

Multiple discord reports:
- https://discord.com/channels/1020123559063990373/1020123559831539744/1325485934908670022
- https://discord.com/channels/1020123559063990373/1020123559831539744/1325707642844348488

## QA Instructions

Release to affected users so they can test it.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_