### PR TITLE
fix(ui): sticky preset image tooltip

### DIFF
--- a/invokeai/frontend/web/src/features/stylePresets/components/StylePresetImage.tsx
+++ b/invokeai/frontend/web/src/features/stylePresets/components/StylePresetImage.tsx
@@ -9,6 +9,7 @@ const StylePresetImage = ({ presetImageUrl, imageWidth }: { presetImageUrl: stri
   return (
     <Tooltip
       closeOnScroll
+      openDelay={0}
       label={
         presetImageUrl && (
           <Image


### PR DESCRIPTION
## Summary

There's a bug where preset image tooltips get stuck open in the list.

After much fiddling, debugging, and review of upstream dependencies, I have determined that this is bug in Chakra-UI v2.

Specifically, it appears to be a race condition related to the Tooltip component's internal use of the `useDisclosure` hook to manage tooltip open state, and the react render cycle.

Unfortunately, Chakra v2 is no longer being updated, and it's a pain in the butt to vendor and fix that component given its dependencies. Not 100% sure I could easily fix it, anyways.

Fortunately, there is a workaround - reduce the tooltip openDelay to 0ms. I prefer the current 500ms delay but I think it's preferable to have too-quick tooltips than too-sticky tooltips...

## QA Instructions

@hipsterusername please give this a spin and try to get the tooltip to stick

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_