### PR TITLE
Make T5 models interchangeable between FLUX/SD3 workflows

### DIFF
--- a/invokeai/app/invocations/flux_model_loader.py
+++ b/invokeai/app/invocations/flux_model_loader.py
@@ -10,6 +10,10 @@ from invokeai.app.invocations.baseinvocation import (
 from invokeai.app.invocations.fields import FieldDescriptions, Input, InputField, OutputField, UIType
 from invokeai.app.invocations.model import CLIPField, ModelIdentifierField, T5EncoderField, TransformerField, VAEField
 from invokeai.app.services.shared.invocation_context import InvocationContext
+from invokeai.app.util.t5_model_identifier import (
+    preprocess_t5_encoder_model_identifier,
+    preprocess_t5_tokenizer_model_identifier,
+)
 from invokeai.backend.flux.util import max_seq_lengths
 from invokeai.backend.model_manager.config import (
     CheckpointConfigBase,
@@ -74,8 +78,8 @@ class FluxModelLoaderInvocation(BaseInvocation):
         tokenizer = self.clip_embed_model.model_copy(update={"submodel_type": SubModelType.Tokenizer})
         clip_encoder = self.clip_embed_model.model_copy(update={"submodel_type": SubModelType.TextEncoder})
 
-        tokenizer2 = self.t5_encoder_model.model_copy(update={"submodel_type": SubModelType.Tokenizer2})
-        t5_encoder = self.t5_encoder_model.model_copy(update={"submodel_type": SubModelType.TextEncoder2})
+        tokenizer2 = preprocess_t5_tokenizer_model_identifier(self.t5_encoder_model)
+        t5_encoder = preprocess_t5_encoder_model_identifier(self.t5_encoder_model)
 
         transformer_config = context.models.get_config(transformer)
         assert isinstance(transformer_config, CheckpointConfigBase)

--- a/invokeai/app/invocations/flux_text_encoder.py
+++ b/invokeai/app/invocations/flux_text_encoder.py
@@ -2,7 +2,7 @@ from contextlib import ExitStack
 from typing import Iterator, Literal, Optional, Tuple
 
 import torch
-from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokenizer
+from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokenizer, T5TokenizerFast
 
 from invokeai.app.invocations.baseinvocation import BaseInvocation, Classification, invocation
 from invokeai.app.invocations.fields import (
@@ -76,7 +76,7 @@ class FluxTextEncoderInvocation(BaseInvocation):
             context.models.load(self.t5_encoder.tokenizer) as t5_tokenizer,
         ):
             assert isinstance(t5_text_encoder, T5EncoderModel)
-            assert isinstance(t5_tokenizer, T5Tokenizer)
+            assert isinstance(t5_tokenizer, (T5Tokenizer, T5TokenizerFast))
 
             t5_encoder = HFEncoder(t5_text_encoder, t5_tokenizer, False, self.t5_max_seq_len)
 

--- a/invokeai/app/invocations/sd3_model_loader.py
+++ b/invokeai/app/invocations/sd3_model_loader.py
@@ -10,6 +10,10 @@ from invokeai.app.invocations.baseinvocation import (
 from invokeai.app.invocations.fields import FieldDescriptions, Input, InputField, OutputField, UIType
 from invokeai.app.invocations.model import CLIPField, ModelIdentifierField, T5EncoderField, TransformerField, VAEField
 from invokeai.app.services.shared.invocation_context import InvocationContext
+from invokeai.app.util.t5_model_identifier import (
+    preprocess_t5_encoder_model_identifier,
+    preprocess_t5_tokenizer_model_identifier,
+)
 from invokeai.backend.model_manager.config import SubModelType
 
 
@@ -88,16 +92,8 @@ class Sd3ModelLoaderInvocation(BaseInvocation):
             if self.clip_g_model
             else self.model.model_copy(update={"submodel_type": SubModelType.TextEncoder2})
         )
-        tokenizer_t5 = (
-            self.t5_encoder_model.model_copy(update={"submodel_type": SubModelType.Tokenizer3})
-            if self.t5_encoder_model
-            else self.model.model_copy(update={"submodel_type": SubModelType.Tokenizer3})
-        )
-        t5_encoder = (
-            self.t5_encoder_model.model_copy(update={"submodel_type": SubModelType.TextEncoder3})
-            if self.t5_encoder_model
-            else self.model.model_copy(update={"submodel_type": SubModelType.TextEncoder3})
-        )
+        tokenizer_t5 = preprocess_t5_tokenizer_model_identifier(self.t5_encoder_model or self.model)
+        t5_encoder = preprocess_t5_encoder_model_identifier(self.t5_encoder_model or self.model)
 
         return Sd3ModelLoaderOutput(
             transformer=TransformerField(transformer=transformer, loras=[]),

--- a/invokeai/app/util/t5_model_identifier.py
+++ b/invokeai/app/util/t5_model_identifier.py
@@ -1,0 +1,26 @@
+from invokeai.app.invocations.model import ModelIdentifierField
+from invokeai.backend.model_manager.config import BaseModelType, SubModelType
+
+
+def preprocess_t5_encoder_model_identifier(model_identifier: ModelIdentifierField) -> ModelIdentifierField:
+    """A helper function to normalize a T5 encoder model identifier so that T5 models associated with FLUX
+    or SD3 models can be used interchangeably.
+    """
+    if model_identifier.base == BaseModelType.Any:
+        return model_identifier.model_copy(update={"submodel_type": SubModelType.TextEncoder2})
+    elif model_identifier.base == BaseModelType.StableDiffusion3:
+        return model_identifier.model_copy(update={"submodel_type": SubModelType.TextEncoder3})
+    else:
+        raise ValueError(f"Unsupported model base: {model_identifier.base}")
+
+
+def preprocess_t5_tokenizer_model_identifier(model_identifier: ModelIdentifierField) -> ModelIdentifierField:
+    """A helper function to normalize a T5 tokenizer model identifier so that T5 models associated with FLUX
+    or SD3 models can be used interchangeably.
+    """
+    if model_identifier.base == BaseModelType.Any:
+        return model_identifier.model_copy(update={"submodel_type": SubModelType.Tokenizer2})
+    elif model_identifier.base == BaseModelType.StableDiffusion3:
+        return model_identifier.model_copy(update={"submodel_type": SubModelType.Tokenizer3})
+    else:
+        raise ValueError(f"Unsupported model base: {model_identifier.base}")

--- a/invokeai/backend/flux/modules/conditioner.py
+++ b/invokeai/backend/flux/modules/conditioner.py
@@ -1,13 +1,19 @@
 # Initially pulled from https://github.com/black-forest-labs/flux
 
 from torch import Tensor, nn
-from transformers import PreTrainedModel, PreTrainedTokenizer
+from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from invokeai.backend.util.devices import TorchDevice
 
 
 class HFEncoder(nn.Module):
-    def __init__(self, encoder: PreTrainedModel, tokenizer: PreTrainedTokenizer, is_clip: bool, max_length: int):
+    def __init__(
+        self,
+        encoder: PreTrainedModel,
+        tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
+        is_clip: bool,
+        max_length: int,
+    ):
         super().__init__()
         self.max_length = max_length
         self.is_clip = is_clip


### PR DESCRIPTION
## Summary

Prior to this change, attempting to use a T5 model that was bundled with an SD3 base model in a FLUX workflow resulted in the following exception.
```
[2025-01-09 22:58:53,711]::[InvokeAI]::ERROR --> Error while invoking session 3f4f9287-bb23-44f7-8e52-bbf6c4b114e8, invocation c3bd3f6d-71cd-4b86-a4c2-8e43758e4185 (flux_text_encoder): 
[2025-01-09 22:58:53,711]::[InvokeAI]::ERROR --> Traceback (most recent call last):
  File "/home/ryan/src/InvokeAI/invokeai/app/services/session_processor/session_processor_default.py", line 129, in run_node
    output = invocation.invoke_internal(context=context, services=self._services)
  File "/home/ryan/src/InvokeAI/invokeai/app/invocations/baseinvocation.py", line 300, in invoke_internal
    output = self.invoke(context)
  File "/home/ryan/.pyenv/versions/3.10.14/envs/InvokeAI_3.10.14/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/home/ryan/src/InvokeAI/invokeai/app/invocations/flux_text_encoder.py", line 60, in invoke
    t5_embeddings = self._t5_encode(context)
  File "/home/ryan/src/InvokeAI/invokeai/app/invocations/flux_text_encoder.py", line 78, in _t5_encode
    assert isinstance(t5_text_encoder, T5EncoderModel)
AssertionError
```

After this change, all T5 models can be used interchangeably for both FLUX and SD3 workflows.

## Related Issues / Discussions

- Closes #7370 

## QA Instructions

I tested the following combinations:

- [x] FLUX text-to-image, standalone T5
- [x] FLUX text-to-image, SD3-bundled T5
- [x] SD3 text-to-image, SD3-bundled T5
- [x] SD3 text-to-image, standalone T5
- [x] SD3 text-to-image, BnB-quantized T5

## Merge Plan

No special instructions.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
