### PR TITLE
fix(ui): use window instead of document for image pasting

### DIFF
--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -146,7 +146,7 @@ export const FullscreenDropzone = memo(() => {
   useEffect(() => {
     const controller = new AbortController();
 
-    document.addEventListener(
+    window.addEventListener(
       'paste',
       (e) => {
         if (!e.clipboardData?.files) {


### PR DESCRIPTION
## Summary

Use `window.addEventListener` instead of `document.addEventListener` for better compatibility with react wrapper when pasting images 

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
