### PR TITLE
fix(ui): remove AbortController logic from paste to upload

### DIFF
--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -4,14 +4,14 @@ import { containsFiles, getFiles } from '@atlaskit/pragmatic-drag-and-drop/exter
 import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { Box, Flex, Heading } from '@invoke-ai/ui-library';
+import { logger } from 'app/logging/logger';
 import { getStore } from 'app/store/nanostores/store';
 import { useAppSelector } from 'app/store/storeHooks';
 import { DndDropOverlay } from 'features/dnd/DndDropOverlay';
 import type { DndTargetState } from 'features/dnd/types';
 import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
-import { selectMaxImageUploadCount } from 'features/system/store/configSlice';
 import { toast } from 'features/toast/toast';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { uploadImages } from 'services/api/endpoints/images';
 import { useBoardName } from 'services/api/hooks/useBoardName';
@@ -20,6 +20,7 @@ import { z } from 'zod';
 
 const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
 const ACCEPTED_FILE_EXTENSIONS = ['.png', '.jpg', '.jpeg'];
+const log = logger('paste');
 
 // const MAX_IMAGE_SIZE = 4; //In MegaBytes
 // const sizeInMB = (sizeInBytes: number, decimalsNum = 2) => {
@@ -66,17 +67,18 @@ const sx = {
   },
 } satisfies SystemStyleObject;
 
+const maxImageUploadCount = undefined;
+
 export const FullscreenDropzone = memo(() => {
   const { t } = useTranslation();
   const ref = useRef<HTMLDivElement>(null);
-  const maxImageUploadCount = useAppSelector(selectMaxImageUploadCount);
-  const [dndState, setDndState] = useState<DndTargetState>('idle');
 
-  const uploadFilesSchema = useMemo(() => getFilesSchema(maxImageUploadCount), [maxImageUploadCount]);
+  const [dndState, setDndState] = useState<DndTargetState>('idle');
 
   const validateAndUploadFiles = useCallback(
     (files: File[]) => {
       const { getState } = getStore();
+      const uploadFilesSchema = getFilesSchema(maxImageUploadCount);
       const parseResult = uploadFilesSchema.safeParse(files);
 
       if (!parseResult.success) {
@@ -105,7 +107,7 @@ export const FullscreenDropzone = memo(() => {
 
       uploadImages(uploadArgs);
     },
-    [maxImageUploadCount, t, uploadFilesSchema]
+    [maxImageUploadCount, t]
   );
 
   useEffect(() => {
@@ -144,24 +146,59 @@ export const FullscreenDropzone = memo(() => {
   }, [validateAndUploadFiles]);
 
   useEffect(() => {
+    log.info('use effect');
     const controller = new AbortController();
 
     window.addEventListener(
       'paste',
       (e) => {
+        log.info('event listener');
+        log.info(JSON.stringify(e.clipboardData));
         if (!e.clipboardData?.files) {
+          log.info('no files');
           return;
         }
         const files = Array.from(e.clipboardData.files);
-        validateAndUploadFiles(files);
+        const { getState } = getStore();
+        const uploadFilesSchema = getFilesSchema(undefined);
+        const parseResult = uploadFilesSchema.safeParse(files);
+
+        if (!parseResult.success) {
+          // const description =
+          //   maxImageUploadCount === undefined
+          //     ? t('toast.uploadFailedInvalidUploadDesc')
+          //     : t('toast.uploadFailedInvalidUploadDesc_withCount', { count: maxImageUploadCount });
+
+          // toast({
+          //   id: 'UPLOAD_FAILED',
+          //   title: t('toast.uploadFailed'),
+          //   description,
+          //   status: 'error',
+          // });
+          log.info("couldn't parse");
+          return;
+        }
+        const autoAddBoardId = selectAutoAddBoardId(getState());
+
+        const uploadArgs: UploadImageArg[] = files.map((file, i) => ({
+          file,
+          image_category: 'user',
+          is_intermediate: false,
+          board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+          isFirstUploadOfBatch: i === 0,
+        }));
+
+        uploadImages(uploadArgs);
+        // validateAndUploadFiles(files);
       },
       { signal: controller.signal }
     );
 
     return () => {
+      log.info('aborted');
       controller.abort();
     };
-  }, [validateAndUploadFiles]);
+  }, []);
 
   return (
     <Box ref={ref} data-dnd-state={dndState} sx={sx}>

--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -4,7 +4,6 @@ import { containsFiles, getFiles } from '@atlaskit/pragmatic-drag-and-drop/exter
 import { preventUnhandled } from '@atlaskit/pragmatic-drag-and-drop/prevent-unhandled';
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { Box, Flex, Heading } from '@invoke-ai/ui-library';
-import { logger } from 'app/logging/logger';
 import { getStore } from 'app/store/nanostores/store';
 import { useAppSelector } from 'app/store/storeHooks';
 import { DndDropOverlay } from 'features/dnd/DndDropOverlay';
@@ -21,8 +20,6 @@ import { z } from 'zod';
 
 const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
 const ACCEPTED_FILE_EXTENSIONS = ['.png', '.jpg', '.jpeg'];
-
-const log = logger('generation');
 
 // const MAX_IMAGE_SIZE = 4; //In MegaBytes
 // const sizeInMB = (sizeInBytes: number, decimalsNum = 2) => {
@@ -77,11 +74,9 @@ export const FullscreenDropzone = memo(() => {
 
   const validateAndUploadFiles = useCallback(
     (files: File[]) => {
-      log.info('validateAndUploadFiles');
       const { getState } = getStore();
       const uploadFilesSchema = getFilesSchema(maxImageUploadCount);
       const parseResult = uploadFilesSchema.safeParse(files);
-      log.info('parseResult');
 
       if (!parseResult.success) {
         const description =
@@ -114,10 +109,7 @@ export const FullscreenDropzone = memo(() => {
 
   const onPaste = useCallback(
     (e: ClipboardEvent) => {
-      log.info('in paste');
-      log.info(`clipboardData: ${JSON.stringify(e.clipboardData)}`);
       if (!e.clipboardData?.files) {
-        log.info('no files');
         return;
       }
       const files = Array.from(e.clipboardData.files);
@@ -162,18 +154,10 @@ export const FullscreenDropzone = memo(() => {
   }, [validateAndUploadFiles]);
 
   useEffect(() => {
-    log.info('use effect');
-    // const controller = new AbortController();
-    try {
-      window.addEventListener('paste', onPaste);
-    } catch (error) {
-      log.info(`error: ${JSON.stringify(error)}`);
-    }
+    window.addEventListener('paste', onPaste);
 
     return () => {
-      log.info('abort');
       window.removeEventListener('paste', onPaste);
-      // controller.abort();
     };
   }, [onPaste]);
 

--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -20,7 +20,7 @@ import { z } from 'zod';
 
 const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
 const ACCEPTED_FILE_EXTENSIONS = ['.png', '.jpg', '.jpeg'];
-const log = logger('paste');
+const log = logger('gallery');
 
 // const MAX_IMAGE_SIZE = 4; //In MegaBytes
 // const sizeInMB = (sizeInBytes: number, decimalsNum = 2) => {
@@ -107,7 +107,7 @@ export const FullscreenDropzone = memo(() => {
 
       uploadImages(uploadArgs);
     },
-    [maxImageUploadCount, t]
+    [t]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

After lots of debugging, it seems that the AbortController and unmount logic was causing paste-to-upload logic not to work in some environments. This PR removes that and uses `removeEventListener` instead, while also simplifying dependencies.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
