### PR TITLE
fix(ui): string field textarea accidentally readonly

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldInputComponent.tsx
@@ -25,9 +25,7 @@ const StringFieldInputComponent = (props: FieldComponentProps<StringFieldInputIn
   );
 
   if (fieldTemplate.ui_component === 'textarea') {
-    return (
-      <Textarea className="nodrag" onChange={handleValueChanged} value={field.value} rows={5} resize="none" readOnly />
-    );
+    return <Textarea className="nodrag" onChange={handleValueChanged} value={field.value} rows={5} resize="none" />;
   }
 
   return <Input className="nodrag" onChange={handleValueChanged} value={field.value} />;


### PR DESCRIPTION
## Summary

Not sure how or why but I accidentally made string field textarea elements read-only in 10f2c0dc9a6ddf8b61f75c1c66e3fa79a758e088. Cannot type into them in workflow editor. 

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_