### PR TITLE
Fix bug with some LoRA variants when applied to bitsandbytes NF4 quantized models

### DIFF
--- a/invokeai/backend/patches/layers/lora_layer_base.py
+++ b/invokeai/backend/patches/layers/lora_layer_base.py
@@ -4,6 +4,7 @@ import torch
 
 import invokeai.backend.util.logging as logger
 from invokeai.backend.patches.layers.base_layer_patch import BaseLayerPatch
+from invokeai.backend.patches.layers.param_shape_utils import get_param_shape
 from invokeai.backend.util.calc_tensor_size import calc_tensors_size
 
 
@@ -67,8 +68,8 @@ class LoRALayerBase(BaseLayerPatch):
         # Reshape all params to match the original module's shape.
         for param_name, param_weight in params.items():
             orig_param = orig_parameters[param_name]
-            if param_weight.shape != orig_param.shape:
-                params[param_name] = param_weight.reshape(orig_param.shape)
+            if param_weight.shape != get_param_shape(orig_param):
+                params[param_name] = param_weight.reshape(get_param_shape(orig_param))
 
         return params
 

--- a/invokeai/backend/patches/layers/param_shape_utils.py
+++ b/invokeai/backend/patches/layers/param_shape_utils.py
@@ -1,0 +1,19 @@
+import torch
+
+try:
+    from bitsandbytes.nn.modules import Params4bit
+
+    bnb_available: bool = True
+except ImportError:
+    bnb_available: bool = False
+
+
+def get_param_shape(param: torch.Tensor) -> torch.Size:
+    """A helper function to get the shape of a parameter that handles `bitsandbytes.nn.Params4Bit` correctly."""
+    # Accessing the `.shape` attribute of `bitsandbytes.nn.Params4Bit` will return an incorrect result. Instead, we must
+    # access the `.quant_state.shape` attribute.
+    if bnb_available and type(param) is Params4bit:  # type: ignore
+        quant_state = param.quant_state
+        if quant_state is not None:
+            return quant_state.shape
+    return param.shape

--- a/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py
+++ b/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py
@@ -15,6 +15,7 @@ from invokeai.backend.patches.layer_patcher import LayerPatcher
 from invokeai.backend.patches.layers.base_layer_patch import BaseLayerPatch
 from invokeai.backend.patches.layers.concatenated_lora_layer import ConcatenatedLoRALayer
 from invokeai.backend.patches.layers.flux_control_lora_layer import FluxControlLoRALayer
+from invokeai.backend.patches.layers.lokr_layer import LoKRLayer
 from invokeai.backend.patches.layers.lora_layer import LoRALayer
 from invokeai.backend.util.original_weights_storage import OriginalWeightsStorage
 from tests.backend.model_manager.load.model_cache.torch_module_autocast.custom_modules.test_custom_invoke_linear_8_bit_lt import (
@@ -282,6 +283,7 @@ PatchUnderTest = tuple[list[tuple[BaseLayerPatch, float]], torch.Tensor]
         "multiple_loras",
         "concatenated_lora",
         "flux_control_lora",
+        "single_lokr",
     ]
 )
 def patch_under_test(request: pytest.FixtureRequest) -> PatchUnderTest:
@@ -350,6 +352,20 @@ def patch_under_test(request: pytest.FixtureRequest) -> PatchUnderTest:
 
         input = torch.randn(1, patched_in_features)
         return ([(lora_layer, 0.7)], input)
+    elif layer_type == "single_lokr":
+        lokr_layer = LoKRLayer(
+            w1=torch.randn(rank, rank),
+            w1_a=None,
+            w1_b=None,
+            w2=torch.randn(out_features // rank, in_features // rank),
+            w2_a=None,
+            w2_b=None,
+            t2=None,
+            alpha=1.0,
+            bias=torch.randn(out_features),
+        )
+        input = torch.randn(1, in_features)
+        return ([(lokr_layer, 0.7)], input)
     else:
         raise ValueError(f"Unsupported layer_type: {layer_type}")
 


### PR DESCRIPTION
## Summary

Fixes a bug with some LoRA variants (LoKR, LoHA and some other obscure variants - LoRA is not affected) when they are applied to bitsandbytes NF4 quantized models. Unit tests were added to exercise the affected case.

## Related Issues / Discussions

- Closes #6998 
- Closes #7134

## QA Instructions

- [x] Test LoKR on full FLUX dev
- [x] Test LoKR on GGUF quantized FLUX dev
- [x] Test LoKR on BnB NF4 quantized FLUX dev

Regression tests:
- [x] Test LoRA on full FLUX dev
- [x] Test LoRA on GGUF quantized FLUX dev
- [x] Test LoRA on BnB NF4 quantized FLUX dev
- [x] Test FLUX control LoRA on BnB NF4 quantized FLUX dev
- [x] Test a LoRA on MPS system (to confirm that missing bitsandbytes package is handled)

## Merge Plan

No special isntructions.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
