### PR TITLE
fix: string batch input fields

### DIFF
--- a/invokeai/app/invocations/batch.py
+++ b/invokeai/app/invocations/batch.py
@@ -83,7 +83,9 @@ class StringBatchInvocation(BaseBatchInvocation):
     """Create a batched generation, where the workflow is executed once for each string in the batch."""
 
     strings: list[str] = InputField(
-        default=[], min_length=1, description="The strings to batch over", input=Input.Direct
+        default=[],
+        min_length=1,
+        description="The strings to batch over",
     )
 
     def invoke(self, context: InvocationContext) -> StringOutput:

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -132,6 +132,8 @@ export const parseSchema = (
           fieldType.batch = true;
         } else if (type === 'integer_batch' && propertyName === 'integers') {
           fieldType.batch = true;
+        } else if (type === 'string_batch' && propertyName === 'strings') {
+          fieldType.batch = true;
         }
 
         const fieldInputTemplate = buildFieldInputTemplate(property, propertyName, fieldType);

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -64,6 +64,32 @@ const isAllowedOutputField = (nodeType: string, fieldName: string) => {
   return true;
 };
 
+const isBatchInputField = (nodeType: string, fieldName: string) => {
+  if (nodeType === 'float_batch' && fieldName === 'floats') {
+    return true;
+  }
+  if (nodeType === 'integer_batch' && fieldName === 'integers') {
+    return true;
+  }
+  if (nodeType === 'string_batch' && fieldName === 'strings') {
+    return true;
+  }
+  return false;
+};
+
+const isBatchOutputField = (nodeType: string, fieldName: string) => {
+  if (nodeType === 'float_generator' && fieldName === 'floats') {
+    return true;
+  }
+  if (nodeType === 'integer_generator' && fieldName === 'integers') {
+    return true;
+  }
+  if (nodeType === 'string_generator' && fieldName === 'strings') {
+    return true;
+  }
+  return false;
+};
+
 const isNotInDenylist = (schema: InvocationSchemaObject) =>
   !invocationDenylist.includes(schema.properties.type.default);
 
@@ -128,11 +154,7 @@ export const parseSchema = (
           fieldType.originalType = deepClone(originalFieldType);
         }
 
-        if (type === 'float_batch' && propertyName === 'floats') {
-          fieldType.batch = true;
-        } else if (type === 'integer_batch' && propertyName === 'integers') {
-          fieldType.batch = true;
-        } else if (type === 'string_batch' && propertyName === 'strings') {
+        if (isBatchInputField(type, propertyName)) {
           fieldType.batch = true;
         }
 
@@ -197,11 +219,7 @@ export const parseSchema = (
           fieldType.originalType = deepClone(originalFieldType);
         }
 
-        if (type === 'float_generator' && propertyName === 'floats') {
-          fieldType.batch = true;
-        } else if (type === 'integer_generator' && propertyName === 'integers') {
-          fieldType.batch = true;
-        } else if (type === 'string_generator' && propertyName === 'strings') {
+        if (isBatchOutputField(type, propertyName)) {
           fieldType.batch = true;
         }
 


### PR DESCRIPTION
## Summary

String batch inputs were marked as supporting direct input only (not connection), so you couldn't use generators with them. Fixed this.

## Related Issues / Discussions

Reported by @skunkworxdark on discord: https://discord.com/channels/1020123559063990373/1049495067846524939/1330867272193019948

Thanks!

## QA Instructions

Confirm string generator and string batch nodes may be connected by a noodle (glory to nodes).

<video src="https://github.com/user-attachments/assets/8abbbe0c-3449-4db2-a540-8545739dc5f8"></video>

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_