### PR TITLE
LoRA Collection Loader make optional LoRA Collection input

### DIFF
--- a/invokeai/app/invocations/flux_lora_loader.py
+++ b/invokeai/app/invocations/flux_lora_loader.py
@@ -91,14 +91,14 @@ class FluxLoRALoaderInvocation(BaseInvocation):
     title="FLUX LoRA Collection Loader",
     tags=["lora", "model", "flux"],
     category="model",
-    version="1.1.0",
+    version="1.2.0",
     classification=Classification.Prototype,
 )
 class FLUXLoRACollectionLoader(BaseInvocation):
     """Applies a collection of LoRAs to a FLUX transformer."""
 
-    loras: LoRAField | list[LoRAField] = InputField(
-        description="LoRA models and weights. May be a single LoRA or collection.", title="LoRAs"
+    loras: Optional[LoRAField | list[LoRAField]] = InputField(
+        default=[], description="LoRA models and weights. May be a single LoRA or collection.", title="LoRAs"
     )
 
     transformer: Optional[TransformerField] = InputField(
@@ -119,7 +119,14 @@ class FLUXLoRACollectionLoader(BaseInvocation):
         loras = self.loras if isinstance(self.loras, list) else [self.loras]
         added_loras: list[str] = []
 
+        if self.transformer is not None:
+            output.transformer = self.transformer.model_copy(deep=True)
+
+        if self.clip is not None:
+            output.clip = self.clip.model_copy(deep=True)
+
         for lora in loras:
+            assert lora is LoRAField
             if lora.lora.key in added_loras:
                 continue
 
@@ -130,14 +137,10 @@ class FLUXLoRACollectionLoader(BaseInvocation):
 
             added_loras.append(lora.lora.key)
 
-            if self.transformer is not None:
-                if output.transformer is None:
-                    output.transformer = self.transformer.model_copy(deep=True)
+            if self.transformer is not None and output.transformer is not None:
                 output.transformer.loras.append(lora)
 
-            if self.clip is not None:
-                if output.clip is None:
-                    output.clip = self.clip.model_copy(deep=True)
+            if self.clip is not None and output.clip is not None:
                 output.clip.loras.append(lora)
 
         return output

--- a/invokeai/app/invocations/model.py
+++ b/invokeai/app/invocations/model.py
@@ -256,12 +256,12 @@ class LoRASelectorInvocation(BaseInvocation):
         return LoRASelectorOutput(lora=LoRAField(lora=self.lora, weight=self.weight))
 
 
-@invocation("lora_collection_loader", title="LoRA Collection Loader", tags=["model"], category="model", version="1.0.0")
+@invocation("lora_collection_loader", title="LoRA Collection Loader", tags=["model"], category="model", version="1.1.0")
 class LoRACollectionLoader(BaseInvocation):
     """Applies a collection of LoRAs to the provided UNet and CLIP models."""
 
-    loras: LoRAField | list[LoRAField] = InputField(
-        description="LoRA models and weights. May be a single LoRA or collection.", title="LoRAs"
+    loras: Optional[LoRAField | list[LoRAField]] = InputField(
+        default=[], description="LoRA models and weights. May be a single LoRA or collection.", title="LoRAs"
     )
     unet: Optional[UNetField] = InputField(
         default=None,
@@ -281,7 +281,13 @@ class LoRACollectionLoader(BaseInvocation):
         loras = self.loras if isinstance(self.loras, list) else [self.loras]
         added_loras: list[str] = []
 
+        if self.unet is not None:
+            output.unet = self.unet.model_copy(deep=True)
+        if self.clip is not None:
+            output.clip = self.clip.model_copy(deep=True)
+
         for lora in loras:
+            assert lora is LoRAField
             if lora.lora.key in added_loras:
                 continue
 
@@ -292,14 +298,10 @@ class LoRACollectionLoader(BaseInvocation):
 
             added_loras.append(lora.lora.key)
 
-            if self.unet is not None:
-                if output.unet is None:
-                    output.unet = self.unet.model_copy(deep=True)
+            if self.unet is not None and output.unet is not None:
                 output.unet.loras.append(lora)
 
-            if self.clip is not None:
-                if output.clip is None:
-                    output.clip = self.clip.model_copy(deep=True)
+            if self.clip is not None and output.clip is not None:
                 output.clip.loras.append(lora)
 
         return output
@@ -399,13 +401,13 @@ class SDXLLoRALoaderInvocation(BaseInvocation):
     title="SDXL LoRA Collection Loader",
     tags=["model"],
     category="model",
-    version="1.0.0",
+    version="1.1.0",
 )
 class SDXLLoRACollectionLoader(BaseInvocation):
     """Applies a collection of SDXL LoRAs to the provided UNet and CLIP models."""
 
-    loras: LoRAField | list[LoRAField] = InputField(
-        description="LoRA models and weights. May be a single LoRA or collection.", title="LoRAs"
+    loras: Optional[LoRAField | list[LoRAField]] = InputField(
+        default=[], description="LoRA models and weights. May be a single LoRA or collection.", title="LoRAs"
     )
     unet: Optional[UNetField] = InputField(
         default=None,
@@ -431,7 +433,17 @@ class SDXLLoRACollectionLoader(BaseInvocation):
         loras = self.loras if isinstance(self.loras, list) else [self.loras]
         added_loras: list[str] = []
 
+        if self.unet is not None:
+            output.unet = self.unet.model_copy(deep=True)
+
+        if self.clip is not None:
+            output.clip = self.clip.model_copy(deep=True)
+
+        if self.clip2 is not None:
+            output.clip2 = self.clip2.model_copy(deep=True)
+
         for lora in loras:
+            assert lora is LoRAField
             if lora.lora.key in added_loras:
                 continue
 
@@ -442,19 +454,13 @@ class SDXLLoRACollectionLoader(BaseInvocation):
 
             added_loras.append(lora.lora.key)
 
-            if self.unet is not None:
-                if output.unet is None:
-                    output.unet = self.unet.model_copy(deep=True)
+            if self.unet is not None and output.unet is not None:
                 output.unet.loras.append(lora)
 
-            if self.clip is not None:
-                if output.clip is None:
-                    output.clip = self.clip.model_copy(deep=True)
+            if self.clip is not None and output.clip is not None:
                 output.clip.loras.append(lora)
 
-            if self.clip2 is not None:
-                if output.clip2 is None:
-                    output.clip2 = self.clip2.model_copy(deep=True)
+            if self.clip2 is not None and output.clip2 is not None:
                 output.clip2.loras.append(lora)
 
         return output
@@ -472,7 +478,7 @@ class VAELoaderInvocation(BaseInvocation):
         key = self.vae_model.key
 
         if not context.models.exists(key):
-            raise Exception(f"Unkown vae: {key}!")
+            raise Exception(f"Unknown vae: {key}!")
 
         return VAEOutput(vae=VAEField(vae=self.vae_model))
 


### PR DESCRIPTION
Update the `LoRA Collection Loader` nodes to make the Lora Collection input Optional

## Summary

LoRACollectionLoader, SDXLLoRACollectionLoader & FLUXLoRACollectionLoader changed to make the LoRAs input optional.  This will allow a workflow to disable all Loras by simply disconnecting the collection input to the LoRACollectionLoader node. 

This will also allow my custom metadata node `Metadata To LoRA Collection` to operate even when the metadata has no LoRA data. 

## Related Issues / Discussions

NA

## QA Instructions

Test All three LoRA Collection loader nodes SD1.5, SDXL and Flux separately.  Existing functionality should not change

 - Test Current operation by Adding a lora collection loader and all loras in the collection should be applied during generation.
 - Test new functionality - Disconnect Lora Collection input but leave the LoRAS Collection Loader in the workflow. No Loras should be applied to the generations. 

## Merge Plan

NA

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
