### PR TITLE
fix(ui): field handle positioning for non-batch fields

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FieldHandle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FieldHandle.tsx
@@ -38,9 +38,12 @@ const FieldHandle = (props: FieldHandleProps) => {
       borderColor: color,
       borderRadius: isModelType || type.batch ? 4 : '100%',
       zIndex: 1,
-      transform: type.batch ? 'rotate(45deg) translateX(-0.3rem) translateY(-0.3rem)' : 'none',
       transformOrigin: 'center',
     };
+
+    if (type.batch) {
+      s.transform = 'rotate(45deg) translateX(-0.3rem) translateY(-0.3rem)';
+    }
 
     if (handleType === 'target') {
       s.insetInlineStart = '-1rem';


### PR DESCRIPTION
## Summary

Accidentally overwrote some reactflow styles which caused field handles to be positioned differently for non-batch fields. Just a minor visual issue.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_