### PR TITLE
Feature: Adjust Image filter

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -866,9 +866,9 @@ class ImageChannelOffsetInvocation(BaseInvocation, WithMetadata, WithBoard):
         if self.channel == "Hue (HSV)":
             # loop around the values because hue is special
             image_channel = (image_channel + self.offset) % 256
-
-        # Adjust the value, clipping to 0..255
-        image_channel = numpy.clip(image_channel + self.offset, 0, 255)
+        else:
+            # Adjust the value, clipping to 0..255
+            image_channel = numpy.clip(image_channel + self.offset, 0, 255)
 
         # Put the channel back into the image
         converted_image[:, :, channel_number] = image_channel

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -863,6 +863,10 @@ class ImageChannelOffsetInvocation(BaseInvocation, WithMetadata, WithBoard):
         converted_image = numpy.array(pil_image.convert(mode)).astype(int)
         image_channel = converted_image[:, :, channel_number]
 
+        if self.channel == "Hue (HSV)":
+            # loop around the values because hue is special
+            image_channel = (image_channel + self.offset) % 256
+
         # Adjust the value, clipping to 0..255
         image_channel = numpy.clip(image_channel + self.offset, 0, 255)
 

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -843,7 +843,7 @@ CHANNEL_FORMATS = {
         "value",
     ],
     category="image",
-    version="1.2.2",
+    version="1.2.3",
 )
 class ImageChannelOffsetInvocation(BaseInvocation, WithMetadata, WithBoard):
     """Add or subtract a value from a specific color channel of an image."""
@@ -907,7 +907,7 @@ class ImageChannelOffsetInvocation(BaseInvocation, WithMetadata, WithBoard):
         "value",
     ],
     category="image",
-    version="1.2.2",
+    version="1.2.3",
 )
 class ImageChannelMultiplyInvocation(BaseInvocation, WithMetadata, WithBoard):
     """Scale a specific color channel of an image."""

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1994,6 +1994,30 @@
                 "salt_and_pepper_type": "Salt and Pepper",
                 "noise_color": "Colored Noise",
                 "size": "Noise Size"
+            },
+            "adjust_image": {
+                "label": "Adjust Image",
+                "description": "Adjusts the selected channel of an image.",
+                "channel": "Channel",
+                "value_setting": "Value",
+                "scale_values": "Scale Values",
+                "red": "Red (RGBA)",
+                "green": "Green (RGBA)",
+                "blue": "Blue (RGBA)",
+                "alpha": "Alpha (RGBA)",
+                "cyan": "Cyan (CMYK)",
+                "magenta": "Magenta (CMYK)",
+                "yellow": "Yellow (CMYK)",
+                "black": "Black (CMYK)",
+                "hue": "Hue (HSV)",
+                "saturation": "Saturation (HSV)",
+                "value": "Value (HSV)",
+                "luminosity": "Luminosity (LAB)",
+                "a": "A (LAB)",
+                "b": "B (LAB)",
+                "y": "Y (YCbCr)",
+                "cb": "Cb (YCbCr)",
+                "cr": "Cr (YCbCr)"
             }
         },
         "transform": {

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterAdjustImage.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterAdjustImage.tsx
@@ -76,7 +76,7 @@ export const FilterAdjustImage = memo(({ onChange, config }: Props) => {
           onChange={handleValueChange}
           min={0}
           max={2}
-          step={0.01}
+          step={0.0025}
           marks
         />
         <CompositeNumberInput
@@ -85,7 +85,7 @@ export const FilterAdjustImage = memo(({ onChange, config }: Props) => {
           onChange={handleValueChange}
           min={0}
           max={255}
-          step={0.01}
+          step={0.0025}
         />
       </FormControl>
       <FormControl w="max-content">

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterAdjustImage.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterAdjustImage.tsx
@@ -69,7 +69,7 @@ export const FilterAdjustImage = memo(({ onChange, config }: Props) => {
         <Combobox value={value} options={options} onChange={handleChannelChange} isSearchable={false} />
       </FormControl>
       <FormControl>
-        <FormLabel m={0}>{t('controlLayers.filter.adjust_image.value')}</FormLabel>
+        <FormLabel m={0}>{t('controlLayers.filter.adjust_image.value_setting')}</FormLabel>
         <CompositeSlider
           value={config.value}
           defaultValue={DEFAULTS.value}

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterAdjustImage.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterAdjustImage.tsx
@@ -1,0 +1,99 @@
+import type { ComboboxOnChange } from '@invoke-ai/ui-library';
+import { Combobox, CompositeNumberInput, CompositeSlider, FormControl, FormLabel, Switch } from '@invoke-ai/ui-library';
+import type { AdjustImageFilterConfig, AjustImageChannels } from 'features/controlLayers/store/filters';
+import { IMAGE_FILTERS, isAjustImageChannels } from 'features/controlLayers/store/filters';
+import type { ChangeEvent } from 'react';
+import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { FilterComponentProps } from './types';
+
+type Props = FilterComponentProps<AdjustImageFilterConfig>;
+const DEFAULTS = IMAGE_FILTERS.adjust_image.buildDefaults();
+
+export const FilterAdjustImage = memo(({ onChange, config }: Props) => {
+  const { t } = useTranslation();
+  const handleChannelChange = useCallback<ComboboxOnChange>(
+    (v) => {
+      if (!isAjustImageChannels(v?.value)) {
+        return;
+      }
+      onChange({ ...config, channel: v.value });
+    },
+    [config, onChange]
+  );
+
+  const handleValueChange = useCallback(
+    (v: number) => {
+      onChange({ ...config, value: v });
+    },
+    [config, onChange]
+  );
+
+  const handleScaleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onChange({ ...config, scale_values: e.target.checked });
+    },
+    [config, onChange]
+  );
+
+  const options: { label: string; value: AjustImageChannels }[] = useMemo(
+    () => [
+      { label: t('controlLayers.filter.adjust_image.red'), value: 'Red (RGBA)' },
+      { label: t('controlLayers.filter.adjust_image.green'), value: 'Green (RGBA)' },
+      { label: t('controlLayers.filter.adjust_image.blue'), value: 'Blue (RGBA)' },
+      { label: t('controlLayers.filter.adjust_image.alpha'), value: 'Alpha (RGBA)' },
+      { label: t('controlLayers.filter.adjust_image.cyan'), value: 'Cyan (CMYK)' },
+      { label: t('controlLayers.filter.adjust_image.magenta'), value: 'Magenta (CMYK)' },
+      { label: t('controlLayers.filter.adjust_image.yellow'), value: 'Yellow (CMYK)' },
+      { label: t('controlLayers.filter.adjust_image.black'), value: 'Black (CMYK)' },
+      { label: t('controlLayers.filter.adjust_image.hue'), value: 'Hue (HSV)' },
+      { label: t('controlLayers.filter.adjust_image.saturation'), value: 'Saturation (HSV)' },
+      { label: t('controlLayers.filter.adjust_image.value'), value: 'Value (HSV)' },
+      { label: t('controlLayers.filter.adjust_image.luminosity'), value: 'Luminosity (LAB)' },
+      { label: t('controlLayers.filter.adjust_image.a'), value: 'A (LAB)' },
+      { label: t('controlLayers.filter.adjust_image.b'), value: 'B (LAB)' },
+      { label: t('controlLayers.filter.adjust_image.y'), value: 'Y (YCbCr)' },
+      { label: t('controlLayers.filter.adjust_image.cb'), value: 'Cb (YCbCr)' },
+      { label: t('controlLayers.filter.adjust_image.cr'), value: 'Cr (YCbCr)' },
+    ],
+    [t]
+  );
+
+  const value = useMemo(() => options.filter((o) => o.value === config.channel)[0], [options, config.channel]);
+
+  return (
+    <>
+      <FormControl>
+        <FormLabel m={0}>{t('controlLayers.filter.adjust_image.channel')}</FormLabel>
+        <Combobox value={value} options={options} onChange={handleChannelChange} isSearchable={false} />
+      </FormControl>
+      <FormControl>
+        <FormLabel m={0}>{t('controlLayers.filter.adjust_image.value')}</FormLabel>
+        <CompositeSlider
+          value={config.value}
+          defaultValue={DEFAULTS.value}
+          onChange={handleValueChange}
+          min={0}
+          max={2}
+          step={0.01}
+          marks
+        />
+        <CompositeNumberInput
+          value={config.value}
+          defaultValue={DEFAULTS.value}
+          onChange={handleValueChange}
+          min={0}
+          max={255}
+          step={0.01}
+        />
+      </FormControl>
+      <FormControl w="max-content">
+        <FormLabel m={0}>{t('controlLayers.filter.adjust_image.scale_values')}</FormLabel>
+        <Switch defaultChecked={DEFAULTS.scale_values} isChecked={config.scale_values} onChange={handleScaleChange} />
+      </FormControl>
+    </>
+  );
+});
+
+FilterAdjustImage.displayName = 'FilterAdjustImage';

--- a/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterSettings.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Filters/FilterSettings.tsx
@@ -1,4 +1,5 @@
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
+import { FilterAdjustImage } from 'features/controlLayers/components/Filters/FilterAdjustImage';
 import { FilterBlur } from 'features/controlLayers/components/Filters/FilterBlur';
 import { FilterCannyEdgeDetection } from 'features/controlLayers/components/Filters/FilterCannyEdgeDetection';
 import { FilterColorMap } from 'features/controlLayers/components/Filters/FilterColorMap';
@@ -21,8 +22,8 @@ type Props = { filterConfig: FilterConfig; onChange: (filterConfig: FilterConfig
 export const FilterSettings = memo(({ filterConfig, onChange }: Props) => {
   const { t } = useTranslation();
 
-  if (filterConfig.type === 'img_blur') {
-    return <FilterBlur config={filterConfig} onChange={onChange} />;
+  if (filterConfig.type === 'adjust_image') {
+    return <FilterAdjustImage config={filterConfig} onChange={onChange} />;
   }
 
   if (filterConfig.type === 'canny_edge_detection') {
@@ -63,6 +64,10 @@ export const FilterSettings = memo(({ filterConfig, onChange }: Props) => {
 
   if (filterConfig.type === 'pidi_edge_detection') {
     return <FilterPiDiNetEdgeDetection config={filterConfig} onChange={onChange} />;
+  }
+
+  if (filterConfig.type === 'img_blur') {
+    return <FilterBlur config={filterConfig} onChange={onChange} />;
   }
 
   if (filterConfig.type === 'img_noise') {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer.ts
@@ -68,7 +68,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
   /**
    * The config for the filter.
    */
-  $filterConfig = atom<FilterConfig>(IMAGE_FILTERS.canny_edge_detection.buildDefaults());
+  $filterConfig = atom<FilterConfig>(IMAGE_FILTERS.adjust_image.buildDefaults());
 
   /**
    * The initial filter config, used to reset the filter config.
@@ -212,7 +212,7 @@ export class CanvasEntityFilterer extends CanvasModuleBase {
       return filter.buildDefaults();
     } else {
       // Otherwise, used the default filter
-      return IMAGE_FILTERS.canny_edge_detection.buildDefaults();
+      return IMAGE_FILTERS.adjust_image.buildDefaults();
     }
   };
 

--- a/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
@@ -225,7 +225,7 @@ export const IMAGE_FILTERS: { [key in FilterConfig['type']]: ImageFilterData<key
           type: 'img_channel_offset',
           image: { image_name },
           channel,
-          offset: 255 * (value - 1), // value is in range [0, 2], offset is in range [-255, 255]
+          offset: Math.round(255 * (value - 1)), // value is in range [0, 2], offset is in range [-255, 255]
         });
       }
       return {

--- a/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
@@ -202,7 +202,7 @@ export const IMAGE_FILTERS: { [key in FilterConfig['type']]: ImageFilterData<key
     type: 'adjust_image',
     buildDefaults: () => ({
       type: 'adjust_image',
-      channel: 'Value (HSV)',
+      channel: 'Luminosity (LAB)',
       value: 1,
       scale_values: false,
     }),

--- a/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/filters.ts
@@ -6,6 +6,35 @@ import type { ControlLoRAModelConfig, ControlNetModelConfig, T2IAdapterModelConf
 import { assert } from 'tsafe';
 import { z } from 'zod';
 
+const zAjustImageChannels = z.enum([
+  'Red (RGBA)',
+  'Green (RGBA)',
+  'Blue (RGBA)',
+  'Alpha (RGBA)',
+  'Cyan (CMYK)',
+  'Magenta (CMYK)',
+  'Yellow (CMYK)',
+  'Black (CMYK)',
+  'Hue (HSV)',
+  'Saturation (HSV)',
+  'Value (HSV)',
+  'Luminosity (LAB)',
+  'A (LAB)',
+  'B (LAB)',
+  'Y (YCbCr)',
+  'Cb (YCbCr)',
+  'Cr (YCbCr)',
+]);
+export type AjustImageChannels = z.infer<typeof zAjustImageChannels>;
+export const isAjustImageChannels = (v: unknown): v is AjustImageChannels => zAjustImageChannels.safeParse(v).success;
+const zAdjustImageFilterConfig = z.object({
+  type: z.literal('adjust_image'),
+  channel: zAjustImageChannels,
+  value: z.number(),
+  scale_values: z.boolean().optional(),
+});
+export type AdjustImageFilterConfig = z.infer<typeof zAdjustImageFilterConfig>;
+
 const zCannyEdgeDetectionFilterConfig = z.object({
   type: z.literal('canny_edge_detection'),
   low_threshold: z.number().int().gte(0).lte(255),
@@ -118,6 +147,7 @@ const zNoiseFilterConfig = z.object({
 export type NoiseFilterConfig = z.infer<typeof zNoiseFilterConfig>;
 
 const zFilterConfig = z.discriminatedUnion('type', [
+  zAdjustImageFilterConfig,
   zCannyEdgeDetectionFilterConfig,
   zColorMapFilterConfig,
   zContentShuffleFilterConfig,
@@ -137,6 +167,7 @@ const zFilterConfig = z.discriminatedUnion('type', [
 export type FilterConfig = z.infer<typeof zFilterConfig>;
 
 const zFilterType = z.enum([
+  'adjust_image',
   'canny_edge_detection',
   'color_map',
   'content_shuffle',
@@ -167,6 +198,42 @@ type ImageFilterData<T extends FilterConfig['type']> = {
 };
 
 export const IMAGE_FILTERS: { [key in FilterConfig['type']]: ImageFilterData<key> } = {
+  adjust_image: {
+    type: 'adjust_image',
+    buildDefaults: () => ({
+      type: 'adjust_image',
+      channel: 'Value (HSV)',
+      value: 1,
+      scale_values: false,
+    }),
+    buildGraph: ({ image_name }, { channel, value, scale_values }) => {
+      const graph = new Graph(getPrefixedId('adjust_image_filter'));
+      let node;
+      if (scale_values) {
+        node = graph.addNode({
+          id: getPrefixedId('img_channel_multiply'),
+          type: 'img_channel_multiply',
+          image: { image_name },
+          channel,
+          scale: value,
+          invert_channel: false,
+        });
+      } else {
+        value = Math.min(value, 2); // Limit value to a maximum of 2
+        node = graph.addNode({
+          id: getPrefixedId('img_channel_offset'),
+          type: 'img_channel_offset',
+          image: { image_name },
+          channel,
+          offset: 255 * (value - 1), // value is in range [0, 2], offset is in range [-255, 255]
+        });
+      }
+      return {
+        graph,
+        outputNodeId: node.id,
+      };
+    },
+  },
   canny_edge_detection: {
     type: 'canny_edge_detection',
     buildDefaults: () => ({


### PR DESCRIPTION
## Summary

Adds a new Canvas filter that exposes the ImageChannelOffsetInvocation and ImageChannelMultiplyInvocation functions.

* Adjust Image is now the default when opening the Filters menu, which is alphabetically pleasing and less jarring than the Canny filter. 
* ImageChannel invocations now reuse the original Alpha channel (when Alpha is not the channel being modified) to preserve transparent canvas operations.
* ImageChannelOffset now lets Hue (HSV) loop over when out of [0..255] bounds

## Related Issues / Discussions

Mostly satisfies #4942 but does not have contrast/sharpness abilities.

## QA Instructions

A Value of 1 is no change. 0 and 2 are -255 and +255 respectively. At Value=0.5, 128 will be subtracted from each pixel in the selected channel, with results clipping to a minimum of 0.
If "Scale Values" is true, the graph will switch to using using the Multiply node, which directly uses the Value slider as the scalar input. Values above 2 can be entered manually.

https://github.com/user-attachments/assets/0d68feb3-465c-400d-8e96-24ac5993d4be

## Merge Plan

Ready to merge.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
