### PR TITLE
Add endpoint for emptying the model cache

### DIFF
--- a/invokeai/app/api/routers/model_manager.py
+++ b/invokeai/app/api/routers/model_manager.py
@@ -858,6 +858,18 @@ async def get_stats() -> Optional[CacheStats]:
     return ApiDependencies.invoker.services.model_manager.load.ram_cache.stats
 
 
+@model_manager_router.post(
+    "/empty_model_cache",
+    operation_id="empty_model_cache",
+    status_code=200,
+)
+async def empty_model_cache() -> None:
+    """Drop all models from the model cache to free RAM/VRAM. 'Locked' models that are in active use will not be dropped."""
+    # Request 1000GB of room in order to force the cache to drop all models.
+    ApiDependencies.invoker.services.logger.info("Emptying model cache.")
+    ApiDependencies.invoker.services.model_manager.load.ram_cache.make_room(1000 * 2**30)
+
+
 class HFTokenStatus(str, Enum):
     VALID = "valid"
     INVALID = "invalid"

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -294,6 +294,11 @@
         "disableFailed": "Problem Disabling Invocation Cache",
         "useCache": "Use Cache"
     },
+    "modelCache": {
+        "clear": "Clear Model Cache",
+        "clearSucceeded": "Model Cache Cleared",
+        "clearFailed": "Problem Clearing Model Cache"
+    },
     "gallery": {
         "gallery": "Gallery",
         "alwaysShowImageSizeBadge": "Always Show Image Size Badge",

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -23,6 +23,7 @@ export type AppFeature =
   | 'pauseQueue'
   | 'resumeQueue'
   | 'invocationCache'
+  | 'modelCache'
   | 'bulkDownload'
   | 'starterModels'
   | 'hfToken';

--- a/invokeai/frontend/web/src/features/queue/components/ClearModelCacheButton.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/ClearModelCacheButton.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@invoke-ai/ui-library';
+import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
+import { toast } from 'features/toast/toast';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useEmptyModelCacheMutation } from 'services/api/endpoints/models';
+
+const ClearModelCacheButton = () => {
+  const isModelCacheEnabled = useFeatureStatus('modelCache');
+  const [emptyModelCache, { isLoading }] = useEmptyModelCacheMutation();
+  const { t } = useTranslation();
+
+  const handleClearCache = useCallback(async () => {
+    try {
+      await emptyModelCache().unwrap();
+      toast({
+        status: 'success',
+        title: t('modelCache.clearSucceeded'),
+      });
+    } catch (error) {
+      toast({
+        status: 'error',
+        title: t('modelCache.clearFailed'),
+      });
+    }
+  }, [emptyModelCache, t]);
+
+  if (!isModelCacheEnabled) {
+    return <></>;
+  }
+
+  return (
+    <Button size="sm" colorScheme="red" onClick={handleClearCache} isLoading={isLoading}>
+      {t('modelCache.clear')}
+    </Button>
+  );
+};
+
+export default memo(ClearModelCacheButton);

--- a/invokeai/frontend/web/src/features/queue/components/QueueTabQueueControls.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/QueueTabQueueControls.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable i18next/no-literal-string */
 import { ButtonGroup, Flex } from '@invoke-ai/ui-library';
 import { useFeatureStatus } from 'features/system/hooks/useFeatureStatus';
 import { memo } from 'react';
 
+import ClearModelCacheButton from './ClearModelCacheButton';
 import ClearQueueButton from './ClearQueueButton';
 import PauseProcessorButton from './PauseProcessorButton';
 import PruneQueueButton from './PruneQueueButton';
@@ -11,19 +13,22 @@ const QueueTabQueueControls = () => {
   const isPauseEnabled = useFeatureStatus('pauseQueue');
   const isResumeEnabled = useFeatureStatus('resumeQueue');
   return (
-    <Flex layerStyle="first" borderRadius="base" p={2} gap={2}>
-      {isPauseEnabled || isResumeEnabled ? (
+    <Flex flexDir="column" layerStyle="first" borderRadius="base" p={2} gap={2}>
+      <Flex gap={2}>
+        {isPauseEnabled || isResumeEnabled ? (
+          <ButtonGroup w={28} orientation="vertical" size="sm">
+            {isResumeEnabled ? <ResumeProcessorButton /> : <></>}
+            {isPauseEnabled ? <PauseProcessorButton /> : <></>}
+          </ButtonGroup>
+        ) : (
+          <></>
+        )}
         <ButtonGroup w={28} orientation="vertical" size="sm">
-          {isResumeEnabled ? <ResumeProcessorButton /> : <></>}
-          {isPauseEnabled ? <PauseProcessorButton /> : <></>}
+          <PruneQueueButton />
+          <ClearQueueButton />
         </ButtonGroup>
-      ) : (
-        <></>
-      )}
-      <ButtonGroup w={28} orientation="vertical" size="sm">
-        <PruneQueueButton />
-        <ClearQueueButton />
-      </ButtonGroup>
+      </Flex>
+      <ClearModelCacheButton />
     </Flex>
   );
 };

--- a/invokeai/frontend/web/src/services/api/endpoints/models.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/models.ts
@@ -275,6 +275,9 @@ export const modelsApi = api.injectEndpoints({
         }
       },
     }),
+    emptyModelCache: build.mutation<void, void>({
+      query: () => ({ url: buildModelsUrl('empty_model_cache'), method: 'POST' }),
+    }),
   }),
 });
 
@@ -295,6 +298,7 @@ export const {
   useGetStarterModelsQuery,
   useGetHFTokenStatusQuery,
   useSetHFTokenMutation,
+  useEmptyModelCacheMutation,
 } = modelsApi;
 
 export const selectModelConfigsQuery = modelsApi.endpoints.getModelConfigs.select();

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -320,6 +320,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/models/empty_model_cache": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Empty Model Cache
+         * @description Drop all models from the model cache to free RAM/VRAM. 'Locked' models that are in active use will not be dropped.
+         */
+        post: operations["empty_model_cache"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/models/hf_login": {
         parameters: {
             query?: never;
@@ -20323,6 +20343,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CacheStats"] | null;
+                };
+            };
+        };
+    };
+    empty_model_cache: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
## Summary

This PR adds a backend endpoint that can be used to empty the model cache (to free RAM / VRAM). 'Locked' models that are actively being used will not be dropped.

Locking was added to `ModelCache` to make it thread-safe. But, I suspect that it might be possible to trigger https://github.com/invoke-ai/InvokeAI/issues/7513 with an ill-timed request to empty the cache (in the middle of graph execution). Even if this does happen, the current graph execution would fail, but subsequent graph executions _should_ recover smoothly.

## QA Instructions

I tested that the new endpoint successfully empties the model cache with `curl -X POST 127.0.0.1:9090/api/v2/models/empty_model_cache`.

I tried to break things by hitting the endpoint throughout graph execution. Nothing broke, which is a good sign. Of course, this is far from testing the thread interactions thoroughly.

## Merge Plan

No special instructions.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
