### PR TITLE
Fix T5EncoderField initialization in SD3 model loader

### DIFF
--- a/invokeai/app/invocations/sd3_model_loader.py
+++ b/invokeai/app/invocations/sd3_model_loader.py
@@ -99,6 +99,6 @@ class Sd3ModelLoaderInvocation(BaseInvocation):
             transformer=TransformerField(transformer=transformer, loras=[]),
             clip_l=CLIPField(tokenizer=tokenizer_l, text_encoder=clip_encoder_l, loras=[], skipped_layers=0),
             clip_g=CLIPField(tokenizer=tokenizer_g, text_encoder=clip_encoder_g, loras=[], skipped_layers=0),
-            t5_encoder=T5EncoderField(tokenizer=tokenizer_t5, text_encoder=t5_encoder),
+            t5_encoder=T5EncoderField(tokenizer=tokenizer_t5, text_encoder=t5_encoder, loras=[]),
             vae=VAEField(vae=vae),
         )


### PR DESCRIPTION
## Summary

Fixes a minor bug that was introduced in https://github.com/invoke-ai/InvokeAI/pull/7590.

Prior to this fix, loading an SD3.5 model would produce this error:
```
[2025-01-28 22:41:48,643]::[InvokeAI]::ERROR --> Error while invoking session 1f03b5d1-f099-4a79-816c-1bae1aafa4c9, invocation 40c782ff-b38b-4137-9deb-a04874cb56be (sd3_model_loader): 1 validation error for T5EncoderField
loras
  Field required [type=missing, input_value={'tokenizer': ModelIdenti...er3: 'text_encoder_3'>)}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
[2025-01-28 22:41:48,643]::[InvokeAI]::ERROR --> Traceback (most recent call last):
  File "/home/ryan/src/InvokeAI/invokeai/app/services/session_processor/session_processor_default.py", line 129, in run_node
    output = invocation.invoke_internal(context=context, services=self._services)
  File "/home/ryan/src/InvokeAI/invokeai/app/invocations/baseinvocation.py", line 300, in invoke_internal
    output = self.invoke(context)
  File "/home/ryan/src/InvokeAI/invokeai/app/invocations/sd3_model_loader.py", line 102, in invoke
    t5_encoder=T5EncoderField(tokenizer=tokenizer_t5, text_encoder=t5_encoder),
  File "/home/ryan/.pyenv/versions/3.10.14/envs/InvokeAI_3.10.14/lib/python3.10/site-packages/pydantic/main.py", line 176, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for T5EncoderField
loras
  Field required [type=missing, input_value={'tokenizer': ModelIdenti...er3: 'text_encoder_3'>)}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
```

## Related Issues / Discussions

Introduced in https://github.com/invoke-ai/InvokeAI/pull/7590

## QA Instructions

Tested that an SD3.5 model runs successfully.

## Merge Plan

Merge once approved.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
