### PR TITLE
feat: better graph validation errors

### DIFF
--- a/invokeai/app/services/shared/graph.py
+++ b/invokeai/app/services/shared/graph.py
@@ -51,6 +51,9 @@ class Edge(BaseModel):
     source: EdgeConnection = Field(description="The connection for the edge's from node and field")
     destination: EdgeConnection = Field(description="The connection for the edge's to node and field")
 
+    def __str__(self):
+        return f"{self.source.node_id}.{self.source.field} -> {self.destination.node_id}.{self.destination.field}"
+
 
 def get_output_field(node: BaseInvocation, field: str) -> Any:
     node_type = type(node)
@@ -440,17 +443,19 @@ class Graph(BaseModel):
                 self.get_node(edge.destination.node_id),
                 edge.destination.field,
             ):
-                raise InvalidEdgeError(
-                    f"Invalid edge from {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-                )
+                raise InvalidEdgeError(f"Edge source and target types do not match ({edge})")
 
         # Validate all iterators & collectors
         # TODO: may need to validate all iterators & collectors in subgraphs so edge connections in parent graphs will be available
         for node in self.nodes.values():
-            if isinstance(node, IterateInvocation) and not self._is_iterator_connection_valid(node.id):
-                raise InvalidEdgeError(f"Invalid iterator node {node.id}")
-            if isinstance(node, CollectInvocation) and not self._is_collector_connection_valid(node.id):
-                raise InvalidEdgeError(f"Invalid collector node {node.id}")
+            if isinstance(node, IterateInvocation):
+                err = self._is_iterator_connection_valid(node.id)
+                if err is not None:
+                    raise InvalidEdgeError(f"Invalid iterator node ({node.id}): {err}")
+            if isinstance(node, CollectInvocation):
+                err = self._is_collector_connection_valid(node.id)
+                if err is not None:
+                    raise InvalidEdgeError(f"Invalid collector node ({node.id}): {err}")
 
         return None
 
@@ -491,55 +496,44 @@ class Graph(BaseModel):
             from_node = self.get_node(edge.source.node_id)
             to_node = self.get_node(edge.destination.node_id)
         except NodeNotFoundError:
-            raise InvalidEdgeError("One or both nodes don't exist: {edge.source.node_id} -> {edge.destination.node_id}")
+            raise InvalidEdgeError(f"One or both nodes don't exist ({edge})")
 
         # Validate that an edge to this node+field doesn't already exist
         input_edges = self._get_input_edges(edge.destination.node_id, edge.destination.field)
         if len(input_edges) > 0 and not isinstance(to_node, CollectInvocation):
-            raise InvalidEdgeError(
-                f"Edge to node {edge.destination.node_id} field {edge.destination.field} already exists"
-            )
+            raise InvalidEdgeError(f"Edge already exists ({edge})")
 
         # Validate that no cycles would be created
         g = self.nx_graph_flat()
         g.add_edge(edge.source.node_id, edge.destination.node_id)
         if not nx.is_directed_acyclic_graph(g):
-            raise InvalidEdgeError(
-                f"Edge creates a cycle in the graph: {edge.source.node_id} -> {edge.destination.node_id}"
-            )
+            raise InvalidEdgeError(f"Edge creates a cycle in the graph ({edge})")
 
         # Validate that the field types are compatible
         if not are_connections_compatible(from_node, edge.source.field, to_node, edge.destination.field):
-            raise InvalidEdgeError(
-                f"Fields are incompatible: cannot connect {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-            )
+            raise InvalidEdgeError(f"Field types are incompatible ({edge})")
 
         # Validate if iterator output type matches iterator input type (if this edge results in both being set)
         if isinstance(to_node, IterateInvocation) and edge.destination.field == "collection":
-            if not self._is_iterator_connection_valid(edge.destination.node_id, new_input=edge.source):
-                raise InvalidEdgeError(
-                    f"Iterator input type does not match iterator output type: {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-                )
+            err = self._is_iterator_connection_valid(edge.destination.node_id, new_input=edge.source)
+            if err is not None:
+                raise InvalidEdgeError(f"Iterator input type does not match iterator output type ({edge}): {err}")
 
         # Validate if iterator input type matches output type (if this edge results in both being set)
         if isinstance(from_node, IterateInvocation) and edge.source.field == "item":
-            if not self._is_iterator_connection_valid(edge.source.node_id, new_output=edge.destination):
-                raise InvalidEdgeError(
-                    f"Iterator output type does not match iterator input type:, {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-                )
+            err = self._is_iterator_connection_valid(edge.source.node_id, new_output=edge.destination)
+            if err is not None:
+                raise InvalidEdgeError(f"Iterator output type does not match iterator input type ({edge}): {err}")
 
         # Validate if collector input type matches output type (if this edge results in both being set)
         if isinstance(to_node, CollectInvocation) and edge.destination.field == "item":
-            if not self._is_collector_connection_valid(edge.destination.node_id, new_input=edge.source):
-                raise InvalidEdgeError(
-                    f"Collector output type does not match collector input type: {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-                )
+            err = self._is_collector_connection_valid(edge.destination.node_id, new_input=edge.source)
+            if err is not None:
+                raise InvalidEdgeError(f"Collector output type does not match collector input type ({edge}): {err}")
 
         # Validate that we are not connecting collector to iterator (currently unsupported)
         if isinstance(from_node, CollectInvocation) and isinstance(to_node, IterateInvocation):
-            raise InvalidEdgeError(
-                f"Cannot connect collector to iterator: {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-            )
+            raise InvalidEdgeError(f"Cannot connect collector to iterator ({edge})")
 
         # Validate if collector output type matches input type (if this edge results in both being set) - skip if the destination field is not Any or list[Any]
         if (
@@ -548,10 +542,9 @@ class Graph(BaseModel):
             and not self._is_destination_field_list_of_Any(edge)
             and not self._is_destination_field_Any(edge)
         ):
-            if not self._is_collector_connection_valid(edge.source.node_id, new_output=edge.destination):
-                raise InvalidEdgeError(
-                    f"Collector input type does not match collector output type: {edge.source.node_id}.{edge.source.field} to {edge.destination.node_id}.{edge.destination.field}"
-                )
+            err = self._is_collector_connection_valid(edge.source.node_id, new_output=edge.destination)
+            if err is not None:
+                raise InvalidEdgeError(f"Collector input type does not match collector output type ({edge}): {err}")
 
     def has_node(self, node_id: str) -> bool:
         """Determines whether or not a node exists in the graph."""
@@ -634,7 +627,7 @@ class Graph(BaseModel):
         node_id: str,
         new_input: Optional[EdgeConnection] = None,
         new_output: Optional[EdgeConnection] = None,
-    ) -> bool:
+    ) -> str | None:
         inputs = [e.source for e in self._get_input_edges(node_id, "collection")]
         outputs = [e.destination for e in self._get_output_edges(node_id, "item")]
 
@@ -645,7 +638,7 @@ class Graph(BaseModel):
 
         # Only one input is allowed for iterators
         if len(inputs) > 1:
-            return False
+            return "Iterator may only have one input edge"
 
         # Get input and output fields (the fields linked to the iterator's input/output)
         input_field = get_output_field(self.get_node(inputs[0].node_id), inputs[0].field)
@@ -653,21 +646,21 @@ class Graph(BaseModel):
 
         # Input type must be a list
         if get_origin(input_field) is not list:
-            return False
+            return "Iterator input must be a collection"
 
         # Validate that all outputs match the input type
         input_field_item_type = get_args(input_field)[0]
         if not all((are_connection_types_compatible(input_field_item_type, f) for f in output_fields)):
-            return False
+            return "Iterator outputs must connect to an input with a matching type"
 
-        return True
+        return None
 
     def _is_collector_connection_valid(
         self,
         node_id: str,
         new_input: Optional[EdgeConnection] = None,
         new_output: Optional[EdgeConnection] = None,
-    ) -> bool:
+    ) -> str | None:
         inputs = [e.source for e in self._get_input_edges(node_id, "item")]
         outputs = [e.destination for e in self._get_output_edges(node_id, "collection")]
 
@@ -692,23 +685,23 @@ class Graph(BaseModel):
         type_tree.add_edges_from([e for e in itertools.permutations(input_field_types, 2) if issubclass(e[1], e[0])])
         type_degrees = type_tree.in_degree(type_tree.nodes)
         if sum((t[1] == 0 for t in type_degrees)) != 1:  # type: ignore
-            return False  # There is more than one root type
+            return "Collector input collection items must be of a single type"
 
         # Get the input root type
         input_root_type = next(t[0] for t in type_degrees if t[1] == 0)  # type: ignore
 
         # Verify that all outputs are lists
         if not all(is_list_or_contains_list(f) for f in output_fields):
-            return False
+            return "Collector output must connect to a collection input"
 
         # Verify that all outputs match the input type (are a base class or the same class)
         if not all(
             is_union_subtype(input_root_type, get_args(f)[0]) or issubclass(input_root_type, get_args(f)[0])
             for f in output_fields
         ):
-            return False
+            return "Collector outputs must connect to a collection input with a matching type"
 
-        return True
+        return None
 
     def nx_graph(self) -> nx.DiGraph:
         """Returns a NetworkX DiGraph representing the layout of this graph"""

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/batchEnqueued.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/batchEnqueued.ts
@@ -3,7 +3,7 @@ import type { AppStartListening } from 'app/store/middleware/listenerMiddleware'
 import { zPydanticValidationError } from 'features/system/store/zodSchemas';
 import { toast } from 'features/toast/toast';
 import { t } from 'i18next';
-import { truncate, upperFirst } from 'lodash-es';
+import { truncate } from 'lodash-es';
 import { serializeError } from 'serialize-error';
 import { queueApi } from 'services/api/endpoints/queue';
 import type { JsonObject } from 'type-fest';
@@ -52,15 +52,12 @@ export const addBatchEnqueuedListener = (startAppListening: AppStartListening) =
       const result = zPydanticValidationError.safeParse(response);
       if (result.success) {
         result.data.data.detail.map((e) => {
+          const description = truncate(e.msg.replace(/^(Value|Index|Key) error, /i, ''), { length: 256 });
           toast({
             id: 'QUEUE_BATCH_FAILED',
-            title: truncate(upperFirst(e.msg), { length: 128 }),
+            title: t('queue.batchFailedToQueue'),
             status: 'error',
-            description: truncate(
-              `Path:
-              ${e.loc.join('.')}`,
-              { length: 128 }
-            ),
+            description,
           });
         });
       } else if (response.status !== 403) {

--- a/invokeai/frontend/web/src/features/nodes/store/util/validateConnectionTypes.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/validateConnectionTypes.test.ts
@@ -63,14 +63,6 @@ describe(validateConnectionTypes.name, () => {
   });
 
   describe('special cases', () => {
-    it('should reject a COLLECTION input to a COLLECTION input', () => {
-      const r = validateConnectionTypes(
-        { name: 'CollectionField', cardinality: 'COLLECTION', batch: false },
-        { name: 'CollectionField', cardinality: 'COLLECTION', batch: false }
-      );
-      expect(r).toBe(false);
-    });
-
     it('should accept equal types', () => {
       const r = validateConnectionTypes(
         { name: 'IntegerField', cardinality: 'SINGLE', batch: false },

--- a/invokeai/frontend/web/src/features/nodes/store/util/validateConnectionTypes.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/validateConnectionTypes.ts
@@ -8,13 +8,6 @@ import { type FieldType, isCollection, isSingle, isSingleOrCollection } from 'fe
  * @returns True if the connection is valid, false otherwise.
  */
 export const validateConnectionTypes = (sourceType: FieldType, targetType: FieldType) => {
-  // TODO: There's a bug with Collect -> Iterate nodes:
-  // https://github.com/invoke-ai/InvokeAI/issues/3956
-  // Once this is resolved, we can remove this check.
-  if (sourceType.name === 'CollectionField' && targetType.name === 'CollectionField') {
-    return false;
-  }
-
   if (areTypesEqual(sourceType, targetType)) {
     return true;
   }

--- a/tests/test_node_graph.py
+++ b/tests/test_node_graph.py
@@ -9,7 +9,9 @@ from invokeai.app.invocations.baseinvocation import (
     invocation,
     invocation_output,
 )
+from invokeai.app.invocations.math import AddInvocation
 from invokeai.app.invocations.primitives import (
+    ColorInvocation,
     FloatCollectionInvocation,
     FloatInvocation,
     IntegerInvocation,
@@ -689,9 +691,6 @@ def test_any_accepts_any():
 
 
 def test_iterate_accepts_collection():
-    """We need to update the validation for Collect -> Iterate to traverse to the Iterate
-    node's output and compare that against the item type of the Collect node's collection. Until
-    then, Collect nodes may not output into Iterate nodes."""
     g = Graph()
     n1 = IntegerInvocation(id="1", value=1)
     n2 = IntegerInvocation(id="2", value=2)
@@ -706,9 +705,36 @@ def test_iterate_accepts_collection():
     e3 = create_edge(n3.id, "collection", n4.id, "collection")
     g.add_edge(e1)
     g.add_edge(e2)
-    # Once we fix the validation logic as described, this should should not raise an error
-    with pytest.raises(InvalidEdgeError, match="Cannot connect collector to iterator"):
-        g.add_edge(e3)
+    g.add_edge(e3)
+
+
+def test_iterate_validates_collection_inputs_against_iterator_outputs():
+    g = Graph()
+    n1 = IntegerInvocation(id="1", value=1)
+    n2 = IntegerInvocation(id="2", value=2)
+    n3 = CollectInvocation(id="3")
+    n4 = IterateInvocation(id="4")
+    n5 = AddInvocation(id="5")
+    g.add_node(n1)
+    g.add_node(n2)
+    g.add_node(n3)
+    g.add_node(n4)
+    g.add_node(n5)
+    e1 = create_edge(n1.id, "value", n3.id, "item")
+    e2 = create_edge(n2.id, "value", n3.id, "item")
+    e3 = create_edge(n3.id, "collection", n4.id, "collection")
+    e4 = create_edge(n4.id, "item", n5.id, "a")
+    g.add_edge(e1)
+    g.add_edge(e2)
+    g.add_edge(e3)
+    # Not throwing on this line indicates the collector's input types validated successfully against the iterator's output types
+    g.add_edge(e4)
+    with pytest.raises(InvalidEdgeError, match="Iterator collection type must match all iterator output types"):
+        # Connect iterator to a node with a different type than the collector inputs which is not allowed
+        n6 = ColorInvocation(id="6")
+        g.add_node(n6)
+        e5 = create_edge(n4.id, "item", n6.id, "color")
+        g.add_edge(e5)
 
 
 def test_graph_can_generate_schema():


### PR DESCRIPTION
## Summary

- When validating edges, return the error message instead of just a boolean.
- When raising `InvalidEdgeError`, ensure we use that error message.
- Surface the error message to the user in the UI.
- Tweak the error toast to be a bit less cryptic.
- Fix issue with `Any` type fields not accepting collections
- Fix longstanding issue with iterate nodes not accepting connections from collect nodes

Error before:
<img width="581" alt="image" src="https://github.com/user-attachments/assets/f3e21ebd-33a3-47c5-8151-58bec1924b4d" />

Error after:
![image](https://github.com/user-attachments/assets/e4d0e469-fc57-471d-8e01-b6918b8a3972)


## Related Issues / Discussions

Should help in troubleshooting the issue here https://discord.com/channels/1020123559063990373/1083864753543331981/1334888935242858506

Closes #3956

## QA Instructions

@skunkworxdark Could you please try reproducing that issue with this PR? Hopefully it's easier to see what's going on.

For this specific issue, might need to set breakpoints for each of the 3 fail case returns in these two methods in `graph.py` to get the full picture:
- `Graph._is_iterator_connection_valid()`
- `Graph._is_collector_connection_valid()`

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
