### PR TITLE
Fix: Multiply Image Channel allows RGB inputs again

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -918,7 +918,7 @@ class ImageChannelMultiplyInvocation(BaseInvocation, WithMetadata, WithBoard):
     invert_channel: bool = InputField(default=False, description="Invert the channel after scaling")
 
     def invoke(self, context: InvocationContext) -> ImageOutput:
-        image = context.images.get_pil(self.image.image_name)
+        image = context.images.get_pil(self.image.image_name, "RGBA")
 
         # extract the channel and mode from the input and reference tuple
         mode = CHANNEL_FORMATS[self.channel][0]


### PR DESCRIPTION
## Summary

The alpha handling that lets image multiply work on canvas filters broke if it was downstream of certain nodes that always output RGB instead of RGBA. ImageChannelMultiply node now loads as RGBA first. I had this fix in the Offset node already, but forgot to add it to the multiply one. Oops.

## Merge Plan

ready to merge

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
