### PR TITLE
fix(ui): prevent overflow on document root

### DIFF
--- a/invokeai/frontend/web/index.html
+++ b/invokeai/frontend/web/index.html
@@ -11,9 +11,11 @@
   <link id="invoke-favicon" rel="icon" type="icon" href="assets/images/invoke-favicon.svg" />
   <style>
     html,
-    body {
+    body,
+    #root {
       padding: 0;
       margin: 0;
+      overflow: hidden;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary

Add `overflow: hidden` to `index.html`'s CSS to hopefully prevent the UI from slipping out of view during an edge case. Cannot repro so not sure it fixes it.

## Related Issues / Discussions

offline discussion

## QA Instructions

If you can repro the issue, great. If not, nothing to check really.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
