### PR TITLE
Increase default VAE tile size in upscaling tab

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildMultidiffusionUpscaleGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildMultidiffusionUpscaleGraph.ts
@@ -62,6 +62,7 @@ export const buildMultidiffusionUpscaleGraph = async (
     type: 'i2l',
     id: getPrefixedId('i2l'),
     fp32: vaePrecision === 'fp32',
+    tile_size: 1024,
     tiled: true,
   });
 
@@ -71,6 +72,7 @@ export const buildMultidiffusionUpscaleGraph = async (
     type: 'l2i',
     id: getPrefixedId('l2i'),
     fp32: vaePrecision === 'fp32',
+    tile_size: 1024,
     tiled: true,
     board: getBoardField(state),
     is_intermediate: false,


### PR DESCRIPTION
## Summary

Prior to this PR, upscaling workflows run from the Upscaling Tab used the default tile size for VAE encode/decode (512x512 for SD1, 1024x1024 for SDXL). The small tile size of 512x512 sometimes produces visible tile artifacts in the output image. This is most evident in regions with limited 'texture'.

This PR increases the default VAE encode/decode tile size to 1024 for all base model types.

Note: This change will increase the peak VRAM usage for SD1 upscale jobs. There are mitigations that we could apply if this causes issues for users with limited VRAM, but for now we are rolling forward since the number of affected users is expected to be small.

## Example

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/a9a7fceb-c9f7-4de1-bc2c-d1dc8a562f3e" alt="Image 1" width="400"/><br>
      <sub>Original (1024x1024)</sub>
    </td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/71afba4f-e5a0-4a9f-a066-245a61a884eb" alt="Image 1" width="400"/><br>
      <sub>4x upscale, tile size 512x512 (note artifacts at top of image)</sub>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/63acbdfa-e66a-4230-b171-37f2125cb596" alt="Image 2" width="400"/><br>
      <sub>4x upscale, tile size 1024x1024</sub>
    </td>
  </tr>
</table>


## Related Issues / Discussions

This issue with tiling artifacts was previously explored in:
- #6555 
- #6144 

## QA Instructions

See the example image for results before / after this change.

## Merge Plan

No special instructions.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
