### PR TITLE
ui: workflow builder iteration

### DIFF
--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -136,8 +136,8 @@
     "@types/react-dom": "^18.3.0",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react-swc": "^3.8.0",
-    "@vitest/coverage-v8": "^3.0.5",
-    "@vitest/ui": "^3.0.5",
+    "@vitest/coverage-v8": "^3.0.6",
+    "@vitest/ui": "^3.0.6",
     "concurrently": "^8.2.2",
     "csstype": "^3.1.3",
     "dpdm": "^3.14.0",
@@ -158,7 +158,7 @@
     "vite-plugin-dts": "^4.5.0",
     "vite-plugin-eslint": "^1.8.1",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.6"
   },
   "engines": {
     "pnpm": "8"

--- a/invokeai/frontend/web/pnpm-lock.yaml
+++ b/invokeai/frontend/web/pnpm-lock.yaml
@@ -242,11 +242,11 @@ devDependencies:
     specifier: ^3.8.0
     version: 3.8.0(vite@6.1.0)
   '@vitest/coverage-v8':
-    specifier: ^3.0.5
-    version: 3.0.5(vitest@1.6.0)
+    specifier: ^3.0.6
+    version: 3.0.6(vitest@3.0.6)
   '@vitest/ui':
-    specifier: ^3.0.5
-    version: 3.0.5(vitest@1.6.0)
+    specifier: ^3.0.6
+    version: 3.0.6(vitest@3.0.6)
   concurrently:
     specifier: ^8.2.2
     version: 8.2.2
@@ -308,8 +308,8 @@ devDependencies:
     specifier: ^5.1.4
     version: 5.1.4(typescript@5.6.2)(vite@6.1.0)
   vitest:
-    specifier: ^1.6.0
-    version: 1.6.0(@types/node@20.16.10)(@vitest/ui@3.0.5)
+    specifier: ^3.0.6
+    version: 3.0.6(@types/node@20.16.10)(@vitest/ui@3.0.6)
 
 packages:
 
@@ -440,9 +440,19 @@ packages:
     resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-string-parser@7.25.9:
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier@7.25.7:
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.25.9:
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-option@7.25.7:
     resolution: {integrity: sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==}
@@ -472,6 +482,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.25.7
+
+  /@babel/parser@7.26.9:
+    resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.26.9
+    dev: true
 
   /@babel/runtime@7.25.7:
     resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
@@ -508,6 +526,14 @@ packages:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.26.9:
+    resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+    dev: true
 
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -1218,15 +1244,6 @@ packages:
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
     dev: false
 
-  /@esbuild/aix-ppc64@0.21.5:
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/aix-ppc64@0.23.1:
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
     engines: {node: '>=18'}
@@ -1245,15 +1262,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.21.5:
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm64@0.23.1:
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
     engines: {node: '>=18'}
@@ -1267,15 +1275,6 @@ packages:
     resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.21.5:
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
@@ -1299,15 +1298,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.21.5:
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-x64@0.23.1:
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
     engines: {node: '>=18'}
@@ -1326,15 +1316,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.21.5:
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.23.1:
     resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
     engines: {node: '>=18'}
@@ -1348,15 +1329,6 @@ packages:
     resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.21.5:
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -1380,15 +1352,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.21.5:
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.23.1:
     resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
     engines: {node: '>=18'}
@@ -1402,15 +1365,6 @@ packages:
     resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.21.5:
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
@@ -1434,15 +1388,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.21.5:
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm64@0.23.1:
     resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
     engines: {node: '>=18'}
@@ -1456,15 +1401,6 @@ packages:
     resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.21.5:
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1488,15 +1424,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.21.5:
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-ia32@0.23.1:
     resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
     engines: {node: '>=18'}
@@ -1510,15 +1437,6 @@ packages:
     resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.21.5:
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1542,15 +1460,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.21.5:
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-mips64el@0.23.1:
     resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
     engines: {node: '>=18'}
@@ -1564,15 +1473,6 @@ packages:
     resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.21.5:
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1596,15 +1496,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.21.5:
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-riscv64@0.23.1:
     resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
     engines: {node: '>=18'}
@@ -1623,15 +1514,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.21.5:
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-s390x@0.23.1:
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
     engines: {node: '>=18'}
@@ -1645,15 +1527,6 @@ packages:
     resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.21.5:
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1681,15 +1554,6 @@ packages:
     resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.21.5:
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [netbsd]
     requiresBuild: true
     dev: true
@@ -1731,15 +1595,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.21.5:
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.23.1:
     resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
     engines: {node: '>=18'}
@@ -1754,15 +1609,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.21.5:
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
     requiresBuild: true
     dev: true
     optional: true
@@ -1785,15 +1631,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.21.5:
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-arm64@0.23.1:
     resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
     engines: {node: '>=18'}
@@ -1812,15 +1649,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.21.5:
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-ia32@0.23.1:
     resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
     engines: {node: '>=18'}
@@ -1834,15 +1662,6 @@ packages:
     resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.21.5:
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -2034,13 +1853,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /@jest/schemas@29.6.3:
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.27.8
-    dev: true
-
   /@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.6.2)(vite@6.1.0):
     resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
     peerDependencies:
@@ -2116,7 +1928,7 @@ packages:
       '@rushstack/ts-command-line': 4.23.5(@types/node@20.16.10)
       lodash: 4.17.21
       minimatch: 3.0.8
-      resolve: 1.22.8
+      resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.7.2
@@ -2130,7 +1942,7 @@ packages:
       '@microsoft/tsdoc': 0.15.1
       ajv: 8.12.0
       jju: 1.4.0
-      resolve: 1.22.8
+      resolve: 1.22.10
     dev: true
 
   /@microsoft/tsdoc@0.15.1:
@@ -2563,280 +2375,152 @@ packages:
       picomatch: 4.0.2
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.24.0:
-    resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
+  /@rollup/rollup-android-arm-eabi@4.34.8:
+    resolution: {integrity: sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm-eabi@4.34.6:
-    resolution: {integrity: sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.24.0:
-    resolution: {integrity: sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==}
+  /@rollup/rollup-android-arm64@4.34.8:
+    resolution: {integrity: sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.34.6:
-    resolution: {integrity: sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-darwin-arm64@4.24.0:
-    resolution: {integrity: sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==}
+  /@rollup/rollup-darwin-arm64@4.34.8:
+    resolution: {integrity: sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.34.6:
-    resolution: {integrity: sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.24.0:
-    resolution: {integrity: sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==}
+  /@rollup/rollup-darwin-x64@4.34.8:
+    resolution: {integrity: sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.34.6:
-    resolution: {integrity: sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-freebsd-arm64@4.34.6:
-    resolution: {integrity: sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==}
+  /@rollup/rollup-freebsd-arm64@4.34.8:
+    resolution: {integrity: sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-freebsd-x64@4.34.6:
-    resolution: {integrity: sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==}
+  /@rollup/rollup-freebsd-x64@4.34.8:
+    resolution: {integrity: sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.24.0:
-    resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.34.8:
+    resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.34.6:
-    resolution: {integrity: sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==}
+  /@rollup/rollup-linux-arm-musleabihf@4.34.8:
+    resolution: {integrity: sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.24.0:
-    resolution: {integrity: sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm-musleabihf@4.34.6:
-    resolution: {integrity: sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-gnu@4.24.0:
-    resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
+  /@rollup/rollup-linux-arm64-gnu@4.34.8:
+    resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.34.6:
-    resolution: {integrity: sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==}
+  /@rollup/rollup-linux-arm64-musl@4.34.8:
+    resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.24.0:
-    resolution: {integrity: sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-musl@4.34.6:
-    resolution: {integrity: sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-loongarch64-gnu@4.34.6:
-    resolution: {integrity: sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==}
+  /@rollup/rollup-linux-loongarch64-gnu@4.34.8:
+    resolution: {integrity: sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.24.0:
-    resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
+  /@rollup/rollup-linux-powerpc64le-gnu@4.34.8:
+    resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.34.6:
-    resolution: {integrity: sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.24.0:
-    resolution: {integrity: sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==}
+  /@rollup/rollup-linux-riscv64-gnu@4.34.8:
+    resolution: {integrity: sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.34.6:
-    resolution: {integrity: sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-s390x-gnu@4.24.0:
-    resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
+  /@rollup/rollup-linux-s390x-gnu@4.34.8:
+    resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.34.6:
-    resolution: {integrity: sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-gnu@4.24.0:
-    resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
+  /@rollup/rollup-linux-x64-gnu@4.34.8:
+    resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.34.6:
-    resolution: {integrity: sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==}
+  /@rollup/rollup-linux-x64-musl@4.34.8:
+    resolution: {integrity: sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.24.0:
-    resolution: {integrity: sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.34.6:
-    resolution: {integrity: sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-arm64-msvc@4.24.0:
-    resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
+  /@rollup/rollup-win32-arm64-msvc@4.34.8:
+    resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.34.6:
-    resolution: {integrity: sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-ia32-msvc@4.24.0:
-    resolution: {integrity: sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==}
+  /@rollup/rollup-win32-ia32-msvc@4.34.8:
+    resolution: {integrity: sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.34.6:
-    resolution: {integrity: sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.24.0:
-    resolution: {integrity: sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.34.6:
-    resolution: {integrity: sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==}
+  /@rollup/rollup-win32-x64-msvc@4.34.8:
+    resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -2862,14 +2546,14 @@ packages:
       fs-extra: 11.3.0
       import-lazy: 4.0.0
       jju: 1.4.0
-      resolve: 1.22.8
+      resolve: 1.22.10
       semver: 7.5.4
     dev: true
 
   /@rushstack/rig-package@0.5.3:
     resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
     dependencies:
-      resolve: 1.22.8
+      resolve: 1.22.10
       strip-json-comments: 3.1.1
     dev: true
 
@@ -2895,10 +2579,6 @@ packages:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-    dev: true
-
-  /@sinclair/typebox@0.27.8:
-    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
   /@snyk/github-codeowners@1.1.0:
@@ -3425,8 +3105,8 @@ packages:
       storybook: 8.3.4
     dev: true
 
-  /@swc/core-darwin-arm64@1.10.16:
-    resolution: {integrity: sha512-iikIxwqCQ4Bvz79vJ4ELh26efPf1u5D9TFdmXSJUBs7C3mmMHvk5zyWD9A9cTowXiW6WHs2gE58U1R9HOTTIcg==}
+  /@swc/core-darwin-arm64@1.10.17:
+    resolution: {integrity: sha512-LSQhSjESleTc0c45BnVKRacp9Nl4zhJMlV/nmhpFCOv/CqHI5YBDX5c9bPk9jTRNHIf0QH92uTtswt8yN++TCQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -3434,8 +3114,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-darwin-x64@1.10.16:
-    resolution: {integrity: sha512-R2Eb9aktWd62vPfW9H/c/OaQ0e94iURibBo4uzUUcgxNNmB4+wb6piKbHxGdr/5bEsT+vJ1lwZFSRzfb45E7DA==}
+  /@swc/core-darwin-x64@1.10.17:
+    resolution: {integrity: sha512-TTaZFS4jLuA3y6+D2HYv4yVGhmjkOGG6KyAwBiJEeoUaazX5MYOyQwaZBPhRGtzHZFrzi4t4jNix4kAkMajPkQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -3443,8 +3123,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.10.16:
-    resolution: {integrity: sha512-mkqN3HBAMnuiSGZ/k2utScuH8rAPshvNj0T1LjBWon+X9DkMNHSA+aMLdWsy0yZKF1zjOPc4L3Uq2l2wzhUlzA==}
+  /@swc/core-linux-arm-gnueabihf@1.10.17:
+    resolution: {integrity: sha512-8P+ESJyGnVdJi0nUcQfxkbTiB/7hnu6N3U72KbvHFBcuroherwzW4DId1XD4RTU2Cjsh1dztZoCcOLY8W9RW1Q==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -3452,8 +3132,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.10.16:
-    resolution: {integrity: sha512-PH/+q/L5nVZJ91CU07CL6Q9Whs6iR6nneMZMAgtVF9Ix8ST0cWVItdUhs6D38kFklCFhaOrpHhS01HlMJ72vWw==}
+  /@swc/core-linux-arm64-gnu@1.10.17:
+    resolution: {integrity: sha512-zT21jDQCe+IslzOtw+BD/9ElO/H4qU4fkkOeVQ68PcxuqYS2gwyDxWqa9IGwpzWexYM+Lzi1rAbl/1BM6nGW8Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -3461,8 +3141,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.10.16:
-    resolution: {integrity: sha512-1169+C9XbydKKc6Ec1XZxTGKtHjZHDIFn0r+Nqp/QSVwkORrOY1Vz2Hdu7tn/lWMg36ZkGePS+LnnyV67s/7yg==}
+  /@swc/core-linux-arm64-musl@1.10.17:
+    resolution: {integrity: sha512-C2jaW1X+93HscVcesKYgSuZ9GaKqKcQvwvD+q+4JZkaKF4Zopt/aguc6Tmn/nuavRk0WV8yVCpHXoP7lz/2akA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -3470,8 +3150,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.10.16:
-    resolution: {integrity: sha512-n2rV0XwkjoHn4MDJmpYp5RBrnyi94/6GsJVpbn6f+/eqSrZn3mh3dT7pdZc9zCN1Qp9eDHo+uI6e/wgvbL22uA==}
+  /@swc/core-linux-x64-gnu@1.10.17:
+    resolution: {integrity: sha512-vfyxqV5gddurG2NVJLemR/68s7GTe0QruozrZiDpNqr9V4VX9t3PadDKMDAvQz6jKrtiqMtshNXQTNRKAKlzFw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -3479,8 +3159,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-musl@1.10.16:
-    resolution: {integrity: sha512-EevCpwreBrkPrJjQVIbiM81lK42ukNNSlBmrSRxxbx2V9VGmOd5qxX0cJBn0TRRSLIPi62BuMS76F9iYjqsjgg==}
+  /@swc/core-linux-x64-musl@1.10.17:
+    resolution: {integrity: sha512-8M+nI5MHZGQUnXyfTLsGw85a3oQRXMsFjgMZuOEJO9ZGBIEnYVuWOxENfcP6MmlJmTOW+cJxHnMGhKY+fjcntw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -3488,8 +3168,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.10.16:
-    resolution: {integrity: sha512-BvE7RWAnKJeELVQWLok6env5I4GUVBTZSvaSN/VPgxnTjF+4PsTeQptYx0xCYhp5QCv68wWYsBnZKuPDS+SBsw==}
+  /@swc/core-win32-arm64-msvc@1.10.17:
+    resolution: {integrity: sha512-iUeIBFM6c/NwsreLFSAH395Dahc+54mSi0Kq//IrZ2Y16VlqCV7VHdOIMrdAyDoBFUvh0jKuLJPWt+jlKGtSLg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -3497,8 +3177,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.10.16:
-    resolution: {integrity: sha512-7Jf/7AeCgbLR/JsQgMJuacHIq4Jeie3knf6+mXxn8aCvRypsOTIEu0eh7j24SolOboxK1ijqJ86GyN1VA2Rebg==}
+  /@swc/core-win32-ia32-msvc@1.10.17:
+    resolution: {integrity: sha512-lPXYFvkfYIN8HdNmG6dCnQqgA+rOSTgeAjIhGsYCEyLsYkkhF2FQw34OF6PnWawQ6hOdOE9v6Bw3T4enj3Lb6w==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -3506,8 +3186,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.10.16:
-    resolution: {integrity: sha512-p0blVm0R8bjaTtmW+FoPmLxLSQdRNbqhuWcR/8g80OzMSkka9mk5/J3kn/5JRVWh+MaR9LHRHZc1Q1L8zan13g==}
+  /@swc/core-win32-x64-msvc@1.10.17:
+    resolution: {integrity: sha512-KrnkFEWpBmxSe8LixhAZXeeUwTNDVukrPeXJ1PiG+pmb5nI989I9J9IQVIgBv+JXXaK+rmiWjlcIkphaDJJEAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -3515,8 +3195,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core@1.10.16:
-    resolution: {integrity: sha512-nOINg/OUcZazCW7B55QV2/UB8QAqz9FYe4+z229+4RYboBTZ102K7ebOEjY5sKn59JgAkhjZTz+5BKmXpDFopw==}
+  /@swc/core@1.10.17:
+    resolution: {integrity: sha512-FXZx7jHpiwz4fTuuueWwsvN7VFLSoeS3mcxCTPUNOHs/K2ecaBO+slh5T5Xvt/KGuD2I/2T8G6Zts0maPkt2lQ==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -3528,16 +3208,16 @@ packages:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.17
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.10.16
-      '@swc/core-darwin-x64': 1.10.16
-      '@swc/core-linux-arm-gnueabihf': 1.10.16
-      '@swc/core-linux-arm64-gnu': 1.10.16
-      '@swc/core-linux-arm64-musl': 1.10.16
-      '@swc/core-linux-x64-gnu': 1.10.16
-      '@swc/core-linux-x64-musl': 1.10.16
-      '@swc/core-win32-arm64-msvc': 1.10.16
-      '@swc/core-win32-ia32-msvc': 1.10.16
-      '@swc/core-win32-x64-msvc': 1.10.16
+      '@swc/core-darwin-arm64': 1.10.17
+      '@swc/core-darwin-x64': 1.10.17
+      '@swc/core-linux-arm-gnueabihf': 1.10.17
+      '@swc/core-linux-arm64-gnu': 1.10.17
+      '@swc/core-linux-arm64-musl': 1.10.17
+      '@swc/core-linux-x64-gnu': 1.10.17
+      '@swc/core-linux-x64-musl': 1.10.17
+      '@swc/core-win32-arm64-msvc': 1.10.17
+      '@swc/core-win32-ia32-msvc': 1.10.17
+      '@swc/core-win32-x64-msvc': 1.10.17
     dev: true
 
   /@swc/counter@0.1.3:
@@ -4054,17 +3734,17 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6
     dependencies:
-      '@swc/core': 1.10.16
+      '@swc/core': 1.10.17
       vite: 6.1.0(@types/node@20.16.10)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@vitest/coverage-v8@3.0.5(vitest@1.6.0):
-    resolution: {integrity: sha512-zOOWIsj5fHh3jjGwQg+P+J1FW3s4jBu1Zqga0qW60yutsBtqEqNEJKWYh7cYn1yGD+1bdPsPdC/eL4eVK56xMg==}
+  /@vitest/coverage-v8@3.0.6(vitest@3.0.6):
+    resolution: {integrity: sha512-JRTlR8Bw+4BcmVTICa7tJsxqphAktakiLsAmibVLAWbu1lauFddY/tXeM6sAyl1cgkPuXtpnUgaCPhTdz1Qapg==}
     peerDependencies:
-      '@vitest/browser': 3.0.5
-      vitest: 3.0.5
+      '@vitest/browser': 3.0.6
+      vitest: 3.0.6
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -4081,17 +3761,9 @@ packages:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 1.6.0(@types/node@20.16.10)(@vitest/ui@3.0.5)
+      vitest: 3.0.6(@types/node@20.16.10)(@vitest/ui@3.0.6)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@vitest/expect@1.6.0:
-    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
-    dependencies:
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      chai: 4.5.0
     dev: true
 
   /@vitest/expect@2.0.5:
@@ -4101,6 +3773,32 @@ packages:
       '@vitest/utils': 2.0.5
       chai: 5.1.1
       tinyrainbow: 1.2.0
+    dev: true
+
+  /@vitest/expect@3.0.6:
+    resolution: {integrity: sha512-zBduHf/ja7/QRX4HdP1DSq5XrPgdN+jzLOwaTq/0qZjYfgETNFCKf9nOAp2j3hmom3oTbczuUzrzg9Hafh7hNg==}
+    dependencies:
+      '@vitest/spy': 3.0.6
+      '@vitest/utils': 3.0.6
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+    dev: true
+
+  /@vitest/mocker@3.0.6(vite@6.1.0):
+    resolution: {integrity: sha512-KPztr4/tn7qDGZfqlSPQoF2VgJcKxnDNhmfR3VgZ6Fy1bO8T9Fc1stUiTXtqz0yG24VpD00pZP5f8EOFknjNuQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.0.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      vite: 6.1.0(@types/node@20.16.10)
     dev: true
 
   /@vitest/pretty-format@2.0.5:
@@ -4115,32 +3813,25 @@ packages:
       tinyrainbow: 1.2.0
     dev: true
 
-  /@vitest/pretty-format@3.0.5:
-    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
+  /@vitest/pretty-format@3.0.6:
+    resolution: {integrity: sha512-Zyctv3dbNL+67qtHfRnUE/k8qxduOamRfAL1BurEIQSyOEFffoMvx2pnDSSbKAAVxY0Ej2J/GH2dQKI0W2JyVg==}
     dependencies:
       tinyrainbow: 2.0.0
     dev: true
 
-  /@vitest/runner@1.6.0:
-    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+  /@vitest/runner@3.0.6:
+    resolution: {integrity: sha512-JopP4m/jGoaG1+CBqubV/5VMbi7L+NQCJTu1J1Pf6YaUbk7bZtaq5CX7p+8sY64Sjn1UQ1XJparHfcvTTdu9cA==}
     dependencies:
-      '@vitest/utils': 1.6.0
-      p-limit: 5.0.0
-      pathe: 1.1.2
+      '@vitest/utils': 3.0.6
+      pathe: 2.0.3
     dev: true
 
-  /@vitest/snapshot@1.6.0:
-    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
+  /@vitest/snapshot@3.0.6:
+    resolution: {integrity: sha512-qKSmxNQwT60kNwwJHMVwavvZsMGXWmngD023OHSgn873pV0lylK7dwBTfYP7e4URy5NiBCHHiQGA9DHkYkqRqg==}
     dependencies:
-      magic-string: 0.30.11
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-    dev: true
-
-  /@vitest/spy@1.6.0:
-    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
-    dependencies:
-      tinyspy: 2.2.1
+      '@vitest/pretty-format': 3.0.6
+      magic-string: 0.30.17
+      pathe: 2.0.3
     dev: true
 
   /@vitest/spy@2.0.5:
@@ -4149,28 +3840,25 @@ packages:
       tinyspy: 3.0.2
     dev: true
 
-  /@vitest/ui@3.0.5(vitest@1.6.0):
-    resolution: {integrity: sha512-gw2noso6WI+2PeMVCZFntdATS6xl9qhQcbhkPQ9sOmx/Xn0f4Bx4KDSbD90jpJPF0l5wOzSoGCmKyVR3W612mg==}
-    peerDependencies:
-      vitest: 3.0.5
+  /@vitest/spy@3.0.6:
+    resolution: {integrity: sha512-HfOGx/bXtjy24fDlTOpgiAEJbRfFxoX3zIGagCqACkFKKZ/TTOE6gYMKXlqecvxEndKFuNHcHqP081ggZ2yM0Q==}
     dependencies:
-      '@vitest/utils': 3.0.5
-      fflate: 0.8.2
-      flatted: 3.3.2
-      pathe: 2.0.3
-      sirv: 3.0.0
-      tinyglobby: 0.2.10
-      tinyrainbow: 2.0.0
-      vitest: 1.6.0(@types/node@20.16.10)(@vitest/ui@3.0.5)
+      tinyspy: 3.0.2
     dev: true
 
-  /@vitest/utils@1.6.0:
-    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+  /@vitest/ui@3.0.6(vitest@3.0.6):
+    resolution: {integrity: sha512-N4M2IUG2Q5LCeX4OWs48pQF4P3qsFejmDTc6QWGRFTLPrEe5EvM5HN0WSUnGAmuzQpSWv7ItfSsIJIWaEM2wpQ==}
+    peerDependencies:
+      vitest: 3.0.6
     dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      '@vitest/utils': 3.0.6
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.1
+      tinyglobby: 0.2.11
+      tinyrainbow: 2.0.0
+      vitest: 3.0.6(@types/node@20.16.10)(@vitest/ui@3.0.6)
     dev: true
 
   /@vitest/utils@2.0.5:
@@ -4190,10 +3878,10 @@ packages:
       tinyrainbow: 1.2.0
     dev: true
 
-  /@vitest/utils@3.0.5:
-    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
+  /@vitest/utils@3.0.6:
+    resolution: {integrity: sha512-18ktZpf4GQFTbf9jK543uspU03Q2qya7ZGya5yiZ0Gx0nnnalBvd5ZBislbl2EhLjM8A8rt4OilqKG7QwcGkvQ==}
     dependencies:
-      '@vitest/pretty-format': 3.0.5
+      '@vitest/pretty-format': 3.0.6
       loupe: 3.1.3
       tinyrainbow: 2.0.0
     dev: true
@@ -4216,21 +3904,21 @@ packages:
       vscode-uri: 3.1.0
     dev: true
 
-  /@vue/compiler-core@3.5.10:
-    resolution: {integrity: sha512-iXWlk+Cg/ag7gLvY0SfVucU8Kh2CjysYZjhhP70w9qI4MvSox4frrP+vDGvtQuzIcgD8+sxM6lZvCtdxGunTAA==}
+  /@vue/compiler-core@3.5.13:
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
     dependencies:
-      '@babel/parser': 7.25.7
-      '@vue/shared': 3.5.10
+      '@babel/parser': 7.26.9
+      '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
     dev: true
 
-  /@vue/compiler-dom@3.5.10:
-    resolution: {integrity: sha512-DyxHC6qPcktwYGKOIy3XqnHRrrXyWR2u91AjP+nLkADko380srsC2DC3s7Y1Rk6YfOlxOlvEQKa9XXmLI+W4ZA==}
+  /@vue/compiler-dom@3.5.13:
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
     dependencies:
-      '@vue/compiler-core': 3.5.10
-      '@vue/shared': 3.5.10
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
     dev: true
 
   /@vue/compiler-vue2@2.7.16:
@@ -4249,9 +3937,9 @@ packages:
         optional: true
     dependencies:
       '@volar/language-core': 2.4.11
-      '@vue/compiler-dom': 3.5.10
+      '@vue/compiler-dom': 3.5.13
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.10
+      '@vue/shared': 3.5.13
       alien-signals: 0.4.14
       minimatch: 9.0.5
       muggle-string: 0.4.1
@@ -4259,8 +3947,8 @@ packages:
       typescript: 5.6.2
     dev: true
 
-  /@vue/shared@3.5.10:
-    resolution: {integrity: sha512-VkkBhU97Ki+XJ0xvl4C9YJsIZ2uIlQ7HqPpZOS3m9VCvmROPaChZU6DexdMJqvz9tbgG+4EtFVrSuailUq5KGQ==}
+  /@vue/shared@3.5.13:
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
     dev: true
 
   /@xobotyi/scrollbar-width@1.9.5:
@@ -4336,13 +4024,6 @@ packages:
   /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
-    engines: {node: '>=0.4.0'}
-    dependencies:
-      acorn: 8.12.1
     dev: true
 
   /acorn@7.4.1:
@@ -4597,10 +4278,6 @@ packages:
       is-shared-array-buffer: 1.0.3
     dev: true
 
-  /assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-    dev: true
-
   /assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4762,19 +4439,6 @@ packages:
     resolution: {integrity: sha512-gD14ICmoV5ZZM1OdzPWmpx+q4GyefaK06zi8hmfHV5xe4/2nOQX3+Dw5o+fSqOws2xVwL9j+anOPFwHzdEdV4g==}
     dev: true
 
-  /chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-    dev: true
-
   /chai@5.1.1:
     resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
     engines: {node: '>=12'}
@@ -4783,6 +4447,17 @@ packages:
       check-error: 2.1.1
       deep-eql: 5.0.2
       loupe: 3.1.1
+      pathval: 2.0.0
+    dev: true
+
+  /chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
       pathval: 2.0.0
     dev: true
 
@@ -4865,12 +4540,6 @@ packages:
 
   /change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
-    dev: true
-
-  /check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
-    dependencies:
-      get-func-name: 2.0.2
     dev: true
 
   /check-error@2.1.1:
@@ -4986,10 +4655,6 @@ packages:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
-    dev: true
-
-  /confbox@0.1.7:
-    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
     dev: true
 
   /confbox@0.1.8:
@@ -5245,13 +4910,6 @@ packages:
     engines: {node: '>=14.16'}
     dev: false
 
-  /deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
-    dependencies:
-      type-detect: 4.1.0
-    dev: true
-
   /deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -5311,11 +4969,6 @@ packages:
   /diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
     dev: false
-
-  /diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -5534,6 +5187,10 @@ packages:
       safe-array-concat: 1.1.2
     dev: true
 
+  /es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+    dev: true
+
   /es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
@@ -5574,37 +5231,6 @@ packages:
       esbuild: 0.23.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
     dev: true
 
   /esbuild@0.23.1:
@@ -6018,19 +5644,9 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
+  /expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /express@4.21.0:
@@ -6196,8 +5812,8 @@ packages:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
 
-  /flatted@3.3.2:
-    resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
+  /flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
     dev: true
 
   /focus-lock@1.3.5:
@@ -6353,11 +5969,6 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
     dev: false
-
-  /get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-    dev: true
 
   /get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -6561,11 +6172,6 @@ packages:
       - supports-color
     dev: true
 
-  /human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-    dev: true
-
   /hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
     dev: false
@@ -6730,6 +6336,13 @@ packages:
     dependencies:
       hasown: 2.0.2
 
+  /is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      hasown: 2.0.2
+    dev: true
+
   /is-data-view@1.0.1:
     resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
     engines: {node: '>= 0.4'}
@@ -6835,11 +6448,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
-    dev: true
-
-  /is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /is-string@1.0.7:
@@ -6973,10 +6581,6 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  /js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
-    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -7123,14 +6727,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
-    dependencies:
-      mlly: 1.7.1
-      pkg-types: 1.2.0
-    dev: true
-
   /local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
@@ -7179,12 +6775,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-
-  /loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-    dependencies:
-      get-func-name: 2.0.2
-    dev: true
 
   /loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
@@ -7245,8 +6835,8 @@ packages:
   /magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
     dependencies:
-      '@babel/parser': 7.25.7
-      '@babel/types': 7.25.7
+      '@babel/parser': 7.26.9
+      '@babel/types': 7.26.9
       source-map-js: 1.2.1
     dev: true
 
@@ -7254,7 +6844,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /map-or-similar@1.5.0:
@@ -7291,10 +6881,6 @@ packages:
 
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-    dev: true
-
-  /merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
 
   /merge2@1.4.1:
@@ -7338,11 +6924,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-    dev: true
-
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -7383,15 +6964,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dev: true
 
-  /mlly@1.7.1:
-    resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
-    dependencies:
-      acorn: 8.12.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      ufo: 1.5.4
-    dev: true
-
   /mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
     dependencies:
@@ -7405,8 +6977,8 @@ packages:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
     dev: false
 
-  /mrmime@2.0.0:
-    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
+  /mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
     dev: true
 
@@ -7442,12 +7014,6 @@ packages:
       stacktrace-js: 2.0.2
       stylis: 4.3.4
     dev: false
-
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: true
 
   /nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -7503,13 +7069,6 @@ packages:
 
   /node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
-    dev: true
-
-  /npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      path-key: 4.0.0
     dev: true
 
   /object-assign@4.1.1:
@@ -7592,13 +7151,6 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      mimic-fn: 4.0.0
-    dev: true
-
   /open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -7677,13 +7229,6 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
-  /p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      yocto-queue: 1.1.1
-    dev: true
-
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -7756,11 +7301,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-    dev: true
-
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -7780,16 +7320,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-    dev: true
-
   /pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-    dev: true
-
-  /pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
   /pathval@2.0.0:
@@ -7818,14 +7350,6 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /pkg-types@1.2.0:
-    resolution: {integrity: sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==}
-    dependencies:
-      confbox: 0.1.7
-      mlly: 1.7.1
-      pathe: 1.1.2
-    dev: true
-
   /pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
     dependencies:
@@ -7849,15 +7373,6 @@ packages:
   /possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /postcss@8.4.47:
-    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.0
-      source-map-js: 1.2.1
     dev: true
 
   /postcss@8.5.2:
@@ -7887,15 +7402,6 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-    dev: true
-
-  /pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
     dev: true
 
   /pretty-ms@9.1.0:
@@ -8179,10 +7685,6 @@ packages:
 
   /react-is@18.1.0:
     resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}
-    dev: true
-
-  /react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
     dev: true
 
   /react-redux@9.1.2(@types/react@18.3.11)(react@18.3.1)(redux@5.0.1):
@@ -8543,6 +8045,16 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  /resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -8623,58 +8135,32 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /rollup@4.24.0:
-    resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
+  /rollup@4.34.8:
+    resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.24.0
-      '@rollup/rollup-android-arm64': 4.24.0
-      '@rollup/rollup-darwin-arm64': 4.24.0
-      '@rollup/rollup-darwin-x64': 4.24.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.24.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.24.0
-      '@rollup/rollup-linux-arm64-gnu': 4.24.0
-      '@rollup/rollup-linux-arm64-musl': 4.24.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.24.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.24.0
-      '@rollup/rollup-linux-s390x-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-musl': 4.24.0
-      '@rollup/rollup-win32-arm64-msvc': 4.24.0
-      '@rollup/rollup-win32-ia32-msvc': 4.24.0
-      '@rollup/rollup-win32-x64-msvc': 4.24.0
-      fsevents: 2.3.3
-    dev: true
-
-  /rollup@4.34.6:
-    resolution: {integrity: sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.34.6
-      '@rollup/rollup-android-arm64': 4.34.6
-      '@rollup/rollup-darwin-arm64': 4.34.6
-      '@rollup/rollup-darwin-x64': 4.34.6
-      '@rollup/rollup-freebsd-arm64': 4.34.6
-      '@rollup/rollup-freebsd-x64': 4.34.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.34.6
-      '@rollup/rollup-linux-arm-musleabihf': 4.34.6
-      '@rollup/rollup-linux-arm64-gnu': 4.34.6
-      '@rollup/rollup-linux-arm64-musl': 4.34.6
-      '@rollup/rollup-linux-loongarch64-gnu': 4.34.6
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.34.6
-      '@rollup/rollup-linux-s390x-gnu': 4.34.6
-      '@rollup/rollup-linux-x64-gnu': 4.34.6
-      '@rollup/rollup-linux-x64-musl': 4.34.6
-      '@rollup/rollup-win32-arm64-msvc': 4.34.6
-      '@rollup/rollup-win32-ia32-msvc': 4.34.6
-      '@rollup/rollup-win32-x64-msvc': 4.34.6
+      '@rollup/rollup-android-arm-eabi': 4.34.8
+      '@rollup/rollup-android-arm64': 4.34.8
+      '@rollup/rollup-darwin-arm64': 4.34.8
+      '@rollup/rollup-darwin-x64': 4.34.8
+      '@rollup/rollup-freebsd-arm64': 4.34.8
+      '@rollup/rollup-freebsd-x64': 4.34.8
+      '@rollup/rollup-linux-arm-gnueabihf': 4.34.8
+      '@rollup/rollup-linux-arm-musleabihf': 4.34.8
+      '@rollup/rollup-linux-arm64-gnu': 4.34.8
+      '@rollup/rollup-linux-arm64-musl': 4.34.8
+      '@rollup/rollup-linux-loongarch64-gnu': 4.34.8
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.8
+      '@rollup/rollup-linux-riscv64-gnu': 4.34.8
+      '@rollup/rollup-linux-s390x-gnu': 4.34.8
+      '@rollup/rollup-linux-x64-gnu': 4.34.8
+      '@rollup/rollup-linux-x64-musl': 4.34.8
+      '@rollup/rollup-win32-arm64-msvc': 4.34.8
+      '@rollup/rollup-win32-ia32-msvc': 4.34.8
+      '@rollup/rollup-win32-x64-msvc': 4.34.8
       fsevents: 2.3.3
     dev: true
 
@@ -8757,6 +8243,12 @@ packages:
 
   /semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
@@ -8871,12 +8363,12 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /sirv@3.0.0:
-    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+  /sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
     dependencies:
       '@polka/url': 1.0.0-next.28
-      mrmime: 2.0.0
+      mrmime: 2.0.1
       totalist: 3.0.1
     dev: true
 
@@ -8991,10 +8483,6 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-    dev: true
-
-  /std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
 
   /std-env@3.8.0:
@@ -9112,11 +8600,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-    dev: true
-
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -9139,12 +8622,6 @@ packages:
   /strip-json-comments@5.0.1:
     resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
     engines: {node: '>=14.16'}
-    dev: true
-
-  /strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
-    dependencies:
-      js-tokens: 9.0.0
     dev: true
 
   /stylis@4.2.0:
@@ -9223,17 +8700,21 @@ packages:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
     dev: true
 
-  /tinyglobby@0.2.10:
-    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
+  /tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    dev: true
+
+  /tinyglobby@0.2.11:
+    resolution: {integrity: sha512-32TmKeeKUahv0Go8WmQgiEp9Y21NuxjwjqiRC1nrUB51YacfSwuB44xgXD+HdIppmMRgjQNPdrHyA6vIybYZ+g==}
     engines: {node: '>=12.0.0'}
     dependencies:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
     dev: true
 
-  /tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
+  /tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     dev: true
 
   /tinyrainbow@1.2.0:
@@ -9243,11 +8724,6 @@ packages:
 
   /tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-    dev: true
-
-  /tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -9315,8 +8791,8 @@ packages:
     resolution: {integrity: sha512-tbNyyBSbwfbilFfiuXkSOj82a6++ovgANwcoqBAcO9/REPoZMEQoE8kWPeO0dy5A2D/2Lajr8Ohue5T0ifIvLQ==}
     dev: true
 
-  /tsconfck@3.1.3(typescript@5.6.2):
-    resolution: {integrity: sha512-ulNZP1SVpRDesxeMLON/LtWM8HIgAJEIVpVVhBM6gsmvQ8+Rh+ZG7FWGvHh7Ah3pRABwVJWklWCr/BTZSv0xnQ==}
+  /tsconfck@3.1.5(typescript@5.6.2):
+    resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -9372,11 +8848,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
-    dev: true
-
-  /type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
     dev: true
 
   /type-fest@0.20.2:
@@ -9682,18 +9153,19 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-node@1.6.0(@types/node@20.16.10):
-    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vite-node@3.0.6(@types/node@20.16.10):
+    resolution: {integrity: sha512-s51RzrTkXKJrhNbUzQRsarjmAae7VmMPAsRT7lppVpIg6mK3zGthP9Hgz0YQQKuNcF+Ii7DfYk3Fxz40jRmePw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@9.4.0)
-      pathe: 1.1.2
-      picocolors: 1.1.0
-      vite: 5.4.8(@types/node@20.16.10)
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.1.0(@types/node@20.16.10)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -9702,6 +9174,8 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: true
 
   /vite-plugin-css-injected-by-js@3.5.2(vite@6.1.0):
@@ -9759,52 +9233,13 @@ packages:
       vite:
         optional: true
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.3(typescript@5.6.2)
+      tsconfck: 3.1.5(typescript@5.6.2)
       vite: 6.1.0(@types/node@20.16.10)
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /vite@5.4.8(@types/node@20.16.10):
-    resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.16.10
-      esbuild: 0.21.5
-      postcss: 8.4.47
-      rollup: 4.24.0
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /vite@6.1.0(@types/node@20.16.10):
@@ -9850,24 +9285,27 @@ packages:
       '@types/node': 20.16.10
       esbuild: 0.24.2
       postcss: 8.5.2
-      rollup: 4.34.6
+      rollup: 4.34.8
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.6.0(@types/node@20.16.10)(@vitest/ui@3.0.5):
-    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vitest@3.0.6(@types/node@20.16.10)(@vitest/ui@3.0.6):
+    resolution: {integrity: sha512-/iL1Sc5VeDZKPDe58oGK4HUFLhw6b5XdY1MYawjuSaDA4sEfYlY9HnS6aCEG26fX+MgUi7MwlduTBHHAI/OvMA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.0
-      '@vitest/ui': 1.6.0
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.6
+      '@vitest/ui': 3.0.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -9881,36 +9319,40 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.16.10
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/ui': 3.0.5(vitest@1.6.0)
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.3.7(supports-color@9.4.0)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      pathe: 1.1.2
-      picocolors: 1.1.0
-      std-env: 3.7.0
-      strip-literal: 2.1.0
+      '@vitest/expect': 3.0.6
+      '@vitest/mocker': 3.0.6(vite@6.1.0)
+      '@vitest/pretty-format': 3.0.6
+      '@vitest/runner': 3.0.6
+      '@vitest/snapshot': 3.0.6
+      '@vitest/spy': 3.0.6
+      '@vitest/ui': 3.0.6(vitest@3.0.6)
+      '@vitest/utils': 3.0.6
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.0
       tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.8(@types/node@20.16.10)
-      vite-node: 1.6.0(@types/node@20.16.10)
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.1.0(@types/node@20.16.10)
+      vite-node: 3.0.6(@types/node@20.16.10)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: true
 
   /void-elements@3.1.0:
@@ -10108,11 +9550,6 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
-
-  /yocto-queue@1.1.1:
-    resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
-    engines: {node: '>=12.20'}
     dev: true
 
   /zod-validation-error@3.4.0(zod@3.23.8):

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/workflowLoadRequested.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/workflowLoadRequested.ts
@@ -22,12 +22,18 @@ const getWorkflow = async (data: GraphAndWorkflowResponse, templates: Templates)
   if (data.workflow) {
     // Prefer to load the workflow if it's available - it has more information
     const parsed = JSON.parse(data.workflow);
-    return await validateWorkflow(parsed, templates, checkImageAccess, checkBoardAccess, checkModelAccess);
+    return await validateWorkflow({
+      workflow: parsed,
+      templates,
+      checkImageAccess,
+      checkBoardAccess,
+      checkModelAccess,
+    });
   } else if (data.graph) {
     // Else we fall back on the graph, using the graphToWorkflow function to convert and do layout
     const parsed = JSON.parse(data.graph);
     const workflow = graphToWorkflow(parsed as NonNullableGraph, true);
-    return await validateWorkflow(workflow, templates, checkImageAccess, checkBoardAccess, checkModelAccess);
+    return await validateWorkflow({ workflow, templates, checkImageAccess, checkBoardAccess, checkModelAccess });
   } else {
     throw new Error('No workflow or graph provided');
   }

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldEditModeNodes.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldEditModeNodes.tsx
@@ -3,7 +3,7 @@ import { Flex, FormControl, Spacer } from '@invoke-ai/ui-library';
 import { InputFieldDescriptionPopover } from 'features/nodes/components/flow/nodes/Invocation/fields/InputFieldDescriptionPopover';
 import { InputFieldHandle } from 'features/nodes/components/flow/nodes/Invocation/fields/InputFieldHandle';
 import { InputFieldResetToDefaultValueIconButton } from 'features/nodes/components/flow/nodes/Invocation/fields/InputFieldResetToDefaultValueIconButton';
-import { useNodeFieldDnd } from 'features/nodes/components/sidePanel/builder/dnd';
+import { useNodeFieldDnd } from 'features/nodes/components/sidePanel/builder/dnd-hooks';
 import { useInputFieldIsConnected } from 'features/nodes/hooks/useInputFieldIsConnected';
 import { useInputFieldIsInvalid } from 'features/nodes/hooks/useInputFieldIsInvalid';
 import { useInputFieldTemplate } from 'features/nodes/hooks/useInputFieldTemplate';

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldHandle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldHandle.tsx
@@ -9,8 +9,8 @@ import {
 } from 'features/nodes/hooks/useFieldConnectionState';
 import { useInputFieldTemplate } from 'features/nodes/hooks/useInputFieldTemplate';
 import { useFieldTypeName } from 'features/nodes/hooks/usePrettyFieldType';
-import { HANDLE_TOOLTIP_OPEN_DELAY, MODEL_TYPES } from 'features/nodes/types/constants';
-import type { FieldInputTemplate } from 'features/nodes/types/field';
+import { HANDLE_TOOLTIP_OPEN_DELAY } from 'features/nodes/types/constants';
+import { type FieldInputTemplate,isModelFieldType } from 'features/nodes/types/field';
 import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -64,7 +64,7 @@ export const InputFieldHandle = memo(({ nodeId, fieldName }: Props) => {
   const fieldTemplate = useInputFieldTemplate(nodeId, fieldName);
   const fieldTypeName = useFieldTypeName(fieldTemplate.type);
   const fieldColor = useMemo(() => getFieldColor(fieldTemplate.type), [fieldTemplate.type]);
-  const isModelField = useMemo(() => MODEL_TYPES.some((t) => t === fieldTemplate.type.name), [fieldTemplate.type]);
+  const isModelField = useMemo(() => isModelFieldType(fieldTemplate.type), [fieldTemplate.type]);
   const isConnectionInProgress = useIsConnectionInProgress();
 
   if (isConnectionInProgress) {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldHandle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldHandle.tsx
@@ -10,7 +10,8 @@ import {
 import { useInputFieldTemplate } from 'features/nodes/hooks/useInputFieldTemplate';
 import { useFieldTypeName } from 'features/nodes/hooks/usePrettyFieldType';
 import { HANDLE_TOOLTIP_OPEN_DELAY } from 'features/nodes/types/constants';
-import { type FieldInputTemplate,isModelFieldType } from 'features/nodes/types/field';
+import type { FieldInputTemplate } from 'features/nodes/types/field';
+import { isModelFieldType } from 'features/nodes/types/field';
 import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/OutputFieldHandle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/OutputFieldHandle.tsx
@@ -10,7 +10,8 @@ import {
 import { useOutputFieldTemplate } from 'features/nodes/hooks/useOutputFieldTemplate';
 import { useFieldTypeName } from 'features/nodes/hooks/usePrettyFieldType';
 import { HANDLE_TOOLTIP_OPEN_DELAY } from 'features/nodes/types/constants';
-import { type FieldOutputTemplate,isModelFieldType } from 'features/nodes/types/field';
+import type { FieldOutputTemplate } from 'features/nodes/types/field';
+import { isModelFieldType } from 'features/nodes/types/field';
 import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/OutputFieldHandle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/OutputFieldHandle.tsx
@@ -9,8 +9,8 @@ import {
 } from 'features/nodes/hooks/useFieldConnectionState';
 import { useOutputFieldTemplate } from 'features/nodes/hooks/useOutputFieldTemplate';
 import { useFieldTypeName } from 'features/nodes/hooks/usePrettyFieldType';
-import { HANDLE_TOOLTIP_OPEN_DELAY, MODEL_TYPES } from 'features/nodes/types/constants';
-import type { FieldOutputTemplate } from 'features/nodes/types/field';
+import { HANDLE_TOOLTIP_OPEN_DELAY } from 'features/nodes/types/constants';
+import { type FieldOutputTemplate,isModelFieldType } from 'features/nodes/types/field';
 import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -64,7 +64,7 @@ export const OutputFieldHandle = memo(({ nodeId, fieldName }: Props) => {
   const fieldTemplate = useOutputFieldTemplate(nodeId, fieldName);
   const fieldTypeName = useFieldTypeName(fieldTemplate.type);
   const fieldColor = useMemo(() => getFieldColor(fieldTemplate.type), [fieldTemplate.type]);
-  const isModelField = useMemo(() => MODEL_TYPES.some((t) => t === fieldTemplate.type.name), [fieldTemplate.type]);
+  const isModelField = useMemo(() => isModelFieldType(fieldTemplate.type), [fieldTemplate.type]);
   const isConnectionInProgress = useIsConnectionInProgress();
 
   if (isConnectionInProgress) {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeTitle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/common/NodeTitle.tsx
@@ -48,7 +48,7 @@ const NodeTitle = ({ nodeId, title }: Props) => {
   }, [batchGroupId, editable.value, t]);
 
   return (
-    <Flex overflow="hidden" w="full" h="full" alignItems="center" justifyContent="center" cursor="text">
+    <Flex overflow="hidden" w="full" h="full" alignItems="center" justifyContent="center">
       {!editable.isEditing && (
         <Text fontWeight="semibold" color={batchGroupColorToken} onDoubleClick={editable.startEditing}>
           {titleWithBatchGroupId}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
@@ -4,13 +4,14 @@ import { useAppDispatch } from 'app/store/storeHooks';
 import { ContainerElementSettings } from 'features/nodes/components/sidePanel/builder/ContainerElementSettings';
 import { useDepthContext } from 'features/nodes/components/sidePanel/builder/contexts';
 import { NodeFieldElementSettings } from 'features/nodes/components/sidePanel/builder/NodeFieldElementSettings';
-import { useIsRootElement } from 'features/nodes/components/sidePanel/builder/shared';
 import { formElementRemoved } from 'features/nodes/store/workflowSlice';
 import { type FormElement, isContainerElement, isNodeFieldElement } from 'features/nodes/types/workflow';
 import { startCase } from 'lodash-es';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiXBold } from 'react-icons/pi';
+
+import { useIsRootElement } from './dnd-hooks';
 
 const sx: SystemStyleObject = {
   w: 'full',

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeWrapper.tsx
@@ -4,7 +4,11 @@ import { useContainerContext } from 'features/nodes/components/sidePanel/builder
 import { useFormElementDnd } from 'features/nodes/components/sidePanel/builder/dnd';
 import { DndListDropIndicator } from 'features/nodes/components/sidePanel/builder/DndListDropIndicator';
 import { FormElementEditModeHeader } from 'features/nodes/components/sidePanel/builder/FormElementEditModeHeader';
-import { EDIT_MODE_WRAPPER_CLASS_NAME, getEditModeWrapperId } from 'features/nodes/components/sidePanel/builder/shared';
+import {
+  EDIT_MODE_WRAPPER_CLASS_NAME,
+  getEditModeWrapperId,
+  useIsRootElement,
+} from 'features/nodes/components/sidePanel/builder/shared';
 import type { FormElement } from 'features/nodes/types/workflow';
 import type { PropsWithChildren } from 'react';
 import { memo, useRef } from 'react';
@@ -46,6 +50,7 @@ export const FormElementEditModeWrapper = memo(({ element, children }: PropsWith
   const dragHandleRef = useRef<HTMLDivElement>(null);
   const [activeDropRegion, isDragging] = useFormElementDnd(element.id, draggableRef, dragHandleRef);
   const containerCtx = useContainerContext();
+  const isRootElement = useIsRootElement(element.id);
 
   return (
     <Flex
@@ -53,6 +58,7 @@ export const FormElementEditModeWrapper = memo(({ element, children }: PropsWith
       ref={draggableRef}
       className={EDIT_MODE_WRAPPER_CLASS_NAME}
       sx={wrapperSx}
+      data-is-root={isRootElement}
       data-element-type={element.type}
       data-layout={containerCtx?.layout}
     >

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeWrapper.tsx
@@ -1,17 +1,18 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { Flex } from '@invoke-ai/ui-library';
+import { getPrefixedId } from 'features/controlLayers/konva/util';
 import { useContainerContext } from 'features/nodes/components/sidePanel/builder/contexts';
 import { useFormElementDnd } from 'features/nodes/components/sidePanel/builder/dnd-hooks';
 import { DndListDropIndicator } from 'features/nodes/components/sidePanel/builder/DndListDropIndicator';
 import { FormElementEditModeHeader } from 'features/nodes/components/sidePanel/builder/FormElementEditModeHeader';
-import {
-  EDIT_MODE_WRAPPER_CLASS_NAME,
-  getEditModeWrapperId,
-  useIsRootElement,
-} from 'features/nodes/components/sidePanel/builder/shared';
+import { getEditModeWrapperId } from 'features/nodes/components/sidePanel/builder/shared';
 import type { FormElement } from 'features/nodes/types/workflow';
 import type { PropsWithChildren } from 'react';
 import { memo, useRef } from 'react';
+
+import { useIsRootElement } from './dnd-hooks';
+
+const EDIT_MODE_WRAPPER_CLASS_NAME = getPrefixedId('edit-mode-wrapper', '-');
 
 const wrapperSx: SystemStyleObject = {
   position: 'relative',

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeWrapper.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeWrapper.tsx
@@ -1,7 +1,7 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { Flex } from '@invoke-ai/ui-library';
 import { useContainerContext } from 'features/nodes/components/sidePanel/builder/contexts';
-import { useFormElementDnd } from 'features/nodes/components/sidePanel/builder/dnd';
+import { useFormElementDnd } from 'features/nodes/components/sidePanel/builder/dnd-hooks';
 import { DndListDropIndicator } from 'features/nodes/components/sidePanel/builder/DndListDropIndicator';
 import { FormElementEditModeHeader } from 'features/nodes/components/sidePanel/builder/FormElementEditModeHeader';
 import {

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/WorkflowBuilder.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/WorkflowBuilder.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
 import { firefoxDndFix } from 'features/dnd/util';
 import { FormElementComponent } from 'features/nodes/components/sidePanel/builder/ContainerElementComponent';
-import { buildFormElementDndData, useBuilderDndMonitor } from 'features/nodes/components/sidePanel/builder/dnd';
+import { buildFormElementDndData, useBuilderDndMonitor } from 'features/nodes/components/sidePanel/builder/dnd-hooks';
 import { formReset, selectFormRootElementId } from 'features/nodes/store/workflowSlice';
 import type { FormElement } from 'features/nodes/types/workflow';
 import { buildContainer, buildDivider, buildHeading, buildText } from 'features/nodes/types/workflow';

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/WorkflowBuilder.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/WorkflowBuilder.tsx
@@ -1,17 +1,12 @@
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
 import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { Alert, AlertDescription, AlertIcon, Button, ButtonGroup, Flex, Spacer, Text } from '@invoke-ai/ui-library';
+import { Alert, AlertDescription, AlertIcon, Button, ButtonGroup, Flex, Spacer } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
 import { firefoxDndFix } from 'features/dnd/util';
 import { FormElementComponent } from 'features/nodes/components/sidePanel/builder/ContainerElementComponent';
-import {
-  buildFormElementDndData,
-  useBuilderDndMonitor,
-  useRootDnd,
-} from 'features/nodes/components/sidePanel/builder/dnd';
-import { getEditModeWrapperId } from 'features/nodes/components/sidePanel/builder/shared';
-import { formReset, selectFormIsEmpty, selectFormLayout } from 'features/nodes/store/workflowSlice';
+import { buildFormElementDndData, useBuilderDndMonitor } from 'features/nodes/components/sidePanel/builder/dnd';
+import { formReset, selectFormRootElementId } from 'features/nodes/store/workflowSlice';
 import type { FormElement } from 'features/nodes/types/workflow';
 import { buildContainer, buildDivider, buildHeading, buildText } from 'features/nodes/types/workflow';
 import { startCase } from 'lodash-es';
@@ -24,7 +19,7 @@ import { assert } from 'tsafe';
 export const WorkflowBuilder = memo(() => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const isEmpty = useAppSelector(selectFormIsEmpty);
+  const rootElementId = useAppSelector(selectFormRootElementId);
   useBuilderDndMonitor();
 
   const resetForm = useCallback(() => {
@@ -49,52 +44,15 @@ export const WorkflowBuilder = memo(() => {
               {t('common.reset')}
             </Button>
           </ButtonGroup>
-          {!isEmpty && <FormLayout />}
-          {isEmpty && <EmptyStateEditMode />}
+          <Flex>
+            <FormElementComponent id={rootElementId} />
+          </Flex>
         </Flex>
       </Flex>
     </ScrollableContent>
   );
 });
 WorkflowBuilder.displayName = 'WorkflowBuilder';
-
-export const FormLayout = memo(() => {
-  const layout = useAppSelector(selectFormLayout);
-
-  return (
-    <Flex flexDir="column" gap={4} w="full" borderRadius="base">
-      {layout.map((id) => (
-        <FormElementComponent key={id} id={id} />
-      ))}
-    </Flex>
-  );
-});
-FormLayout.displayName = 'FormLayout';
-
-const EmptyStateEditMode = memo(() => {
-  const { t } = useTranslation();
-  const ref = useRef<HTMLDivElement>(null);
-  const isDragging = useRootDnd(ref);
-
-  return (
-    <Flex
-      id={getEditModeWrapperId('root')}
-      ref={ref}
-      w="full"
-      h="full"
-      bg={isDragging ? 'base.800' : undefined}
-      p={4}
-      borderRadius="base"
-      alignItems="center"
-      justifyContent="center"
-    >
-      <Text variant="subtext" fontSize="md">
-        {t('workflows.builder.emptyRootPlaceholderEditMode')}
-      </Text>
-    </Flex>
-  );
-});
-EmptyStateEditMode.displayName = 'EmptyStateEditMode';
 
 const useAddFormElementDnd = (
   type: Exclude<FormElement['type'], 'node-field'>,

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/dnd-hooks.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/dnd-hooks.ts
@@ -200,12 +200,12 @@ export const useBuilderDndMonitor = () => {
               log.error(parseify({ target, source }), 'Expected target to be a container');
               return;
             }
-            sourceElement.parentId = targetElement.id;
             dispatchAndFlash(
               formElementAdded({
                 element: sourceElement,
-                initialValue: getInitialValue(sourceElement),
+                parentId: targetElement.id,
                 index: 0,
+                initialValue: getInitialValue(sourceElement),
               }),
               sourceElement.id
             );
@@ -224,10 +224,10 @@ export const useBuilderDndMonitor = () => {
               closestEdgeOfTarget,
               axis: parent.data.layout === 'row' ? 'horizontal' : 'vertical',
             });
-            sourceElement.parentId = parent.id;
             dispatchAndFlash(
               formElementAdded({
                 element: sourceElement,
+                parentId: parent.id,
                 index,
                 initialValue: getInitialValue(sourceElement),
               }),

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/dnd-hooks.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/dnd-hooks.ts
@@ -38,7 +38,7 @@ import type { FieldIdentifier, FieldInputTemplate, StatefulFieldValue } from 'fe
 import type { ElementId, FormElement } from 'features/nodes/types/workflow';
 import { buildNodeFieldElement, isContainerElement } from 'features/nodes/types/workflow';
 import type { RefObject } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
 import type { Param0 } from 'tsafe';
 
@@ -450,4 +450,15 @@ export const useNodeFieldDnd = (
   }, [dragHandleRef, draggableRef, fieldIdentifier, fieldTemplate]);
 
   return isDragging;
+};
+
+/**
+ * Hook that returns whether an element is the root element.
+ * @param elementId The id of the element
+ * @returns Whether the element is the root element
+ */
+export const useIsRootElement = (elementId: string) => {
+  const rootElementId = useAppSelector(selectFormRootElementId);
+  const isRootElement = useMemo(() => rootElementId === elementId, [rootElementId, elementId]);
+  return isRootElement;
 };

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.test.ts
@@ -1,0 +1,759 @@
+import { deepClone } from 'common/util/deepClone';
+import {
+  addElement,
+  elementExists,
+  getAllowedDropRegions,
+  getElement,
+  removeElement,
+  reparentElement,
+} from 'features/nodes/components/sidePanel/builder/form-manipulation';
+import type { ContainerElement } from 'features/nodes/types/workflow';
+import {
+  buildContainer,
+  buildText,
+  getDefaultForm,
+  isContainerElement,
+  isNodeFieldElement,
+} from 'features/nodes/types/workflow';
+import type { Equals } from 'tsafe';
+import { assert, AssertionError } from 'tsafe';
+import { describe, expect, it } from 'vitest';
+
+describe('workflow builder form manipulation', () => {
+  describe('elementExists', () => {
+    const form = getDefaultForm();
+
+    it('should return true if the element exists', () => {
+      expect(elementExists(form, form.rootElementId)).toBe(true);
+    });
+
+    it('should return false if the element does not exist', () => {
+      expect(elementExists(form, 'non-existent-id')).toBe(false);
+    });
+  });
+
+  describe('getElement', () => {
+    const form = getDefaultForm();
+
+    it('should return the element with the given ID', () => {
+      const element = getElement(form, form.rootElementId);
+      expect(element).toBe(form.elements[form.rootElementId]);
+    });
+
+    it('should return raise if the element does not exist', () => {
+      expect(() => getElement(form, 'non-existent-id')).toThrow(AssertionError);
+    });
+
+    it('should raise if a type guard is provided and the element does not match', () => {
+      expect(() => getElement(form, form.rootElementId, isNodeFieldElement)).toThrow(AssertionError);
+    });
+
+    it('should narrow the type of the element if a type guard is provided and the element matches', () => {
+      const element = getElement(form, form.rootElementId, isContainerElement);
+      assert<Equals<typeof element, ContainerElement>>();
+    });
+  });
+
+  describe('addElement', () => {
+    it('should add the element to the form', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(getElement(form, el.id)).toBe(el);
+    });
+
+    it('should add the element to the specified parent', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(getElement(form, el.id, isContainerElement).parentId).toBe(form.rootElementId);
+    });
+
+    it('should add the element at the given index', () => {
+      const form = getDefaultForm();
+
+      const el1 = buildText('foo');
+      addElement({
+        form,
+        element: el1,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(getElement(form, form.rootElementId, isContainerElement).data.children[0]).toBe(el1.id);
+
+      const el2 = buildText('foo');
+      addElement({
+        form,
+        element: el2,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(getElement(form, form.rootElementId, isContainerElement).data.children[0]).toBe(el2.id);
+      expect(getElement(form, form.rootElementId, isContainerElement).data.children[1]).toBe(el1.id);
+    });
+
+    it('should return true if the element was added', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+
+      expect(
+        addElement({
+          form,
+          element: el,
+          parentId: form.rootElementId,
+          index: 0,
+        })
+      ).toBe(true);
+    });
+
+    it('should noop and return false if the element already exists', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      const prevForm = deepClone(form);
+
+      expect(
+        addElement({
+          form,
+          element: el,
+          parentId: form.rootElementId,
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it('should noop and return false if the parent does not exist or is not a container', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+
+      const prevForm = deepClone(form);
+
+      expect(
+        addElement({
+          form,
+          element: el,
+          parentId: 'non-existent-id',
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+  });
+
+  describe('removeElement', () => {
+    it('should remove the element from the form', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(elementExists(form, el.id)).toBe(true);
+
+      expect(removeElement({ form, id: el.id })).toBe(true);
+      expect(elementExists(form, el.id)).toBe(false);
+    });
+
+    it('should remove the element from its parent if it has a parent', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(getElement(form, form.rootElementId, isContainerElement).data.children[0]).toBe(el.id);
+
+      removeElement({ form, id: el.id });
+
+      expect(getElement(form, form.rootElementId, isContainerElement).data.children).toEqual([]);
+    });
+
+    it('should recursively remove the element and its children', () => {
+      const form = getDefaultForm();
+
+      const el1 = buildContainer('row', []);
+      addElement({
+        form,
+        element: el1,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      const el2 = buildContainer('row', []);
+      addElement({
+        form,
+        element: el2,
+        parentId: el1.id,
+        index: 0,
+      });
+
+      const el3 = buildText('foo');
+      addElement({
+        form,
+        element: el3,
+        parentId: el2.id,
+        index: 0,
+      });
+
+      expect(elementExists(form, el1.id)).toBe(true);
+      expect(elementExists(form, el2.id)).toBe(true);
+      expect(elementExists(form, el3.id)).toBe(true);
+
+      removeElement({ form, id: el1.id });
+
+      expect(elementExists(form, el1.id)).toBe(false);
+      expect(elementExists(form, el2.id)).toBe(false);
+      expect(elementExists(form, el3.id)).toBe(false);
+    });
+
+    it('should return true if the element was removed', () => {
+      const form = getDefaultForm();
+
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      expect(removeElement({ form, id: el.id })).toBe(true);
+    });
+
+    it('should noop and return false if the element does not exist', () => {
+      const form = getDefaultForm();
+
+      const prevForm = deepClone(form);
+
+      expect(removeElement({ form, id: 'non-existent-id' })).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it('should noop and return false if the element is the root element', () => {
+      const form = getDefaultForm();
+
+      const prevForm = deepClone(form);
+
+      expect(removeElement({ form, id: form.rootElementId })).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it("should noop and return false if the element's parent does not exist", () => {
+      const form = getDefaultForm();
+
+      const el = buildContainer('row', []);
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+
+      el.parentId = 'non-existent-id';
+
+      const prevForm = deepClone(form);
+
+      expect(removeElement({ form, id: el.id })).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+  });
+
+  describe('getAllowedDropRegions', () => {
+    it("should return only ['center'] if the target is the root container element and is empty", () => {
+      const form = getDefaultForm();
+      const rootElement = getElement(form, form.rootElementId);
+      expect(getAllowedDropRegions(form, rootElement)).toEqual(['center']);
+    });
+
+    it("should return ['center', 'left' and 'right'] if the target is an empty non-root container and its parent has a row layout", () => {
+      const form = getDefaultForm();
+      const container = buildContainer('row', []);
+      addElement({
+        form,
+        element: container,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildContainer('row', []);
+      addElement({
+        form,
+        element: el,
+        parentId: container.id,
+        index: 0,
+      });
+      expect(getAllowedDropRegions(form, el)).toEqual(['center', 'left', 'right']);
+    });
+
+    it("should return ['center', 'top' and 'bottom'] if the target is an empty non-root container and its parent has a column layout", () => {
+      const form = getDefaultForm();
+      const container = buildContainer('column', []);
+      addElement({
+        form,
+        element: container,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildContainer('row', []);
+      addElement({
+        form,
+        element: el,
+        parentId: container.id,
+        index: 0,
+      });
+      expect(getAllowedDropRegions(form, el)).toEqual(['center', 'top', 'bottom']);
+    });
+
+    it('should return [] when the target is a container with no parent (i.e. it is the root)', () => {
+      const form = getDefaultForm();
+      const el = buildContainer('row', []);
+      addElement({
+        form,
+        element: el,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      expect(getAllowedDropRegions(form, getElement(form, form.rootElementId))).toEqual([]);
+    });
+
+    it("should return ['left', 'right'] when the target's parent has a row layout", () => {
+      const form = getDefaultForm();
+      const parent = buildContainer('row', []);
+      addElement({
+        form,
+        element: parent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildContainer('row', []);
+      addElement({
+        form,
+        element: el,
+        parentId: parent.id,
+        index: 0,
+      });
+      const child = buildText('foo');
+      addElement({
+        form,
+        element: child,
+        parentId: el.id,
+        index: 0,
+      });
+      expect(getAllowedDropRegions(form, el)).toEqual(['left', 'right']);
+    });
+
+    it("should return ['top', 'bottom'] when the target's parent has a column layout", () => {
+      const form = getDefaultForm();
+      const parent = buildContainer('column', []);
+      addElement({
+        form,
+        element: parent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildContainer('column', []);
+      addElement({
+        form,
+        element: el,
+        parentId: parent.id,
+        index: 0,
+      });
+      const child = buildText('foo');
+      addElement({
+        form,
+        element: child,
+        parentId: el.id,
+        index: 0,
+      });
+      expect(getAllowedDropRegions(form, el)).toEqual(['top', 'bottom']);
+    });
+  });
+
+  describe('reparentElement', () => {
+    it('should move the element to the new parent (removing it from the old parent)', () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const newParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: newParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+
+      reparentElement({
+        form,
+        id: el.id,
+        newParentId: newParent.id,
+        index: 0,
+      });
+
+      expect(getElement(form, el.id).parentId).toBe(newParent.id);
+      expect(getElement(form, newParent.id, isContainerElement).data.children.length).toBe(1);
+      expect(getElement(form, newParent.id, isContainerElement).data.children[0]).toBe(el.id);
+      expect(getElement(form, oldParent.id, isContainerElement).data.children).toEqual([]);
+    });
+    it('should insert the element at the specified index in the new parent', () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const newParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: newParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      addElement({
+        form,
+        element: buildText('bar'),
+        parentId: newParent.id,
+        index: 0,
+      });
+      addElement({
+        form,
+        element: buildText('baz'),
+        parentId: newParent.id,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+
+      reparentElement({
+        form,
+        id: el.id,
+        newParentId: newParent.id,
+        index: 1,
+      });
+
+      expect(getElement(form, el.id).parentId).toBe(newParent.id);
+      expect(getElement(form, newParent.id, isContainerElement).data.children.length).toBe(3);
+      expect(getElement(form, newParent.id, isContainerElement).data.children[1]).toBe(el.id);
+      expect(getElement(form, oldParent.id, isContainerElement).data.children).toEqual([]);
+    });
+
+    it('should return true if the element was reparented', () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const newParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: newParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: newParent.id,
+          index: 0,
+        })
+      ).toBe(true);
+    });
+
+    it('should noop and return true if the new parent is the old parent', () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: oldParent.id,
+          index: 0,
+        })
+      ).toBe(true);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it('should noop and return false if the element does not exist', () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const newParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: newParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: newParent.id,
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it('should noop and return false if the is the root', () => {
+      const form = getDefaultForm();
+      const rootElement = getElement(form, form.rootElementId);
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: rootElement.id,
+          newParentId: 'non-existent-id',
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it("should noop and return false if the old parent doesn't exist", () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+      el.parentId = 'non-existent-id';
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: oldParent.id,
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it("should noop and return false if the old parent isn't a container", () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const notAContainer = buildText('foo');
+      addElement({
+        form,
+        element: notAContainer,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const newParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: newParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+      el.parentId = notAContainer.id;
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: newParent.id,
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it("should noop and return false if the new parent doesn't exist", () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: 'non-existent-id',
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+
+    it("should noop and return false if the old parent isn't a container", () => {
+      const form = getDefaultForm();
+      const oldParent = buildContainer('row', []);
+      addElement({
+        form,
+        element: oldParent,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const notAContainer = buildText('foo');
+      addElement({
+        form,
+        element: notAContainer,
+        parentId: form.rootElementId,
+        index: 0,
+      });
+      const el = buildText('foo');
+      addElement({
+        form,
+        element: el,
+        parentId: oldParent.id,
+        index: 0,
+      });
+
+      const prevForm = deepClone(form);
+
+      expect(
+        reparentElement({
+          form,
+          id: el.id,
+          newParentId: notAContainer.id,
+          index: 0,
+        })
+      ).toBe(false);
+
+      expect(form).toEqual(prevForm);
+    });
+  });
+});

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.test.ts
@@ -80,7 +80,7 @@ describe('workflow builder form manipulation', () => {
         index: 0,
       });
 
-      expect(getElement(form, el.id, isContainerElement).parentId).toBe(form.rootElementId);
+      expect(getElement(form, el.id).parentId).toBe(form.rootElementId);
     });
 
     it('should add the element at the given index', () => {

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.ts
@@ -1,0 +1,241 @@
+import type { CenterOrEdge } from 'features/nodes/components/sidePanel/builder/center-or-closest-edge';
+import type { NodesState } from 'features/nodes/store/types';
+import type { StatefulFieldValue } from 'features/nodes/types/field';
+import { isInvocationNode } from 'features/nodes/types/invocation';
+import type { BuilderForm, ElementId, FormElement } from 'features/nodes/types/workflow';
+import { isContainerElement, isNodeFieldElement } from 'features/nodes/types/workflow';
+import { assert } from 'tsafe';
+/**
+ * Removes an element from the form.
+ * The element is removed from its parent. If the element is a container, its children are also recursively removed.
+ * The form is mutated in place.
+ *
+ * @param args.form The form to remove the element from
+ * @param args.id The ID of the element to remove
+ *
+ * @returns True if the element was removed, false otherwise
+ */
+export const removeElement = (args: { form: BuilderForm; id: string }): boolean => {
+  const { id, form } = args;
+
+  const element = form.elements[id];
+
+  // Bail if the element doesn't exist
+  if (!element) {
+    return false;
+  }
+
+  if (form.rootElementId === id || !element.parentId) {
+    // Can't remove the root element
+    return false;
+  }
+
+  const parent = form.elements[element.parentId];
+  if (!parent || !isContainerElement(parent)) {
+    // This should never happen!
+    return false;
+  }
+
+  // Recursively remove children if the element is a container
+  // TODO(psyche): Handle/guard against circular references?
+  if (isContainerElement(element)) {
+    for (const childId of [...element.data.children]) {
+      removeElement({ form, id: childId });
+    }
+  }
+
+  delete form.elements[id];
+  parent.data.children = parent.data.children.filter((childId) => childId !== id);
+
+  return true;
+};
+
+/**
+ * Reparents an element in the form.
+ * The element is removed from its parent and inserted at the given index in the new parent.
+ * The form is mutated in place.
+ *
+ * @param args.form The form to reparent the element in
+ * @param args.id The ID of the element to reparent
+ * @param args.newParentId The ID of the new parent element
+ * @param args.index The index to insert the element at in the new parent
+ *
+ * @returns True if the element was reparented, false otherwise
+ */
+export const reparentElement = (args: {
+  form: BuilderForm;
+  id: string;
+  newParentId: string;
+  index: number;
+}): boolean => {
+  const { form, id, newParentId, index } = args;
+  const { elements } = form;
+
+  const element = elements[id];
+
+  // Bail if the element doesn't exist
+  if (!element) {
+    return false;
+  }
+
+  if (!element.parentId) {
+    // Can't reparent the root element
+    return false;
+  }
+
+  if (newParentId === element.parentId) {
+    // Nothing to do
+    return false;
+  }
+
+  const oldParent = elements[element.parentId];
+  if (!oldParent || !isContainerElement(oldParent)) {
+    // This should never happen
+    return false;
+  }
+
+  const newParent = elements[newParentId];
+  if (!newParent || !isContainerElement(newParent)) {
+    return false;
+  }
+
+  newParent.data.children.splice(index, 0, id);
+  oldParent.data.children = oldParent.data.children.filter((elementId) => elementId !== id);
+  element.parentId = newParentId;
+  return true;
+};
+
+/**
+ * Adds an element to the form.
+ * The element is added as a child of the given parent at the given index.
+ * The form is mutated in place.
+ *
+ * @param args.form The form to add the element to
+ * @param args.element The element to add
+ * @param args.index The index to insert the element at in the parent
+ *
+ * @returns True if the element was added, false otherwise
+ */
+export const addElement = (args: { form: BuilderForm; element: FormElement; index: number }): boolean => {
+  const { form, element, index } = args;
+  const { elements } = form;
+
+  if (!element.parentId) {
+    // We cannot add a root element
+    return false;
+  }
+
+  const parent = elements[element.parentId];
+  if (!parent || !isContainerElement(parent)) {
+    return false;
+  }
+
+  elements[element.id] = element;
+  parent.data.children.splice(index, 0, element.id);
+  return true;
+};
+
+/**
+ * Checks if an element exists in the form.
+ *
+ * @param form The form to check
+ * @param elementId The id of the element to check
+ *
+ * @returns True if the element exists, false otherwise
+ */
+export const elementExists = (form: BuilderForm, elementId: ElementId): boolean => {
+  return form.elements[elementId] !== undefined;
+};
+
+export type FormElementTypeGuard<T extends FormElement> = (element: FormElement) => element is T;
+
+/**
+ * Gets an element from the form.
+ *
+ * @param form The form to get the element from
+ * @param elementId The id of the element to get
+ * @param guard An optional guard to ensure the element is of the correct type
+ *
+ * @returns The element
+ *
+ * @raises If the element does not exist or the guard is provided and fails
+ */
+export const getElement = <T extends FormElement>(
+  form: BuilderForm,
+  elementId: ElementId,
+  guard?: FormElementTypeGuard<T>
+): T => {
+  const el = form.elements[elementId];
+  assert(el);
+  if (guard) {
+    assert(guard(el));
+    return el;
+  } else {
+    return el as T;
+  }
+};
+
+/**
+ * Gets the initial value of a node field element.
+ *
+ * @param nodes The nodes state to get the initial value from
+ * @param element The element to get the initial value for
+ *
+ * @returns The initial value of the element, if it exists
+ */
+export const getInitialValue = (nodes: NodesState['nodes'], element: FormElement): StatefulFieldValue => {
+  if (!isNodeFieldElement(element)) {
+    return undefined;
+  }
+  const { nodeId, fieldName } = element.data.fieldIdentifier;
+  const node = nodes.find((n) => n.id === nodeId);
+
+  // The node or input not existing as we add it to the builder indicates something is wrong, but we don't want to
+  // throw an error here as it could break the builder. Can we handle this better?
+  if (!node) {
+    return undefined;
+  }
+  if (!isInvocationNode(node)) {
+    return undefined;
+  }
+  const input = node.data.inputs[fieldName];
+  if (!input) {
+    return undefined;
+  }
+  return input.value;
+};
+
+/**
+ * Gets the allowed drop regions for an form element drop target.
+ *
+ * Containers without children have only one allowed drop region, 'center'. This indicates the element will be added
+ * as the first child of the container.
+ *
+ * In all other cases, elements can be dropped to the 'left' and 'right, or 'top' and 'bottom' edges of the target
+ * element. This indicates the element will be inserted in the target's parent container before or after the target.
+ *
+ * @param form The form
+ * @param element The element to get allowed drop regions for
+ *
+ * @returns The allowed drop regions
+ */
+export const getAllowedDropRegions = (form: BuilderForm, element: FormElement): CenterOrEdge[] => {
+  const dropRegions: CenterOrEdge[] = [];
+
+  if (isContainerElement(element) && element.data.children.length === 0) {
+    dropRegions.push('center');
+  }
+
+  // Parent is a container
+  if (element.parentId !== undefined) {
+    const parentContainer = getElement(form, element.parentId, isContainerElement);
+    if (parentContainer.data.layout === 'row') {
+      dropRegions.push('left', 'right');
+    } else {
+      // parentContainer.data.layout === 'column'
+      dropRegions.push('top', 'bottom');
+    }
+  }
+
+  return dropRegions;
+};

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.ts
@@ -125,6 +125,11 @@ export const addElement = (args: {
   const { form, element, parentId, index } = args;
   const { elements } = form;
 
+  if (element.id in elements) {
+    // Element already exists
+    return false;
+  }
+
   const parent = elements[parentId];
   if (!parent || !isContainerElement(parent)) {
     return false;

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/form-manipulation.ts
@@ -78,14 +78,14 @@ export const reparentElement = (args: {
     return false;
   }
 
-  if (!element.parentId) {
+  if (form.rootElementId === element.id || !element.parentId) {
     // Can't reparent the root element
     return false;
   }
 
   if (newParentId === element.parentId) {
-    // Nothing to do
-    return false;
+    // Nothing to do if the element is already a child of the new parent
+    return true;
   }
 
   const oldParent = elements[element.parentId];
@@ -116,20 +116,21 @@ export const reparentElement = (args: {
  *
  * @returns True if the element was added, false otherwise
  */
-export const addElement = (args: { form: BuilderForm; element: FormElement; index: number }): boolean => {
-  const { form, element, index } = args;
+export const addElement = (args: {
+  form: BuilderForm;
+  element: FormElement;
+  parentId: string;
+  index: number;
+}): boolean => {
+  const { form, element, parentId, index } = args;
   const { elements } = form;
 
-  if (!element.parentId) {
-    // We cannot add a root element
-    return false;
-  }
-
-  const parent = elements[element.parentId];
+  const parent = elements[parentId];
   if (!parent || !isContainerElement(parent)) {
     return false;
   }
 
+  element.parentId = parentId;
   elements[element.id] = element;
   parent.data.children.splice(index, 0, element.id);
   return true;

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/shared.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/shared.ts
@@ -1,5 +1,14 @@
+import { useAppSelector } from 'app/store/storeHooks';
 import { getPrefixedId } from 'features/controlLayers/konva/util';
+import { selectFormRootElementId } from 'features/nodes/store/workflowSlice';
+import { useMemo } from 'react';
 
 export const EDIT_MODE_WRAPPER_CLASS_NAME = getPrefixedId('edit-mode-wrapper', '-');
 
 export const getEditModeWrapperId = (id: string) => `${id}-edit-mode-wrapper`;
+
+export const useIsRootElement = (id: string) => {
+  const rootElementId = useAppSelector(selectFormRootElementId);
+  const isRootElement = useMemo(() => rootElementId === id, [rootElementId, id]);
+  return isRootElement;
+};

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/shared.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/shared.ts
@@ -1,14 +1,2 @@
-import { useAppSelector } from 'app/store/storeHooks';
-import { getPrefixedId } from 'features/controlLayers/konva/util';
-import { selectFormRootElementId } from 'features/nodes/store/workflowSlice';
-import { useMemo } from 'react';
-
-export const EDIT_MODE_WRAPPER_CLASS_NAME = getPrefixedId('edit-mode-wrapper', '-');
-
+// This must be in this file to avoid circular dependencies
 export const getEditModeWrapperId = (id: string) => `${id}-edit-mode-wrapper`;
-
-export const useIsRootElement = (id: string) => {
-  const rootElementId = useAppSelector(selectFormRootElementId);
-  const isRootElement = useMemo(() => rootElementId === id, [rootElementId, id]);
-  return isRootElement;
-};

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/viewMode/ViewModeLeftPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/viewMode/ViewModeLeftPanelContent.tsx
@@ -2,9 +2,9 @@ import { Box, Flex } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
-import { FormLayout } from 'features/nodes/components/sidePanel/builder/WorkflowBuilder';
+import { FormElementComponent } from 'features/nodes/components/sidePanel/builder/ContainerElementComponent';
 import { ViewContextProvider } from 'features/nodes/contexts/ViewContext';
-import { selectFormIsEmpty } from 'features/nodes/store/workflowSlice';
+import { selectFormRootElementId } from 'features/nodes/store/workflowSlice';
 import { t } from 'i18next';
 import { memo } from 'react';
 import { useGetOpenAPISchemaQuery } from 'services/api/endpoints/appInfo';
@@ -30,16 +30,16 @@ ViewModeLeftPanelContent.displayName = 'ViewModeLeftPanelContent';
 
 const ViewModeLeftPanelContentInner = memo(() => {
   const { isLoading } = useGetOpenAPISchemaQuery();
-  const isEmpty = useAppSelector(selectFormIsEmpty);
+  const rootElementId = useAppSelector(selectFormRootElementId);
 
   if (isLoading) {
     return <IAINoContentFallback label={t('nodes.loadingNodes')} icon={null} />;
   }
 
-  if (isEmpty) {
+  if (!rootElementId) {
     return <EmptyState />;
   }
 
-  return <FormLayout />;
+  return <FormElementComponent id={rootElementId} />;
 });
 ViewModeLeftPanelContentInner.displayName = ' ViewModeLeftPanelContentInner';

--- a/invokeai/frontend/web/src/features/nodes/store/reactFlowInstance.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/reactFlowInstance.ts
@@ -3,4 +3,4 @@ import type { AnyEdge, AnyNode } from 'features/nodes/types/invocation';
 import { atom } from 'nanostores';
 
 export const $flow = atom<ReactFlowInstance<AnyNode, AnyEdge> | null>(null);
-export const $needsFit = atom<boolean>(true);
+export const $needsFit = atom<boolean>(false);

--- a/invokeai/frontend/web/src/features/nodes/store/workflowSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/workflowSlice.ts
@@ -164,15 +164,16 @@ export const workflowSlice = createSlice({
       state,
       action: PayloadAction<{
         element: FormElement;
+        parentId: ElementId;
         index: number;
         initialValue?: StatefulFieldValue;
       }>
     ) => {
       const { form } = state;
-      const { element, index } = action.payload;
-      addElement({ form, element, index });
+      const { element, parentId, index, initialValue } = action.payload;
+      addElement({ form, element, parentId, index });
       if (isNodeFieldElement(element)) {
-        state.formFieldInitialValues[element.id] = action.payload.initialValue;
+        state.formFieldInitialValues[element.id] = initialValue;
       }
     },
     formElementRemoved: (state, action: PayloadAction<{ id: string }>) => {

--- a/invokeai/frontend/web/src/features/nodes/types/constants.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/constants.ts
@@ -24,27 +24,6 @@ export const SHARED_NODE_PROPERTIES: Partial<AnyNode> = {
 };
 
 /**
- * Model types' handles are rendered as squares in the UI.
- */
-export const MODEL_TYPES = [
-  'IPAdapterModelField',
-  'ControlNetModelField',
-  'LoRAModelField',
-  'MainModelField',
-  'FluxMainModelField',
-  'SD3MainModelField',
-  'SDXLMainModelField',
-  'SDXLRefinerModelField',
-  'VaeModelField',
-  'UNetField',
-  'VAEField',
-  'CLIPField',
-  'T2IAdapterModelField',
-  'T5EncoderField',
-  'SpandrelImageToImageModelField',
-];
-
-/**
  * Colors for each field type - applies to their handles and edges.
  */
 export const FIELD_COLORS: { [key: string]: string } = {

--- a/invokeai/frontend/web/src/features/nodes/types/field.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/field.ts
@@ -278,6 +278,38 @@ export const isStatefulFieldType = (fieldType: FieldType): fieldType is Stateful
 const zFieldType = z.union([zStatefulFieldType, zStatelessFieldType]);
 export type FieldType = z.infer<typeof zFieldType>;
 
+const modelFieldTypeNames = [
+  // Stateful model fields
+  zModelIdentifierFieldType.shape.name.value,
+  zMainModelFieldType.shape.name.value,
+  zSDXLMainModelFieldType.shape.name.value,
+  zSD3MainModelFieldType.shape.name.value,
+  zFluxMainModelFieldType.shape.name.value,
+  zSDXLRefinerModelFieldType.shape.name.value,
+  zVAEModelFieldType.shape.name.value,
+  zLoRAModelFieldType.shape.name.value,
+  zControlNetModelFieldType.shape.name.value,
+  zIPAdapterModelFieldType.shape.name.value,
+  zT2IAdapterModelFieldType.shape.name.value,
+  zSpandrelImageToImageModelFieldType.shape.name.value,
+  zT5EncoderModelFieldType.shape.name.value,
+  zCLIPEmbedModelFieldType.shape.name.value,
+  zCLIPLEmbedModelFieldType.shape.name.value,
+  zCLIPGEmbedModelFieldType.shape.name.value,
+  zControlLoRAModelFieldType.shape.name.value,
+  zFluxVAEModelFieldType.shape.name.value,
+  // Stateless model fields
+  'UNetField',
+  'VAEField',
+  'CLIPField',
+  'T5EncoderField',
+  'TransformerField',
+  'ControlLoRAField',
+];
+export const isModelFieldType = (fieldType: FieldType) => {
+  return (modelFieldTypeNames as string[]).includes(fieldType.name);
+};
+
 export const isSingle = (fieldType: FieldType): boolean => fieldType.cardinality === zCardinality.enum.SINGLE;
 export const isCollection = (fieldType: FieldType): boolean => fieldType.cardinality === zCardinality.enum.COLLECTION;
 export const isSingleOrCollection = (fieldType: FieldType): boolean =>

--- a/invokeai/frontend/web/src/features/nodes/types/workflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/workflow.ts
@@ -57,34 +57,6 @@ const zWorkflowEdgeCollapsed = zWorkflowEdgeBase.extend({
 const zWorkflowEdge = z.union([zWorkflowEdgeDefault, zWorkflowEdgeCollapsed]);
 // #endregion
 
-// #region Workflow
-export const zWorkflowV3 = z.object({
-  id: z.string().min(1).optional(),
-  name: z.string(),
-  author: z.string(),
-  description: z.string(),
-  version: z.string(),
-  contact: z.string(),
-  tags: z.string(),
-  notes: z.string(),
-  nodes: z.array(zWorkflowNode),
-  edges: z.array(zWorkflowEdge),
-  exposedFields: z.array(zFieldIdentifier),
-  meta: z.object({
-    category: zWorkflowCategory.default('user'),
-    version: z.literal('3.0.0'),
-  }),
-  form: z
-    .object({
-      elements: z.record(z.lazy(() => zFormElement)),
-      layout: z.array(z.lazy(() => zElementId)),
-    })
-    // Catch must be a function else changes to the workflows parsed with this schema will mutate the catch value D:
-    .catch(() => ({ elements: {}, layout: [] })),
-});
-export type WorkflowV3 = z.infer<typeof zWorkflowV3>;
-// #endregion
-
 // #region Workflow Builder
 const zElementId = z.string().trim().min(1);
 export type ElementId = z.infer<typeof zElementId>;
@@ -257,3 +229,44 @@ export const buildContainer = (
 const zFormElement = z.union([zContainerElement, zNodeFieldElement, zHeadingElement, zTextElement, zDividerElement]);
 
 export type FormElement = z.infer<typeof zFormElement>;
+
+export const getDefaultForm = () => {
+  const rootElement = buildContainer('column', []);
+  return {
+    elements: {
+      [rootElement.id]: rootElement,
+    },
+    rootElementId: rootElement.id,
+  };
+};
+
+const zBuilderForm = z
+  .object({
+    elements: z.record(zFormElement),
+    rootElementId: zElementId,
+  })
+  .default(getDefaultForm);
+export type BuilderForm = z.infer<typeof zBuilderForm>;
+//# endregion
+
+// #region Workflow
+export const zWorkflowV3 = z.object({
+  id: z.string().min(1).optional(),
+  name: z.string(),
+  author: z.string(),
+  description: z.string(),
+  version: z.string(),
+  contact: z.string(),
+  tags: z.string(),
+  notes: z.string(),
+  nodes: z.array(zWorkflowNode),
+  edges: z.array(zWorkflowEdge),
+  exposedFields: z.array(zFieldIdentifier),
+  meta: z.object({
+    category: zWorkflowCategory.default('user'),
+    version: z.literal('3.0.0'),
+  }),
+  form: zBuilderForm,
+});
+export type WorkflowV3 = z.infer<typeof zWorkflowV3>;
+// #endregion

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
@@ -4,6 +4,7 @@ import { $templates } from 'features/nodes/store/nodesSlice';
 import { NODE_WIDTH } from 'features/nodes/types/constants';
 import type { FieldInputInstance } from 'features/nodes/types/field';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
+import { getDefaultForm } from 'features/nodes/types/workflow';
 import { buildFieldInputInstance } from 'features/nodes/util/schema/buildFieldInputInstance';
 import { forEach } from 'lodash-es';
 import type { NonNullableGraph } from 'services/api/types';
@@ -37,10 +38,7 @@ export const graphToWorkflow = (graph: NonNullableGraph, autoLayout = true): Wor
     exposedFields: [],
     edges: [],
     nodes: [],
-    form: {
-      elements: {},
-      layout: [],
-    },
+    form: getDefaultForm(),
   };
 
   // Convert nodes

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
@@ -1,9 +1,11 @@
 import { img_resize, main_model_loader } from 'features/nodes/store/util/testUtils';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
+import { getDefaultForm } from 'features/nodes/types/workflow';
 import { validateWorkflow } from 'features/nodes/util/workflow/validateWorkflow';
 import { get } from 'lodash-es';
 import { describe, expect, it } from 'vitest';
 
+//TODO(psyche): Test workflow validation for form builder fields
 describe('validateWorkflow', () => {
   const workflow: WorkflowV3 = {
     name: '',
@@ -14,10 +16,7 @@ describe('validateWorkflow', () => {
     tags: '',
     notes: '',
     exposedFields: [],
-    form: {
-      elements: {},
-      layout: [],
-    },
+    form: getDefaultForm(),
     meta: { version: '3.0.0', category: 'user' },
     nodes: [
       {

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
@@ -95,35 +95,35 @@ describe('validateWorkflow', () => {
       resolve(false);
     });
   it('should reset images that are inaccessible', async () => {
-    const validationResult = await validateWorkflow(
+    const validationResult = await validateWorkflow({
       workflow,
-      { img_resize, main_model_loader },
-      resolveFalse,
-      resolveTrue,
-      resolveTrue
-    );
+      templates: { img_resize, main_model_loader },
+      checkImageAccess: resolveFalse,
+      checkBoardAccess: resolveTrue,
+      checkModelAccess: resolveTrue,
+    });
     expect(validationResult.warnings.length).toBe(1);
     expect(get(validationResult, 'workflow.nodes[1].data.inputs.image.value')).toBeUndefined();
   });
   it('should reset boards that are inaccessible', async () => {
-    const validationResult = await validateWorkflow(
+    const validationResult = await validateWorkflow({
       workflow,
-      { img_resize, main_model_loader },
-      resolveTrue,
-      resolveFalse,
-      resolveTrue
-    );
+      templates: { img_resize, main_model_loader },
+      checkImageAccess: resolveTrue,
+      checkBoardAccess: resolveFalse,
+      checkModelAccess: resolveTrue,
+    });
     expect(validationResult.warnings.length).toBe(1);
     expect(get(validationResult, 'workflow.nodes[1].data.inputs.board.value')).toBeUndefined();
   });
   it('should reset models that are inaccessible', async () => {
-    const validationResult = await validateWorkflow(
+    const validationResult = await validateWorkflow({
       workflow,
-      { img_resize, main_model_loader },
-      resolveTrue,
-      resolveTrue,
-      resolveFalse
-    );
+      templates: { img_resize, main_model_loader },
+      checkImageAccess: resolveTrue,
+      checkBoardAccess: resolveTrue,
+      checkModelAccess: resolveFalse,
+    });
     expect(validationResult.warnings.length).toBe(1);
     expect(get(validationResult, 'workflow.nodes[0].data.inputs.model.value')).toBeUndefined();
   });

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -26,6 +26,14 @@ type WorkflowWarning = {
   data: JsonObject;
 };
 
+type ValidateWorkflowArgs = {
+  workflow: unknown;
+  templates: Templates;
+  checkImageAccess: (name: string) => Promise<boolean>;
+  checkBoardAccess: (id: string) => Promise<boolean>;
+  checkModelAccess: (key: string) => Promise<boolean>;
+};
+
 type ValidateWorkflowResult = {
   workflow: WorkflowV3;
   warnings: WorkflowWarning[];
@@ -37,18 +45,11 @@ type ValidateWorkflowResult = {
  * - Validates the workflow against the node templates, warning if the template is not known.
  * - Attempts to update nodes which have a mismatched version.
  * - Removes edges which are invalid.
- * @param workflow The raw workflow object (e.g. JSON.parse(stringifiedWorkflow))
- * @param templates The node templates to validate against.
- * @throws {WorkflowVersionError} If the workflow version is not recognized.
+ * - Reset image, board and model fields which are not accessible
  * @throws {z.ZodError} If there is a validation error.
  */
-export const validateWorkflow = async (
-  workflow: unknown,
-  templates: Templates,
-  checkImageAccess: (name: string) => Promise<boolean>,
-  checkBoardAccess: (id: string) => Promise<boolean>,
-  checkModelAccess: (key: string) => Promise<boolean>
-): Promise<ValidateWorkflowResult> => {
+export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<ValidateWorkflowResult> => {
+  const { workflow, templates, checkImageAccess, checkBoardAccess, checkModelAccess } = args;
   // Parse the raw workflow data & migrate it to the latest version
   const _workflow = parseAndMigrateWorkflow(workflow);
 


### PR DESCRIPTION
## Summary

I implemented these kinda-unrelated changes as I encountered them and didn't create a separate branch, so they are bundled up here. Some cross-pollination w/ the other changes, not gonna worry about splitting them.

- Fix: Model fields that reference nonexistent models weren't reset during workflow loading.
- Fix: After loading a workflow, the first click in the editor resets the zoom.
- Fix: Node title cursor is 'text' - should be 'grab'.
- Chore: Update `vitest`'s UI related packages, fixing a version mismatch taht prevented the test UI dashboard from loading.

Builder changes.

- Refactor: Use root container instead of non-container list for form root, substantially simplifying internal logic. Only tradeoff is a small amount of special handling needed in the UI for the for the root container (e.g. it cannot be deleted and other elements cannot be dragged outside of it).
    ❗ **This is a breaking change. Workflows saved in the alpha will no longer load, and users who have a WIP form will get a fatal error and need to click Reset Web UI to fix it.** ❗
- Tidy: Organize a lot of builder files.
- Docs: Document the builder utils and hooks. Components still lack comments.
- Feat: When adding an element, the parent id for the new is now required.
- Tests: Add test coverage for form tree manipulation and other utilities. Caught a couple minor issues!


## Related Issues / Discussions

Closes #7648

## QA Instructions

The change to the data structure for the form has indirectly caused a styling issue w/ the form. I will fix this in a followup.

The form root is now a container, so there's one extra box in the edit view. You cannot delete the root. It'll make sense when you try it.

Besides that, the functionality should be the same.

A good chunk of the code changes are to the lock file.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
