### PR TITLE
workflow builder iteration 4

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1722,7 +1722,7 @@
             "nodeFieldTooltip": "To add a node field, click the small plus sign button on the field in the Workflow Editor, or drag the field by its name into the form.",
             "addToForm": "Add to Form",
             "label": "Label",
-            "description": "Description",
+            "showDescription": "Show Description",
             "component": "Component",
             "numberInput": "Number Input",
             "singleLine": "Single Line",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1719,6 +1719,7 @@
             "row": "Row",
             "column": "Column",
             "nodeField": "Node Field",
+            "zoomToNode": "Zoom to Node",
             "nodeFieldTooltip": "To add a node field, click the small plus sign button on the field in the Workflow Editor, or drag the field by its name into the form.",
             "addToForm": "Add to Form",
             "label": "Label",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1725,6 +1725,8 @@
             "description": "Description",
             "component": "Component",
             "numberInput": "Number Input",
+            "singleLine": "Single Line",
+            "multiLine": "Multi Line",
             "slider": "Slider",
             "both": "Both",
             "emptyRootPlaceholderViewMode": "Click Edit to start building a form for this workflow.",

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldEditModeNodes.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldEditModeNodes.tsx
@@ -8,6 +8,7 @@ import { useNodeFieldDnd } from 'features/nodes/components/sidePanel/builder/dnd
 import { useInputFieldIsConnected } from 'features/nodes/hooks/useInputFieldIsConnected';
 import { useInputFieldIsInvalid } from 'features/nodes/hooks/useInputFieldIsInvalid';
 import { useInputFieldTemplate } from 'features/nodes/hooks/useInputFieldTemplate';
+import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { FieldInputTemplate } from 'features/nodes/types/field';
 import { memo, useCallback, useRef, useState } from 'react';
 
@@ -112,7 +113,7 @@ const DirectField = memo(({ nodeId, fieldName, isInvalid, isConnected, fieldTemp
         data-is-dragging={isDragging}
       >
         <Flex gap={1}>
-          <Flex ref={dragHandleRef}>
+          <Flex className={NO_DRAG_CLASS} ref={dragHandleRef}>
             <InputFieldTitle nodeId={nodeId} fieldName={fieldName} isInvalid={isInvalid} isDragging={isDragging} />
           </Flex>
           <Spacer />

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldTitle.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldTitle.tsx
@@ -12,7 +12,7 @@ import { useInputFieldIsConnected } from 'features/nodes/hooks/useInputFieldIsCo
 import { useInputFieldLabel } from 'features/nodes/hooks/useInputFieldLabel';
 import { useInputFieldTemplateTitle } from 'features/nodes/hooks/useInputFieldTemplateTitle';
 import { fieldLabelChanged } from 'features/nodes/store/nodesSlice';
-import { HANDLE_TOOLTIP_OPEN_DELAY, NO_DRAG_CLASS, NO_FIT_ON_DOUBLE_CLICK_CLASS } from 'features/nodes/types/constants';
+import { HANDLE_TOOLTIP_OPEN_DELAY, NO_FIT_ON_DOUBLE_CLICK_CLASS } from 'features/nodes/types/constants';
 import type { MouseEvent } from 'react';
 import { memo, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -88,7 +88,7 @@ export const InputFieldTitle = memo((props: Props) => {
         isDisabled={isDragging}
       >
         <Text
-          className={`${NO_DRAG_CLASS} ${NO_FIT_ON_DOUBLE_CLICK_CLASS}`}
+          className={NO_FIT_ON_DOUBLE_CLICK_CLASS}
           sx={labelSx}
           noOfLines={1}
           data-is-invalid={isInvalid}
@@ -104,7 +104,6 @@ export const InputFieldTitle = memo((props: Props) => {
   return (
     <Input
       ref={inputRef}
-      className={NO_DRAG_CLASS}
       variant="outline"
       {...editable.inputProps}
       _focusVisible={{ borderRadius: 'base', h: 'unset', px: 2 }}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/BooleanFieldInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/BooleanFieldInputComponent.tsx
@@ -1,7 +1,7 @@
 import { Switch } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { fieldBooleanValueChanged } from 'features/nodes/store/nodesSlice';
-import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
+import { NO_DRAG_CLASS, NO_FIT_ON_DOUBLE_CLICK_CLASS } from 'features/nodes/types/constants';
 import type { BooleanFieldInputInstance, BooleanFieldInputTemplate } from 'features/nodes/types/field';
 import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
@@ -28,7 +28,13 @@ const BooleanFieldInputComponent = (
     [dispatch, field.name, nodeId]
   );
 
-  return <Switch className={NO_DRAG_CLASS} onChange={handleValueChanged} isChecked={field.value} />;
+  return (
+    <Switch
+      className={`${NO_DRAG_CLASS} ${NO_FIT_ON_DOUBLE_CLICK_CLASS}`}
+      onChange={handleValueChanged}
+      isChecked={field.value}
+    />
+  );
 };
 
 export default memo(BooleanFieldInputComponent);

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/WorkflowListMenu/ActiveWorkflowNameAndActions.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/WorkflowListMenu/ActiveWorkflowNameAndActions.tsx
@@ -12,7 +12,7 @@ export const ActiveWorkflowNameAndActions = memo(() => {
   const mode = useAppSelector(selectWorkflowMode);
 
   return (
-    <Flex w="full" alignItems="center" gap={2} minW={0}>
+    <Flex w="full" alignItems="center" gap={1} minW={0}>
       <WorkflowListMenuTrigger />
       <Spacer />
       {mode === 'edit' && <SaveWorkflowButton />}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/WorkflowListMenu/WorkflowListMenuTrigger.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/WorkflowListMenu/WorkflowListMenuTrigger.tsx
@@ -1,4 +1,14 @@
-import { Box, Button, Flex, Popover, PopoverBody, PopoverContent, PopoverTrigger, Portal } from '@invoke-ai/ui-library';
+import {
+  Box,
+  Button,
+  Flex,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
+  Text,
+} from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { $workflowCategories } from 'app/store/nanostores/workflowCategories';
 import { useAppSelector } from 'app/store/storeHooks';
@@ -32,8 +42,17 @@ export const WorkflowListMenuTrigger = () => {
       initialFocusRef={searchInputRef}
     >
       <PopoverTrigger>
-        <Button variant="ghost" rightIcon={<PiFolderOpenFill />}>
-          {workflowName || t('workflows.chooseWorkflowFromLibrary')}
+        <Button variant="ghost" rightIcon={<PiFolderOpenFill />} size="sm">
+          <Text
+            display="auto"
+            noOfLines={1}
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            wordBreak="break-all"
+          >
+            {workflowName || t('workflows.chooseWorkflowFromLibrary')}
+          </Text>
         </Button>
       </PopoverTrigger>
       <Portal>

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/ContainerElementSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/ContainerElementSettings.tsx
@@ -32,7 +32,7 @@ export const ContainerElementSettings = memo(({ element }: { element: ContainerE
   }, [dispatch, id]);
 
   return (
-    <Popover isLazy lazyBehavior="unmount">
+    <Popover placement="top" isLazy lazyBehavior="unmount">
       <PopoverTrigger>
         <IconButton aria-label="settings" icon={<PiWrenchFill />} variant="link" size="sm" alignSelf="stretch" />
       </PopoverTrigger>

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
@@ -5,13 +5,12 @@ import { ContainerElementSettings } from 'features/nodes/components/sidePanel/bu
 import { useDepthContext } from 'features/nodes/components/sidePanel/builder/contexts';
 import { NodeFieldElementSettings } from 'features/nodes/components/sidePanel/builder/NodeFieldElementSettings';
 import { formElementRemoved } from 'features/nodes/store/workflowSlice';
-import { type FormElement, isContainerElement, isNodeFieldElement } from 'features/nodes/types/workflow';
+import type { FormElement } from 'features/nodes/types/workflow';
+import { isContainerElement, isNodeFieldElement } from 'features/nodes/types/workflow';
 import { startCase } from 'lodash-es';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiXBold } from 'react-icons/pi';
-
-import { useIsRootElement } from './dnd-hooks';
 
 const sx: SystemStyleObject = {
   w: 'full',
@@ -26,56 +25,62 @@ const sx: SystemStyleObject = {
   '&[data-depth="0"]': { bg: 'baseAlpha.100' },
   '&[data-depth="1"]': { bg: 'baseAlpha.150' },
   '&[data-depth="2"]': { bg: 'baseAlpha.200' },
-  '&[data-is-root="false"]': { cursor: 'grab' },
 };
 
 export const FormElementEditModeHeader = memo(
   forwardRef(({ element }: { element: FormElement }, ref) => {
-    const { t } = useTranslation();
     const depth = useDepthContext();
-    const dispatch = useAppDispatch();
-    const isRootElement = useIsRootElement(element.id);
-    const removeElement = useCallback(() => {
-      if (isRootElement) {
-        return;
-      }
-      dispatch(formElementRemoved({ id: element.id }));
-    }, [dispatch, element.id, isRootElement]);
-    const label = useMemo(() => {
-      if (isRootElement) {
-        return 'Root Container';
-      }
-      if (isContainerElement(element) && element.data.layout === 'column') {
-        return `Container (column layout)`;
-      }
-      if (isContainerElement(element) && element.data.layout === 'row') {
-        return `Container (row layout)`;
-      }
-      return startCase(element.type);
-    }, [element, isRootElement]);
 
     return (
-      <Flex ref={ref} sx={sx} data-depth={depth} data-is-root={isRootElement}>
-        <Text fontWeight="semibold" noOfLines={1} wordBreak="break-all" userSelect="none">
-          {label}
-        </Text>
+      <Flex ref={ref} sx={sx} data-depth={depth}>
+        <Label element={element} />
         <Spacer />
-        {isContainerElement(element) && !isRootElement && <ContainerElementSettings element={element} />}
+        {isContainerElement(element) && <ContainerElementSettings element={element} />}
         {isNodeFieldElement(element) && <NodeFieldElementSettings element={element} />}
-        {!isRootElement && (
-          <IconButton
-            tooltip={t('common.delete')}
-            aria-label={t('common.delete')}
-            onClick={removeElement}
-            icon={<PiXBold />}
-            variant="link"
-            size="sm"
-            alignSelf="stretch"
-            colorScheme="error"
-          />
-        )}
+        <RemoveElementButton element={element} />
       </Flex>
     );
   })
 );
 FormElementEditModeHeader.displayName = 'FormElementEditModeHeader';
+
+const RemoveElementButton = memo(({ element }: { element: FormElement }) => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const removeElement = useCallback(() => {
+    dispatch(formElementRemoved({ id: element.id }));
+  }, [dispatch, element.id]);
+
+  return (
+    <IconButton
+      tooltip={t('common.delete')}
+      aria-label={t('common.delete')}
+      onClick={removeElement}
+      icon={<PiXBold />}
+      variant="link"
+      size="sm"
+      alignSelf="stretch"
+      colorScheme="error"
+    />
+  );
+});
+RemoveElementButton.displayName = 'RemoveElementButton';
+
+const Label = memo(({ element }: { element: FormElement }) => {
+  const label = useMemo(() => {
+    if (isContainerElement(element) && element.data.layout === 'column') {
+      return `Container (column layout)`;
+    }
+    if (isContainerElement(element) && element.data.layout === 'row') {
+      return `Container (row layout)`;
+    }
+    return startCase(element.type);
+  }, [element]);
+
+  return (
+    <Text fontWeight="semibold" noOfLines={1} wordBreak="break-all" userSelect="none">
+      {label}
+    </Text>
+  );
+});
+Label.displayName = 'Label';

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
@@ -21,7 +21,7 @@ const sx: SystemStyleObject = {
   maxH: 8,
   borderTopRadius: 'base',
   alignItems: 'center',
-  color: 'base.300',
+  color: 'base.500',
   bg: 'baseAlpha.250',
   '&[data-depth="0"]': { bg: 'baseAlpha.100' },
   '&[data-depth="1"]': { bg: 'baseAlpha.150' },

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
@@ -4,13 +4,14 @@ import { useAppDispatch } from 'app/store/storeHooks';
 import { ContainerElementSettings } from 'features/nodes/components/sidePanel/builder/ContainerElementSettings';
 import { useDepthContext } from 'features/nodes/components/sidePanel/builder/contexts';
 import { NodeFieldElementSettings } from 'features/nodes/components/sidePanel/builder/NodeFieldElementSettings';
+import { useZoomToNode } from 'features/nodes/hooks/useZoomToNode';
 import { formElementRemoved } from 'features/nodes/store/workflowSlice';
-import type { FormElement } from 'features/nodes/types/workflow';
+import type { FormElement, NodeFieldElement } from 'features/nodes/types/workflow';
 import { isContainerElement, isNodeFieldElement } from 'features/nodes/types/workflow';
 import { startCase } from 'lodash-es';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiXBold } from 'react-icons/pi';
+import { PiGpsFixBold, PiXBold } from 'react-icons/pi';
 
 const sx: SystemStyleObject = {
   w: 'full',
@@ -36,6 +37,7 @@ export const FormElementEditModeHeader = memo(
         <Label element={element} />
         <Spacer />
         {isContainerElement(element) && <ContainerElementSettings element={element} />}
+        {isNodeFieldElement(element) && <ZoomToNodeButton element={element} />}
         {isNodeFieldElement(element) && <NodeFieldElementSettings element={element} />}
         <RemoveElementButton element={element} />
       </Flex>
@@ -43,6 +45,27 @@ export const FormElementEditModeHeader = memo(
   })
 );
 FormElementEditModeHeader.displayName = 'FormElementEditModeHeader';
+
+const ZoomToNodeButton = memo(({ element }: { element: NodeFieldElement }) => {
+  const { t } = useTranslation();
+  const zoomToNode = useZoomToNode();
+  const onClick = useCallback(() => {
+    zoomToNode(element.data.fieldIdentifier.nodeId);
+  }, [element.data.fieldIdentifier.nodeId, zoomToNode]);
+
+  return (
+    <IconButton
+      tooltip={t('workflows.builder.zoomToNode')}
+      aria-label={t('workflows.builder.zoomToNode')}
+      onClick={onClick}
+      icon={<PiGpsFixBold />}
+      variant="link"
+      size="sm"
+      alignSelf="stretch"
+    />
+  );
+});
+ZoomToNodeButton.displayName = 'ZoomToNodeButton';
 
 const RemoveElementButton = memo(({ element }: { element: FormElement }) => {
   const { t } = useTranslation();

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/FormElementEditModeHeader.tsx
@@ -56,7 +56,7 @@ export const FormElementEditModeHeader = memo(
 
     return (
       <Flex ref={ref} sx={sx} data-depth={depth} data-is-root={isRootElement}>
-        <Text fontWeight="semibold" noOfLines={1} wordBreak="break-all">
+        <Text fontWeight="semibold" noOfLines={1} wordBreak="break-all" userSelect="none">
           {label}
         </Text>
         <Spacer />

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/HeadingElementComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/HeadingElementComponent.tsx
@@ -111,9 +111,11 @@ const EditableHeading = memo(({ el }: { el: HeadingElement }) => {
       minRows={1}
       maxRows={10}
       resize="none"
-      p={2}
+      p={1}
+      px={2}
       fontWeight="bold"
       fontSize={FONT_SIZE}
+      _focusVisible={{ borderRadius: 'base', h: 'unset' }}
     />
   );
 });

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementComponent.tsx
@@ -135,7 +135,16 @@ const NodeFieldEditableLabel = memo(({ el }: { el: NodeFieldElement }) => {
     );
   }
 
-  return <Input ref={inputRef} variant="outline" {...editable.inputProps} />;
+  return (
+    <Input
+      ref={inputRef}
+      variant="outline"
+      p={1}
+      px={2}
+      _focusVisible={{ borderRadius: 'base', h: 'unset' }}
+      {...editable.inputProps}
+    />
+  );
 });
 NodeFieldEditableLabel.displayName = 'NodeFieldEditableLabel';
 
@@ -171,6 +180,16 @@ const NodeFieldEditableDescription = memo(({ el }: { el: NodeFieldElement }) => 
     return <FormHelperText onDoubleClick={editable.startEditing}>{editable.value}</FormHelperText>;
   }
 
-  return <Textarea ref={inputRef} variant="outline" {...editable.inputProps} />;
+  return (
+    <Textarea
+      ref={inputRef}
+      variant="outline"
+      fontSize="sm"
+      p={1}
+      px={2}
+      _focusVisible={{ borderRadius: 'base', h: 'unset' }}
+      {...editable.inputProps}
+    />
+  );
 });
 NodeFieldEditableDescription.displayName = 'NodeFieldEditableDescription';

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementSettings.tsx
@@ -69,7 +69,7 @@ export const NodeFieldElementSettings = memo(({ element }: { element: NodeFieldE
         <PopoverArrow />
         <PopoverBody minW={48}>
           <FormControl>
-            <FormLabel flex={1}>{t('workflows.builder.description')}</FormLabel>
+            <FormLabel flex={1}>{t('workflows.builder.showDescription')}</FormLabel>
             <Switch size="sm" isChecked={showDescription} onChange={toggleShowDescription} />
           </FormControl>
           {settings?.type === 'integer-field-config' && <NodeFieldElementIntegerConfig id={id} config={settings} />}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
@@ -26,8 +26,8 @@ export const NodeFieldElementStringSettings = memo(
       <FormControl>
         <FormLabel flex={1}>{t('workflows.builder.component')}</FormLabel>
         <Select value={config.component} onChange={onChangeComponent} size="sm">
-          <option value="input">{t('workflows.builder.input')}</option>
-          <option value="textarea">{t('workflows.builder.textarea')}</option>
+          <option value="input">{t('workflows.builder.singleLine')}</option>
+          <option value="textarea">{t('workflows.builder.multiLine')}</option>
         </Select>
       </FormControl>
     );

--- a/invokeai/frontend/web/src/features/nodes/hooks/useZoomToNode.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useZoomToNode.ts
@@ -1,13 +1,17 @@
-import { useReactFlow } from '@xyflow/react';
+import { logger } from 'app/logging/logger';
+import { $flow } from 'features/nodes/store/reactFlowInstance';
 import { useCallback } from 'react';
 
+const log = logger('workflows');
+
 export const useZoomToNode = () => {
-  const flow = useReactFlow();
-  const zoomToNode = useCallback(
-    (nodeId: string) => {
-      flow.fitView({ duration: 300, maxZoom: 1.5, nodes: [{ id: nodeId }] });
-    },
-    [flow]
-  );
+  const zoomToNode = useCallback((nodeId: string) => {
+    const flow = $flow.get();
+    if (!flow) {
+      log.warn('No flow instance found, cannot zoom to node');
+      return;
+    }
+    flow.fitView({ duration: 300, maxZoom: 1.5, nodes: [{ id: nodeId }] });
+  }, []);
   return zoomToNode;
 };


### PR DESCRIPTION
## Summary

- Fix overflow in workflow title
- Make form element edit mode headers less bright (just a bit less busy looking)
- Prevent accidental selection of edit mode headers (hard to de-select due to dnd interactions)
- Tweak styling of heading and text element editables
- Add missing translations for string field settings
- Fix issue where double-clicking a switch in a boolean field would zoom to node
- Fix issue preventing dragging a whole node on certain field names
- Add button to zoom to node on node field headers

## Related Issues / Discussions

n/a

## QA Instructions

Try it out

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
