### PR TITLE
Increase VAE decode memory estimates

### DIFF
--- a/docs/features/low-vram.md
+++ b/docs/features/low-vram.md
@@ -86,23 +86,25 @@ But, if your GPU has enough VRAM to hold models fully, you might get a perf boos
 # As an example, if your system has 32GB of RAM and no other heavy processes, setting the `max_cache_ram_gb` to 28GB
 # might be a good value to achieve aggressive model caching.
 max_cache_ram_gb: 28
+
 # The default max cache VRAM size is adjusted dynamically based on the amount of available VRAM (taking into
 # consideration the VRAM used by other processes).
-# You can override the default value by setting `max_cache_vram_gb`. Note that this value takes precedence over the
-# `device_working_mem_gb`.
-# It is recommended to set the VRAM cache size to be as large as possible while leaving enough room for the working
-# memory of the tasks you will be doing. For example, on a 24GB GPU that will be running unquantized FLUX without any
-# auxiliary models, 18GB might be a good value.
-max_cache_vram_gb: 18
+# You can override the default value by setting `max_cache_vram_gb`.
+# CAUTION: Most users should not manually set this value. See warning below.
+max_cache_vram_gb: 16
 ```
 
-!!! tip "Max safe value for `max_cache_vram_gb`"
+!!! warning "Max safe value for `max_cache_vram_gb`"
 
-    To determine the max safe value for `max_cache_vram_gb`, subtract `device_working_mem_gb` from your GPU's VRAM. As described below, the default for `device_working_mem_gb` is 3GB.
+    Most users should not manually configure the `max_cache_vram_gb`. This configuration value takes precedence over the `device_working_mem_gb` and any operations that explicitly reserve additional working memory (e.g. VAE decode). As such, manually configuring it increases the likelihood of encountering out-of-memory errors.
+
+    For users who wish to configure `max_cache_vram_gb`, the max safe value can be determined by subtracting `device_working_mem_gb` from your GPU's VRAM. As described below, the default for `device_working_mem_gb` is 3GB.
 
     For example, if you have a 12GB GPU, the max safe value for `max_cache_vram_gb` is `12GB - 3GB = 9GB`.
 
     If you had increased `device_working_mem_gb` to 4GB, then the max safe value for `max_cache_vram_gb` is `12GB - 4GB = 8GB`.
+
+    Most users who override `max_cache_vram_gb` are doing so because they wish to use significantly less VRAM, and should be setting `max_cache_vram_gb` to a value significantly less than the 'max safe value'.
 
 ### Working memory
 

--- a/invokeai/app/invocations/flux_vae_decode.py
+++ b/invokeai/app/invocations/flux_vae_decode.py
@@ -41,16 +41,11 @@ class FluxVaeDecodeInvocation(BaseInvocation, WithMetadata, WithBoard):
 
     def _estimate_working_memory(self, latents: torch.Tensor, vae: AutoEncoder) -> int:
         """Estimate the working memory required by the invocation in bytes."""
-        # It was found experimentally that the peak working memory scales linearly with the number of pixels and the
-        # element size (precision).
         out_h = LATENT_SCALE_FACTOR * latents.shape[-2]
         out_w = LATENT_SCALE_FACTOR * latents.shape[-1]
         element_size = next(vae.parameters()).element_size()
-        scaling_constant = 1090  # Determined experimentally.
+        scaling_constant = 2200  # Determined experimentally.
         working_memory = out_h * out_w * element_size * scaling_constant
-
-        # We add a 20% buffer to the working memory estimate to be safe.
-        working_memory = working_memory * 1.2
         return int(working_memory)
 
     def _vae_decode(self, vae_info: LoadedModel, latents: torch.Tensor) -> Image.Image:

--- a/invokeai/app/invocations/latents_to_image.py
+++ b/invokeai/app/invocations/latents_to_image.py
@@ -60,7 +60,7 @@ class LatentsToImageInvocation(BaseInvocation, WithMetadata, WithBoard):
         # It was found experimentally that the peak working memory scales linearly with the number of pixels and the
         # element size (precision). This estimate is accurate for both SD1 and SDXL.
         element_size = 4 if self.fp32 else 2
-        scaling_constant = 960  # Determined experimentally.
+        scaling_constant = 2200  # Determined experimentally.
 
         if use_tiling:
             tile_size = self.tile_size
@@ -84,9 +84,7 @@ class LatentsToImageInvocation(BaseInvocation, WithMetadata, WithBoard):
             # If we are running in FP32, then we should account for the likely increase in model size (~250MB).
             working_memory += 250 * 2**20
 
-        # We add 20% to the working memory estimate to be safe.
-        working_memory = int(working_memory * 1.2)
-        return working_memory
+        return int(working_memory)
 
     @torch.no_grad()
     def invoke(self, context: InvocationContext) -> ImageOutput:

--- a/invokeai/app/invocations/sd3_latents_to_image.py
+++ b/invokeai/app/invocations/sd3_latents_to_image.py
@@ -43,16 +43,11 @@ class SD3LatentsToImageInvocation(BaseInvocation, WithMetadata, WithBoard):
 
     def _estimate_working_memory(self, latents: torch.Tensor, vae: AutoencoderKL) -> int:
         """Estimate the working memory required by the invocation in bytes."""
-        # It was found experimentally that the peak working memory scales linearly with the number of pixels and the
-        # element size (precision).
         out_h = LATENT_SCALE_FACTOR * latents.shape[-2]
         out_w = LATENT_SCALE_FACTOR * latents.shape[-1]
         element_size = next(vae.parameters()).element_size()
-        scaling_constant = 1230  # Determined experimentally.
+        scaling_constant = 2200  # Determined experimentally.
         working_memory = out_h * out_w * element_size * scaling_constant
-
-        # We add a 20% buffer to the working memory estimate to be safe.
-        working_memory = working_memory * 1.2
         return int(working_memory)
 
     @torch.no_grad()


### PR DESCRIPTION
## Summary

This PR increases the working memory estimates for VAE decode operations. The previous values were set based on memory _allocations_ and were pretty aggressive about trying to make full use of the available VRAM. The updated values were set based on experimentally-observed _reserved_ memory (not just _allocated_) levels, and also aim to be conservative by including some buffer room.

This change is intended to address reports of slow VAE decoding.

The more conservative memory estimate values could cause more memory to be offloaded from the GPU during VAE decode. This in turn could result in slower model reloading on subsequent runs. The net impact of this change is expected to be positive, but there may be a noticeable regression for some users. We will want to keep a close eye on this when it is released in an RC.

## Related Issues / Discussions

N/A

## QA Instructions

I tested several common VAE decode scenarios with memory profiling enabled. Results:

```
All tests run with `pytorch_cuda_alloc_conf: "backend:cudaMallocAsync"`.

fp32, SD1, 512x512
- Estimated: 2450 MB
- Reserved:  1696 MB

fp16, SDXL, 1024x1024
- Estimated: 4400 MB
- Reserved:  3232 MB

fp32, SDXL, 1024x1024
- Estimated: 9050 MB
- Reserved:  5568 MB
Note: Even in fp32, we apply some optimizations to still run some layers in fp16. We don't account for this in the estimate, which explains why there is so much buffer in this case.

fp16, FLUX, 1024x1024
- Estimated: 4400 MB
- Reserved:  2944 MB

fp16, SD3, 1024x1024
- Estimated: 4400 MB
- Reserved:  3136 MB
```

## Merge Plan

- [x] Merge #7673 first and change target branch to `main`
- [ ] Monitor this change closely during RC. The net benefit is expected to be positive, but there is a risk of regression on some systems.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [x] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
