### PR TITLE
fix(backend): ValuesToInsertTuple.retried_from_item_id should be an int

### DIFF
--- a/invokeai/app/services/session_queue/session_queue_common.py
+++ b/invokeai/app/services/session_queue/session_queue_common.py
@@ -568,7 +568,7 @@ ValueToInsertTuple: TypeAlias = tuple[
     str | None,  # workflow (optional, as stringified JSON)
     str | None,  # origin (optional)
     str | None,  # destination (optional)
-    str | None,  # retried_from_item_id (optional, this is always None for new items)
+    int | None,  # retried_from_item_id (optional, this is always None for new items)
 ]
 """A type alias for the tuple of values to insert into the session queue table."""
 


### PR DESCRIPTION
## Summary

Changes the type of `retried_from_item_id` to match the DB schema.
This only affects type annotations and does not affect operation of the app.

## Merge Plan

Merge at will

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
