### PR TITLE
fix:(app): Fix input type of default_value on MetadataToFloatInvocation

### DIFF
--- a/invokeai/app/invocations/metadata_linked.py
+++ b/invokeai/app/invocations/metadata_linked.py
@@ -361,7 +361,7 @@ class MetadataToIntegerInvocation(BaseInvocation, WithMetadata):
     title="Metadata To Float",
     tags=["metadata"],
     category="metadata",
-    version="1.0.0",
+    version="1.1.0",
     classification=Classification.Beta,
 )
 class MetadataToFloatInvocation(BaseInvocation, WithMetadata):
@@ -377,7 +377,7 @@ class MetadataToFloatInvocation(BaseInvocation, WithMetadata):
         description=FieldDescriptions.metadata_item_label,
         input=Input.Direct,
     )
-    default_value: int = InputField(description="The default float to use if not found in the metadata")
+    default_value: float = InputField(description="The default float to use if not found in the metadata")
 
     _validate_custom_label = model_validator(mode="after")(validate_custom_label)
 


### PR DESCRIPTION
## Summary
Fix the input type of the default_value on `MetadataToFloatInvocation`. 
Changed default_value type from an int to a float to match the output type of the node.
## Related Issues / Discussions
NA
## QA Instructions
You should now be able to enter a float as the default_value for the metatdataToFloat node.
## Merge Plan
NA
## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
