### PR TITLE
Do not cache image layers in CI docker build

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -76,9 +76,6 @@ jobs:
             latest=${{ matrix.gpu-driver == 'cuda' && github.ref == 'refs/heads/main' }}
             suffix=-${{ matrix.gpu-driver }},onlatest=false
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -103,7 +100,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' || github.ref_type == 'tag' || github.event.inputs.push-to-registry }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha,scope=${{ github.ref_name }}-${{ matrix.gpu-driver }}
-            type=gha,scope=main-${{ matrix.gpu-driver }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.gpu-driver }}
+          # cache-from: |
+          #   type=gha,scope=${{ github.ref_name }}-${{ matrix.gpu-driver }}
+          #   type=gha,scope=main-${{ matrix.gpu-driver }}
+          # cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.gpu-driver }}


### PR DESCRIPTION
## Summary

GHA runners run out of disk space trying to pull and store the docker build cache. Additionally, this is very slow.

This PR disables the cache. Theoretically this may increase the size of our images, but because caching has been broken anyway, this will have no impact.

Will come back and take another stab on improving caching behaviours.

## Merge Plan

Merge at will.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
