### PR TITLE
feat(app): non blocking enqueue_batch

### DIFF
--- a/invokeai/app/api/routers/session_queue.py
+++ b/invokeai/app/api/routers/session_queue.py
@@ -48,7 +48,9 @@ async def enqueue_batch(
 ) -> EnqueueBatchResult:
     """Processes a batch and enqueues the output graphs for execution."""
 
-    return ApiDependencies.invoker.services.session_queue.enqueue_batch(queue_id=queue_id, batch=batch, prepend=prepend)
+    return await ApiDependencies.invoker.services.session_queue.enqueue_batch(
+        queue_id=queue_id, batch=batch, prepend=prepend
+    )
 
 
 @session_queue_router.get(

--- a/invokeai/app/api/sockets.py
+++ b/invokeai/app/api/sockets.py
@@ -90,7 +90,7 @@ class SocketIO:
     _unsub_bulk_download = "unsubscribe_bulk_download"
 
     def __init__(self, app: FastAPI):
-        self._sio = AsyncServer(async_mode="asgi", cors_allowed_origins="*", ping_interval=1)
+        self._sio = AsyncServer(async_mode="asgi", cors_allowed_origins="*")
         self._app = ASGIApp(socketio_server=self._sio, socketio_path="/ws/socket.io")
         app.mount("/ws", self._app)
 

--- a/invokeai/app/api/sockets.py
+++ b/invokeai/app/api/sockets.py
@@ -90,7 +90,7 @@ class SocketIO:
     _unsub_bulk_download = "unsubscribe_bulk_download"
 
     def __init__(self, app: FastAPI):
-        self._sio = AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+        self._sio = AsyncServer(async_mode="asgi", cors_allowed_origins="*", ping_interval=1)
         self._app = ASGIApp(socketio_server=self._sio, socketio_path="/ws/socket.io")
         app.mount("/ws", self._app)
 

--- a/invokeai/app/services/board_image_records/board_image_records_sqlite.py
+++ b/invokeai/app/services/board_image_records/board_image_records_sqlite.py
@@ -19,7 +19,6 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()
-        self._lock = db.lock
         self._conn = db.conn
         self._cursor = self._conn.cursor()
 
@@ -29,7 +28,6 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
         image_name: str,
     ) -> None:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 INSERT INTO board_images (board_id, image_name)
@@ -42,15 +40,12 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise e
-        finally:
-            self._lock.release()
 
     def remove_image_from_board(
         self,
         image_name: str,
     ) -> None:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 DELETE FROM board_images
@@ -62,8 +57,6 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise e
-        finally:
-            self._lock.release()
 
     def get_images_for_board(
         self,
@@ -72,33 +65,26 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
         limit: int = 10,
     ) -> OffsetPaginatedResults[ImageRecord]:
         # TODO: this isn't paginated yet?
-        try:
-            self._lock.acquire()
-            self._cursor.execute(
-                """--sql
-                SELECT images.*
-                FROM board_images
-                INNER JOIN images ON board_images.image_name = images.image_name
-                WHERE board_images.board_id = ?
-                ORDER BY board_images.updated_at DESC;
-                """,
-                (board_id,),
-            )
-            result = cast(list[sqlite3.Row], self._cursor.fetchall())
-            images = [deserialize_image_record(dict(r)) for r in result]
+        self._cursor.execute(
+            """--sql
+            SELECT images.*
+            FROM board_images
+            INNER JOIN images ON board_images.image_name = images.image_name
+            WHERE board_images.board_id = ?
+            ORDER BY board_images.updated_at DESC;
+            """,
+            (board_id,),
+        )
+        result = cast(list[sqlite3.Row], self._cursor.fetchall())
+        images = [deserialize_image_record(dict(r)) for r in result]
 
-            self._cursor.execute(
-                """--sql
-                SELECT COUNT(*) FROM images WHERE 1=1;
-                """
-            )
-            count = cast(int, self._cursor.fetchone()[0])
+        self._cursor.execute(
+            """--sql
+            SELECT COUNT(*) FROM images WHERE 1=1;
+            """
+        )
+        count = cast(int, self._cursor.fetchone()[0])
 
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
         return OffsetPaginatedResults(items=images, offset=offset, limit=limit, total=count)
 
     def get_all_board_image_names_for_board(
@@ -107,98 +93,76 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
         categories: list[ImageCategory] | None,
         is_intermediate: bool | None,
     ) -> list[str]:
-        try:
-            self._lock.acquire()
+        params: list[str | bool] = []
 
-            params: list[str | bool] = []
-
-            # Base query is a join between images and board_images
-            stmt = """
+        # Base query is a join between images and board_images
+        stmt = """
                 SELECT images.image_name
                 FROM images
                 LEFT JOIN board_images ON board_images.image_name = images.image_name
                 WHERE 1=1
                 AND board_images.board_id = ?
                 """
-            params.append(board_id)
+        params.append(board_id)
 
-            # Add the category filter
-            if categories is not None:
-                # Convert the enum values to unique list of strings
-                category_strings = [c.value for c in set(categories)]
-                # Create the correct length of placeholders
-                placeholders = ",".join("?" * len(category_strings))
-                stmt += f"""--sql
+        # Add the category filter
+        if categories is not None:
+            # Convert the enum values to unique list of strings
+            category_strings = [c.value for c in set(categories)]
+            # Create the correct length of placeholders
+            placeholders = ",".join("?" * len(category_strings))
+            stmt += f"""--sql
                 AND images.image_category IN ( {placeholders} )
                 """
 
-                # Unpack the included categories into the query params
-                for c in category_strings:
-                    params.append(c)
+            # Unpack the included categories into the query params
+            for c in category_strings:
+                params.append(c)
 
-            # Add the is_intermediate filter
-            if is_intermediate is not None:
-                stmt += """--sql
+        # Add the is_intermediate filter
+        if is_intermediate is not None:
+            stmt += """--sql
                 AND images.is_intermediate = ?
                 """
-                params.append(is_intermediate)
+            params.append(is_intermediate)
 
-            # Put a ring on it
-            stmt += ";"
+        # Put a ring on it
+        stmt += ";"
 
-            # Execute the query
-            self._cursor.execute(stmt, params)
+        # Execute the query
+        self._cursor.execute(stmt, params)
 
-            result = cast(list[sqlite3.Row], self._cursor.fetchall())
-            image_names = [r[0] for r in result]
-            return image_names
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
+        result = cast(list[sqlite3.Row], self._cursor.fetchall())
+        image_names = [r[0] for r in result]
+        return image_names
 
     def get_board_for_image(
         self,
         image_name: str,
     ) -> Optional[str]:
-        try:
-            self._lock.acquire()
-            self._cursor.execute(
-                """--sql
+        self._cursor.execute(
+            """--sql
                 SELECT board_id
                 FROM board_images
                 WHERE image_name = ?;
                 """,
-                (image_name,),
-            )
-            result = self._cursor.fetchone()
-            if result is None:
-                return None
-            return cast(str, result[0])
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
+            (image_name,),
+        )
+        result = self._cursor.fetchone()
+        if result is None:
+            return None
+        return cast(str, result[0])
 
     def get_image_count_for_board(self, board_id: str) -> int:
-        try:
-            self._lock.acquire()
-            self._cursor.execute(
-                """--sql
+        self._cursor.execute(
+            """--sql
                 SELECT COUNT(*)
                 FROM board_images
                 INNER JOIN images ON board_images.image_name = images.image_name
                 WHERE images.is_intermediate = FALSE
                 AND board_images.board_id = ?;
                 """,
-                (board_id,),
-            )
-            count = cast(int, self._cursor.fetchone()[0])
-            return count
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
+            (board_id,),
+        )
+        count = cast(int, self._cursor.fetchone()[0])
+        return count

--- a/invokeai/app/services/board_image_records/board_image_records_sqlite.py
+++ b/invokeai/app/services/board_image_records/board_image_records_sqlite.py
@@ -1,5 +1,4 @@
 import sqlite3
-import threading
 from typing import Optional, cast
 
 from invokeai.app.services.board_image_records.board_image_records_base import BoardImageRecordStorageBase
@@ -15,7 +14,6 @@ from invokeai.app.services.shared.sqlite.sqlite_database import SqliteDatabase
 class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
-    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()

--- a/invokeai/app/services/board_records/board_records_sqlite.py
+++ b/invokeai/app/services/board_records/board_records_sqlite.py
@@ -1,5 +1,4 @@
 import sqlite3
-import threading
 from typing import Union, cast
 
 from invokeai.app.services.board_records.board_records_base import BoardRecordStorageBase
@@ -21,7 +20,6 @@ from invokeai.app.util.misc import uuid_string
 class SqliteBoardRecordStorage(BoardRecordStorageBase):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
-    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()

--- a/invokeai/app/services/board_records/board_records_sqlite.py
+++ b/invokeai/app/services/board_records/board_records_sqlite.py
@@ -25,13 +25,11 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()
-        self._lock = db.lock
         self._conn = db.conn
         self._cursor = self._conn.cursor()
 
     def delete(self, board_id: str) -> None:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 DELETE FROM boards
@@ -40,14 +38,9 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
                 (board_id,),
             )
             self._conn.commit()
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise BoardRecordDeleteException from e
         except Exception as e:
             self._conn.rollback()
             raise BoardRecordDeleteException from e
-        finally:
-            self._lock.release()
 
     def save(
         self,
@@ -55,7 +48,6 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
     ) -> BoardRecord:
         try:
             board_id = uuid_string()
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 INSERT OR IGNORE INTO boards (board_id, board_name)
@@ -67,8 +59,6 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise BoardRecordSaveException from e
-        finally:
-            self._lock.release()
         return self.get(board_id)
 
     def get(
@@ -76,7 +66,6 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
         board_id: str,
     ) -> BoardRecord:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 SELECT *
@@ -88,10 +77,7 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
 
             result = cast(Union[sqlite3.Row, None], self._cursor.fetchone())
         except sqlite3.Error as e:
-            self._conn.rollback()
             raise BoardRecordNotFoundException from e
-        finally:
-            self._lock.release()
         if result is None:
             raise BoardRecordNotFoundException
         return BoardRecord(**dict(result))
@@ -102,8 +88,6 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
         changes: BoardChanges,
     ) -> BoardRecord:
         try:
-            self._lock.acquire()
-
             # Change the name of a board
             if changes.board_name is not None:
                 self._cursor.execute(
@@ -141,8 +125,6 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise BoardRecordSaveException from e
-        finally:
-            self._lock.release()
         return self.get(board_id)
 
     def get_many(
@@ -153,11 +135,8 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
         limit: int = 10,
         include_archived: bool = False,
     ) -> OffsetPaginatedResults[BoardRecord]:
-        try:
-            self._lock.acquire()
-
-            # Build base query
-            base_query = """
+        # Build base query
+        base_query = """
                 SELECT *
                 FROM boards
                 {archived_filter}
@@ -165,81 +144,66 @@ class SqliteBoardRecordStorage(BoardRecordStorageBase):
                 LIMIT ? OFFSET ?;
             """
 
-            # Determine archived filter condition
-            archived_filter = "" if include_archived else "WHERE archived = 0"
+        # Determine archived filter condition
+        archived_filter = "" if include_archived else "WHERE archived = 0"
 
-            final_query = base_query.format(
-                archived_filter=archived_filter, order_by=order_by.value, direction=direction.value
-            )
+        final_query = base_query.format(
+            archived_filter=archived_filter, order_by=order_by.value, direction=direction.value
+        )
 
-            # Execute query to fetch boards
-            self._cursor.execute(final_query, (limit, offset))
+        # Execute query to fetch boards
+        self._cursor.execute(final_query, (limit, offset))
 
-            result = cast(list[sqlite3.Row], self._cursor.fetchall())
-            boards = [deserialize_board_record(dict(r)) for r in result]
+        result = cast(list[sqlite3.Row], self._cursor.fetchall())
+        boards = [deserialize_board_record(dict(r)) for r in result]
 
-            # Determine count query
-            if include_archived:
-                count_query = """
+        # Determine count query
+        if include_archived:
+            count_query = """
                     SELECT COUNT(*)
                     FROM boards;
                 """
-            else:
-                count_query = """
+        else:
+            count_query = """
                     SELECT COUNT(*)
                     FROM boards
                     WHERE archived = 0;
                 """
 
-            # Execute count query
-            self._cursor.execute(count_query)
+        # Execute count query
+        self._cursor.execute(count_query)
 
-            count = cast(int, self._cursor.fetchone()[0])
+        count = cast(int, self._cursor.fetchone()[0])
 
-            return OffsetPaginatedResults[BoardRecord](items=boards, offset=offset, limit=limit, total=count)
-
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
+        return OffsetPaginatedResults[BoardRecord](items=boards, offset=offset, limit=limit, total=count)
 
     def get_all(
         self, order_by: BoardRecordOrderBy, direction: SQLiteDirection, include_archived: bool = False
     ) -> list[BoardRecord]:
-        try:
-            self._lock.acquire()
-
-            if order_by == BoardRecordOrderBy.Name:
-                base_query = """
+        if order_by == BoardRecordOrderBy.Name:
+            base_query = """
                     SELECT *
                     FROM boards
                     {archived_filter}
                     ORDER BY LOWER(board_name) {direction}
                 """
-            else:
-                base_query = """
+        else:
+            base_query = """
                     SELECT *
                     FROM boards
                     {archived_filter}
                     ORDER BY {order_by} {direction}
                 """
 
-            archived_filter = "" if include_archived else "WHERE archived = 0"
+        archived_filter = "" if include_archived else "WHERE archived = 0"
 
-            final_query = base_query.format(
-                archived_filter=archived_filter, order_by=order_by.value, direction=direction.value
-            )
+        final_query = base_query.format(
+            archived_filter=archived_filter, order_by=order_by.value, direction=direction.value
+        )
 
-            self._cursor.execute(final_query)
+        self._cursor.execute(final_query)
 
-            result = cast(list[sqlite3.Row], self._cursor.fetchall())
-            boards = [deserialize_board_record(dict(r)) for r in result]
+        result = cast(list[sqlite3.Row], self._cursor.fetchall())
+        boards = [deserialize_board_record(dict(r)) for r in result]
 
-            return boards
-
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
+        return boards

--- a/invokeai/app/services/image_records/image_records_sqlite.py
+++ b/invokeai/app/services/image_records/image_records_sqlite.py
@@ -1,5 +1,4 @@
 import sqlite3
-import threading
 from datetime import datetime
 from typing import Optional, Union, cast
 
@@ -24,7 +23,6 @@ from invokeai.app.services.shared.sqlite.sqlite_database import SqliteDatabase
 class SqliteImageRecordStorage(ImageRecordStorageBase):
     _conn: sqlite3.Connection
     _cursor: sqlite3.Cursor
-    _lock: threading.RLock
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()

--- a/invokeai/app/services/image_records/image_records_sqlite.py
+++ b/invokeai/app/services/image_records/image_records_sqlite.py
@@ -28,14 +28,11 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()
-        self._lock = db.lock
         self._conn = db.conn
         self._cursor = self._conn.cursor()
 
     def get(self, image_name: str) -> ImageRecord:
         try:
-            self._lock.acquire()
-
             self._cursor.execute(
                 f"""--sql
                 SELECT {IMAGE_DTO_COLS} FROM images
@@ -46,10 +43,7 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
 
             result = cast(Optional[sqlite3.Row], self._cursor.fetchone())
         except sqlite3.Error as e:
-            self._conn.rollback()
             raise ImageRecordNotFoundException from e
-        finally:
-            self._lock.release()
 
         if not result:
             raise ImageRecordNotFoundException
@@ -58,8 +52,6 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
 
     def get_metadata(self, image_name: str) -> Optional[MetadataField]:
         try:
-            self._lock.acquire()
-
             self._cursor.execute(
                 """--sql
                 SELECT metadata FROM images
@@ -77,10 +69,7 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
             metadata_raw = cast(Optional[str], as_dict.get("metadata", None))
             return MetadataFieldValidator.validate_json(metadata_raw) if metadata_raw is not None else None
         except sqlite3.Error as e:
-            self._conn.rollback()
             raise ImageRecordNotFoundException from e
-        finally:
-            self._lock.release()
 
     def update(
         self,
@@ -88,7 +77,6 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         changes: ImageRecordChanges,
     ) -> None:
         try:
-            self._lock.acquire()
             # Change the category of the image
             if changes.image_category is not None:
                 self._cursor.execute(
@@ -137,8 +125,6 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise ImageRecordSaveException from e
-        finally:
-            self._lock.release()
 
     def get_many(
         self,
@@ -152,109 +138,100 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         board_id: Optional[str] = None,
         search_term: Optional[str] = None,
     ) -> OffsetPaginatedResults[ImageRecord]:
-        try:
-            self._lock.acquire()
+        # Manually build two queries - one for the count, one for the records
+        count_query = """--sql
+        SELECT COUNT(*)
+        FROM images
+        LEFT JOIN board_images ON board_images.image_name = images.image_name
+        WHERE 1=1
+        """
 
-            # Manually build two queries - one for the count, one for the records
-            count_query = """--sql
-            SELECT COUNT(*)
-            FROM images
-            LEFT JOIN board_images ON board_images.image_name = images.image_name
-            WHERE 1=1
+        images_query = f"""--sql
+        SELECT {IMAGE_DTO_COLS}
+        FROM images
+        LEFT JOIN board_images ON board_images.image_name = images.image_name
+        WHERE 1=1
+        """
+
+        query_conditions = ""
+        query_params: list[Union[int, str, bool]] = []
+
+        if image_origin is not None:
+            query_conditions += """--sql
+            AND images.image_origin = ?
+            """
+            query_params.append(image_origin.value)
+
+        if categories is not None:
+            # Convert the enum values to unique list of strings
+            category_strings = [c.value for c in set(categories)]
+            # Create the correct length of placeholders
+            placeholders = ",".join("?" * len(category_strings))
+
+            query_conditions += f"""--sql
+            AND images.image_category IN ( {placeholders} )
             """
 
-            images_query = f"""--sql
-            SELECT {IMAGE_DTO_COLS}
-            FROM images
-            LEFT JOIN board_images ON board_images.image_name = images.image_name
-            WHERE 1=1
+            # Unpack the included categories into the query params
+            for c in category_strings:
+                query_params.append(c)
+
+        if is_intermediate is not None:
+            query_conditions += """--sql
+            AND images.is_intermediate = ?
             """
 
-            query_conditions = ""
-            query_params: list[Union[int, str, bool]] = []
+            query_params.append(is_intermediate)
 
-            if image_origin is not None:
-                query_conditions += """--sql
-                AND images.image_origin = ?
-                """
-                query_params.append(image_origin.value)
+        # board_id of "none" is reserved for images without a board
+        if board_id == "none":
+            query_conditions += """--sql
+            AND board_images.board_id IS NULL
+            """
+        elif board_id is not None:
+            query_conditions += """--sql
+            AND board_images.board_id = ?
+            """
+            query_params.append(board_id)
 
-            if categories is not None:
-                # Convert the enum values to unique list of strings
-                category_strings = [c.value for c in set(categories)]
-                # Create the correct length of placeholders
-                placeholders = ",".join("?" * len(category_strings))
+        # Search term condition
+        if search_term:
+            query_conditions += """--sql
+            AND images.metadata LIKE ?
+            """
+            query_params.append(f"%{search_term.lower()}%")
 
-                query_conditions += f"""--sql
-                AND images.image_category IN ( {placeholders} )
-                """
+        if starred_first:
+            query_pagination = f"""--sql
+            ORDER BY images.starred DESC, images.created_at {order_dir.value} LIMIT ? OFFSET ?
+            """
+        else:
+            query_pagination = f"""--sql
+            ORDER BY images.created_at {order_dir.value} LIMIT ? OFFSET ?
+            """
 
-                # Unpack the included categories into the query params
-                for c in category_strings:
-                    query_params.append(c)
+        # Final images query with pagination
+        images_query += query_conditions + query_pagination + ";"
+        # Add all the parameters
+        images_params = query_params.copy()
+        # Add the pagination parameters
+        images_params.extend([limit, offset])
 
-            if is_intermediate is not None:
-                query_conditions += """--sql
-                AND images.is_intermediate = ?
-                """
+        # Build the list of images, deserializing each row
+        self._cursor.execute(images_query, images_params)
+        result = cast(list[sqlite3.Row], self._cursor.fetchall())
+        images = [deserialize_image_record(dict(r)) for r in result]
 
-                query_params.append(is_intermediate)
-
-            # board_id of "none" is reserved for images without a board
-            if board_id == "none":
-                query_conditions += """--sql
-                AND board_images.board_id IS NULL
-                """
-            elif board_id is not None:
-                query_conditions += """--sql
-                AND board_images.board_id = ?
-                """
-                query_params.append(board_id)
-
-            # Search term condition
-            if search_term:
-                query_conditions += """--sql
-                AND images.metadata LIKE ?
-                """
-                query_params.append(f"%{search_term.lower()}%")
-
-            if starred_first:
-                query_pagination = f"""--sql
-                ORDER BY images.starred DESC, images.created_at {order_dir.value} LIMIT ? OFFSET ?
-                """
-            else:
-                query_pagination = f"""--sql
-                ORDER BY images.created_at {order_dir.value} LIMIT ? OFFSET ?
-                """
-
-            # Final images query with pagination
-            images_query += query_conditions + query_pagination + ";"
-            # Add all the parameters
-            images_params = query_params.copy()
-            # Add the pagination parameters
-            images_params.extend([limit, offset])
-
-            # Build the list of images, deserializing each row
-            self._cursor.execute(images_query, images_params)
-            result = cast(list[sqlite3.Row], self._cursor.fetchall())
-            images = [deserialize_image_record(dict(r)) for r in result]
-
-            # Set up and execute the count query, without pagination
-            count_query += query_conditions + ";"
-            count_params = query_params.copy()
-            self._cursor.execute(count_query, count_params)
-            count = cast(int, self._cursor.fetchone()[0])
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise e
-        finally:
-            self._lock.release()
+        # Set up and execute the count query, without pagination
+        count_query += query_conditions + ";"
+        count_params = query_params.copy()
+        self._cursor.execute(count_query, count_params)
+        count = cast(int, self._cursor.fetchone()[0])
 
         return OffsetPaginatedResults(items=images, offset=offset, limit=limit, total=count)
 
     def delete(self, image_name: str) -> None:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 DELETE FROM images
@@ -266,14 +243,10 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise ImageRecordDeleteException from e
-        finally:
-            self._lock.release()
 
     def delete_many(self, image_names: list[str]) -> None:
         try:
             placeholders = ",".join("?" for _ in image_names)
-
-            self._lock.acquire()
 
             # Construct the SQLite query with the placeholders
             query = f"DELETE FROM images WHERE image_name IN ({placeholders})"
@@ -285,30 +258,20 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise ImageRecordDeleteException from e
-        finally:
-            self._lock.release()
 
     def get_intermediates_count(self) -> int:
-        try:
-            self._lock.acquire()
-            self._cursor.execute(
-                """--sql
-                SELECT COUNT(*) FROM images
-                WHERE is_intermediate = TRUE;
-                """
-            )
-            count = cast(int, self._cursor.fetchone()[0])
-            self._conn.commit()
-            return count
-        except sqlite3.Error as e:
-            self._conn.rollback()
-            raise ImageRecordDeleteException from e
-        finally:
-            self._lock.release()
+        self._cursor.execute(
+            """--sql
+            SELECT COUNT(*) FROM images
+            WHERE is_intermediate = TRUE;
+            """
+        )
+        count = cast(int, self._cursor.fetchone()[0])
+        self._conn.commit()
+        return count
 
     def delete_intermediates(self) -> list[str]:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 SELECT image_name FROM images
@@ -328,8 +291,6 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise ImageRecordDeleteException from e
-        finally:
-            self._lock.release()
 
     def save(
         self,
@@ -346,7 +307,6 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         metadata: Optional[str] = None,
     ) -> datetime:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 INSERT OR IGNORE INTO images (
@@ -395,28 +355,23 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         except sqlite3.Error as e:
             self._conn.rollback()
             raise ImageRecordSaveException from e
-        finally:
-            self._lock.release()
 
     def get_most_recent_image_for_board(self, board_id: str) -> Optional[ImageRecord]:
-        try:
-            self._lock.acquire()
-            self._cursor.execute(
-                """--sql
-                SELECT images.*
-                FROM images
-                JOIN board_images ON images.image_name = board_images.image_name
-                WHERE board_images.board_id = ?
-                AND images.is_intermediate = FALSE
-                ORDER BY images.starred DESC, images.created_at DESC
-                LIMIT 1;
-                """,
-                (board_id,),
-            )
+        self._cursor.execute(
+            """--sql
+            SELECT images.*
+            FROM images
+            JOIN board_images ON images.image_name = board_images.image_name
+            WHERE board_images.board_id = ?
+            AND images.is_intermediate = FALSE
+            ORDER BY images.starred DESC, images.created_at DESC
+            LIMIT 1;
+            """,
+            (board_id,),
+        )
 
-            result = cast(Optional[sqlite3.Row], self._cursor.fetchone())
-        finally:
-            self._lock.release()
+        result = cast(Optional[sqlite3.Row], self._cursor.fetchone())
+
         if result is None:
             return None
 

--- a/invokeai/app/services/model_records/model_records_sql.py
+++ b/invokeai/app/services/model_records/model_records_sql.py
@@ -96,38 +96,37 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
 
         Can raise DuplicateModelException and InvalidModelConfigException exceptions.
         """
-        with self._db.lock:
-            try:
-                self._cursor.execute(
-                    """--sql
-                    INSERT INTO models (
-                       id,
-                       config
-                      )
-                    VALUES (?,?);
-                    """,
-                    (
-                        config.key,
-                        config.model_dump_json(),
-                    ),
-                )
-                self._db.conn.commit()
+        try:
+            self._cursor.execute(
+                """--sql
+                INSERT INTO models (
+                    id,
+                    config
+                    )
+                VALUES (?,?);
+                """,
+                (
+                    config.key,
+                    config.model_dump_json(),
+                ),
+            )
+            self._db.conn.commit()
 
-            except sqlite3.IntegrityError as e:
-                self._db.conn.rollback()
-                if "UNIQUE constraint failed" in str(e):
-                    if "models.path" in str(e):
-                        msg = f"A model with path '{config.path}' is already installed"
-                    elif "models.name" in str(e):
-                        msg = f"A model with name='{config.name}', type='{config.type}', base='{config.base}' is already installed"
-                    else:
-                        msg = f"A model with key '{config.key}' is already installed"
-                    raise DuplicateModelException(msg) from e
+        except sqlite3.IntegrityError as e:
+            self._db.conn.rollback()
+            if "UNIQUE constraint failed" in str(e):
+                if "models.path" in str(e):
+                    msg = f"A model with path '{config.path}' is already installed"
+                elif "models.name" in str(e):
+                    msg = f"A model with name='{config.name}', type='{config.type}', base='{config.base}' is already installed"
                 else:
-                    raise e
-            except sqlite3.Error as e:
-                self._db.conn.rollback()
+                    msg = f"A model with key '{config.key}' is already installed"
+                raise DuplicateModelException(msg) from e
+            else:
                 raise e
+        except sqlite3.Error as e:
+            self._db.conn.rollback()
+            raise e
 
         return self.get_model(config.key)
 
@@ -139,21 +138,20 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
 
         Can raise an UnknownModelException
         """
-        with self._db.lock:
-            try:
-                self._cursor.execute(
-                    """--sql
-                    DELETE FROM models
-                    WHERE id=?;
-                    """,
-                    (key,),
-                )
-                if self._cursor.rowcount == 0:
-                    raise UnknownModelException("model not found")
-                self._db.conn.commit()
-            except sqlite3.Error as e:
-                self._db.conn.rollback()
-                raise e
+        try:
+            self._cursor.execute(
+                """--sql
+                DELETE FROM models
+                WHERE id=?;
+                """,
+                (key,),
+            )
+            if self._cursor.rowcount == 0:
+                raise UnknownModelException("model not found")
+            self._db.conn.commit()
+        except sqlite3.Error as e:
+            self._db.conn.rollback()
+            raise e
 
     def update_model(self, key: str, changes: ModelRecordChanges) -> AnyModelConfig:
         record = self.get_model(key)
@@ -164,23 +162,22 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
 
         json_serialized = record.model_dump_json()
 
-        with self._db.lock:
-            try:
-                self._cursor.execute(
-                    """--sql
-                    UPDATE models
-                    SET
-                        config=?
-                    WHERE id=?;
-                    """,
-                    (json_serialized, key),
-                )
-                if self._cursor.rowcount == 0:
-                    raise UnknownModelException("model not found")
-                self._db.conn.commit()
-            except sqlite3.Error as e:
-                self._db.conn.rollback()
-                raise e
+        try:
+            self._cursor.execute(
+                """--sql
+                UPDATE models
+                SET
+                    config=?
+                WHERE id=?;
+                """,
+                (json_serialized, key),
+            )
+            if self._cursor.rowcount == 0:
+                raise UnknownModelException("model not found")
+            self._db.conn.commit()
+        except sqlite3.Error as e:
+            self._db.conn.rollback()
+            raise e
 
         return self.get_model(key)
 
@@ -192,33 +189,31 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
 
         Exceptions: UnknownModelException
         """
-        with self._db.lock:
-            self._cursor.execute(
-                """--sql
-                SELECT config, strftime('%s',updated_at) FROM models
-                WHERE id=?;
-                """,
-                (key,),
-            )
-            rows = self._cursor.fetchone()
-            if not rows:
-                raise UnknownModelException("model not found")
-            model = ModelConfigFactory.make_config(json.loads(rows[0]), timestamp=rows[1])
+        self._cursor.execute(
+            """--sql
+            SELECT config, strftime('%s',updated_at) FROM models
+            WHERE id=?;
+            """,
+            (key,),
+        )
+        rows = self._cursor.fetchone()
+        if not rows:
+            raise UnknownModelException("model not found")
+        model = ModelConfigFactory.make_config(json.loads(rows[0]), timestamp=rows[1])
         return model
 
     def get_model_by_hash(self, hash: str) -> AnyModelConfig:
-        with self._db.lock:
-            self._cursor.execute(
-                """--sql
-                SELECT config, strftime('%s',updated_at) FROM models
-                WHERE hash=?;
-                """,
-                (hash,),
-            )
-            rows = self._cursor.fetchone()
-            if not rows:
-                raise UnknownModelException("model not found")
-            model = ModelConfigFactory.make_config(json.loads(rows[0]), timestamp=rows[1])
+        self._cursor.execute(
+            """--sql
+            SELECT config, strftime('%s',updated_at) FROM models
+            WHERE hash=?;
+            """,
+            (hash,),
+        )
+        rows = self._cursor.fetchone()
+        if not rows:
+            raise UnknownModelException("model not found")
+        model = ModelConfigFactory.make_config(json.loads(rows[0]), timestamp=rows[1])
         return model
 
     def exists(self, key: str) -> bool:
@@ -227,16 +222,14 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
 
         :param key: Unique key for the model to be deleted
         """
-        count = 0
-        with self._db.lock:
-            self._cursor.execute(
-                """--sql
-                select count(*) FROM models
-                WHERE id=?;
-                """,
-                (key,),
-            )
-            count = self._cursor.fetchone()[0]
+        self._cursor.execute(
+            """--sql
+            select count(*) FROM models
+            WHERE id=?;
+            """,
+            (key,),
+        )
+        count = self._cursor.fetchone()[0]
         return count > 0
 
     def search_by_attr(
@@ -284,17 +277,16 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
             where_clause.append("format=?")
             bindings.append(model_format)
         where = f"WHERE {' AND '.join(where_clause)}" if where_clause else ""
-        with self._db.lock:
-            self._cursor.execute(
-                f"""--sql
-                SELECT config, strftime('%s',updated_at)
-                FROM models
-                {where}
-                ORDER BY {ordering[order_by]} -- using ? to bind doesn't work here for some reason;
-                """,
-                tuple(bindings),
-            )
-            result = self._cursor.fetchall()
+        self._cursor.execute(
+            f"""--sql
+            SELECT config, strftime('%s',updated_at)
+            FROM models
+            {where}
+            ORDER BY {ordering[order_by]} -- using ? to bind doesn't work here for some reason;
+            """,
+            tuple(bindings),
+        )
+        result = self._cursor.fetchall()
 
         # Parse the model configs.
         results: list[AnyModelConfig] = []
@@ -313,34 +305,26 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
 
     def search_by_path(self, path: Union[str, Path]) -> List[AnyModelConfig]:
         """Return models with the indicated path."""
-        results = []
-        with self._db.lock:
-            self._cursor.execute(
-                """--sql
-                SELECT config, strftime('%s',updated_at) FROM models
-                WHERE path=?;
-                """,
-                (str(path),),
-            )
-            results = [
-                ModelConfigFactory.make_config(json.loads(x[0]), timestamp=x[1]) for x in self._cursor.fetchall()
-            ]
+        self._cursor.execute(
+            """--sql
+            SELECT config, strftime('%s',updated_at) FROM models
+            WHERE path=?;
+            """,
+            (str(path),),
+        )
+        results = [ModelConfigFactory.make_config(json.loads(x[0]), timestamp=x[1]) for x in self._cursor.fetchall()]
         return results
 
     def search_by_hash(self, hash: str) -> List[AnyModelConfig]:
         """Return models with the indicated hash."""
-        results = []
-        with self._db.lock:
-            self._cursor.execute(
-                """--sql
-                SELECT config, strftime('%s',updated_at) FROM models
-                WHERE hash=?;
-                """,
-                (hash,),
-            )
-            results = [
-                ModelConfigFactory.make_config(json.loads(x[0]), timestamp=x[1]) for x in self._cursor.fetchall()
-            ]
+        self._cursor.execute(
+            """--sql
+            SELECT config, strftime('%s',updated_at) FROM models
+            WHERE hash=?;
+            """,
+            (hash,),
+        )
+        results = [ModelConfigFactory.make_config(json.loads(x[0]), timestamp=x[1]) for x in self._cursor.fetchall()]
         return results
 
     def list_models(
@@ -357,32 +341,29 @@ class ModelRecordServiceSQL(ModelRecordServiceBase):
         }
 
         # Lock so that the database isn't updated while we're doing the two queries.
-        with self._db.lock:
-            # query1: get the total number of model configs
-            self._cursor.execute(
-                """--sql
-                select count(*) from models;
-                """,
-                (),
-            )
-            total = int(self._cursor.fetchone()[0])
+        # query1: get the total number of model configs
+        self._cursor.execute(
+            """--sql
+            select count(*) from models;
+            """,
+            (),
+        )
+        total = int(self._cursor.fetchone()[0])
 
-            # query2: fetch key fields
-            self._cursor.execute(
-                f"""--sql
-                SELECT config
-                FROM models
-                ORDER BY {ordering[order_by]} -- using ? to bind doesn't work here for some reason
-                LIMIT ?
-                OFFSET ?;
-                """,
-                (
-                    per_page,
-                    page * per_page,
-                ),
-            )
-            rows = self._cursor.fetchall()
-            items = [ModelSummary.model_validate(dict(x)) for x in rows]
-            return PaginatedResults(
-                page=page, pages=ceil(total / per_page), per_page=per_page, total=total, items=items
-            )
+        # query2: fetch key fields
+        self._cursor.execute(
+            f"""--sql
+            SELECT config
+            FROM models
+            ORDER BY {ordering[order_by]} -- using ? to bind doesn't work here for some reason
+            LIMIT ?
+            OFFSET ?;
+            """,
+            (
+                per_page,
+                page * per_page,
+            ),
+        )
+        rows = self._cursor.fetchall()
+        items = [ModelSummary.model_validate(dict(x)) for x in rows]
+        return PaginatedResults(page=page, pages=ceil(total / per_page), per_page=per_page, total=total, items=items)

--- a/invokeai/app/services/session_queue/session_queue_base.py
+++ b/invokeai/app/services/session_queue/session_queue_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Coroutine, Optional
 
 from invokeai.app.services.session_queue.session_queue_common import (
     QUEUE_ITEM_STATUS,
@@ -33,7 +33,7 @@ class SessionQueueBase(ABC):
         pass
 
     @abstractmethod
-    def enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
+    def enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> Coroutine[Any, Any, EnqueueBatchResult]:
         """Enqueues all permutations of a batch for execution."""
         pass
 

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -57,7 +57,6 @@ class SqliteSessionQueue(SessionQueueBase):
 
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()
-        self.__lock = db.lock
         self.__conn = db.conn
         self.__cursor = self.__conn.cursor()
 
@@ -67,7 +66,6 @@ class SqliteSessionQueue(SessionQueueBase):
         This is necessary because the invoker may have been killed while processing a queue item.
         """
         try:
-            self.__lock.acquire()
             self.__cursor.execute(
                 """--sql
                 UPDATE session_queue
@@ -78,8 +76,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
 
     def _get_current_queue_size(self, queue_id: str) -> int:
         """Gets the current number of pending queue items"""
@@ -115,8 +111,6 @@ class SqliteSessionQueue(SessionQueueBase):
 
     def _enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
         try:
-            self.__lock.acquire()
-
             # TODO: how does this work in a multi-user scenario?
             current_queue_size = self._get_current_queue_size(queue_id)
             max_queue_size = self.__invoker.services.configuration.max_queue_size
@@ -151,8 +145,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         enqueue_result = EnqueueBatchResult(
             queue_id=queue_id,
             requested=requested_count,
@@ -164,25 +156,18 @@ class SqliteSessionQueue(SessionQueueBase):
         return enqueue_result
 
     def dequeue(self) -> Optional[SessionQueueItem]:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT *
-                FROM session_queue
-                WHERE status = 'pending'
-                ORDER BY
-                  priority DESC,
-                  item_id ASC
-                LIMIT 1
-                """
-            )
-            result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT *
+            FROM session_queue
+            WHERE status = 'pending'
+            ORDER BY
+                priority DESC,
+                item_id ASC
+            LIMIT 1
+            """
+        )
+        result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
         if result is None:
             return None
         queue_item = SessionQueueItem.queue_item_from_dict(dict(result))
@@ -190,52 +175,38 @@ class SqliteSessionQueue(SessionQueueBase):
         return queue_item
 
     def get_next(self, queue_id: str) -> Optional[SessionQueueItem]:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT *
-                FROM session_queue
-                WHERE
-                  queue_id = ?
-                  AND status = 'pending'
-                ORDER BY
-                  priority DESC,
-                  created_at ASC
-                LIMIT 1
-                """,
-                (queue_id,),
-            )
-            result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT *
+            FROM session_queue
+            WHERE
+                queue_id = ?
+                AND status = 'pending'
+            ORDER BY
+                priority DESC,
+                created_at ASC
+            LIMIT 1
+            """,
+            (queue_id,),
+        )
+        result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
         if result is None:
             return None
         return SessionQueueItem.queue_item_from_dict(dict(result))
 
     def get_current(self, queue_id: str) -> Optional[SessionQueueItem]:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT *
-                FROM session_queue
-                WHERE
-                  queue_id = ?
-                  AND status = 'in_progress'
-                LIMIT 1
-                """,
-                (queue_id,),
-            )
-            result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT *
+            FROM session_queue
+            WHERE
+                queue_id = ?
+                AND status = 'in_progress'
+            LIMIT 1
+            """,
+            (queue_id,),
+        )
+        result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
         if result is None:
             return None
         return SessionQueueItem.queue_item_from_dict(dict(result))
@@ -249,7 +220,6 @@ class SqliteSessionQueue(SessionQueueBase):
         error_traceback: Optional[str] = None,
     ) -> SessionQueueItem:
         try:
-            self.__lock.acquire()
             self.__cursor.execute(
                 """--sql
                 UPDATE session_queue
@@ -262,8 +232,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         queue_item = self.get_queue_item(item_id)
         batch_status = self.get_batch_status(queue_id=queue_item.queue_id, batch_id=queue_item.batch_id)
         queue_status = self.get_queue_status(queue_id=queue_item.queue_id)
@@ -271,47 +239,32 @@ class SqliteSessionQueue(SessionQueueBase):
         return queue_item
 
     def is_empty(self, queue_id: str) -> IsEmptyResult:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT count(*)
-                FROM session_queue
-                WHERE queue_id = ?
-                """,
-                (queue_id,),
-            )
-            is_empty = cast(int, self.__cursor.fetchone()[0]) == 0
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT count(*)
+            FROM session_queue
+            WHERE queue_id = ?
+            """,
+            (queue_id,),
+        )
+        is_empty = cast(int, self.__cursor.fetchone()[0]) == 0
         return IsEmptyResult(is_empty=is_empty)
 
     def is_full(self, queue_id: str) -> IsFullResult:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT count(*)
-                FROM session_queue
-                WHERE queue_id = ?
-                """,
-                (queue_id,),
-            )
-            max_queue_size = self.__invoker.services.configuration.max_queue_size
-            is_full = cast(int, self.__cursor.fetchone()[0]) >= max_queue_size
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT count(*)
+            FROM session_queue
+            WHERE queue_id = ?
+            """,
+            (queue_id,),
+        )
+        max_queue_size = self.__invoker.services.configuration.max_queue_size
+        is_full = cast(int, self.__cursor.fetchone()[0]) >= max_queue_size
         return IsFullResult(is_full=is_full)
 
     def clear(self, queue_id: str) -> ClearResult:
         try:
-            self.__lock.acquire()
             self.__cursor.execute(
                 """--sql
                 SELECT COUNT(*)
@@ -333,8 +286,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         self.__invoker.services.events.emit_queue_cleared(queue_id)
         return ClearResult(deleted=count)
 
@@ -349,7 +300,6 @@ class SqliteSessionQueue(SessionQueueBase):
                     OR status = 'canceled'
                   )
                 """
-            self.__lock.acquire()
             self.__cursor.execute(
                 f"""--sql
                 SELECT COUNT(*)
@@ -371,8 +321,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         return PruneResult(deleted=count)
 
     def cancel_queue_item(self, item_id: int) -> SessionQueueItem:
@@ -402,7 +350,6 @@ class SqliteSessionQueue(SessionQueueBase):
     def cancel_by_batch_ids(self, queue_id: str, batch_ids: list[str]) -> CancelByBatchIDsResult:
         try:
             current_queue_item = self.get_current(queue_id)
-            self.__lock.acquire()
             placeholders = ", ".join(["?" for _ in batch_ids])
             where = f"""--sql
                 WHERE
@@ -436,14 +383,11 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         return CancelByBatchIDsResult(canceled=count)
 
     def cancel_by_destination(self, queue_id: str, destination: str) -> CancelByDestinationResult:
         try:
             current_queue_item = self.get_current(queue_id)
-            self.__lock.acquire()
             where = """--sql
                 WHERE
                   queue_id == ?
@@ -476,14 +420,11 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         return CancelByDestinationResult(canceled=count)
 
     def cancel_by_queue_id(self, queue_id: str) -> CancelByQueueIDResult:
         try:
             current_queue_item = self.get_current(queue_id)
-            self.__lock.acquire()
             where = """--sql
                 WHERE
                   queue_id is ?
@@ -519,8 +460,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         return CancelByQueueIDResult(canceled=count)
 
     def cancel_all_except_current(self, queue_id: str) -> CancelAllExceptCurrentResult:
@@ -530,7 +469,6 @@ class SqliteSessionQueue(SessionQueueBase):
                   queue_id == ?
                   AND status == 'pending'
                 """
-            self.__lock.acquire()
             self.__cursor.execute(
                 f"""--sql
                 SELECT COUNT(*)
@@ -552,27 +490,18 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         return CancelAllExceptCurrentResult(canceled=count)
 
     def get_queue_item(self, item_id: int) -> SessionQueueItem:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT * FROM session_queue
-                WHERE
-                  item_id = ?
-                """,
-                (item_id,),
-            )
-            result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT * FROM session_queue
+            WHERE
+                item_id = ?
+            """,
+            (item_id,),
+        )
+        result = cast(Union[sqlite3.Row, None], self.__cursor.fetchone())
         if result is None:
             raise SessionQueueItemNotFoundError(f"No queue item with id {item_id}")
         return SessionQueueItem.queue_item_from_dict(dict(result))
@@ -583,7 +512,6 @@ class SqliteSessionQueue(SessionQueueBase):
             # when the graph is loaded. Graph execution occurs purely in memory - the session saved here is not referenced
             # during execution.
             session_json = session.model_dump_json(warnings=False, exclude_none=True)
-            self.__lock.acquire()
             self.__cursor.execute(
                 """--sql
                 UPDATE session_queue
@@ -596,8 +524,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         return self.get_queue_item(item_id)
 
     def list_queue_items(
@@ -608,83 +534,69 @@ class SqliteSessionQueue(SessionQueueBase):
         cursor: Optional[int] = None,
         status: Optional[QUEUE_ITEM_STATUS] = None,
     ) -> CursorPaginatedResults[SessionQueueItemDTO]:
-        try:
-            item_id = cursor
-            self.__lock.acquire()
-            query = """--sql
-                SELECT item_id,
-                    status,
-                    priority,
-                    field_values,
-                    error_type,
-                    error_message,
-                    error_traceback,
-                    created_at,
-                    updated_at,
-                    completed_at,
-                    started_at,
-                    session_id,
-                    batch_id,
-                    queue_id,
-                    origin,
-                    destination
-                FROM session_queue
-                WHERE queue_id = ?
-            """
-            params: list[Union[str, int]] = [queue_id]
+        item_id = cursor
+        query = """--sql
+            SELECT item_id,
+                status,
+                priority,
+                field_values,
+                error_type,
+                error_message,
+                error_traceback,
+                created_at,
+                updated_at,
+                completed_at,
+                started_at,
+                session_id,
+                batch_id,
+                queue_id,
+                origin,
+                destination
+            FROM session_queue
+            WHERE queue_id = ?
+        """
+        params: list[Union[str, int]] = [queue_id]
 
-            if status is not None:
-                query += """--sql
-                    AND status = ?
-                    """
-                params.append(status)
-
-            if item_id is not None:
-                query += """--sql
-                    AND (priority < ?) OR (priority = ? AND item_id > ?)
-                    """
-                params.extend([priority, priority, item_id])
-
+        if status is not None:
             query += """--sql
-                ORDER BY
-                  priority DESC,
-                  item_id ASC
-                LIMIT ?
+                AND status = ?
                 """
-            params.append(limit + 1)
-            self.__cursor.execute(query, params)
-            results = cast(list[sqlite3.Row], self.__cursor.fetchall())
-            items = [SessionQueueItemDTO.queue_item_dto_from_dict(dict(result)) for result in results]
-            has_more = False
-            if len(items) > limit:
-                # remove the extra item
-                items.pop()
-                has_more = True
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+            params.append(status)
+
+        if item_id is not None:
+            query += """--sql
+                AND (priority < ?) OR (priority = ? AND item_id > ?)
+                """
+            params.extend([priority, priority, item_id])
+
+        query += """--sql
+            ORDER BY
+                priority DESC,
+                item_id ASC
+            LIMIT ?
+            """
+        params.append(limit + 1)
+        self.__cursor.execute(query, params)
+        results = cast(list[sqlite3.Row], self.__cursor.fetchall())
+        items = [SessionQueueItemDTO.queue_item_dto_from_dict(dict(result)) for result in results]
+        has_more = False
+        if len(items) > limit:
+            # remove the extra item
+            items.pop()
+            has_more = True
         return CursorPaginatedResults(items=items, limit=limit, has_more=has_more)
 
     def get_queue_status(self, queue_id: str) -> SessionQueueStatus:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT status, count(*)
-                FROM session_queue
-                WHERE queue_id = ?
-                GROUP BY status
-                """,
-                (queue_id,),
-            )
-            counts_result = cast(list[sqlite3.Row], self.__cursor.fetchall())
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT status, count(*)
+            FROM session_queue
+            WHERE queue_id = ?
+            GROUP BY status
+            """,
+            (queue_id,),
+        )
+        counts_result = cast(list[sqlite3.Row], self.__cursor.fetchall())
 
         current_item = self.get_current(queue_id=queue_id)
         total = sum(row[1] for row in counts_result)
@@ -703,29 +615,22 @@ class SqliteSessionQueue(SessionQueueBase):
         )
 
     def get_batch_status(self, queue_id: str, batch_id: str) -> BatchStatus:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT status, count(*), origin, destination
-                FROM session_queue
-                WHERE
-                  queue_id = ?
-                  AND batch_id = ?
-                GROUP BY status
-                """,
-                (queue_id, batch_id),
-            )
-            result = cast(list[sqlite3.Row], self.__cursor.fetchall())
-            total = sum(row[1] for row in result)
-            counts: dict[str, int] = {row[0]: row[1] for row in result}
-            origin = result[0]["origin"] if result else None
-            destination = result[0]["destination"] if result else None
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT status, count(*), origin, destination
+            FROM session_queue
+            WHERE
+                queue_id = ?
+                AND batch_id = ?
+            GROUP BY status
+            """,
+            (queue_id, batch_id),
+        )
+        result = cast(list[sqlite3.Row], self.__cursor.fetchall())
+        total = sum(row[1] for row in result)
+        counts: dict[str, int] = {row[0]: row[1] for row in result}
+        origin = result[0]["origin"] if result else None
+        destination = result[0]["destination"] if result else None
 
         return BatchStatus(
             batch_id=batch_id,
@@ -741,24 +646,17 @@ class SqliteSessionQueue(SessionQueueBase):
         )
 
     def get_counts_by_destination(self, queue_id: str, destination: str) -> SessionQueueCountsByDestination:
-        try:
-            self.__lock.acquire()
-            self.__cursor.execute(
-                """--sql
-                SELECT status, count(*)
-                FROM session_queue
-                WHERE queue_id = ?
-                AND destination = ?
-                GROUP BY status
-                """,
-                (queue_id, destination),
-            )
-            counts_result = cast(list[sqlite3.Row], self.__cursor.fetchall())
-        except Exception:
-            self.__conn.rollback()
-            raise
-        finally:
-            self.__lock.release()
+        self.__cursor.execute(
+            """--sql
+            SELECT status, count(*)
+            FROM session_queue
+            WHERE queue_id = ?
+            AND destination = ?
+            GROUP BY status
+            """,
+            (queue_id, destination),
+        )
+        counts_result = cast(list[sqlite3.Row], self.__cursor.fetchall())
 
         total = sum(row[1] for row in counts_result)
         counts: dict[str, int] = {row[0]: row[1] for row in counts_result}
@@ -777,8 +675,6 @@ class SqliteSessionQueue(SessionQueueBase):
     def retry_items_by_id(self, queue_id: str, item_ids: list[int]) -> RetryItemsResult:
         """Retries the given queue items"""
         try:
-            self.__lock.acquire()
-
             values_to_insert: list[tuple] = []
             retried_item_ids: list[int] = []
 
@@ -833,8 +729,6 @@ class SqliteSessionQueue(SessionQueueBase):
         except Exception:
             self.__conn.rollback()
             raise
-        finally:
-            self.__lock.release()
         retry_result = RetryItemsResult(
             queue_id=queue_id,
             retried_item_ids=retried_item_ids,

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import sqlite3
 import threading
@@ -108,7 +109,11 @@ class SqliteSessionQueue(SessionQueueBase):
         )
         return cast(Union[int, None], self.__cursor.fetchone()[0]) or 0
 
-    def enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
+    async def enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, self._enqueue_batch, queue_id, batch, prepend)
+
+    def _enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
         try:
             self.__lock.acquire()
 

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import sqlite3
-import threading
 from typing import Optional, Union, cast
 
 from pydantic_core import to_jsonable_python
@@ -40,7 +39,6 @@ class SqliteSessionQueue(SessionQueueBase):
     __invoker: Invoker
     __conn: sqlite3.Connection
     __cursor: sqlite3.Cursor
-    __lock: threading.RLock
 
     def start(self, invoker: Invoker) -> None:
         self.__invoker = invoker

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -103,8 +103,7 @@ class SqliteSessionQueue(SessionQueueBase):
         return cast(Union[int, None], self.__cursor.fetchone()[0]) or 0
 
     async def enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, self._enqueue_batch, queue_id, batch, prepend)
+        return await asyncio.to_thread(self._enqueue_batch, queue_id, batch, prepend)
 
     def _enqueue_batch(self, queue_id: str, batch: Batch, prepend: bool) -> EnqueueBatchResult:
         try:

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 import threading
+from time import sleep
 from typing import Optional, Union, cast
 
 from pydantic_core import to_jsonable_python
@@ -115,6 +116,8 @@ class SqliteSessionQueue(SessionQueueBase):
             current_queue_size = self._get_current_queue_size(queue_id)
             max_queue_size = self.__invoker.services.configuration.max_queue_size
             max_new_queue_items = max_queue_size - current_queue_size
+
+            sleep(15)  # Simulate a slow operation
 
             priority = 0
             if prepend:

--- a/invokeai/app/services/session_queue/session_queue_sqlite.py
+++ b/invokeai/app/services/session_queue/session_queue_sqlite.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import sqlite3
 import threading
-from time import sleep
 from typing import Optional, Union, cast
 
 from pydantic_core import to_jsonable_python
@@ -115,8 +114,6 @@ class SqliteSessionQueue(SessionQueueBase):
             current_queue_size = self._get_current_queue_size(queue_id)
             max_queue_size = self.__invoker.services.configuration.max_queue_size
             max_new_queue_items = max_queue_size - current_queue_size
-
-            sleep(15)  # Simulate a slow operation
 
             priority = 0
             if prepend:

--- a/invokeai/app/services/shared/sqlite_migrator/sqlite_migrator_impl.py
+++ b/invokeai/app/services/shared/sqlite_migrator/sqlite_migrator_impl.py
@@ -43,46 +43,45 @@ class SqliteMigrator:
 
     def run_migrations(self) -> bool:
         """Migrates the database to the latest version."""
-        with self._db.lock:
-            # This throws if there is a problem.
-            self._migration_set.validate_migration_chain()
-            cursor = self._db.conn.cursor()
-            self._create_migrations_table(cursor=cursor)
+        # This throws if there is a problem.
+        self._migration_set.validate_migration_chain()
+        cursor = self._db.conn.cursor()
+        self._create_migrations_table(cursor=cursor)
 
-            if self._migration_set.count == 0:
-                self._logger.debug("No migrations registered")
-                return False
+        if self._migration_set.count == 0:
+            self._logger.debug("No migrations registered")
+            return False
 
-            if self._get_current_version(cursor=cursor) == self._migration_set.latest_version:
-                self._logger.debug("Database is up to date, no migrations to run")
-                return False
+        if self._get_current_version(cursor=cursor) == self._migration_set.latest_version:
+            self._logger.debug("Database is up to date, no migrations to run")
+            return False
 
-            self._logger.info("Database update needed")
+        self._logger.info("Database update needed")
 
-            # Make a backup of the db if it needs to be updated and is a file db
-            if self._db.db_path is not None:
-                timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-                self._backup_path = self._db.db_path.parent / f"{self._db.db_path.stem}_backup_{timestamp}.db"
-                self._logger.info(f"Backing up database to {str(self._backup_path)}")
-                # Use SQLite to do the backup
-                with closing(sqlite3.connect(self._backup_path)) as backup_conn:
-                    self._db.conn.backup(backup_conn)
-            else:
-                self._logger.info("Using in-memory database, no backup needed")
+        # Make a backup of the db if it needs to be updated and is a file db
+        if self._db.db_path is not None:
+            timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            self._backup_path = self._db.db_path.parent / f"{self._db.db_path.stem}_backup_{timestamp}.db"
+            self._logger.info(f"Backing up database to {str(self._backup_path)}")
+            # Use SQLite to do the backup
+            with closing(sqlite3.connect(self._backup_path)) as backup_conn:
+                self._db.conn.backup(backup_conn)
+        else:
+            self._logger.info("Using in-memory database, no backup needed")
 
-            next_migration = self._migration_set.get(from_version=self._get_current_version(cursor))
-            while next_migration is not None:
-                self._run_migration(next_migration)
-                next_migration = self._migration_set.get(self._get_current_version(cursor))
-            self._logger.info("Database updated successfully")
-            return True
+        next_migration = self._migration_set.get(from_version=self._get_current_version(cursor))
+        while next_migration is not None:
+            self._run_migration(next_migration)
+            next_migration = self._migration_set.get(self._get_current_version(cursor))
+        self._logger.info("Database updated successfully")
+        return True
 
     def _run_migration(self, migration: Migration) -> None:
         """Runs a single migration."""
         try:
             # Using sqlite3.Connection as a context manager commits a the transaction on exit, or rolls it back if an
             # exception is raised.
-            with self._db.lock, self._db.conn as conn:
+            with self._db.conn as conn:
                 cursor = conn.cursor()
                 if self._get_current_version(cursor) != migration.from_version:
                     raise MigrationError(
@@ -108,27 +107,26 @@ class SqliteMigrator:
 
     def _create_migrations_table(self, cursor: sqlite3.Cursor) -> None:
         """Creates the migrations table for the database, if one does not already exist."""
-        with self._db.lock:
-            try:
-                cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='migrations';")
-                if cursor.fetchone() is not None:
-                    return
-                cursor.execute(
-                    """--sql
-                    CREATE TABLE migrations (
-                        version INTEGER PRIMARY KEY,
-                        migrated_at DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
-                    );
-                    """
-                )
-                cursor.execute("INSERT INTO migrations (version) VALUES (0);")
-                cursor.connection.commit()
-                self._logger.debug("Created migrations table")
-            except sqlite3.Error as e:
-                msg = f"Problem creating migrations table: {e}"
-                self._logger.error(msg)
-                cursor.connection.rollback()
-                raise MigrationError(msg) from e
+        try:
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='migrations';")
+            if cursor.fetchone() is not None:
+                return
+            cursor.execute(
+                """--sql
+                CREATE TABLE migrations (
+                    version INTEGER PRIMARY KEY,
+                    migrated_at DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
+                );
+                """
+            )
+            cursor.execute("INSERT INTO migrations (version) VALUES (0);")
+            cursor.connection.commit()
+            self._logger.debug("Created migrations table")
+        except sqlite3.Error as e:
+            msg = f"Problem creating migrations table: {e}"
+            self._logger.error(msg)
+            cursor.connection.rollback()
+            raise MigrationError(msg) from e
 
     @classmethod
     def _get_current_version(cls, cursor: sqlite3.Cursor) -> int:

--- a/invokeai/app/services/style_preset_records/style_preset_records_sqlite.py
+++ b/invokeai/app/services/style_preset_records/style_preset_records_sqlite.py
@@ -17,7 +17,6 @@ from invokeai.app.util.misc import uuid_string
 class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
     def __init__(self, db: SqliteDatabase) -> None:
         super().__init__()
-        self._lock = db.lock
         self._conn = db.conn
         self._cursor = self._conn.cursor()
 
@@ -27,30 +26,22 @@ class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
 
     def get(self, style_preset_id: str) -> StylePresetRecordDTO:
         """Gets a style preset by ID."""
-        try:
-            self._lock.acquire()
-            self._cursor.execute(
-                """--sql
-                SELECT *
-                FROM style_presets
-                WHERE id = ?;
-                """,
-                (style_preset_id,),
-            )
-            row = self._cursor.fetchone()
-            if row is None:
-                raise StylePresetNotFoundError(f"Style preset with id {style_preset_id} not found")
-            return StylePresetRecordDTO.from_dict(dict(row))
-        except Exception:
-            self._conn.rollback()
-            raise
-        finally:
-            self._lock.release()
+        self._cursor.execute(
+            """--sql
+            SELECT *
+            FROM style_presets
+            WHERE id = ?;
+            """,
+            (style_preset_id,),
+        )
+        row = self._cursor.fetchone()
+        if row is None:
+            raise StylePresetNotFoundError(f"Style preset with id {style_preset_id} not found")
+        return StylePresetRecordDTO.from_dict(dict(row))
 
     def create(self, style_preset: StylePresetWithoutId) -> StylePresetRecordDTO:
         style_preset_id = uuid_string()
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 INSERT OR IGNORE INTO style_presets (
@@ -72,14 +63,11 @@ class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
         except Exception:
             self._conn.rollback()
             raise
-        finally:
-            self._lock.release()
         return self.get(style_preset_id)
 
     def create_many(self, style_presets: list[StylePresetWithoutId]) -> None:
         style_preset_ids = []
         try:
-            self._lock.acquire()
             for style_preset in style_presets:
                 style_preset_id = uuid_string()
                 style_preset_ids.append(style_preset_id)
@@ -104,14 +92,11 @@ class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
         except Exception:
             self._conn.rollback()
             raise
-        finally:
-            self._lock.release()
 
         return None
 
     def update(self, style_preset_id: str, changes: StylePresetChanges) -> StylePresetRecordDTO:
         try:
-            self._lock.acquire()
             # Change the name of a style preset
             if changes.name is not None:
                 self._cursor.execute(
@@ -138,13 +123,10 @@ class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
         except Exception:
             self._conn.rollback()
             raise
-        finally:
-            self._lock.release()
         return self.get(style_preset_id)
 
     def delete(self, style_preset_id: str) -> None:
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 DELETE from style_presets
@@ -156,45 +138,35 @@ class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
         except Exception:
             self._conn.rollback()
             raise
-        finally:
-            self._lock.release()
         return None
 
     def get_many(self, type: PresetType | None = None) -> list[StylePresetRecordDTO]:
-        try:
-            self._lock.acquire()
-            main_query = """
-                SELECT
-                    *
-                FROM style_presets
-                """
+        main_query = """
+            SELECT
+                *
+            FROM style_presets
+            """
 
-            if type is not None:
-                main_query += "WHERE type = ? "
+        if type is not None:
+            main_query += "WHERE type = ? "
 
-            main_query += "ORDER BY LOWER(name) ASC"
+        main_query += "ORDER BY LOWER(name) ASC"
 
-            if type is not None:
-                self._cursor.execute(main_query, (type,))
-            else:
-                self._cursor.execute(main_query)
+        if type is not None:
+            self._cursor.execute(main_query, (type,))
+        else:
+            self._cursor.execute(main_query)
 
-            rows = self._cursor.fetchall()
-            style_presets = [StylePresetRecordDTO.from_dict(dict(row)) for row in rows]
+        rows = self._cursor.fetchall()
+        style_presets = [StylePresetRecordDTO.from_dict(dict(row)) for row in rows]
 
-            return style_presets
-        except Exception:
-            self._conn.rollback()
-            raise
-        finally:
-            self._lock.release()
+        return style_presets
 
     def _sync_default_style_presets(self) -> None:
         """Syncs default style presets to the database. Internal use only."""
 
         # First delete all existing default style presets
         try:
-            self._lock.acquire()
             self._cursor.execute(
                 """--sql
                 DELETE FROM style_presets
@@ -205,10 +177,8 @@ class SqliteStylePresetRecordsStorage(StylePresetRecordsStorageBase):
         except Exception:
             self._conn.rollback()
             raise
-        finally:
-            self._lock.release()
         # Next, parse and create the default style presets
-        with self._lock, open(Path(__file__).parent / Path("default_style_presets.json"), "r") as file:
+        with open(Path(__file__).parent / Path("default_style_presets.json"), "r") as file:
             presets = json.load(file)
             for preset in presets:
                 style_preset = StylePresetWithoutId.model_validate(preset)

--- a/invokeai/frontend/web/src/services/api/index.ts
+++ b/invokeai/frontend/web/src/services/api/index.ts
@@ -103,6 +103,7 @@ export const api = customCreateApi({
   reducerPath: 'api',
   tagTypes,
   endpoints: () => ({}),
+  invalidationBehavior: 'immediately',
 });
 
 function getCircularReplacer() {


### PR DESCRIPTION
## Summary

Most service methods in the application are blocking. For example, `enqueue_batch` blocks the main thread - preventing HTTP and socket traffic. When enqueuing very large or complicated batches, this can cause unresponsiveness.

To make `enqueue_batch` non-blocking, we can make it async and run it in a thread. However, we have another source of "blocking" - a global mutex on database operations. 

This global mutex is required because SQLite, by default, does not support concurrent reads and writes. We painstakingly wrap _all_ DB operations in a re-entrant lock to prevent issues with interacting with a locked database.

SQLite has an alternate mode called [WAL (write-ahead logging) mode](https://www.sqlite.org/wal.html), which supports concurrent reads and allow us to treat writes as concurrent. 

(Technically, in WAL mode, SQLite will queue writes using the WAL log as a buffer, so it's not true concurrency. But we can interact with the DB as it if was concurrent.)

We can also enable the SQLite busy timeout at 5s. If we are waiting on an operation for more than 5s, SQLite will error. This is _plenty_ of time for any SQLite operation we may need to do. If something takes longer than that, we have problems and should fail loudly.

The busy timeout ends up being a better failure mode than we had before w/ the global mutex, which had no timeout and could lock up the app indefinitely if something went awry.

So, to make `enqueue_batch` non-blocking, we need to:
- Run that function in a thread and await it in the router.
- Enable WAL mode and set a busy timeout.
- Remove the global mutex. 
    - As a bonus, this makes every method that touches the DB simpler to read.

I also cleaned up many methods that touched the DB. Many read operations caught errors and did a connection rollback, but this is not necessary. Reads do not have anything to roll back and calling rollback is a noop, so we can remove this nonfunctional logic.

There's one draw-back to WAL mode. You cannot open the DB file over the network. For example, if your host machine is different from your client, and you share the DB via SMB, you cannot connect to the DB over SMB from the client. 

Long ago, this drawback was the reason to _not_ use WAL mode. But now, I think it is a fine tradeoff. You can still SSH to the host and connect to the DB directly. 

Finally, I made a change to our RTKQ implementation fixing an issue where, during a long-running mutation (e.g. enqueuing a big batch), invalidated queries are not immediately re-fetched (e.g. changing a board's name would wait until the enqueue completes before refreshing).

## Related Issues / Discussions

n/a

## QA Instructions

Try the app. Everything should work. When enqueuing huge, complicated batches, the app should remain responsive. 

Thanks to the massive perf improvements to batch prep in #7688, the benefits from making this change will be less impactful as we should never be blocked for long. Nevertheless, this really cleans up our DB code and reduces footgun potential from mishandled mutexes.

## Merge Plan

n/a

## Checklist

- [z] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
