### PR TITLE
experiment: allow Any as output type in nodes

### DIFF
--- a/invokeai/app/invocations/primitives.py
+++ b/invokeai/app/invocations/primitives.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Kyle Schouviller (https://github.com/kyle0654)
 
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 
@@ -26,6 +26,7 @@ from invokeai.app.invocations.fields import (
     SD3ConditioningField,
     TensorField,
     UIComponent,
+    UIType,
 )
 from invokeai.app.services.images.images_common import ImageDTO
 from invokeai.app.services.shared.invocation_context import InvocationContext
@@ -535,3 +536,25 @@ class BoundingBoxInvocation(BaseInvocation):
 
 
 # endregion
+
+
+@invocation_output("any_output")
+class AnyOutput(BaseInvocationOutput):
+    value: Any = OutputField(description="The output value", ui_type=UIType.Any)
+
+
+@invocation(
+    "switcher",
+    title="Switcher",
+    tags=["primitives", "switcher"],
+    category="primitives",
+    version="1.0.0",
+)
+class SwitcherInvocation(BaseInvocation):
+    a: Any = InputField(description="The first input", ui_type=UIType.Any)
+    b: Any = InputField(description="The second input", ui_type=UIType.Any)
+    switch: bool = InputField(description="Switch between the two inputs")
+
+    def invoke(self, context: InvocationContext) -> AnyOutput:
+        value = self.a if self.switch else self.b
+        return AnyOutput(value=value)

--- a/invokeai/frontend/web/src/features/nodes/store/util/validateConnectionTypes.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/util/validateConnectionTypes.ts
@@ -58,6 +58,7 @@ export const validateConnectionTypes = (sourceType: FieldType, targetType: Field
   const isSubTypeMatch = doesCardinalityMatch && (isIntToFloat || isIntToString || isFloatToString);
 
   const isTargetAnyType = targetType.name === 'AnyField';
+  const isSourceAnyType = sourceType.name === 'AnyField';
 
   // One of these must be true for the connection to be valid
   return (
@@ -67,6 +68,7 @@ export const validateConnectionTypes = (sourceType: FieldType, targetType: Field
     isGenericCollectionToAnyCollectionOrSingleOrCollection ||
     isCollectionToGenericCollection ||
     isSubTypeMatch ||
-    isTargetAnyType
+    isTargetAnyType ||
+    isSourceAnyType
   );
 };

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -144,7 +144,7 @@ export const parseSchema = (
 
         const fieldType = fieldTypeOverride ?? originalFieldType;
         if (!fieldType) {
-          log.trace({ node: type, field: propertyName, schema: parseify(property) }, 'Unable to parse field type');
+          log.warn({ node: type, field: propertyName, schema: parseify(property) }, 'Unable to parse field type');
           return inputsAccumulator;
         }
 
@@ -214,7 +214,7 @@ export const parseSchema = (
 
         const fieldType = fieldTypeOverride ?? originalFieldType;
         if (!fieldType) {
-          log.trace({ node: type, field: propertyName, schema: parseify(property) }, 'Unable to parse field type');
+          log.warn({ node: type, field: propertyName, schema: parseify(property) }, 'Unable to parse field type');
           return outputsAccumulator;
         }
 
@@ -269,7 +269,7 @@ const getFieldType = (
   } catch (e) {
     const tKey = kind === 'input' ? 'nodes.inputFieldTypeParseError' : 'nodes.outputFieldTypeParseError';
     if (e instanceof FieldParseError) {
-      log.warn(
+      log.trace(
         {
           node: type,
           field: propertyName,
@@ -282,7 +282,7 @@ const getFieldType = (
         })
       );
     } else {
-      log.warn(
+      log.trace(
         {
           node: type,
           field: propertyName,


### PR DESCRIPTION
## Summary

Allow `Any` to be an _output_ type for node fields. This introduces a major footgun, so we haven't enabled it.

It's safe for nodes to have `Any` type inputs, because that node knows up front that it could get literally anything as an input. The node knows it must handle literally anything and it is able to take that responsibility.

It is unsafe for nodes to have `Any` type _outputs_, because then _every node must be able to handle literally anything as an input._ It shifts the responsibility of dealing with untyped inputs to every node, instead of only the nodes that explicitly accept them.

This also encourages node authors to just slap `Any` on every output because that's way easier than actually defining types.

Ok, all that said, this _does_ increase node power. For example, we can provide a flexible Switcher node (included in this PR). This node has 2 `Any` inputs and 1 `Any` output. A `switch: bool` input lets you choose between the two inputs. 

If we want to accept the change in this PR, we could add a setting the workflow editor to make this opt-in:
- Besides `Iterate` and `Collect` nodes, which are special cases, hide all nodes with `Any` outputs.
- Besides `Iterate` and `Collect` nodes, which are special cases, do not allow nodes with `Any` outputs to pass validation.

Another way to reduce footguns would be to special-case nodes like the Switcher, making the `Any` type function more like a generic. The type would be inferred from one of the inputs, and its output would be treated as the inferred type. Obviously this reduces the flexibility of the node.

I think I'm OK with this change if it is opt-in.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1278825261432967169/1347633191816527985

## QA Instructions

Try the switcher node out.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
