### PR TITLE
make sure that recent view always sorts by opened_at

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/store/workflowLibrarySlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/workflowLibrarySlice.ts
@@ -39,6 +39,10 @@ export const workflowLibrarySlice = createSlice({
     workflowLibraryViewChanged: (state, action: PayloadAction<WorkflowLibraryState['view']>) => {
       state.view = action.payload;
       state.searchTerm = '';
+      if (action.payload === 'recent') {
+        state.orderBy = 'opened_at';
+        state.direction = 'DESC';
+      }
     },
     workflowLibraryTagToggled: (state, action: PayloadAction<string>) => {
       const tag = action.payload;


### PR DESCRIPTION

## Summary

make sure that recent view always sorts by opened_at even if not available as sort option in UI


## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
