### PR TITLE
feat(ui): allow pasting into gallery on canvas and workflows tabs

### DIFF
--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -7,6 +7,7 @@ import { Box, Flex, Heading } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { getStore } from 'app/store/nanostores/store';
 import { useAppSelector } from 'app/store/storeHooks';
+import { $focusedRegion } from 'common/hooks/focus';
 import { setFileToPaste } from 'features/controlLayers/components/CanvasPasteModal';
 import { DndDropOverlay } from 'features/dnd/DndDropOverlay';
 import type { DndTargetState } from 'features/dnd/types';
@@ -99,10 +100,18 @@ export const FullscreenDropzone = memo(() => {
         return;
       }
 
+      const focusedRegion = $focusedRegion.get();
+
       // While on the canvas tab and when pasting a single image, canvas may want to create a new layer. Let it handle
       // the paste event.
       const [firstImageFile] = files;
-      if (!isImageViewerOpen && activeTab === 'canvas' && files.length === 1 && firstImageFile) {
+      if (
+        focusedRegion === 'canvas' &&
+        !isImageViewerOpen &&
+        activeTab === 'canvas' &&
+        files.length === 1 &&
+        firstImageFile
+      ) {
         setFileToPaste(firstImageFile);
         return;
       }

--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -252,7 +252,7 @@ export const Flow = memo(() => {
     id: 'pasteSelection',
     category: 'workflows',
     callback: pasteSelection,
-    options: { preventDefault: true },
+    options: { enabled: isWorkflowsFocused, preventDefault: true },
     dependencies: [pasteSelection],
   });
 
@@ -260,7 +260,7 @@ export const Flow = memo(() => {
     id: 'pasteSelectionWithEdges',
     category: 'workflows',
     callback: pasteSelectionWithEdges,
-    options: { preventDefault: true },
+    options: { enabled: isWorkflowsFocused, preventDefault: true },
     dependencies: [pasteSelectionWithEdges],
   });
 
@@ -270,7 +270,7 @@ export const Flow = memo(() => {
     callback: () => {
       dispatch(undo());
     },
-    options: { enabled: mayUndo, preventDefault: true },
+    options: { enabled: isWorkflowsFocused && mayUndo, preventDefault: true },
     dependencies: [mayUndo],
   });
 
@@ -280,7 +280,7 @@ export const Flow = memo(() => {
     callback: () => {
       dispatch(redo());
     },
-    options: { enabled: mayRedo, preventDefault: true },
+    options: { enabled: isWorkflowsFocused && mayRedo, preventDefault: true },
     dependencies: [mayRedo],
   });
 


### PR DESCRIPTION
## Summary

- When focused in the Canvas, pasting is handled by the Canvas. Images will be pasted into the Canvas.
- When focused in the Workflow Editor, pasting is handled by the Workflow editor. Image pastes are ignored.
- When on either Canvas or Workflows tabs, when focused _outside_ the work areas, pasting is handled by the global image upload handler. Images will be pasted and then uploaded to gallery.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1349877631566483456

## QA Instructions

Try it out

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
