### PR TITLE
feat: :sparkles: Highlight Focused UI Regions

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1207,6 +1207,7 @@
         "informationalPopoversDisabled": "Informational Popovers Disabled",
         "informationalPopoversDisabledDesc": "Informational popovers have been disabled. Enable them in Settings.",
         "enableModelDescriptions": "Enable Model Descriptions in Dropdowns",
+        "enableHighlightFocusedRegions": "Highlight Focused Regions",
         "modelDescriptionsDisabled": "Model Descriptions in Dropdowns Disabled",
         "modelDescriptionsDisabledDesc": "Model descriptions in dropdowns have been disabled. Enable them in Settings.",
         "enableInvisibleWatermark": "Enable Invisible Watermark",

--- a/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
+++ b/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
@@ -1,0 +1,50 @@
+import { Box, type BoxProps } from '@invoke-ai/ui-library';
+import { useAppSelector } from 'app/store/storeHooks';
+import { type FocusRegionName, useFocusRegion, useIsRegionFocused } from 'common/hooks/focus';
+import { selectSystemShouldEnableHighlightFocusedRegions } from 'features/system/store/systemSlice';
+import { forwardRef, type RefObject, useMemo, useRef } from 'react';
+
+interface FocusRegionWrapperProps extends BoxProps {
+  region: FocusRegionName;
+  focusOnMount?: boolean;
+  highlightColor?: string;
+}
+
+export const FocusRegionWrapper = forwardRef<HTMLDivElement, FocusRegionWrapperProps>(function RegionHighlighter(
+  { region, focusOnMount = false, highlightColor = 'blue.700', children, ...boxProps },
+  forwardedRef
+) {
+  const shouldHighlightFocusedRegions = useAppSelector(selectSystemShouldEnableHighlightFocusedRegions);
+
+  const innerRef = useRef<HTMLDivElement>(null);
+  const ref = (forwardedRef as RefObject<HTMLDivElement>) || innerRef;
+
+  const options = useMemo(() => ({ focusOnMount }), [focusOnMount]);
+
+  useFocusRegion(region, ref, options);
+  const isFocused = useIsRegionFocused(region);
+
+  return (
+    <Box
+      ref={ref}
+      position="relative"
+      tabIndex={-1}
+      _after={{
+        content: '""',
+        position: 'absolute',
+        inset: 0,
+        zIndex: 1,
+        borderRadius: 'base',
+        border: '2px solid',
+        borderColor: isFocused && shouldHighlightFocusedRegions ? highlightColor : 'transparent',
+        pointerEvents: 'none',
+        transition: 'border-color 0.1s ease-in-out',
+      }}
+      {...boxProps}
+    >
+      {children}
+    </Box>
+  );
+});
+
+FocusRegionWrapper.displayName = 'FocusRegionWrapper';

--- a/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
+++ b/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
@@ -27,7 +27,7 @@ const FOCUS_REGION_STYLES: SystemStyleObject = {
   },
 };
 
-const FocusRegionWrapper = memo(
+export const FocusRegionWrapper = memo(
   ({ region, focusOnMount = false, sx, children, ...boxProps }: FocusRegionWrapperProps) => {
     const shouldHighlightFocusedRegions = useAppSelector(selectSystemShouldEnableHighlightFocusedRegions);
 

--- a/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
+++ b/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
@@ -2,7 +2,7 @@ import { Box, type BoxProps, type SystemStyleObject } from '@invoke-ai/ui-librar
 import { useAppSelector } from 'app/store/storeHooks';
 import { type FocusRegionName, useFocusRegion, useIsRegionFocused } from 'common/hooks/focus';
 import { selectSystemShouldEnableHighlightFocusedRegions } from 'features/system/store/systemSlice';
-import { forwardRef, memo, type RefObject, useMemo, useRef } from 'react';
+import { memo, useMemo, useRef } from 'react';
 
 interface FocusRegionWrapperProps extends BoxProps {
   region: FocusRegionName;
@@ -27,14 +27,12 @@ const FOCUS_REGION_STYLES: SystemStyleObject = {
   }
 };
 
-const FocusRegionWrapperComponent = forwardRef<HTMLDivElement, FocusRegionWrapperProps>(function RegionHighlighter(
-  { region, focusOnMount = false, sx, children, ...boxProps },
-  forwardedRef
-) {
+const FocusRegionWrapper = memo(({
+  region, focusOnMount = false, sx, children, ...boxProps
+}: FocusRegionWrapperProps) => {
   const shouldHighlightFocusedRegions = useAppSelector(selectSystemShouldEnableHighlightFocusedRegions);
 
-  const innerRef = useRef<HTMLDivElement>(null);
-  const ref = (forwardedRef as RefObject<HTMLDivElement>) || innerRef;
+  const ref = useRef<HTMLDivElement>(null);
 
   const options = useMemo(() => ({ focusOnMount }), [focusOnMount]);
 
@@ -55,6 +53,4 @@ const FocusRegionWrapperComponent = forwardRef<HTMLDivElement, FocusRegionWrappe
   );
 });
 
-FocusRegionWrapperComponent.displayName = 'FocusRegionWrapper';
-
-export const FocusRegionWrapper = memo(FocusRegionWrapperComponent);
+FocusRegionWrapper.displayName = 'FocusRegionWrapper';

--- a/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
+++ b/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
@@ -43,8 +43,8 @@ export const FocusRegionWrapper = memo(
       <Box
         ref={ref}
         tabIndex={-1}
-        sx={{ ...FOCUS_REGION_STYLES, ...sx }}
-        data-highlighted={isHighlighted ? true : undefined}
+        sx={useMemo(() => ({ ...FOCUS_REGION_STYLES, ...sx }), [sx])}
+        data-highlighted={isHighlighted}
         {...boxProps}
       >
         {children}

--- a/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
+++ b/invokeai/frontend/web/src/common/components/FocusRegionWrapper.tsx
@@ -24,33 +24,33 @@ const FOCUS_REGION_STYLES: SystemStyleObject = {
     borderColor: 'transparent',
     pointerEvents: 'none',
     transition: 'border-color 0.1s ease-in-out',
-  }
+  },
 };
 
-const FocusRegionWrapper = memo(({
-  region, focusOnMount = false, sx, children, ...boxProps
-}: FocusRegionWrapperProps) => {
-  const shouldHighlightFocusedRegions = useAppSelector(selectSystemShouldEnableHighlightFocusedRegions);
+const FocusRegionWrapper = memo(
+  ({ region, focusOnMount = false, sx, children, ...boxProps }: FocusRegionWrapperProps) => {
+    const shouldHighlightFocusedRegions = useAppSelector(selectSystemShouldEnableHighlightFocusedRegions);
 
-  const ref = useRef<HTMLDivElement>(null);
+    const ref = useRef<HTMLDivElement>(null);
 
-  const options = useMemo(() => ({ focusOnMount }), [focusOnMount]);
+    const options = useMemo(() => ({ focusOnMount }), [focusOnMount]);
 
-  useFocusRegion(region, ref, options);
-  const isFocused = useIsRegionFocused(region);
-  const isHighlighted = isFocused && shouldHighlightFocusedRegions;
+    useFocusRegion(region, ref, options);
+    const isFocused = useIsRegionFocused(region);
+    const isHighlighted = isFocused && shouldHighlightFocusedRegions;
 
-  return (
-    <Box
-      ref={ref}
-      tabIndex={-1}
-      sx={{ ...FOCUS_REGION_STYLES, ...sx}}
-      data-highlighted={isHighlighted ? true : undefined}
-      {...boxProps}
-    >
-      {children}
-    </Box>
-  );
-});
+    return (
+      <Box
+        ref={ref}
+        tabIndex={-1}
+        sx={{ ...FOCUS_REGION_STYLES, ...sx }}
+        data-highlighted={isHighlighted ? true : undefined}
+        {...boxProps}
+      >
+        {children}
+      </Box>
+    );
+  }
+);
 
 FocusRegionWrapper.displayName = 'FocusRegionWrapper';

--- a/invokeai/frontend/web/src/common/hooks/focus.ts
+++ b/invokeai/frontend/web/src/common/hooks/focus.ts
@@ -30,7 +30,7 @@ const log = logger('system');
 /**
  * The names of the focus regions.
  */
-type FocusRegionName = 'gallery' | 'layers' | 'canvas' | 'workflows' | 'viewer';
+export type FocusRegionName = 'gallery' | 'layers' | 'canvas' | 'workflows' | 'viewer';
 
 /**
  * A map of focus regions to the elements that are part of that region.

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasLayersPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasLayersPanelContent.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex } from '@invoke-ai/ui-library';
+import { Divider, Flex, type SystemStyleObject } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { CanvasAddEntityButtons } from 'features/controlLayers/components/CanvasAddEntityButtons';
@@ -9,11 +9,16 @@ import { memo } from 'react';
 
 import { ParamDenoisingStrength } from './ParamDenoisingStrength';
 
+const FOCUS_REGION_STYLES: SystemStyleObject = {
+  width: 'full',
+  height: 'full',
+}
+
 export const CanvasLayersPanelContent = memo(() => {
   const hasEntities = useAppSelector(selectHasEntities);
 
   return (
-    <FocusRegionWrapper region="layers" w="full" h="full">
+    <FocusRegionWrapper region="layers" sx={FOCUS_REGION_STYLES}>
       <Flex flexDir="column" gap={2} w="full" h="full">
         <EntityListSelectedEntityActionBar />
         <Divider py={0} />

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasLayersPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasLayersPanelContent.tsx
@@ -12,7 +12,7 @@ import { ParamDenoisingStrength } from './ParamDenoisingStrength';
 const FOCUS_REGION_STYLES: SystemStyleObject = {
   width: 'full',
   height: 'full',
-}
+};
 
 export const CanvasLayersPanelContent = memo(() => {
   const hasEntities = useAppSelector(selectHasEntities);

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasLayersPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasLayersPanelContent.tsx
@@ -1,28 +1,28 @@
 import { Divider, Flex } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
-import { useFocusRegion } from 'common/hooks/focus';
+import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { CanvasAddEntityButtons } from 'features/controlLayers/components/CanvasAddEntityButtons';
 import { CanvasEntityList } from 'features/controlLayers/components/CanvasEntityList/CanvasEntityList';
 import { EntityListSelectedEntityActionBar } from 'features/controlLayers/components/CanvasEntityList/EntityListSelectedEntityActionBar';
 import { selectHasEntities } from 'features/controlLayers/store/selectors';
-import { memo, useRef } from 'react';
+import { memo } from 'react';
 
 import { ParamDenoisingStrength } from './ParamDenoisingStrength';
 
 export const CanvasLayersPanelContent = memo(() => {
   const hasEntities = useAppSelector(selectHasEntities);
-  const layersPanelFocusRef = useRef<HTMLDivElement>(null);
-  useFocusRegion('layers', layersPanelFocusRef);
 
   return (
-    <Flex ref={layersPanelFocusRef} flexDir="column" gap={2} w="full" h="full">
-      <EntityListSelectedEntityActionBar />
-      <Divider py={0} />
-      <ParamDenoisingStrength />
-      <Divider py={0} />
-      {!hasEntities && <CanvasAddEntityButtons />}
-      {hasEntities && <CanvasEntityList />}
-    </Flex>
+    <FocusRegionWrapper region="layers" w="full" h="full">
+      <Flex flexDir="column" gap={2} w="full" h="full">
+        <EntityListSelectedEntityActionBar />
+        <Divider py={0} />
+        <ParamDenoisingStrength />
+        <Divider py={0} />
+        {!hasEntities && <CanvasAddEntityButtons />}
+        {hasEntities && <CanvasEntityList />}
+      </Flex>
+    </FocusRegionWrapper>
   );
 });
 

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
@@ -1,6 +1,6 @@
 import { ContextMenu, Flex, IconButton, Menu, MenuButton, MenuList } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
-import { useFocusRegion } from 'common/hooks/focus';
+import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { CanvasAlertsPreserveMask } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsPreserveMask';
 import { CanvasAlertsSelectedEntityStatus } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsSelectedEntityStatus';
 import { CanvasAlertsSendingToGallery } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsSendingTo';
@@ -18,7 +18,7 @@ import { Transform } from 'features/controlLayers/components/Transform/Transform
 import { CanvasManagerProviderGate } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import { selectDynamicGrid, selectShowHUD } from 'features/controlLayers/store/canvasSettingsSlice';
 import { GatedImageViewer } from 'features/gallery/components/ImageViewer/ImageViewer';
-import { memo, useCallback, useRef } from 'react';
+import { memo, useCallback } from 'react';
 import { PiDotsThreeOutlineVerticalFill } from 'react-icons/pi';
 
 import { CanvasAlertsInvocationProgress } from './CanvasAlerts/CanvasAlertsInvocationProgress';
@@ -35,7 +35,6 @@ const MenuContent = () => {
 };
 
 export const CanvasMainPanelContent = memo(() => {
-  const ref = useRef<HTMLDivElement>(null);
   const dynamicGrid = useAppSelector(selectDynamicGrid);
   const showHUD = useAppSelector(selectShowHUD);
 
@@ -43,82 +42,81 @@ export const CanvasMainPanelContent = memo(() => {
     return <MenuContent />;
   }, []);
 
-  useFocusRegion('canvas', ref);
-
   return (
-    <Flex
-      tabIndex={-1}
-      ref={ref}
-      borderRadius="base"
-      position="relative"
-      flexDirection="column"
-      height="full"
-      width="full"
-      gap={2}
-      alignItems="center"
-      justifyContent="center"
-      overflow="hidden"
-    >
-      <CanvasManagerProviderGate>
-        <CanvasToolbar />
-      </CanvasManagerProviderGate>
-      <ContextMenu<HTMLDivElement> renderMenu={renderMenu} withLongPress={false}>
-        {(ref) => (
-          <Flex
-            ref={ref}
-            position="relative"
-            w="full"
-            h="full"
-            bg={dynamicGrid ? 'base.850' : 'base.900'}
-            borderRadius="base"
-            overflow="hidden"
-          >
-            <InvokeCanvasComponent />
-            <CanvasManagerProviderGate>
-              <Flex
-                position="absolute"
-                flexDir="column"
-                top={1}
-                insetInlineStart={1}
-                pointerEvents="none"
-                gap={2}
-                alignItems="flex-start"
-              >
-                {showHUD && <CanvasHUD />}
-                <CanvasAlertsSelectedEntityStatus />
-                <CanvasAlertsPreserveMask />
-                <CanvasAlertsSendingToGallery />
-                <CanvasAlertsInvocationProgress />
-              </Flex>
-              <Flex position="absolute" top={1} insetInlineEnd={1}>
-                <Menu>
-                  <MenuButton as={IconButton} icon={<PiDotsThreeOutlineVerticalFill />} colorScheme="base" />
-                  <MenuContent />
-                </Menu>
-              </Flex>
-            </CanvasManagerProviderGate>
-          </Flex>
-        )}
-      </ContextMenu>
-      <Flex position="absolute" bottom={4} gap={2} align="center" justify="center">
+    <FocusRegionWrapper region="canvas" w="full" h="full">
+      <Flex
+        tabIndex={-1}
+        borderRadius="base"
+        position="relative"
+        flexDirection="column"
+        height="full"
+        width="full"
+        gap={2}
+        alignItems="center"
+        justifyContent="center"
+        overflow="hidden"
+      >
         <CanvasManagerProviderGate>
-          <StagingAreaIsStagingGate>
-            <StagingAreaToolbar />
-          </StagingAreaIsStagingGate>
+          <CanvasToolbar />
         </CanvasManagerProviderGate>
-      </Flex>
-      <Flex position="absolute" bottom={4}>
+        <ContextMenu<HTMLDivElement> renderMenu={renderMenu} withLongPress={false}>
+          {(ref) => (
+            <Flex
+              ref={ref}
+              position="relative"
+              w="full"
+              h="full"
+              bg={dynamicGrid ? 'base.850' : 'base.900'}
+              borderRadius="base"
+              overflow="hidden"
+            >
+              <InvokeCanvasComponent />
+              <CanvasManagerProviderGate>
+                <Flex
+                  position="absolute"
+                  flexDir="column"
+                  top={1}
+                  insetInlineStart={1}
+                  pointerEvents="none"
+                  gap={2}
+                  alignItems="flex-start"
+                >
+                  {showHUD && <CanvasHUD />}
+                  <CanvasAlertsSelectedEntityStatus />
+                  <CanvasAlertsPreserveMask />
+                  <CanvasAlertsSendingToGallery />
+                  <CanvasAlertsInvocationProgress />
+                </Flex>
+                <Flex position="absolute" top={1} insetInlineEnd={1}>
+                  <Menu>
+                    <MenuButton as={IconButton} icon={<PiDotsThreeOutlineVerticalFill />} colorScheme="base" />
+                    <MenuContent />
+                  </Menu>
+                </Flex>
+              </CanvasManagerProviderGate>
+            </Flex>
+          )}
+        </ContextMenu>
+        <Flex position="absolute" bottom={4} gap={2} align="center" justify="center">
+          <CanvasManagerProviderGate>
+            <StagingAreaIsStagingGate>
+              <StagingAreaToolbar />
+            </StagingAreaIsStagingGate>
+          </CanvasManagerProviderGate>
+        </Flex>
+        <Flex position="absolute" bottom={4}>
+          <CanvasManagerProviderGate>
+            <Filter />
+            <Transform />
+            <SelectObject />
+          </CanvasManagerProviderGate>
+        </Flex>
         <CanvasManagerProviderGate>
-          <Filter />
-          <Transform />
-          <SelectObject />
+          <CanvasDropArea />
         </CanvasManagerProviderGate>
+        <GatedImageViewer />
       </Flex>
-      <CanvasManagerProviderGate>
-        <CanvasDropArea />
-      </CanvasManagerProviderGate>
-      <GatedImageViewer />
-    </Flex>
+    </FocusRegionWrapper>
   );
 });
 

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
@@ -1,4 +1,4 @@
-import { ContextMenu, Flex, IconButton, Menu, MenuButton, MenuList } from '@invoke-ai/ui-library';
+import { ContextMenu, Flex, IconButton, Menu, MenuButton, MenuList, type SystemStyleObject } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { CanvasAlertsPreserveMask } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsPreserveMask';
@@ -23,6 +23,11 @@ import { PiDotsThreeOutlineVerticalFill } from 'react-icons/pi';
 
 import { CanvasAlertsInvocationProgress } from './CanvasAlerts/CanvasAlertsInvocationProgress';
 
+const FOCUS_REGION_STYLES: SystemStyleObject = {
+  width: 'full',
+  height: 'full',
+}
+
 const MenuContent = () => {
   return (
     <CanvasManagerProviderGate>
@@ -43,7 +48,7 @@ export const CanvasMainPanelContent = memo(() => {
   }, []);
 
   return (
-    <FocusRegionWrapper region="canvas" w="full" h="full">
+    <FocusRegionWrapper region="canvas" sx={FOCUS_REGION_STYLES}>
       <Flex
         tabIndex={-1}
         borderRadius="base"

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
@@ -1,4 +1,12 @@
-import { ContextMenu, Flex, IconButton, Menu, MenuButton, MenuList, type SystemStyleObject } from '@invoke-ai/ui-library';
+import {
+  ContextMenu,
+  Flex,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuList,
+  type SystemStyleObject,
+} from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { CanvasAlertsPreserveMask } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsPreserveMask';
@@ -26,7 +34,7 @@ import { CanvasAlertsInvocationProgress } from './CanvasAlerts/CanvasAlertsInvoc
 const FOCUS_REGION_STYLES: SystemStyleObject = {
   width: 'full',
   height: 'full',
-}
+};
 
 const MenuContent = () => {
   return (

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Collapse, Divider, Flex, IconButton, useDisclosure } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
-import { useFocusRegion } from 'common/hooks/focus';
+import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { GalleryHeader } from 'features/gallery/components/GalleryHeader';
 import { selectBoardSearchText } from 'features/gallery/store/gallerySelectors';
 import { boardSearchTextChanged } from 'features/gallery/store/gallerySlice';
@@ -26,8 +26,6 @@ const GalleryPanelContent = () => {
   const dispatch = useAppDispatch();
   const boardSearchDisclosure = useDisclosure({ defaultIsOpen: !!boardSearchText.length });
   const imperativePanelGroupRef = useRef<ImperativePanelGroupHandle>(null);
-  const galleryPanelFocusRef = useRef<HTMLDivElement>(null);
-  useFocusRegion('gallery', galleryPanelFocusRef);
 
   const boardsListPanelOptions = useMemo<UsePanelOptions>(
     () => ({
@@ -50,7 +48,7 @@ const GalleryPanelContent = () => {
   }, [boardSearchText.length, boardSearchDisclosure, boardsListPanel, dispatch]);
 
   return (
-    <Flex ref={galleryPanelFocusRef} position="relative" flexDirection="column" h="full" w="full" tabIndex={-1}>
+    <FocusRegionWrapper region="gallery" position="relative" flexDirection="column" h="full" w="full">
       <Flex alignItems="center" justifyContent="space-between" w="full">
         <Flex flexGrow={1} flexBasis={0}>
           <Button
@@ -99,7 +97,7 @@ const GalleryPanelContent = () => {
           <Gallery />
         </Panel>
       </PanelGroup>
-    </Flex>
+    </FocusRegionWrapper>
   );
 };
 

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Collapse, Divider, Flex, IconButton, type SystemStyleObject,useDisclosure } from '@invoke-ai/ui-library';
+import {
+  Box,
+  Button,
+  Collapse,
+  Divider,
+  Flex,
+  IconButton,
+  type SystemStyleObject,
+  useDisclosure,
+} from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { GalleryHeader } from 'features/gallery/components/GalleryHeader';
@@ -26,7 +35,7 @@ const FOCUS_REGION_STYLES: SystemStyleObject = {
   position: 'relative',
   flexDirection: 'column',
   display: 'flex',
-}
+};
 
 const GalleryPanelContent = () => {
   const { t } = useTranslation();

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryPanelContent.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Collapse, Divider, Flex, IconButton, useDisclosure } from '@invoke-ai/ui-library';
+import { Box, Button, Collapse, Divider, Flex, IconButton, type SystemStyleObject,useDisclosure } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { GalleryHeader } from 'features/gallery/components/GalleryHeader';
@@ -19,6 +19,14 @@ import BoardsSettingsPopover from './Boards/BoardsSettingsPopover';
 import { Gallery } from './Gallery';
 
 const COLLAPSE_STYLES: CSSProperties = { flexShrink: 0, minHeight: 0 };
+
+const FOCUS_REGION_STYLES: SystemStyleObject = {
+  width: 'full',
+  height: 'full',
+  position: 'relative',
+  flexDirection: 'column',
+  display: 'flex',
+}
 
 const GalleryPanelContent = () => {
   const { t } = useTranslation();
@@ -48,7 +56,7 @@ const GalleryPanelContent = () => {
   }, [boardSearchText.length, boardSearchDisclosure, boardsListPanel, dispatch]);
 
   return (
-    <FocusRegionWrapper region="gallery" position="relative" flexDirection="column" h="full" w="full">
+    <FocusRegionWrapper region="gallery" sx={FOCUS_REGION_STYLES}>
       <Flex alignItems="center" justifyContent="space-between" w="full">
         <Flex flexGrow={1} flexBasis={0}>
           <Button

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
@@ -34,7 +34,7 @@ const FOCUS_REGION_STYLES: SystemStyleObject = {
   alignItems: 'center',
   justifyContent: 'center',
   overflow: 'hidden',
-}
+};
 
 export const ImageViewer = memo(({ closeButton }: Props) => {
   useAssertSingleton('ImageViewer');
@@ -42,12 +42,7 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
   const [containerRef, containerDims] = useMeasure<HTMLDivElement>();
 
   return (
-    <FocusRegionWrapper
-      region="viewer"
-      sx={FOCUS_REGION_STYLES}
-      layerStyle="first"
-      {...useFocusRegionOptions}
-    >
+    <FocusRegionWrapper region="viewer" sx={FOCUS_REGION_STYLES} layerStyle="first" {...useFocusRegionOptions}>
       {hasImageToCompare && <CompareToolbar />}
       {!hasImageToCompare && <ViewerToolbar closeButton={closeButton} />}
       <Box ref={containerRef} w="full" h="full" p={2}>

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex, IconButton } from '@invoke-ai/ui-library';
+import { Box, IconButton } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
-import { useFocusRegion } from 'common/hooks/focus';
+import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
 import { CompareToolbar } from 'features/gallery/components/ImageViewer/CompareToolbar';
 import CurrentImagePreview from 'features/gallery/components/ImageViewer/CurrentImagePreview';
@@ -9,7 +9,7 @@ import { ImageComparisonDroppable } from 'features/gallery/components/ImageViewe
 import { ViewerToolbar } from 'features/gallery/components/ImageViewer/ViewerToolbar';
 import { selectHasImageToCompare } from 'features/gallery/store/gallerySelectors';
 import type { ReactNode } from 'react';
-import { memo, useRef } from 'react';
+import { memo } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 import { PiXBold } from 'react-icons/pi';
@@ -29,15 +29,12 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
   useAssertSingleton('ImageViewer');
   const hasImageToCompare = useAppSelector(selectHasImageToCompare);
   const [containerRef, containerDims] = useMeasure<HTMLDivElement>();
-  const ref = useRef<HTMLDivElement>(null);
-  useFocusRegion('viewer', ref, useFocusRegionOptions);
 
   return (
-    <Flex
-      ref={ref}
-      tabIndex={-1}
-      layerStyle="first"
-      borderRadius="base"
+    <FocusRegionWrapper
+      region="viewer"
+      w="full"
+      h="full"
       position="absolute"
       flexDirection="column"
       top={0}
@@ -47,6 +44,8 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
       alignItems="center"
       justifyContent="center"
       overflow="hidden"
+      layerStyle="first"
+      {...useFocusRegionOptions}
     >
       {hasImageToCompare && <CompareToolbar />}
       {!hasImageToCompare && <ViewerToolbar closeButton={closeButton} />}
@@ -55,7 +54,7 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
         {hasImageToCompare && <ImageComparison containerDims={containerDims} />}
       </Box>
       <ImageComparisonDroppable />
-    </Flex>
+    </FocusRegionWrapper>
   );
 });
 

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton } from '@invoke-ai/ui-library';
+import { Box, IconButton, type SystemStyleObject } from '@invoke-ai/ui-library';
 import { useAppSelector } from 'app/store/storeHooks';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
@@ -25,6 +25,17 @@ const useFocusRegionOptions = {
   focusOnMount: true,
 };
 
+const FOCUS_REGION_STYLES: SystemStyleObject = {
+  width: 'full',
+  height: 'full',
+  position: 'absolute',
+  flexDirection: 'column',
+  inset: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+}
+
 export const ImageViewer = memo(({ closeButton }: Props) => {
   useAssertSingleton('ImageViewer');
   const hasImageToCompare = useAppSelector(selectHasImageToCompare);
@@ -33,17 +44,7 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
   return (
     <FocusRegionWrapper
       region="viewer"
-      w="full"
-      h="full"
-      position="absolute"
-      flexDirection="column"
-      top={0}
-      right={0}
-      bottom={0}
-      left={0}
-      alignItems="center"
-      justifyContent="center"
-      overflow="hidden"
+      sx={FOCUS_REGION_STYLES}
       layerStyle="first"
       {...useFocusRegionOptions}
     >

--- a/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
@@ -1,3 +1,4 @@
+import type { SystemStyleObject } from '@invoke-ai/ui-library'
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import { AddNodeCmdk } from 'features/nodes/components/flow/AddNodeCmdk/AddNodeCmdk';
@@ -12,6 +13,14 @@ import { Flow } from './flow/Flow';
 import BottomLeftPanel from './flow/panels/BottomLeftPanel/BottomLeftPanel';
 import MinimapPanel from './flow/panels/MinimapPanel/MinimapPanel';
 
+const FOCUS_REGION_STYLES: SystemStyleObject = {
+  position: 'relative',
+  width: 'full',
+  height: 'full',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
 const NodeEditor = () => {
   const { data, isLoading } = useGetOpenAPISchemaQuery();
   const { t } = useTranslation();
@@ -20,12 +29,7 @@ const NodeEditor = () => {
     <FocusRegionWrapper
       region="workflows"
       layerStyle="first"
-      position="relative"
-      width="full"
-      height="full"
-      borderRadius="base"
-      alignItems="center"
-      justifyContent="center"
+      sx={FOCUS_REGION_STYLES}
     >
       {data && (
         <>

--- a/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
@@ -1,4 +1,4 @@
-import type { SystemStyleObject } from '@invoke-ai/ui-library'
+import type { SystemStyleObject } from '@invoke-ai/ui-library';
 import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
 import { AddNodeCmdk } from 'features/nodes/components/flow/AddNodeCmdk/AddNodeCmdk';
@@ -19,18 +19,14 @@ const FOCUS_REGION_STYLES: SystemStyleObject = {
   height: 'full',
   alignItems: 'center',
   justifyContent: 'center',
-}
+};
 
 const NodeEditor = () => {
   const { data, isLoading } = useGetOpenAPISchemaQuery();
   const { t } = useTranslation();
 
   return (
-    <FocusRegionWrapper
-      region="workflows"
-      layerStyle="first"
-      sx={FOCUS_REGION_STYLES}
-    >
+    <FocusRegionWrapper region="workflows" layerStyle="first" sx={FOCUS_REGION_STYLES}>
       {data && (
         <>
           <Flow />

--- a/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
@@ -1,10 +1,9 @@
-import { Flex } from '@invoke-ai/ui-library';
+import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { IAINoContentFallback } from 'common/components/IAIImageFallback';
-import { useFocusRegion } from 'common/hooks/focus';
 import { AddNodeCmdk } from 'features/nodes/components/flow/AddNodeCmdk/AddNodeCmdk';
 import TopPanel from 'features/nodes/components/flow/panels/TopPanel/TopPanel';
 import WorkflowEditorSettings from 'features/nodes/components/flow/panels/TopRightPanel/WorkflowEditorSettings';
-import { memo, useRef } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiFlowArrowBold } from 'react-icons/pi';
 import { useGetOpenAPISchemaQuery } from 'services/api/endpoints/appInfo';
@@ -16,13 +15,10 @@ import MinimapPanel from './flow/panels/MinimapPanel/MinimapPanel';
 const NodeEditor = () => {
   const { data, isLoading } = useGetOpenAPISchemaQuery();
   const { t } = useTranslation();
-  const ref = useRef<HTMLDivElement>(null);
-  useFocusRegion('workflows', ref);
 
   return (
-    <Flex
-      tabIndex={-1}
-      ref={ref}
+    <FocusRegionWrapper
+      region="workflows"
       layerStyle="first"
       position="relative"
       width="full"
@@ -42,7 +38,7 @@ const NodeEditor = () => {
       )}
       <WorkflowEditorSettings />
       {isLoading && <IAINoContentFallback label={t('nodes.loadingNodes')} icon={PiFlowArrowBold} />}
-    </Flex>
+    </FocusRegionWrapper>
   );
 };
 

--- a/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/SettingsModal/SettingsModal.tsx
@@ -30,6 +30,7 @@ import {
   selectSystemShouldAntialiasProgressImage,
   selectSystemShouldConfirmOnDelete,
   selectSystemShouldConfirmOnNewSession,
+  selectSystemShouldEnableHighlightFocusedRegions,
   selectSystemShouldEnableInformationalPopovers,
   selectSystemShouldEnableModelDescriptions,
   selectSystemShouldShowInvocationProgressDetail,
@@ -38,6 +39,7 @@ import {
   setShouldConfirmOnDelete,
   setShouldEnableInformationalPopovers,
   setShouldEnableModelDescriptions,
+  setShouldHighlightFocusedRegions,
   setShouldShowInvocationProgressDetail,
   shouldAntialiasProgressImageChanged,
   shouldConfirmOnNewSessionToggled,
@@ -106,6 +108,7 @@ const SettingsModal = ({ config = defaultConfig, children }: SettingsModalProps)
   const shouldUseWatermarker = useAppSelector(selectSystemShouldUseWatermarker);
   const shouldEnableInformationalPopovers = useAppSelector(selectSystemShouldEnableInformationalPopovers);
   const shouldEnableModelDescriptions = useAppSelector(selectSystemShouldEnableModelDescriptions);
+  const shouldHighlightFocusedRegions = useAppSelector(selectSystemShouldEnableHighlightFocusedRegions);
   const shouldConfirmOnNewSession = useAppSelector(selectSystemShouldConfirmOnNewSession);
   const shouldShowInvocationProgressDetail = useAppSelector(selectSystemShouldShowInvocationProgressDetail);
   const onToggleConfirmOnNewSession = useCallback(() => {
@@ -178,6 +181,13 @@ const SettingsModal = ({ config = defaultConfig, children }: SettingsModalProps)
   const handleChangeShouldShowInvocationProgressDetail = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       dispatch(setShouldShowInvocationProgressDetail(e.target.checked));
+    },
+    [dispatch]
+  );
+
+  const handleChangeShouldHighlightFocusedRegions = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      dispatch(setShouldHighlightFocusedRegions(e.target.checked));
     },
     [dispatch]
   );
@@ -261,6 +271,13 @@ const SettingsModal = ({ config = defaultConfig, children }: SettingsModalProps)
                       <Switch
                         isChecked={shouldEnableModelDescriptions}
                         onChange={handleChangeShouldEnableModelDescriptions}
+                      />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel>{t('settings.enableHighlightFocusedRegions')}</FormLabel>
+                      <Switch
+                        isChecked={shouldHighlightFocusedRegions}
+                        onChange={handleChangeShouldHighlightFocusedRegions}
                       />
                     </FormControl>
                   </StickyScrollable>

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -22,7 +22,7 @@ const initialSystemState: SystemState = {
   logLevel: 'debug',
   logNamespaces: [...zLogNamespace.options],
   shouldShowInvocationProgressDetail: false,
-  shouldHighlightFocusedRegions: true,
+  shouldHighlightFocusedRegions: false,
 };
 
 export const systemSlice = createSlice({

--- a/invokeai/frontend/web/src/features/system/store/systemSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/systemSlice.ts
@@ -22,6 +22,7 @@ const initialSystemState: SystemState = {
   logLevel: 'debug',
   logNamespaces: [...zLogNamespace.options],
   shouldShowInvocationProgressDetail: false,
+  shouldHighlightFocusedRegions: true,
 };
 
 export const systemSlice = createSlice({
@@ -68,6 +69,9 @@ export const systemSlice = createSlice({
     setShouldShowInvocationProgressDetail(state, action: PayloadAction<boolean>) {
       state.shouldShowInvocationProgressDetail = action.payload;
     },
+    setShouldHighlightFocusedRegions(state, action: PayloadAction<boolean>) {
+      state.shouldHighlightFocusedRegions = action.payload;
+    },
   },
 });
 
@@ -84,6 +88,7 @@ export const {
   setShouldEnableModelDescriptions,
   shouldConfirmOnNewSessionToggled,
   setShouldShowInvocationProgressDetail,
+  setShouldHighlightFocusedRegions,
 } = systemSlice.actions;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -120,6 +125,9 @@ export const selectSystemShouldEnableInformationalPopovers = createSystemSelecto
 );
 export const selectSystemShouldEnableModelDescriptions = createSystemSelector(
   (system) => system.shouldEnableModelDescriptions
+);
+export const selectSystemShouldEnableHighlightFocusedRegions = createSystemSelector(
+  (system) => system.shouldHighlightFocusedRegions
 );
 export const selectSystemShouldConfirmOnNewSession = createSystemSelector((system) => system.shouldConfirmOnNewSession);
 export const selectSystemShouldShowInvocationProgressDetail = createSystemSelector(

--- a/invokeai/frontend/web/src/features/system/store/types.ts
+++ b/invokeai/frontend/web/src/features/system/store/types.ts
@@ -43,4 +43,5 @@ export interface SystemState {
   logLevel: LogLevel;
   logNamespaces: LogNamespace[];
   shouldShowInvocationProgressDetail: boolean;
+  shouldHighlightFocusedRegions: boolean;
 }


### PR DESCRIPTION
adds a region wrapper with a highlight effect when that region is focused, this behavior can be toggled as a setting

## Summary

Adds a region border highlight on focused regions. My approach to this was to create a Region Wrapper component responsible for handling focus state of children and using a pseudo element to highlight. This both reduces some verbosity in the focus management, and adds some visual clarity to the active region of the app.
This behavior can be toggled as a setting within the settings modal.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
