### PR TITLE
fix(ui): do not mark workflow as touched when setting form field initial values

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/store/workflowSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/workflowSlice.ts
@@ -186,7 +186,6 @@ export const workflowSlice = createSlice({
     ) => {
       const { formFieldInitialValues } = action.payload;
       state.formFieldInitialValues = formFieldInitialValues;
-      state.isTouched = true;
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
## Summary

fix(ui): do not mark workflow as touched when setting form field initial values

## Related Issues / Discussions

Fixes https://discord.com/channels/1020123559063990373/1149506274971631688/1350130951442927687

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
