### PR TITLE
fix(ui): generator widget should stretch to fill when added to builder

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/FloatGeneratorFieldComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/FloatGeneratorFieldComponent.tsx
@@ -80,7 +80,7 @@ export const FloatGeneratorFieldInputComponent = memo(
     }, [debouncedField, t]);
 
     return (
-      <Flex flexDir="column" gap={2}>
+      <Flex flexDir="column" gap={2} flexGrow={1}>
         <Select
           className={`${NO_WHEEL_CLASS} ${NO_DRAG_CLASS}`}
           onChange={onChangeGeneratorType}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/ImageGeneratorFieldComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/ImageGeneratorFieldComponent.tsx
@@ -70,7 +70,7 @@ export const ImageGeneratorFieldInputComponent = memo(
     }, [field, resolveAndSetValuesAsString]);
 
     return (
-      <Flex flexDir="column" gap={2}>
+      <Flex flexDir="column" gap={2} flexGrow={1}>
         <Select
           className={`${NO_WHEEL_CLASS} ${NO_DRAG_CLASS}`}
           onChange={onChangeGeneratorType}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/IntegerGeneratorFieldComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/IntegerGeneratorFieldComponent.tsx
@@ -82,7 +82,7 @@ export const IntegerGeneratorFieldInputComponent = memo(
     }, [debouncedField, t]);
 
     return (
-      <Flex flexDir="column" gap={2}>
+      <Flex flexDir="column" gap={2} flexGrow={1}>
         <Select
           className={`${NO_WHEEL_CLASS} ${NO_DRAG_CLASS}`}
           onChange={onChangeGeneratorType}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringGeneratorFieldComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringGeneratorFieldComponent.tsx
@@ -74,7 +74,7 @@ export const StringGeneratorFieldInputComponent = memo(
     }, [field, resolveAndSetValuesAsString]);
 
     return (
-      <Flex flexDir="column" gap={2}>
+      <Flex flexDir="column" gap={2} flexGrow={1}>
         <Select
           className={`${NO_WHEEL_CLASS} ${NO_DRAG_CLASS}`}
           onChange={onChangeGeneratorType}


### PR DESCRIPTION
## Summary

fix(ui): generator widget should stretch to fill when added to builder

Minor visual issue

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
