### PR TITLE
fix(ui): duplicate edges on reconnect

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
+++ b/invokeai/frontend/web/src/features/nodes/hooks/useConnection.ts
@@ -64,9 +64,9 @@ export const useConnection = () => {
     const edgePendingUpdate = $edgePendingUpdate.get();
     const mouseOverNodeId = $mouseOverNode.get();
 
-    // If we are in the middle of an edge update, and the mouse isn't over a node, we should just bail so the edge
-    // update logic can finish up
-    if (edgePendingUpdate && !mouseOverNodeId) {
+    // If we are in the middle of an edge update, and the mouse isn't over a node, OR we have just updated the edge,
+    // we should just bail and let the edge update (i.e. reconnect) logic handle the connection
+    if ((edgePendingUpdate && !mouseOverNodeId) || $didUpdateEdge.get()) {
       $pendingConnection.set(null);
       return;
     }


### PR DESCRIPTION
## Summary

Fix an issue where an edge reconnect gets handled twice, adding two edges

## Related Issues / Discussions

Closes #7127

## QA Instructions

Repro:
- Create a workflow w/ 2 add integer nodes
- Connect the output of one to the A input of the other
- Drag the edge away from the A input to reconnect it to the B input
- Drop it just to the right of the red circle, such that the edge is snapped to the red circle but your cursor is not over the red circle

The edge connection will be handled both by reactflow's reconnect logic and our custom "drop an edge on the body of a node and have it auto-connect" logic. 

There was some logic to bail out of our custom logic that wasn't fully baked. This PR bakes it the rest of the way

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
