### PR TITLE
fix(ui): clip shift-draw strokes to bbox when clip to bbox enabled

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasBrushToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasBrushToolModule.ts
@@ -301,8 +301,9 @@ export class CanvasBrushToolModule extends CanvasModuleBase {
         points,
         strokeWidth: settings.brushWidth,
         color: this.manager.stateApi.getCurrentColor(),
-        // When shift is held, the line may extend beyond the clip region. No clip for these lines.
-        clip: isShiftDraw ? null : this.parent.getClip(selectedEntity.state),
+        // When shift is held, the line may extend beyond the clip region. Clip only if we are clipping to bbox. If we
+        // are clipping to stage, we don't need to clip at all.
+        clip: isShiftDraw && !settings.clipToBbox ? null : this.parent.getClip(selectedEntity.state),
       });
     } else {
       const lastLinePoint = getLastPointOfLastLine(selectedEntity.state.objects, 'brush_line');
@@ -325,8 +326,9 @@ export class CanvasBrushToolModule extends CanvasModuleBase {
         points,
         strokeWidth: settings.brushWidth,
         color: this.manager.stateApi.getCurrentColor(),
-        // When shift is held, the line may extend beyond the clip region. No clip for these lines.
-        clip: isShiftDraw ? null : this.parent.getClip(selectedEntity.state),
+        // When shift is held, the line may extend beyond the clip region. Clip only if we are clipping to bbox. If we
+        // are clipping to stage, we don't need to clip at all.
+        clip: isShiftDraw && !settings.clipToBbox ? null : this.parent.getClip(selectedEntity.state),
       });
     }
   };


### PR DESCRIPTION
## Summary

When holding shift to draw straight lines, if clip to bbox is enabled, we should clip to bbox. 

Bug was introduced when clipping was totally disabled for shift-drawing in #7651.

## Related Issues / Discussions

Closes #7809

## QA Instructions

Try it out

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
