### PR TITLE
feat(ui): custom dropdowns for strings in builder

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -194,7 +194,9 @@
         "combinatorial": "Combinatorial",
         "layout": "Layout",
         "row": "Row",
-        "column": "Column"
+        "column": "Column",
+        "value": "Value",
+        "label": "Label"
     },
     "hrf": {
         "hrf": "High Resolution Fix",
@@ -1769,6 +1771,7 @@
             "singleLine": "Single Line",
             "multiLine": "Multi Line",
             "slider": "Slider",
+            "dropdown": "Dropdown",
             "both": "Both",
             "emptyRootPlaceholderViewMode": "Click Edit to start building a form for this workflow.",
             "emptyRootPlaceholderEditMode": "Drag a form element or node field here to get started.",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1744,6 +1744,7 @@
         "openLibrary": "Open Library",
         "workflowThumbnail": "Workflow Thumbnail",
         "saveChanges": "Save Changes",
+        "emptyStringPlaceholder": "<empty string>",
         "builder": {
             "deleteAllElements": "Delete All Form Elements",
             "resetAllNodeFields": "Reset All Node Fields",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1772,6 +1772,8 @@
             "multiLine": "Multi Line",
             "slider": "Slider",
             "dropdown": "Dropdown",
+            "addOption": "Add Option",
+            "resetOptions": "Reset Options",
             "both": "Both",
             "emptyRootPlaceholderViewMode": "Click Edit to start building a form for this workflow.",
             "emptyRootPlaceholderEditMode": "Drag a form element or node field here to get started.",

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldRenderer.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldRenderer.tsx
@@ -13,6 +13,7 @@ import { StringGeneratorFieldInputComponent } from 'features/nodes/components/fl
 import { IntegerFieldInput } from 'features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInput';
 import { IntegerFieldInputAndSlider } from 'features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInputAndSlider';
 import { IntegerFieldSlider } from 'features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldSlider';
+import { StringFieldDropdown } from 'features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldDropdown';
 import { StringFieldInput } from 'features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldInput';
 import { StringFieldTextarea } from 'features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldTextarea';
 import { useInputFieldInstance } from 'features/nodes/hooks/useInputFieldInstance';
@@ -151,7 +152,7 @@ export const InputFieldRenderer = memo(({ nodeId, fieldName, settings }: Props) 
     if (!isStringFieldInputInstance(field)) {
       return null;
     }
-    if (settings?.type !== 'string-field-config') {
+    if (!settings || settings.type !== 'string-field-config') {
       if (template.ui_component === 'textarea') {
         return <StringFieldTextarea nodeId={nodeId} field={field} fieldTemplate={template} />;
       } else {
@@ -162,8 +163,10 @@ export const InputFieldRenderer = memo(({ nodeId, fieldName, settings }: Props) 
       return <StringFieldInput nodeId={nodeId} field={field} fieldTemplate={template} />;
     } else if (settings.component === 'textarea') {
       return <StringFieldTextarea nodeId={nodeId} field={field} fieldTemplate={template} />;
+    } else if (settings.component === 'dropdown') {
+      return <StringFieldDropdown nodeId={nodeId} field={field} fieldTemplate={template} settings={settings} />;
     } else {
-      assert<Equals<never, typeof settings.component>>(false, 'Unexpected settings.component');
+      assert<Equals<never, typeof settings>>(false, 'Unexpected settings');
     }
   }
 

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldDropdown.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldDropdown.tsx
@@ -1,0 +1,36 @@
+import { Select } from '@invoke-ai/ui-library';
+import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
+import { useStringField } from 'features/nodes/components/flow/nodes/Invocation/fields/StringField/useStringField';
+import { NO_DRAG_CLASS, NO_PAN_CLASS, NO_WHEEL_CLASS } from 'features/nodes/types/constants';
+import type { StringFieldInputInstance, StringFieldInputTemplate } from 'features/nodes/types/field';
+import type { NodeFieldStringSettings } from 'features/nodes/types/workflow';
+import { memo } from 'react';
+
+export const StringFieldDropdown = memo(
+  (
+    props: FieldComponentProps<
+      StringFieldInputInstance,
+      StringFieldInputTemplate,
+      { settings: Extract<NodeFieldStringSettings, { component: 'dropdown' }> }
+    >
+  ) => {
+    const { value, onChange } = useStringField(props);
+
+    return (
+      <Select
+        onChange={onChange}
+        className={`${NO_DRAG_CLASS} ${NO_PAN_CLASS} ${NO_WHEEL_CLASS}`}
+        isDisabled={props.settings.options.length === 0}
+        value={value}
+      >
+        {props.settings.options.map((choice, i) => (
+          <option key={`${i}_${choice.value}`} value={choice.value}>
+            {choice.label || choice.value || `Option ${i + 1}`}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+);
+
+StringFieldDropdown.displayName = 'StringFieldDropdown';

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldInput.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldInput.tsx
@@ -4,12 +4,21 @@ import { useStringField } from 'features/nodes/components/flow/nodes/Invocation/
 import { NO_DRAG_CLASS, NO_PAN_CLASS, NO_WHEEL_CLASS } from 'features/nodes/types/constants';
 import type { StringFieldInputInstance, StringFieldInputTemplate } from 'features/nodes/types/field';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export const StringFieldInput = memo(
   (props: FieldComponentProps<StringFieldInputInstance, StringFieldInputTemplate>) => {
     const { value, onChange } = useStringField(props);
+    const { t } = useTranslation();
 
-    return <Input className={`${NO_DRAG_CLASS} ${NO_PAN_CLASS} ${NO_WHEEL_CLASS}`} value={value} onChange={onChange} />;
+    return (
+      <Input
+        className={`${NO_DRAG_CLASS} ${NO_PAN_CLASS} ${NO_WHEEL_CLASS}`}
+        placeholder={t('workflows.emptyStringPlaceholder')}
+        value={value}
+        onChange={onChange}
+      />
+    );
   }
 );
 

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldTextarea.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/StringFieldTextarea.tsx
@@ -4,14 +4,17 @@ import { useStringField } from 'features/nodes/components/flow/nodes/Invocation/
 import { NO_DRAG_CLASS, NO_PAN_CLASS, NO_WHEEL_CLASS } from 'features/nodes/types/constants';
 import type { StringFieldInputInstance, StringFieldInputTemplate } from 'features/nodes/types/field';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export const StringFieldTextarea = memo(
   (props: FieldComponentProps<StringFieldInputInstance, StringFieldInputTemplate>) => {
+    const { t } = useTranslation();
     const { value, onChange } = useStringField(props);
 
     return (
       <Textarea
         className={`${NO_DRAG_CLASS} ${NO_PAN_CLASS} ${NO_WHEEL_CLASS}`}
+        placeholder={t('workflows.emptyStringPlaceholder')}
         value={value}
         onChange={onChange}
         h="full"

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/useStringField.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/StringField/useStringField.ts
@@ -10,7 +10,7 @@ export const useStringField = (props: FieldComponentProps<StringFieldInputInstan
   const dispatch = useAppDispatch();
 
   const onChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
       dispatch(
         fieldStringValueChanged({
           nodeId,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldCollectionInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldCollectionInputComponent.tsx
@@ -1,5 +1,5 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
-import { Button, Divider, Flex, FormLabel, Grid, GridItem, IconButton, Input } from '@invoke-ai/ui-library';
+import { Button, Divider, Flex, Grid, GridItem, IconButton, Input, Text } from '@invoke-ai/ui-library';
 import { useAppStore } from 'app/store/nanostores/store';
 import { getOverlayScrollbarsParams, overlayScrollbarsStyles } from 'common/components/OverlayScrollbars/constants';
 import { useInputFieldIsInvalid } from 'features/nodes/hooks/useInputFieldIsInvalid';
@@ -130,9 +130,9 @@ const ListItemContent = memo(({ value, index, onRemoveString, onChangeString }: 
   return (
     <>
       <GridItem>
-        <FormLabel ps={1} m={0}>
+        <Text variant="subtext" textAlign="center" minW={8}>
           {index + 1}.
-        </FormLabel>
+        </Text>
       </GridItem>
       <GridItem>
         <Input
@@ -148,7 +148,8 @@ const ListItemContent = memo(({ value, index, onRemoveString, onChangeString }: 
           tabIndex={-1}
           size="sm"
           variant="link"
-          alignSelf="stretch"
+          minW={8}
+          minH={8}
           onClick={onClickRemove}
           icon={<PiXBold />}
           aria-label={t('common.delete')}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldCollectionInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldCollectionInputComponent.tsx
@@ -107,42 +107,6 @@ export const StringFieldCollectionInputComponent = memo(
 
 StringFieldCollectionInputComponent.displayName = 'StringFieldCollectionInputComponent';
 
-type StringListItemContentProps = {
-  value: string;
-  index: number;
-  onRemoveString: (index: number) => void;
-  onChangeString: (index: number, value: string) => void;
-};
-
-const StringListItemContent = memo(({ value, index, onRemoveString, onChangeString }: StringListItemContentProps) => {
-  const { t } = useTranslation();
-
-  const onClickRemove = useCallback(() => {
-    onRemoveString(index);
-  }, [index, onRemoveString]);
-  const onChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      onChangeString(index, e.target.value);
-    },
-    [index, onChangeString]
-  );
-  return (
-    <Flex alignItems="center" gap={1}>
-      <Input size="xs" resize="none" value={value} onChange={onChange} />
-      <IconButton
-        size="sm"
-        variant="link"
-        alignSelf="stretch"
-        onClick={onClickRemove}
-        icon={<PiXBold />}
-        aria-label={t('common.remove')}
-        tooltip={t('common.remove')}
-      />
-    </Flex>
-  );
-});
-StringListItemContent.displayName = 'StringListItemContent';
-
 type ListItemContentProps = {
   value: string;
   index: number;

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldCollectionInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/StringFieldCollectionInputComponent.tsx
@@ -171,7 +171,13 @@ const ListItemContent = memo(({ value, index, onRemoveString, onChangeString }: 
         </FormLabel>
       </GridItem>
       <GridItem>
-        <Input size="sm" resize="none" value={value} onChange={onChange} />
+        <Input
+          placeholder={t('workflows.emptyStringPlaceholder')}
+          size="sm"
+          resize="none"
+          value={value}
+          onChange={onChange}
+        />
       </GridItem>
       <GridItem>
         <IconButton

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementEditMode.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementEditMode.tsx
@@ -39,6 +39,7 @@ export const NodeFieldElementEditMode = memo(({ el }: { el: NodeFieldElement }) 
   return (
     <Flex ref={draggableRef} id={id} className={NODE_FIELD_CLASS_NAME} sx={sx} data-parent-layout={containerCtx.layout}>
       <NodeFieldElementEditModeContent dragHandleRef={dragHandleRef} el={el} isDragging={isDragging} />
+      <NodeFieldElementOverlay element={el} />
       <DndListDropIndicator activeDropRegion={activeDropRegion} gap="var(--invoke-space-4)" />
     </Flex>
   );

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementEditMode.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementEditMode.tsx
@@ -9,7 +9,7 @@ import { FormElementEditModeContent } from 'features/nodes/components/sidePanel/
 import { FormElementEditModeHeader } from 'features/nodes/components/sidePanel/builder/FormElementEditModeHeader';
 import { NodeFieldElementDescriptionEditable } from 'features/nodes/components/sidePanel/builder/NodeFieldElementDescriptionEditable';
 import { NodeFieldElementLabelEditable } from 'features/nodes/components/sidePanel/builder/NodeFieldElementLabelEditable';
-import { NodeFieldElementStringDropdownConfig } from 'features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig';
+import { NodeFieldElementStringDropdownSettings } from 'features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownSettings';
 import { useMouseOverFormField, useMouseOverNode } from 'features/nodes/hooks/useMouseOverNode';
 import type { NodeFieldElement } from 'features/nodes/types/workflow';
 import { NODE_FIELD_CLASS_NAME } from 'features/nodes/types/workflow';
@@ -77,7 +77,7 @@ const NodeFieldElementEditModeContent = memo(
               {data.settings?.type === 'string-field-config' && data.settings.component === 'dropdown' && (
                 <>
                   <Divider />
-                  <NodeFieldElementStringDropdownConfig id={id} settings={data.settings} />
+                  <NodeFieldElementStringDropdownSettings id={id} settings={data.settings} />
                 </>
               )}
             </FormControl>

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementEditMode.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementEditMode.tsx
@@ -1,5 +1,5 @@
 import type { SystemStyleObject } from '@invoke-ai/ui-library';
-import { Box, Flex, FormControl } from '@invoke-ai/ui-library';
+import { Box, Divider, Flex, FormControl } from '@invoke-ai/ui-library';
 import { InputFieldGate } from 'features/nodes/components/flow/nodes/Invocation/fields/InputFieldGate';
 import { InputFieldRenderer } from 'features/nodes/components/flow/nodes/Invocation/fields/InputFieldRenderer';
 import { useContainerContext } from 'features/nodes/components/sidePanel/builder/contexts';
@@ -9,6 +9,7 @@ import { FormElementEditModeContent } from 'features/nodes/components/sidePanel/
 import { FormElementEditModeHeader } from 'features/nodes/components/sidePanel/builder/FormElementEditModeHeader';
 import { NodeFieldElementDescriptionEditable } from 'features/nodes/components/sidePanel/builder/NodeFieldElementDescriptionEditable';
 import { NodeFieldElementLabelEditable } from 'features/nodes/components/sidePanel/builder/NodeFieldElementLabelEditable';
+import { NodeFieldElementStringDropdownConfig } from 'features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig';
 import { useMouseOverFormField, useMouseOverNode } from 'features/nodes/hooks/useMouseOverNode';
 import type { NodeFieldElement } from 'features/nodes/types/workflow';
 import { NODE_FIELD_CLASS_NAME } from 'features/nodes/types/workflow';
@@ -55,7 +56,7 @@ const NodeFieldElementEditModeContent = memo(
     dragHandleRef: RefObject<HTMLDivElement>;
     isDragging: boolean;
   }) => {
-    const { data } = el;
+    const { id, data } = el;
     const { fieldIdentifier, showDescription } = data;
     return (
       <>
@@ -72,6 +73,12 @@ const NodeFieldElementEditModeContent = memo(
                 />
               </Flex>
               {showDescription && <NodeFieldElementDescriptionEditable el={el} />}
+              {data.settings?.type === 'string-field-config' && data.settings.component === 'dropdown' && (
+                <>
+                  <Divider />
+                  <NodeFieldElementStringDropdownConfig id={id} settings={data.settings} />
+                </>
+              )}
             </FormControl>
           </InputFieldGate>
         </FormElementEditModeContent>

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementFloatSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementFloatSettings.tsx
@@ -14,42 +14,48 @@ import { useTranslation } from 'react-i18next';
 
 type Props = {
   id: string;
-  config: NodeFieldFloatSettings;
+  settings: NodeFieldFloatSettings;
   nodeId: string;
   fieldName: string;
   fieldTemplate: FloatFieldInputTemplate;
 };
 
-export const NodeFieldElementFloatSettings = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props) => {
+export const NodeFieldElementFloatSettings = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
   return (
     <>
-      <SettingComponent id={id} config={config} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-      <SettingMin id={id} config={config} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-      <SettingMax id={id} config={config} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingComponent
+        id={id}
+        settings={settings}
+        nodeId={nodeId}
+        fieldName={fieldName}
+        fieldTemplate={fieldTemplate}
+      />
+      <SettingMin id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingMax id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
     </>
   );
 });
 NodeFieldElementFloatSettings.displayName = 'NodeFieldElementFloatSettings';
 
-const SettingComponent = memo(({ id, config }: Props) => {
+const SettingComponent = memo(({ id, settings }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
   const onChangeComponent = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
-      const newConfig: NodeFieldFloatSettings = {
-        ...config,
+      const newSettings: NodeFieldFloatSettings = {
+        ...settings,
         component: zNumberComponent.parse(e.target.value),
       };
-      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
     },
-    [config, dispatch, id]
+    [settings, dispatch, id]
   );
 
   return (
     <FormControl orientation="vertical">
       <FormLabel flex={1}>{t('workflows.builder.component')}</FormLabel>
-      <Select value={config.component} onChange={onChangeComponent} size="sm">
+      <Select value={settings.component} onChange={onChangeComponent} size="sm">
         <option value="number-input">{t('workflows.builder.numberInput')}</option>
         <option value="slider">{t('workflows.builder.slider')}</option>
         <option value="number-input-and-slider">{t('workflows.builder.both')}</option>
@@ -59,36 +65,36 @@ const SettingComponent = memo(({ id, config }: Props) => {
 });
 SettingComponent.displayName = 'SettingComponent';
 
-const SettingMin = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props) => {
+const SettingMin = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const field = useInputFieldInstance<FloatFieldInputInstance>(nodeId, fieldName);
 
   const floatField = useFloatField(nodeId, fieldName, fieldTemplate);
 
-  const onToggleSetting = useCallback(() => {
-    const newConfig: NodeFieldFloatSettings = {
-      ...config,
-      min: config.min !== undefined ? undefined : floatField.min,
+  const onToggleOverride = useCallback(() => {
+    const newSettings: NodeFieldFloatSettings = {
+      ...settings,
+      min: settings.min !== undefined ? undefined : floatField.min,
     };
-    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
-  }, [config, dispatch, floatField, id]);
+    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+  }, [settings, dispatch, floatField, id]);
 
   const onChange = useCallback(
     (min: number) => {
-      const newConfig: NodeFieldFloatSettings = {
-        ...config,
+      const newSettings: NodeFieldFloatSettings = {
+        ...settings,
         min,
       };
-      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
 
       // We may need to update the value if it is outside the new min/max range
-      const constrained = constrainNumber(field.value, floatField, newConfig);
+      const constrained = constrainNumber(field.value, floatField, newSettings);
       if (field.value !== constrained) {
         dispatch(fieldFloatValueChanged({ nodeId, fieldName, value: constrained }));
       }
     },
-    [config, dispatch, field.value, fieldName, floatField, id, nodeId]
+    [settings, dispatch, field.value, fieldName, floatField, id, nodeId]
   );
 
   const constraintMin = useMemo(
@@ -97,20 +103,20 @@ const SettingMin = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props
   );
 
   const constraintMax = useMemo(
-    () => (config.max ?? floatField.max) - floatField.step,
-    [config.max, floatField.max, floatField.step]
+    () => (settings.max ?? floatField.max) - floatField.step,
+    [settings.max, floatField.max, floatField.step]
   );
 
   return (
     <FormControl orientation="vertical">
       <Flex justifyContent="space-between" w="full" alignItems="center">
         <FormLabel m={0}>{t('workflows.builder.minimum')}</FormLabel>
-        <Switch isChecked={config.min !== undefined} onChange={onToggleSetting} size="sm" />
+        <Switch isChecked={settings.min !== undefined} onChange={onToggleOverride} size="sm" />
       </Flex>
       <CompositeNumberInput
         w="full"
-        isDisabled={config.min === undefined}
-        value={config.min === undefined ? (`${floatField.min} (inherited)` as unknown as number) : config.min}
+        isDisabled={settings.min === undefined}
+        value={settings.min === undefined ? (`${floatField.min} (inherited)` as unknown as number) : settings.min}
         onChange={onChange}
         min={constraintMin}
         max={constraintMax}
@@ -121,41 +127,41 @@ const SettingMin = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props
 });
 SettingMin.displayName = 'SettingMin';
 
-const SettingMax = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props) => {
+const SettingMax = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const field = useInputFieldInstance<FloatFieldInputInstance>(nodeId, fieldName);
 
   const floatField = useFloatField(nodeId, fieldName, fieldTemplate);
 
-  const onToggleSetting = useCallback(() => {
-    const newConfig: NodeFieldFloatSettings = {
-      ...config,
-      max: config.max !== undefined ? undefined : floatField.max,
+  const onToggleOverride = useCallback(() => {
+    const newSettings: NodeFieldFloatSettings = {
+      ...settings,
+      max: settings.max !== undefined ? undefined : floatField.max,
     };
-    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
-  }, [config, dispatch, floatField, id]);
+    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+  }, [settings, dispatch, floatField, id]);
 
   const onChange = useCallback(
     (max: number) => {
-      const newConfig: NodeFieldFloatSettings = {
-        ...config,
+      const newSettings: NodeFieldFloatSettings = {
+        ...settings,
         max,
       };
-      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
 
       // We may need to update the value if it is outside the new min/max range
-      const constrained = constrainNumber(field.value, floatField, newConfig);
+      const constrained = constrainNumber(field.value, floatField, newSettings);
       if (field.value !== constrained) {
         dispatch(fieldFloatValueChanged({ nodeId, fieldName, value: constrained }));
       }
     },
-    [config, dispatch, field.value, fieldName, floatField, id, nodeId]
+    [settings, dispatch, field.value, fieldName, floatField, id, nodeId]
   );
 
   const constraintMin = useMemo(
-    () => (config.min ?? floatField.min) + floatField.step,
-    [config.min, floatField.min, floatField.step]
+    () => (settings.min ?? floatField.min) + floatField.step,
+    [settings.min, floatField.min, floatField.step]
   );
 
   const constraintMax = useMemo(
@@ -167,12 +173,12 @@ const SettingMax = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props
     <FormControl orientation="vertical">
       <Flex justifyContent="space-between" w="full" alignItems="center">
         <FormLabel m={0}>{t('workflows.builder.maximum')}</FormLabel>
-        <Switch isChecked={config.max !== undefined} onChange={onToggleSetting} size="sm" />
+        <Switch isChecked={settings.max !== undefined} onChange={onToggleOverride} size="sm" />
       </Flex>
       <CompositeNumberInput
         w="full"
-        isDisabled={config.max === undefined}
-        value={config.max === undefined ? (`${floatField.max} (inherited)` as unknown as number) : config.max}
+        isDisabled={settings.max === undefined}
+        value={settings.max === undefined ? (`${floatField.max} (inherited)` as unknown as number) : settings.max}
         onChange={onChange}
         min={constraintMin}
         max={constraintMax}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementIntegerSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementIntegerSettings.tsx
@@ -15,42 +15,48 @@ import { useTranslation } from 'react-i18next';
 
 type Props = {
   id: string;
-  config: NodeFieldIntegerSettings;
+  settings: NodeFieldIntegerSettings;
   nodeId: string;
   fieldName: string;
   fieldTemplate: IntegerFieldInputTemplate;
 };
 
-export const NodeFieldElementIntegerSettings = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props) => {
+export const NodeFieldElementIntegerSettings = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
   return (
     <>
-      <SettingComponent id={id} config={config} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-      <SettingMin id={id} config={config} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-      <SettingMax id={id} config={config} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingComponent
+        id={id}
+        settings={settings}
+        nodeId={nodeId}
+        fieldName={fieldName}
+        fieldTemplate={fieldTemplate}
+      />
+      <SettingMin id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingMax id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
     </>
   );
 });
 NodeFieldElementIntegerSettings.displayName = 'NodeFieldElementIntegerSettings';
 
-const SettingComponent = memo(({ id, config }: Props) => {
+const SettingComponent = memo(({ id, settings }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
   const onChangeComponent = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
-      const newConfig: NodeFieldIntegerSettings = {
-        ...config,
+      const newSettings: NodeFieldIntegerSettings = {
+        ...settings,
         component: zNumberComponent.parse(e.target.value),
       };
-      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
     },
-    [config, dispatch, id]
+    [settings, dispatch, id]
   );
 
   return (
     <FormControl orientation="vertical">
       <FormLabel flex={1}>{t('workflows.builder.component')}</FormLabel>
-      <Select value={config.component} onChange={onChangeComponent} size="sm">
+      <Select value={settings.component} onChange={onChangeComponent} size="sm">
         <option value="number-input">{t('workflows.builder.numberInput')}</option>
         <option value="slider">{t('workflows.builder.slider')}</option>
         <option value="number-input-and-slider">{t('workflows.builder.both')}</option>
@@ -60,37 +66,37 @@ const SettingComponent = memo(({ id, config }: Props) => {
 });
 SettingComponent.displayName = 'SettingComponent';
 
-const SettingMin = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props) => {
+const SettingMin = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const field = useInputFieldInstance<IntegerFieldInputInstance>(nodeId, fieldName);
 
   const integerField = useIntegerField(nodeId, fieldName, fieldTemplate);
 
-  const onToggleSetting = useCallback(() => {
-    const newConfig: NodeFieldIntegerSettings = {
-      ...config,
-      min: config.min !== undefined ? undefined : integerField.min,
+  const onToggleOverride = useCallback(() => {
+    const newSettings: NodeFieldIntegerSettings = {
+      ...settings,
+      min: settings.min !== undefined ? undefined : integerField.min,
     };
 
-    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
-  }, [config, dispatch, integerField.min, id]);
+    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+  }, [settings, dispatch, integerField.min, id]);
 
   const onChange = useCallback(
     (min: number) => {
-      const newConfig: NodeFieldIntegerSettings = {
-        ...config,
+      const newSettings: NodeFieldIntegerSettings = {
+        ...settings,
         min,
       };
-      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
 
       // We may need to update the value if it is outside the new min/max range
-      const constrained = constrainNumber(field.value, integerField, newConfig);
+      const constrained = constrainNumber(field.value, integerField, newSettings);
       if (field.value !== constrained) {
         dispatch(fieldIntegerValueChanged({ nodeId, fieldName, value: constrained }));
       }
     },
-    [config, dispatch, id, field, integerField, nodeId, fieldName]
+    [settings, dispatch, id, field, integerField, nodeId, fieldName]
   );
 
   const constraintMin = useMemo(
@@ -99,20 +105,20 @@ const SettingMin = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props
   );
 
   const constraintMax = useMemo(
-    () => (config.max ?? integerField.max) - integerField.step,
-    [config.max, integerField.max, integerField.step]
+    () => (settings.max ?? integerField.max) - integerField.step,
+    [settings.max, integerField.max, integerField.step]
   );
 
   return (
     <FormControl orientation="vertical">
       <Flex justifyContent="space-between" w="full" alignItems="center">
         <FormLabel m={0}>{t('workflows.builder.minimum')}</FormLabel>
-        <Switch isChecked={config.min !== undefined} onChange={onToggleSetting} size="sm" />
+        <Switch isChecked={settings.min !== undefined} onChange={onToggleOverride} size="sm" />
       </Flex>
       <CompositeNumberInput
         w="full"
-        isDisabled={config.min === undefined}
-        value={config.min ?? (`${integerField.min} (inherited)` as unknown as number)}
+        isDisabled={settings.min === undefined}
+        value={settings.min ?? (`${integerField.min} (inherited)` as unknown as number)}
         onChange={onChange}
         min={constraintMin}
         max={constraintMax}
@@ -123,42 +129,42 @@ const SettingMin = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props
 });
 SettingMin.displayName = 'SettingMin';
 
-const SettingMax = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props) => {
+const SettingMax = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const field = useInputFieldInstance<IntegerFieldInputInstance>(nodeId, fieldName);
 
   const integerField = useIntegerField(nodeId, fieldName, fieldTemplate);
 
-  const onToggleSetting = useCallback(() => {
-    const newConfig: NodeFieldIntegerSettings = {
-      ...config,
-      max: config.max !== undefined ? undefined : integerField.max,
+  const onToggleOverride = useCallback(() => {
+    const newSettings: NodeFieldIntegerSettings = {
+      ...settings,
+      max: settings.max !== undefined ? undefined : integerField.max,
     };
-    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
-  }, [config, dispatch, integerField.max, id]);
+    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+  }, [settings, dispatch, integerField.max, id]);
 
   const onChange = useCallback(
     (max: number) => {
-      const newConfig: NodeFieldIntegerSettings = {
-        ...config,
+      const newSettings: NodeFieldIntegerSettings = {
+        ...settings,
         max,
       };
 
-      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
 
       // We may need to update the value if it is outside the new min/max range
-      const constrained = constrainNumber(field.value, integerField, newConfig);
+      const constrained = constrainNumber(field.value, integerField, newSettings);
       if (field.value !== constrained) {
         dispatch(fieldIntegerValueChanged({ nodeId, fieldName, value: constrained }));
       }
     },
-    [config, dispatch, field.value, fieldName, integerField, id, nodeId]
+    [settings, dispatch, field.value, fieldName, integerField, id, nodeId]
   );
 
   const constraintMin = useMemo(
-    () => (config.min ?? integerField.min) + integerField.step,
-    [config.min, integerField.min, integerField.step]
+    () => (settings.min ?? integerField.min) + integerField.step,
+    [settings.min, integerField.min, integerField.step]
   );
 
   const constraintMax = useMemo(
@@ -170,12 +176,12 @@ const SettingMax = memo(({ id, config, nodeId, fieldName, fieldTemplate }: Props
     <FormControl orientation="vertical">
       <Flex justifyContent="space-between" w="full" alignItems="center">
         <FormLabel m={0}>{t('workflows.builder.maximum')}</FormLabel>
-        <Switch isChecked={config.max !== undefined} onChange={onToggleSetting} size="sm" />
+        <Switch isChecked={settings.max !== undefined} onChange={onToggleOverride} size="sm" />
       </Flex>
       <CompositeNumberInput
         w="full"
-        isDisabled={config.max === undefined}
-        value={config.max ?? (`${integerField.max} (inherited)` as unknown as number)}
+        isDisabled={settings.max === undefined}
+        value={settings.max ?? (`${integerField.max} (inherited)` as unknown as number)}
         onChange={onChange}
         min={constraintMin}
         max={constraintMax}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementSettings.tsx
@@ -79,7 +79,7 @@ export const NodeFieldElementSettings = memo(({ element }: { element: NodeFieldE
               {settings?.type === 'integer-field-config' && isIntegerFieldInputTemplate(fieldTemplate) && (
                 <NodeFieldElementIntegerSettings
                   id={id}
-                  config={settings}
+                  settings={settings}
                   nodeId={nodeId}
                   fieldName={fieldName}
                   fieldTemplate={fieldTemplate}
@@ -88,13 +88,15 @@ export const NodeFieldElementSettings = memo(({ element }: { element: NodeFieldE
               {settings?.type === 'float-field-config' && isFloatFieldInputTemplate(fieldTemplate) && (
                 <NodeFieldElementFloatSettings
                   id={id}
-                  config={settings}
+                  settings={settings}
                   nodeId={nodeId}
                   fieldName={fieldName}
                   fieldTemplate={fieldTemplate}
                 />
               )}
-              {settings?.type === 'string-field-config' && <NodeFieldElementStringSettings id={id} config={settings} />}
+              {settings?.type === 'string-field-config' && (
+                <NodeFieldElementStringSettings id={id} settings={settings} />
+              )}
             </Flex>
           </PopoverBody>
         </PopoverContent>

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig.tsx
@@ -1,0 +1,184 @@
+import { Button, Divider, Flex, Grid, GridItem, IconButton, Input, Text } from '@invoke-ai/ui-library';
+import { useAppDispatch } from 'app/store/storeHooks';
+import { getOverlayScrollbarsParams, overlayScrollbarsStyles } from 'common/components/OverlayScrollbars/constants';
+import { formElementNodeFieldDataChanged } from 'features/nodes/store/workflowSlice';
+import { NO_DRAG_CLASS, NO_WHEEL_CLASS } from 'features/nodes/types/constants';
+import type { NodeFieldStringDropdownSettings } from 'features/nodes/types/workflow';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
+import type { ChangeEvent } from 'react';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiXBold } from 'react-icons/pi';
+
+const overlayscrollbarsOptions = getOverlayScrollbarsParams({}).options;
+
+export const NodeFieldElementStringDropdownConfig = memo(
+  ({ id, settings }: { id: string; settings: NodeFieldStringDropdownSettings }) => {
+    const { t } = useTranslation();
+    const dispatch = useAppDispatch();
+
+    const onRemoveOption = useCallback(
+      (index: number) => {
+        const options = [...settings.options];
+        options.splice(index, 1);
+        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: { ...settings, options } } }));
+      },
+      [settings, dispatch, id]
+    );
+
+    const onChangeOptionValue = useCallback(
+      (index: number, value: string) => {
+        if (!settings.options[index]) {
+          return;
+        }
+        const option = { ...settings.options[index], value };
+        const options = [...settings.options];
+        options[index] = option;
+        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: { ...settings, options } } }));
+      },
+      [dispatch, id, settings]
+    );
+
+    const onChangeOptionLabel = useCallback(
+      (index: number, label: string) => {
+        if (!settings.options[index]) {
+          return;
+        }
+        const option = { ...settings.options[index], label };
+        const options = [...settings.options];
+        options[index] = option;
+        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: { ...settings, options } } }));
+      },
+      [dispatch, id, settings]
+    );
+
+    const onAddOption = useCallback(() => {
+      const options = [...settings.options, { label: '', value: '' }];
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: { ...settings, options } } }));
+    }, [dispatch, id, settings]);
+
+    return (
+      <Flex
+        className={NO_DRAG_CLASS}
+        position="relative"
+        w="full"
+        h="auto"
+        maxH={64}
+        alignItems="stretch"
+        justifyContent="center"
+        borderRadius="base"
+        flexDir="column"
+        gap={1}
+      >
+        <Button onClick={onAddOption} variant="ghost">
+          {t('nodes.addItem')}
+        </Button>
+        {settings.options.length > 0 && (
+          <>
+            <Divider />
+            <OverlayScrollbarsComponent
+              className={NO_WHEEL_CLASS}
+              defer
+              style={overlayScrollbarsStyles}
+              options={overlayscrollbarsOptions}
+            >
+              <Grid gap={1} gridTemplateColumns="auto 1fr 1fr auto" gridTemplateRows="auto 1fr" alignItems="center">
+                <GridItem minW={8}>
+                  <Text textAlign="center" variant="subtext">
+                    #
+                  </Text>
+                </GridItem>
+                <GridItem>
+                  <Text textAlign="center" variant="subtext">
+                    {t('common.label')}
+                  </Text>
+                </GridItem>
+                <GridItem>
+                  <Text textAlign="center" variant="subtext">
+                    {t('common.value')}
+                  </Text>
+                </GridItem>
+                <GridItem />
+                {settings.options.map(({ value, label }, index) => (
+                  <ListItemContent
+                    key={index}
+                    value={value}
+                    label={label}
+                    index={index}
+                    onRemoveOption={onRemoveOption}
+                    onChangeOptionValue={onChangeOptionValue}
+                    onChangeOptionLabel={onChangeOptionLabel}
+                  />
+                ))}
+              </Grid>
+            </OverlayScrollbarsComponent>
+          </>
+        )}
+      </Flex>
+    );
+  }
+);
+
+NodeFieldElementStringDropdownConfig.displayName = 'NodeFieldElementStringDropdownConfig';
+
+type ListItemContentProps = {
+  value: string;
+  label: string;
+  index: number;
+  onRemoveOption: (index: number) => void;
+  onChangeOptionValue: (index: number, value: string) => void;
+  onChangeOptionLabel: (index: number, label: string) => void;
+};
+
+const ListItemContent = memo(
+  ({ value, label, index, onRemoveOption, onChangeOptionValue, onChangeOptionLabel }: ListItemContentProps) => {
+    const { t } = useTranslation();
+
+    const onClickRemove = useCallback(() => {
+      onRemoveOption(index);
+    }, [index, onRemoveOption]);
+
+    const onChangeValue = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        onChangeOptionValue(index, e.target.value);
+      },
+      [index, onChangeOptionValue]
+    );
+
+    const onChangeLabel = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        onChangeOptionLabel(index, e.target.value);
+      },
+      [index, onChangeOptionLabel]
+    );
+
+    return (
+      <>
+        <GridItem>
+          <Text variant="subtext" textAlign="center">
+            {index + 1}.
+          </Text>
+        </GridItem>
+        <GridItem>
+          <Input size="sm" resize="none" placeholder="label" value={label} onChange={onChangeLabel} />
+        </GridItem>
+        <GridItem>
+          <Input size="sm" resize="none" placeholder="value" value={value} onChange={onChangeValue} />
+        </GridItem>
+        <GridItem>
+          <IconButton
+            tabIndex={-1}
+            size="sm"
+            variant="link"
+            minW={8}
+            minH={8}
+            onClick={onClickRemove}
+            icon={<PiXBold />}
+            aria-label={t('common.delete')}
+          />
+        </GridItem>
+      </>
+    );
+  }
+);
+ListItemContent.displayName = 'ListItemContent';

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig.tsx
@@ -1,14 +1,17 @@
-import { Button, Divider, Flex, Grid, GridItem, IconButton, Input, Text } from '@invoke-ai/ui-library';
+import { Button, ButtonGroup, Divider, Flex, Grid, GridItem, IconButton, Input, Text } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { getOverlayScrollbarsParams, overlayScrollbarsStyles } from 'common/components/OverlayScrollbars/constants';
 import { formElementNodeFieldDataChanged } from 'features/nodes/store/workflowSlice';
 import { NO_DRAG_CLASS, NO_WHEEL_CLASS } from 'features/nodes/types/constants';
-import type { NodeFieldStringDropdownSettings } from 'features/nodes/types/workflow';
+import {
+  getDefaultStringOption,
+  type NodeFieldStringDropdownSettings,
+} from 'features/nodes/types/workflow';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
 import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiXBold } from 'react-icons/pi';
+import { PiArrowCounterClockwiseBold, PiPlusBold, PiXBold } from 'react-icons/pi';
 
 const overlayscrollbarsOptions = getOverlayScrollbarsParams({}).options;
 
@@ -53,7 +56,12 @@ export const NodeFieldElementStringDropdownConfig = memo(
     );
 
     const onAddOption = useCallback(() => {
-      const options = [...settings.options, { label: '', value: '' }];
+      const options = [...settings.options, getDefaultStringOption()];
+      dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: { ...settings, options } } }));
+    }, [dispatch, id, settings]);
+
+    const onResetOptions = useCallback(() => {
+      const options = [getDefaultStringOption()];
       dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: { ...settings, options } } }));
     }, [dispatch, id, settings]);
 
@@ -68,11 +76,16 @@ export const NodeFieldElementStringDropdownConfig = memo(
         justifyContent="center"
         borderRadius="base"
         flexDir="column"
-        gap={1}
+        gap={2}
       >
-        <Button onClick={onAddOption} variant="ghost">
-          {t('nodes.addItem')}
-        </Button>
+        <ButtonGroup isAttached={false} w="full">
+          <Button onClick={onAddOption} variant="ghost" flex={1} leftIcon={<PiPlusBold />}>
+            {t('workflows.builder.addOption')}
+          </Button>
+          <Button onClick={onResetOptions} variant="ghost" flex={1} leftIcon={<PiArrowCounterClockwiseBold />}>
+            {t('workflows.builder.resetOptions')}
+          </Button>
+        </ButtonGroup>
         {settings.options.length > 0 && (
           <>
             <Divider />
@@ -108,6 +121,7 @@ export const NodeFieldElementStringDropdownConfig = memo(
                     onRemoveOption={onRemoveOption}
                     onChangeOptionValue={onChangeOptionValue}
                     onChangeOptionLabel={onChangeOptionLabel}
+                    isRemoveDisabled={settings.options.length <= 1}
                   />
                 ))}
               </Grid>
@@ -128,10 +142,19 @@ type ListItemContentProps = {
   onRemoveOption: (index: number) => void;
   onChangeOptionValue: (index: number, value: string) => void;
   onChangeOptionLabel: (index: number, label: string) => void;
+  isRemoveDisabled: boolean;
 };
 
 const ListItemContent = memo(
-  ({ value, label, index, onRemoveOption, onChangeOptionValue, onChangeOptionLabel }: ListItemContentProps) => {
+  ({
+    value,
+    label,
+    index,
+    onRemoveOption,
+    onChangeOptionValue,
+    onChangeOptionLabel,
+    isRemoveDisabled,
+  }: ListItemContentProps) => {
     const { t } = useTranslation();
 
     const onClickRemove = useCallback(() => {
@@ -173,6 +196,7 @@ const ListItemContent = memo(
             minW={8}
             minH={8}
             onClick={onClickRemove}
+            isDisabled={isRemoveDisabled}
             icon={<PiXBold />}
             aria-label={t('common.delete')}
           />

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownConfig.tsx
@@ -3,10 +3,7 @@ import { useAppDispatch } from 'app/store/storeHooks';
 import { getOverlayScrollbarsParams, overlayScrollbarsStyles } from 'common/components/OverlayScrollbars/constants';
 import { formElementNodeFieldDataChanged } from 'features/nodes/store/workflowSlice';
 import { NO_DRAG_CLASS, NO_WHEEL_CLASS } from 'features/nodes/types/constants';
-import {
-  getDefaultStringOption,
-  type NodeFieldStringDropdownSettings,
-} from 'features/nodes/types/workflow';
+import { getDefaultStringOption, type NodeFieldStringDropdownSettings } from 'features/nodes/types/workflow';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
 import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringDropdownSettings.tsx
@@ -12,7 +12,7 @@ import { PiArrowCounterClockwiseBold, PiPlusBold, PiXBold } from 'react-icons/pi
 
 const overlayscrollbarsOptions = getOverlayScrollbarsParams({}).options;
 
-export const NodeFieldElementStringDropdownConfig = memo(
+export const NodeFieldElementStringDropdownSettings = memo(
   ({ id, settings }: { id: string; settings: NodeFieldStringDropdownSettings }) => {
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
@@ -130,7 +130,7 @@ export const NodeFieldElementStringDropdownConfig = memo(
   }
 );
 
-NodeFieldElementStringDropdownConfig.displayName = 'NodeFieldElementStringDropdownConfig';
+NodeFieldElementStringDropdownSettings.displayName = 'NodeFieldElementStringDropdownSettings';
 
 type ListItemContentProps = {
   value: string;

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
@@ -20,18 +20,18 @@ export const NodeFieldElementStringSettings = memo(
           return;
         }
         if (component === 'dropdown') {
-          // if the component is changing to dropdown, we need to set the choices
-          const newConfig: NodeFieldStringSettings = {
+          // if the component is changing to dropdown, we need to set the options
+          const settings: NodeFieldStringSettings = {
             ...config,
             component,
             options: [getDefaultStringOption()],
           };
-          dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+          dispatch(formElementNodeFieldDataChanged({ id, changes: { settings } }));
           return;
         }
-        // if the component is changing from dropdown, we need to remove the choices
-        const newConfig: NodeFieldStringSettings = omit({ ...config, component }, 'choices');
-        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
+        // if the component is changing from dropdown, we need to remove the options
+        const settings: NodeFieldStringSettings = omit({ ...config, component }, 'options');
+        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings } }));
       },
       [config, dispatch, id]
     );

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormLabel, Select } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { formElementNodeFieldDataChanged } from 'features/nodes/store/workflowSlice';
-import { type NodeFieldStringSettings, zStringComponent } from 'features/nodes/types/workflow';
+import { getDefaultStringOption, type NodeFieldStringSettings, zStringComponent } from 'features/nodes/types/workflow';
 import { omit } from 'lodash-es';
 import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
@@ -24,7 +24,7 @@ export const NodeFieldElementStringSettings = memo(
           const newConfig: NodeFieldStringSettings = {
             ...config,
             component,
-            options: [{ value: 'my_value', label: 'My Label' }],
+            options: [getDefaultStringOption()],
           };
           dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newConfig } }));
           return;

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementStringSettings.tsx
@@ -7,45 +7,49 @@ import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export const NodeFieldElementStringSettings = memo(
-  ({ id, config }: { id: string; config: NodeFieldStringSettings }) => {
-    const { t } = useTranslation();
-    const dispatch = useAppDispatch();
+type Props = {
+  id: string;
+  settings: NodeFieldStringSettings;
+};
 
-    const onChangeComponent = useCallback(
-      (e: ChangeEvent<HTMLSelectElement>) => {
-        const component = zStringComponent.parse(e.target.value);
-        if (component === config.component) {
-          // no change
-          return;
-        }
-        if (component === 'dropdown') {
-          // if the component is changing to dropdown, we need to set the options
-          const settings: NodeFieldStringSettings = {
-            ...config,
-            component,
-            options: [getDefaultStringOption()],
-          };
-          dispatch(formElementNodeFieldDataChanged({ id, changes: { settings } }));
-          return;
-        }
+export const NodeFieldElementStringSettings = memo(({ id, settings }: Props) => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  const onChangeComponent = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      const component = zStringComponent.parse(e.target.value);
+      if (component === settings.component) {
+        // no change
+        return;
+      }
+      if (component === 'dropdown') {
+        // if the component is changing to dropdown, we need to set the options
+        const newSettings: NodeFieldStringSettings = {
+          ...settings,
+          component,
+          options: [getDefaultStringOption()],
+        };
+        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+        return;
+      } else {
         // if the component is changing from dropdown, we need to remove the options
-        const settings: NodeFieldStringSettings = omit({ ...config, component }, 'options');
-        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings } }));
-      },
-      [config, dispatch, id]
-    );
+        const newSettings: NodeFieldStringSettings = omit({ ...settings, component }, 'options');
+        dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+      }
+    },
+    [settings, dispatch, id]
+  );
 
-    return (
-      <FormControl>
-        <FormLabel flex={1}>{t('workflows.builder.component')}</FormLabel>
-        <Select value={config.component} onChange={onChangeComponent} size="sm">
-          <option value="input">{t('workflows.builder.singleLine')}</option>
-          <option value="textarea">{t('workflows.builder.multiLine')}</option>
-          <option value="dropdown">{t('workflows.builder.dropdown')}</option>
-        </Select>
-      </FormControl>
-    );
-  }
-);
+  return (
+    <FormControl>
+      <FormLabel flex={1}>{t('workflows.builder.component')}</FormLabel>
+      <Select value={settings.component} onChange={onChangeComponent} size="sm">
+        <option value="input">{t('workflows.builder.singleLine')}</option>
+        <option value="textarea">{t('workflows.builder.multiLine')}</option>
+        <option value="dropdown">{t('workflows.builder.dropdown')}</option>
+      </Select>
+    </FormControl>
+  );
+});
 NodeFieldElementStringSettings.displayName = 'NodeFieldElementStringSettings';

--- a/invokeai/frontend/web/src/features/nodes/types/workflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/workflow.ts
@@ -91,14 +91,36 @@ const zNodeFieldIntegerSettings = z.object({
 export type NodeFieldIntegerSettings = z.infer<typeof zNodeFieldIntegerSettings>;
 export const getIntegerFieldSettingsDefaults = (): NodeFieldIntegerSettings => zNodeFieldIntegerSettings.parse({});
 
-export const zStringComponent = z.enum(['input', 'textarea']);
+export const zStringOption = z
+  .object({
+    label: z.string(),
+    value: z.string(),
+  })
+  .default({ label: '', value: '' });
+export type StringChoice = z.infer<typeof zStringOption>;
+export const zStringComponent = z.enum(['input', 'textarea', 'dropdown']);
 const STRING_FIELD_CONFIG_TYPE = 'string-field-config';
-const zNodeFieldStringSettings = z.object({
+const zNodeFieldStringInputSettings = z.object({
   type: z.literal(STRING_FIELD_CONFIG_TYPE).default(STRING_FIELD_CONFIG_TYPE),
-  component: zStringComponent.default('input'),
+  component: z.literal('input').default('input'),
 });
+const zNodeFieldStringTextareaSettings = z.object({
+  type: z.literal(STRING_FIELD_CONFIG_TYPE).default(STRING_FIELD_CONFIG_TYPE),
+  component: z.literal('textarea').default('textarea'),
+});
+const zNodeFieldStringDropdownSettings = z.object({
+  type: z.literal(STRING_FIELD_CONFIG_TYPE).default(STRING_FIELD_CONFIG_TYPE),
+  component: z.literal('dropdown').default('dropdown'),
+  options: z.array(zStringOption),
+});
+export type NodeFieldStringDropdownSettings = z.infer<typeof zNodeFieldStringDropdownSettings>;
+const zNodeFieldStringSettings = z.union([
+  zNodeFieldStringInputSettings,
+  zNodeFieldStringTextareaSettings,
+  zNodeFieldStringDropdownSettings,
+]);
 export type NodeFieldStringSettings = z.infer<typeof zNodeFieldStringSettings>;
-export const getStringFieldSettingsDefaults = (): NodeFieldStringSettings => zNodeFieldStringSettings.parse({});
+export const getStringFieldSettingsDefaults = (): NodeFieldStringSettings => zNodeFieldStringInputSettings.parse({});
 
 const zNodeFieldData = z.object({
   fieldIdentifier: zFieldIdentifier,

--- a/invokeai/frontend/web/src/features/nodes/types/workflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/workflow.ts
@@ -91,14 +91,14 @@ const zNodeFieldIntegerSettings = z.object({
 export type NodeFieldIntegerSettings = z.infer<typeof zNodeFieldIntegerSettings>;
 export const getIntegerFieldSettingsDefaults = (): NodeFieldIntegerSettings => zNodeFieldIntegerSettings.parse({});
 
-export const zStringOption = z
+const zStringOption = z
   .object({
     label: z.string(),
     value: z.string(),
   })
   .default({ label: '', value: '' });
-export type StringChoice = z.infer<typeof zStringOption>;
-export const getDefaultStringOption = (): StringChoice => ({ label: '', value: '' });
+type StringOption = z.infer<typeof zStringOption>;
+export const getDefaultStringOption = (): StringOption => ({ label: '', value: '' });
 export const zStringComponent = z.enum(['input', 'textarea', 'dropdown']);
 const STRING_FIELD_CONFIG_TYPE = 'string-field-config';
 const zNodeFieldStringInputSettings = z.object({

--- a/invokeai/frontend/web/src/features/nodes/types/workflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/workflow.ts
@@ -98,6 +98,7 @@ export const zStringOption = z
   })
   .default({ label: '', value: '' });
 export type StringChoice = z.infer<typeof zStringOption>;
+export const getDefaultStringOption = (): StringChoice => ({ label: '', value: '' });
 export const zStringComponent = z.enum(['input', 'textarea', 'dropdown']);
 const STRING_FIELD_CONFIG_TYPE = 'string-field-config';
 const zNodeFieldStringInputSettings = z.object({


### PR DESCRIPTION
## Summary

Add support for custom dropdowns for string fields in Builder. Workflow Builders can choose this for the string component and add options to it.

<video src="https://github.com/user-attachments/assets/c3af6e44-8f05-4987-b2b2-1c00586f1004"></video>


## Related Issues / Discussions

n/a

## QA Instructions

Try it out.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
