### PR TITLE
fix: make dev_reload work for files in nodes/

### DIFF
--- a/invokeai/app/run_app.py
+++ b/invokeai/app/run_app.py
@@ -49,8 +49,6 @@ def run_app() -> None:
     # Miscellaneous startup tasks.
     apply_monkeypatches()
     register_mime_types()
-    if app_config.dev_reload:
-        enable_dev_reload()
     check_cudnn(logger)
 
     # Initialize the app and event loop.
@@ -60,6 +58,11 @@ def run_app() -> None:
     # invocations module. The ordering here is implicit, but important - we want to load custom nodes after all the
     # core nodes have been imported so that we can catch when a custom node clobbers a core node.
     load_custom_nodes(custom_nodes_path=app_config.custom_nodes_path, logger=logger)
+
+    if app_config.dev_reload:
+        # load_custom_nodes seems to bypass jurrigged's import sniffer, so be sure to call it *after* they're already
+        # imported.
+        enable_dev_reload(custom_nodes_path=app_config.custom_nodes_path)
 
     # Start the server.
     config = uvicorn.Config(

--- a/invokeai/app/util/startup_utils.py
+++ b/invokeai/app/util/startup_utils.py
@@ -1,6 +1,7 @@
 import logging
 import mimetypes
 import socket
+from pathlib import Path
 
 import torch
 
@@ -33,8 +34,9 @@ def check_cudnn(logger: logging.Logger) -> None:
             )
 
 
-def enable_dev_reload() -> None:
+def enable_dev_reload(custom_nodes_path=None) -> None:
     """Enable hot reloading on python file changes during development."""
+    import invokeai
     from invokeai.backend.util.logging import InvokeAILogger
 
     try:
@@ -44,7 +46,10 @@ def enable_dev_reload() -> None:
             'Can\'t start `--dev_reload` because jurigged is not found; `pip install -e ".[dev]"` to include development dependencies.'
         ) from e
     else:
-        jurigged.watch(logger=InvokeAILogger.get_logger(name="jurigged").info)
+        paths = [str(Path(invokeai.__file__).with_name("*.py"))]
+        if custom_nodes_path:
+            paths.append(str(custom_nodes_path / "*.py"))
+        jurigged.watch(pattern=paths, logger=InvokeAILogger.get_logger(name="jurigged").info)
 
 
 def apply_monkeypatches() -> None:


### PR DESCRIPTION
## Summary

The `dev_reload` option to load Python changes on the fly should work for custom nodes as well as Invoke's own sources.

(Have y'all been trying to write nodes without this? Or do you have another hot-reloading mechanism you've been using instead?)

## QA Instructions

1. have some code in a `nodes/` subdirectory.
2. Run invoke with `INVOKEAI_DEV_RELOAD=true` environment variable. (Or set `dev_reload = True` in your `invokeai.yaml'.)
3. Run `invokeai-web`
4. Startup logs should include a `[jurigged] Watch` line for your nodes source.
5. When you edit that file, the log should include a `[jurigged] Update` line for it.

## Merge Plan

N/A

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- N/A _Tests added / updated (if applicable)_
- N/A _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
