### PR TITLE
fix(ui): mask logic in graph builders

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addFLUXFill.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addFLUXFill.ts
@@ -52,7 +52,9 @@ export const addFLUXFill = async ({
 
   const fluxFill = g.addNode({ type: 'flux_fill', id: getPrefixedId('flux_fill') });
 
-  if (!isEqual(scaledSize, originalSize)) {
+  const needsScaleBeforeProcessing = !isEqual(scaledSize, originalSize);
+
+  if (needsScaleBeforeProcessing) {
     // Scale before processing requires some resizing
 
     // Combine the inpaint mask and the initial image's alpha channel into a single mask

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
@@ -60,7 +60,9 @@ export const addInpaint = async ({
     silent: true,
   });
 
-  if (!isEqual(scaledSize, originalSize)) {
+  const needsScaleBeforeProcessing = !isEqual(scaledSize, originalSize);
+
+  if (needsScaleBeforeProcessing) {
     // Scale before processing requires some resizing
     const i2l = g.addNode({
       id: i2lNodeType,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
@@ -129,8 +129,8 @@ export const addInpaint = async ({
 
     // After denoising, resize the image and mask back to original size
     g.addEdge(l2i, 'image', resizeImageToOriginalSize, 'image');
-    g.addEdge(createGradientMask, 'expanded_mask_area', resizeMaskToOriginalSize, 'image');
     g.addEdge(createGradientMask, 'expanded_mask_area', expandMask, 'mask');
+    g.addEdge(expandMask, 'image', resizeMaskToOriginalSize, 'image');
 
     // After denoising, resize the image and mask back to original size
     // Do the paste back if we are sending to gallery (in which case we want to see the full image), or if we are sending

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addOutpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addOutpaint.ts
@@ -63,7 +63,9 @@ export const addOutpaint = async ({
 
   const infill = getInfill(g, params);
 
-  if (!isEqual(scaledSize, originalSize)) {
+  const needsScaleBeforeProcessing = !isEqual(scaledSize, originalSize);
+
+  if (needsScaleBeforeProcessing) {
     // Scale before processing requires some resizing
 
     // Combine the inpaint mask and the initial image's alpha channel into a single mask


### PR DESCRIPTION
## Summary

Fix an issue where the wrong mask was being used in the inpaint graph.

## Related Issues / Discussions

Thanks to @dunkeroni for catching this: https://discord.com/channels/1020123559063990373/1149506274971631688/1353461523842076804

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
