### PR TITLE
fix(ui): restore `display: flex` to image viewer and node editor

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewer.tsx
@@ -26,6 +26,7 @@ const useFocusRegionOptions = {
 };
 
 const FOCUS_REGION_STYLES: SystemStyleObject = {
+  display: 'flex',
   width: 'full',
   height: 'full',
   position: 'absolute',
@@ -45,7 +46,7 @@ export const ImageViewer = memo(({ closeButton }: Props) => {
     <FocusRegionWrapper region="viewer" sx={FOCUS_REGION_STYLES} layerStyle="first" {...useFocusRegionOptions}>
       {hasImageToCompare && <CompareToolbar />}
       {!hasImageToCompare && <ViewerToolbar closeButton={closeButton} />}
-      <Box ref={containerRef} w="full" h="full" p={2}>
+      <Box ref={containerRef} w="full" h="full" p={2} overflow="hidden">
         {!hasImageToCompare && <CurrentImagePreview />}
         {hasImageToCompare && <ImageComparison containerDims={containerDims} />}
       </Box>

--- a/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/NodeEditor.tsx
@@ -14,6 +14,7 @@ import BottomLeftPanel from './flow/panels/BottomLeftPanel/BottomLeftPanel';
 import MinimapPanel from './flow/panels/MinimapPanel/MinimapPanel';
 
 const FOCUS_REGION_STYLES: SystemStyleObject = {
+  display: 'flex',
   position: 'relative',
   width: 'full',
   height: 'full',


### PR DESCRIPTION
## Summary

This was inadventently removed in #7786 and caused some minor layout overflow.

## Related Issues / Discussions

Noticed by aaronlink127 on discord: https://discord.com/channels/1020123559063990373/1020123559831539744/1353737287657062483

## QA Instructions

- Open an image in image viewer
- Resize window until the viewer region is not large enough for the image
- The image should fit to the viewer region and not be cut off/overflow

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
