### PR TITLE
fix: make source location discovery more robust

### DIFF
--- a/invokeai/app/util/startup_utils.py
+++ b/invokeai/app/util/startup_utils.py
@@ -34,9 +34,17 @@ def check_cudnn(logger: logging.Logger) -> None:
             )
 
 
+def invokeai_source_dir() -> Path:
+    # `invokeai.__file__` doesn't always work for editable installs
+    this_module_path = Path(__file__).resolve()
+    # https://youtrack.jetbrains.com/issue/PY-38382/Unresolved-reference-spec-but-this-is-standard-builtin
+    # noinspection PyUnresolvedReferences
+    depth = len(__spec__.parent.split("."))
+    return this_module_path.parents[depth - 1]
+
+
 def enable_dev_reload(custom_nodes_path=None) -> None:
     """Enable hot reloading on python file changes during development."""
-    import invokeai
     from invokeai.backend.util.logging import InvokeAILogger
 
     try:
@@ -46,7 +54,7 @@ def enable_dev_reload(custom_nodes_path=None) -> None:
             'Can\'t start `--dev_reload` because jurigged is not found; `pip install -e ".[dev]"` to include development dependencies.'
         ) from e
     else:
-        paths = [str(Path(invokeai.__file__).with_name("*.py"))]
+        paths = [str(invokeai_source_dir() / "*.py")]
         if custom_nodes_path:
             paths.append(str(custom_nodes_path / "*.py"))
         jurigged.watch(pattern=paths, logger=InvokeAILogger.get_logger(name="jurigged").info)


### PR DESCRIPTION
The top-level `invokeai` package may have an obscured origin due to the way editible installs work, but it's much more likely that this module is from a specific file.

## Summary

Fixes `expected str, bytes or os.PathLike object, not NoneType` error when launching from some editable installs.

https://discord.com/channels/1020123559063990373/1354081031040532524


## QA Instructions

Run invokeai-web with `INVOKEAI_DEV_RELOAD=True` and see that the log contains `[jurigged] Watch` lines for invokeai sources.

## Merge Plan

This is fixes a regression introduced by #7819 and should be included before 5.9 final.

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
