### PR TITLE
feat(ui, api): support for bulk client-side uploads

### DIFF
--- a/invokeai/app/api/routers/images.py
+++ b/invokeai/app/api/routers/images.py
@@ -96,6 +96,22 @@ async def upload_image(
         raise HTTPException(status_code=500, detail="Failed to create image")
 
 
+class ImageUploadEntry(BaseModel):
+    image_dto: ImageDTO = Body(description="The image DTO")
+    presigned_url: str = Body(description="The URL to get the presigned URL for the image upload")
+
+
+@images_router.post("/", operation_id="create_image_upload_entry")
+async def create_image_upload_entry(
+    width: int = Body(description="The width of the image"),
+    height: int = Body(description="The height of the image"),
+    board_id: Optional[str] = Body(default=None, description="The board to add this image to, if any"),
+) -> ImageUploadEntry:
+    """Uploads an image from a URL, not implemented"""
+
+    raise HTTPException(status_code=501, detail="Not implemented")
+
+
 @images_router.delete("/i/{image_name}", operation_id="delete_image")
 async def delete_image(
     image_name: str = Path(description="The name of the image to delete"),

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageUploaded.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageUploaded.ts
@@ -1,6 +1,8 @@
+import { isAnyOf } from '@reduxjs/toolkit';
 import { logger } from 'app/logging/logger';
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
 import type { RootState } from 'app/store/store';
+import { imageUploadedClientSide } from 'features/gallery/store/actions';
 import { selectListBoardsQueryArgs } from 'features/gallery/store/gallerySelectors';
 import { boardIdSelected, galleryViewChanged } from 'features/gallery/store/gallerySlice';
 import { toast } from 'features/toast/toast';
@@ -8,7 +10,7 @@ import { t } from 'i18next';
 import { omit } from 'lodash-es';
 import { boardsApi } from 'services/api/endpoints/boards';
 import { imagesApi } from 'services/api/endpoints/images';
-
+import type { ImageDTO } from 'services/api/types';
 const log = logger('gallery');
 
 /**
@@ -34,18 +36,32 @@ let lastUploadedToastTimeout: number | null = null;
 
 export const addImageUploadedFulfilledListener = (startAppListening: AppStartListening) => {
   startAppListening({
-    matcher: imagesApi.endpoints.uploadImage.matchFulfilled,
+    matcher: isAnyOf(imagesApi.endpoints.uploadImage.matchFulfilled, imageUploadedClientSide),
     effect: (action, { dispatch, getState }) => {
-      const imageDTO = action.payload;
+      let imageDTO: ImageDTO;
+      let silent;
+      let isFirstUploadOfBatch = true;
+
+      if (imageUploadedClientSide.match(action)) {
+        imageDTO = action.payload.imageDTO;
+        silent = action.payload.silent;
+        isFirstUploadOfBatch = action.payload.isFirstUploadOfBatch;
+      } else if (imagesApi.endpoints.uploadImage.matchFulfilled(action)) {
+        imageDTO = action.payload;
+        silent = action.meta.arg.originalArgs.silent;
+        isFirstUploadOfBatch = action.meta.arg.originalArgs.isFirstUploadOfBatch ?? true;
+      } else {
+        return;
+      }
+
+      if (silent || imageDTO.is_intermediate) {
+        // If the image is silent or intermediate, we don't want to show a toast
+        return;
+      }
+
       const state = getState();
 
       log.debug({ imageDTO }, 'Image uploaded');
-
-      if (action.meta.arg.originalArgs.silent || imageDTO.is_intermediate) {
-        // When a "silent" upload is requested, or the image is intermediate, we can skip all post-upload actions,
-        // like toasts and switching the gallery view
-        return;
-      }
 
       const boardId = imageDTO.board_id ?? 'none';
 
@@ -80,7 +96,7 @@ export const addImageUploadedFulfilledListener = (startAppListening: AppStartLis
        *
        * Default to true to not require _all_ image upload handlers to set this value
        */
-      const isFirstUploadOfBatch = action.meta.arg.originalArgs.isFirstUploadOfBatch ?? true;
+
       if (isFirstUploadOfBatch) {
         dispatch(boardIdSelected({ boardId }));
         dispatch(galleryViewChanged('assets'));

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageUploaded.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/imageUploaded.ts
@@ -11,6 +11,7 @@ import { omit } from 'lodash-es';
 import { boardsApi } from 'services/api/endpoints/boards';
 import { imagesApi } from 'services/api/endpoints/images';
 import type { ImageDTO } from 'services/api/types';
+import { getCategories, getListImagesUrl } from 'services/api/util';
 const log = logger('gallery');
 
 /**
@@ -59,6 +60,29 @@ export const addImageUploadedFulfilledListener = (startAppListening: AppStartLis
         return;
       }
 
+      if (imageUploadedClientSide.match(action)) {
+        const categories = getCategories(imageDTO);
+        const boardId = imageDTO.board_id ?? 'none';
+        dispatch(
+          imagesApi.util.invalidateTags([
+            {
+              type: 'ImageList',
+              id: getListImagesUrl({
+                board_id: boardId,
+                categories,
+              }),
+            },
+            {
+              type: 'Board',
+              id: boardId,
+            },
+            {
+              type: 'BoardImagesTotal',
+              id: boardId,
+            },
+          ])
+        );
+      }
       const state = getState();
 
       log.debug({ imageDTO }, 'Image uploaded');

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -73,6 +73,7 @@ export type AppConfig = {
   maxUpscaleDimension?: number;
   allowPrivateBoards: boolean;
   allowPrivateStylePresets: boolean;
+  allowClientSideUpload: boolean;
   disabledTabs: TabName[];
   disabledFeatures: AppFeature[];
   disabledSDFeatures: SDFeature[];
@@ -81,7 +82,6 @@ export type AppConfig = {
   metadataFetchDebounce?: number;
   workflowFetchDebounce?: number;
   isLocal?: boolean;
-  maxImageUploadCount?: number;
   sd: {
     defaultModel?: string;
     disabledControlNetModels: string[];

--- a/invokeai/frontend/web/src/common/hooks/useClientSideUpload.ts
+++ b/invokeai/frontend/web/src/common/hooks/useClientSideUpload.ts
@@ -1,0 +1,105 @@
+import { useStore } from '@nanostores/react';
+import { $authToken } from 'app/store/nanostores/authToken';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import { imageUploadedClientSide } from 'features/gallery/store/actions';
+import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
+import { useCallback } from 'react';
+import { useCreateImageUploadEntryMutation } from 'services/api/endpoints/images';
+import type { ImageDTO } from 'services/api/types';
+export const useClientSideUpload = () => {
+  const dispatch = useAppDispatch();
+  const autoAddBoardId = useAppSelector(selectAutoAddBoardId);
+  const authToken = useStore($authToken);
+  const [createImageUploadEntry] = useCreateImageUploadEntryMutation();
+
+  const clientSideUpload = useCallback(
+    async (file: File, i: number): Promise<ImageDTO> => {
+      const image = new Image();
+      const objectURL = URL.createObjectURL(file);
+      image.src = objectURL;
+      let width = 0;
+      let height = 0;
+      let thumbnail: Blob | undefined;
+
+      await new Promise<void>((resolve) => {
+        image.onload = () => {
+          width = image.naturalWidth;
+          height = image.naturalHeight;
+
+          // Calculate thumbnail dimensions maintaining aspect ratio
+          let thumbWidth = width;
+          let thumbHeight = height;
+          if (width > height && width > 256) {
+            thumbWidth = 256;
+            thumbHeight = Math.round((height * 256) / width);
+          } else if (height > 256) {
+            thumbHeight = 256;
+            thumbWidth = Math.round((width * 256) / height);
+          }
+
+          const canvas = document.createElement('canvas');
+          canvas.width = thumbWidth;
+          canvas.height = thumbHeight;
+          const ctx = canvas.getContext('2d');
+          ctx?.drawImage(image, 0, 0, thumbWidth, thumbHeight);
+
+          canvas.toBlob(
+            (blob) => {
+              if (blob) {
+                thumbnail = blob;
+                // Clean up resources
+                URL.revokeObjectURL(objectURL);
+                image.src = ''; // Clear image source
+                image.remove(); // Remove the image element
+                canvas.width = 0; // Clear canvas
+                canvas.height = 0;
+                resolve();
+              }
+            },
+            'image/webp',
+            0.8
+          );
+        };
+
+        // Handle load errors
+        image.onerror = () => {
+          URL.revokeObjectURL(objectURL);
+          image.remove();
+          resolve();
+        };
+      });
+      const { presigned_url, image_dto } = await createImageUploadEntry({
+        width,
+        height,
+        board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+      }).unwrap();
+
+      await fetch(`${presigned_url}/?type=full`, {
+        method: 'PUT',
+        body: file,
+        ...(authToken && {
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        }),
+      });
+
+      await fetch(`${presigned_url}/?type=thumbnail`, {
+        method: 'PUT',
+        body: thumbnail,
+        ...(authToken && {
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        }),
+      });
+
+      dispatch(imageUploadedClientSide({ imageDTO: image_dto, silent: false, isFirstUploadOfBatch: i === 0 }));
+
+      return image_dto;
+    },
+    [autoAddBoardId, authToken, createImageUploadEntry, dispatch]
+  );
+
+  return clientSideUpload;
+};

--- a/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
+++ b/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
@@ -141,6 +141,7 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
     onDropRejected,
     disabled: isDisabled,
     noDrag: true,
+    multiple: allowMultiple,
   });
 
   return { getUploadButtonProps, getUploadInputProps, openUploader, request };

--- a/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
+++ b/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
@@ -3,7 +3,7 @@ import { IconButton } from '@invoke-ai/ui-library';
 import { logger } from 'app/logging/logger';
 import { useAppSelector } from 'app/store/storeHooks';
 import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
-import { selectMaxImageUploadCount } from 'features/system/store/configSlice';
+import { selectIsClientSideUploadEnabled } from 'features/system/store/configSlice';
 import { toast } from 'features/toast/toast';
 import { useCallback } from 'react';
 import type { FileRejection } from 'react-dropzone';
@@ -15,6 +15,7 @@ import type { ImageDTO } from 'services/api/types';
 import { assert } from 'tsafe';
 import type { SetOptional } from 'type-fest';
 
+import { useClientSideUpload } from './useClientSideUpload';
 type UseImageUploadButtonArgs =
   | {
       isDisabled?: boolean;
@@ -50,8 +51,9 @@ const log = logger('gallery');
  */
 export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: UseImageUploadButtonArgs) => {
   const autoAddBoardId = useAppSelector(selectAutoAddBoardId);
+  const isClientSideUploadEnabled = useAppSelector(selectIsClientSideUploadEnabled);
   const [uploadImage, request] = useUploadImageMutation();
-  const maxImageUploadCount = useAppSelector(selectMaxImageUploadCount);
+  const clientSideUpload = useClientSideUpload();
   const { t } = useTranslation();
 
   const onDropAccepted = useCallback(
@@ -79,22 +81,27 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
           onUpload(imageDTO);
         }
       } else {
-        const imageDTOs = await uploadImages(
-          files.map((file, i) => ({
-            file,
-            image_category: 'user',
-            is_intermediate: false,
-            board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
-            silent: false,
-            isFirstUploadOfBatch: i === 0,
-          }))
-        );
+        let imageDTOs: ImageDTO[] = [];
+        if (isClientSideUploadEnabled) {
+          imageDTOs = await Promise.all(files.map((file, i) => clientSideUpload(file, i)));
+        } else {
+          imageDTOs = await uploadImages(
+            files.map((file, i) => ({
+              file,
+              image_category: 'user',
+              is_intermediate: false,
+              board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+              silent: false,
+              isFirstUploadOfBatch: i === 0,
+            }))
+          );
+        }
         if (onUpload) {
           onUpload(imageDTOs);
         }
       }
     },
-    [allowMultiple, autoAddBoardId, onUpload, uploadImage]
+    [allowMultiple, autoAddBoardId, onUpload, uploadImage, isClientSideUploadEnabled, clientSideUpload]
   );
 
   const onDropRejected = useCallback(
@@ -105,10 +112,7 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
           file: rejection.file.path,
         }));
         log.error({ errors }, 'Invalid upload');
-        const description =
-          maxImageUploadCount === undefined
-            ? t('toast.uploadFailedInvalidUploadDesc')
-            : t('toast.uploadFailedInvalidUploadDesc_withCount', { count: maxImageUploadCount });
+        const description = t('toast.uploadFailedInvalidUploadDesc');
 
         toast({
           id: 'UPLOAD_FAILED',
@@ -120,7 +124,7 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
         return;
       }
     },
-    [maxImageUploadCount, t]
+    [t]
   );
 
   const {
@@ -137,8 +141,6 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
     onDropRejected,
     disabled: isDisabled,
     noDrag: true,
-    multiple: allowMultiple && (maxImageUploadCount === undefined || maxImageUploadCount > 1),
-    maxFiles: maxImageUploadCount,
   });
 
   return { getUploadButtonProps, getUploadInputProps, openUploader, request };

--- a/invokeai/frontend/web/src/features/gallery/components/GalleryUploadButton.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/GalleryUploadButton.tsx
@@ -1,31 +1,18 @@
 import { IconButton } from '@invoke-ai/ui-library';
-import { useAppSelector } from 'app/store/storeHooks';
 import { useImageUploadButton } from 'common/hooks/useImageUploadButton';
-import { selectMaxImageUploadCount } from 'features/system/store/configSlice';
 import { t } from 'i18next';
-import { useMemo } from 'react';
 import { PiUploadBold } from 'react-icons/pi';
 
 export const GalleryUploadButton = () => {
-  const maxImageUploadCount = useAppSelector(selectMaxImageUploadCount);
-  const uploadOptions = useMemo(() => ({ allowMultiple: maxImageUploadCount !== 1 }), [maxImageUploadCount]);
-  const uploadApi = useImageUploadButton(uploadOptions);
+  const uploadApi = useImageUploadButton({ allowMultiple: true });
   return (
     <>
       <IconButton
         size="sm"
         alignSelf="stretch"
         variant="link"
-        aria-label={
-          maxImageUploadCount === undefined || maxImageUploadCount > 1
-            ? t('accessibility.uploadImages')
-            : t('accessibility.uploadImage')
-        }
-        tooltip={
-          maxImageUploadCount === undefined || maxImageUploadCount > 1
-            ? t('accessibility.uploadImages')
-            : t('accessibility.uploadImage')
-        }
+        aria-label={t('accessibility.uploadImages')}
+        tooltip={t('accessibility.uploadImages')}
         icon={<PiUploadBold />}
         {...uploadApi.getUploadButtonProps()}
       />

--- a/invokeai/frontend/web/src/features/gallery/store/actions.ts
+++ b/invokeai/frontend/web/src/features/gallery/store/actions.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@reduxjs/toolkit';
+import type { ImageDTO } from 'services/api/types';
 
 export const sentImageToCanvas = createAction('gallery/sentImageToCanvas');
 
@@ -7,3 +8,9 @@ export const imageDownloaded = createAction('gallery/imageDownloaded');
 export const imageCopiedToClipboard = createAction('gallery/imageCopiedToClipboard');
 
 export const imageOpenedInNewTab = createAction('gallery/imageOpenedInNewTab');
+
+export const imageUploadedClientSide = createAction<{
+  imageDTO: ImageDTO;
+  silent: boolean;
+  isFirstUploadOfBatch: boolean;
+}>('gallery/imageUploadedClientSide');

--- a/invokeai/frontend/web/src/features/system/store/configSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/configSlice.ts
@@ -20,6 +20,7 @@ const initialConfigState: AppConfig = {
   shouldFetchMetadataFromApi: false,
   allowPrivateBoards: false,
   allowPrivateStylePresets: false,
+  allowClientSideUpload: false,
   disabledTabs: [],
   disabledFeatures: ['lightbox', 'faceRestore', 'batches'],
   disabledSDFeatures: ['variation', 'symmetry', 'hires', 'perlinNoise', 'noiseThreshold'],
@@ -218,6 +219,5 @@ export const selectWorkflowFetchDebounce = createConfigSelector((config) => conf
 export const selectMetadataFetchDebounce = createConfigSelector((config) => config.metadataFetchDebounce ?? 300);
 
 export const selectIsModelsTabDisabled = createConfigSelector((config) => config.disabledTabs.includes('models'));
-export const selectMaxImageUploadCount = createConfigSelector((config) => config.maxImageUploadCount);
-
+export const selectIsClientSideUploadEnabled = createConfigSelector((config) => config.allowClientSideUpload);
 export const selectIsLocal = createSelector(selectConfigSlice, (config) => config.isLocal);

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -318,37 +318,11 @@ export const imagesApi = api.injectEndpoints({
       },
     }),
     createImageUploadEntry: build.mutation<ImageUploadEntryResponse, ImageUploadEntryRequest>({
-      query: ({ width, height }) => ({
+      query: ({ width, height, board_id }) => ({
         url: buildImagesUrl(),
         method: 'POST',
-        body: { width, height },
+        body: { width, height, board_id },
       }),
-      invalidatesTags: (result) => {
-        if (!result) {
-          // Don't add it to anything
-          return [];
-        }
-        const categories = getCategories(result.image_dto);
-        const boardId = result.image_dto.board_id ?? 'none';
-
-        return [
-          {
-            type: 'ImageList',
-            id: getListImagesUrl({
-              board_id: boardId,
-              categories,
-            }),
-          },
-          {
-            type: 'Board',
-            id: boardId,
-          },
-          {
-            type: 'BoardImagesTotal',
-            id: boardId,
-          },
-        ];
-      },
     }),
     deleteBoard: build.mutation<DeleteBoardResult, string>({
       query: (board_id) => ({ url: buildBoardsUrl(board_id), method: 'DELETE' }),

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -466,6 +466,30 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/images/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Image Dtos
+         * @description Gets a list of image DTOs
+         */
+        get: operations["list_image_dtos"];
+        put?: never;
+        /**
+         * Create Image Upload Entry
+         * @description Uploads an image from a URL, not implemented
+         */
+        post: operations["create_image_upload_entry"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/images/i/{image_name}": {
         parameters: {
             query?: never;
@@ -611,26 +635,6 @@ export type paths = {
          * @description Gets an image and thumbnail URL
          */
         get: operations["get_image_urls"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/images/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Image Dtos
-         * @description Gets a list of image DTOs
-         */
-        get: operations["list_image_dtos"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2357,6 +2361,24 @@ export type components = {
              * @description The list of batch_ids to cancel all queue items for
              */
             batch_ids: string[];
+        };
+        /** Body_create_image_upload_entry */
+        Body_create_image_upload_entry: {
+            /**
+             * Width
+             * @description The width of the image
+             */
+            width: number;
+            /**
+             * Height
+             * @description The height of the image
+             */
+            height: number;
+            /**
+             * Board Id
+             * @description The board to add this image to, if any
+             */
+            board_id?: string | null;
         };
         /** Body_create_style_preset */
         Body_create_style_preset: {
@@ -10752,6 +10774,16 @@ export type components = {
              * @enum {string}
              */
             type: "i2l";
+        };
+        /** ImageUploadEntry */
+        ImageUploadEntry: {
+            /** @description The image DTO */
+            image_dto: components["schemas"]["ImageDTO"];
+            /**
+             * Presigned Url
+             * @description The URL to get the presigned URL for the image upload
+             */
+            presigned_url: string;
         };
         /**
          * ImageUrlsDTO
@@ -23218,6 +23250,87 @@ export interface operations {
             };
         };
     };
+    list_image_dtos: {
+        parameters: {
+            query?: {
+                /** @description The origin of images to list. */
+                image_origin?: components["schemas"]["ResourceOrigin"] | null;
+                /** @description The categories of image to include. */
+                categories?: components["schemas"]["ImageCategory"][] | null;
+                /** @description Whether to list intermediate images. */
+                is_intermediate?: boolean | null;
+                /** @description The board id to filter by. Use 'none' to find images without a board. */
+                board_id?: string | null;
+                /** @description The page offset */
+                offset?: number;
+                /** @description The number of images per page */
+                limit?: number;
+                /** @description The order of sort */
+                order_dir?: components["schemas"]["SQLiteDirection"];
+                /** @description Whether to sort by starred images first */
+                starred_first?: boolean;
+                /** @description The term to search for */
+                search_term?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OffsetPaginatedResults_ImageDTO_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_image_upload_entry: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Body_create_image_upload_entry"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageUploadEntry"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_image_dto: {
         parameters: {
             query?: never;
@@ -23558,54 +23671,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ImageUrlsDTO"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_image_dtos: {
-        parameters: {
-            query?: {
-                /** @description The origin of images to list. */
-                image_origin?: components["schemas"]["ResourceOrigin"] | null;
-                /** @description The categories of image to include. */
-                categories?: components["schemas"]["ImageCategory"][] | null;
-                /** @description Whether to list intermediate images. */
-                is_intermediate?: boolean | null;
-                /** @description The board id to filter by. Use 'none' to find images without a board. */
-                board_id?: string | null;
-                /** @description The page offset */
-                offset?: number;
-                /** @description The number of images per page */
-                limit?: number;
-                /** @description The order of sort */
-                order_dir?: components["schemas"]["SQLiteDirection"];
-                /** @description Whether to sort by starred images first */
-                starred_first?: boolean;
-                /** @description The term to search for */
-                search_term?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OffsetPaginatedResults_ImageDTO_"];
                 };
             };
             /** @description Validation Error */

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -354,3 +354,6 @@ export type UploadImageArg = {
    */
   isFirstUploadOfBatch?: boolean;
 };
+
+export type ImageUploadEntryResponse = S['ImageUploadEntry'];
+export type ImageUploadEntryRequest = paths['/api/v1/images/']['post']['requestBody']['content']['application/json'];


### PR DESCRIPTION
## Summary

Adds support (behind flag) for client-side uploads. If enabled, image entries will be created via API and then uploaded using presigned URL provided by server. All other upload functionality should remain the same (listener actions, etc)

I tested pasting, drag n drop, and using button above gallery.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
