### PR TITLE
Reduce unnecessary tests

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -61,13 +61,13 @@ jobs:
         if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: pyproject.toml
 
       - name: install ruff
         if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
-        run: pip install ruff==0.9.9
+        run: pip install ruff==0.11.2
         shell: bash
 
       - name: ruff check

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,26 +39,25 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.10'
           - '3.11'
         platform:
-          - linux-cuda-11_7
-          - linux-rocm-5_2
+          # - linux-cuda-12_6
+          # - linux-rocm-6_2
           - linux-cpu
           - macos-default
           - windows-cpu
         include:
-          - platform: linux-cuda-11_7
-            os: ubuntu-22.04
-            github-env: $GITHUB_ENV
-          - platform: linux-rocm-5_2
-            os: ubuntu-22.04
-            extra-index-url: 'https://download.pytorch.org/whl/rocm5.2'
-            github-env: $GITHUB_ENV
+          # - platform: linux-cuda-12_6
+          #   os: ubuntu-24.04
+          #   github-env: $GITHUB_ENV
+          # - platform: linux-rocm-6_2
+          #   os: ubuntu-24.04
+          #   extra-index-url: 'https://download.pytorch.org/whl/rocm6.2'
+          #   github-env: $GITHUB_ENV
           - platform: linux-cpu
-            os: ubuntu-22.04
-            extra-index-url: 'https://download.pytorch.org/whl/cpu'
+            os: ubuntu-24.04
             github-env: $GITHUB_ENV
+            extra-index-url: 'https://download.pytorch.org/whl/cpu'
           - platform: macos-default
             os: macOS-14
             github-env: $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Remove python 3.10 from the test matrix as its use will be deprecated, and to unblock #7846 
- Comment out tests that require GPU because they are meaningless on GPU-less runners. If we at some point launch GPU-backed test runners, these tests can be restored.
- use ubuntu24.04 (latest LTS) in linux tests

NOTE: we need to remove these tests from required checks for the repo

## Merge Plan

Merge when approved

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
