### PR TITLE
fix(mm): flux variant probing

### DIFF
--- a/invokeai/backend/flux/flux_state_dict_utils.py
+++ b/invokeai/backend/flux/flux_state_dict_utils.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from invokeai.backend.model_manager.legacy_probe import CkptType
+
+
+def get_flux_in_channels_from_state_dict(state_dict: "CkptType") -> int | None:
+    """Gets the in channels from the state dict."""
+
+    # "Standard" FLUX models use "img_in.weight", but some community fine tunes use
+    # "model.diffusion_model.img_in.weight". Known models that use the latter key:
+    # - https://civitai.com/models/885098?modelVersionId=990775
+    # - https://civitai.com/models/1018060?modelVersionId=1596255
+    # - https://civitai.com/models/978314/ultrareal-fine-tune?modelVersionId=1413133
+
+    keys = {"img_in.weight", "model.diffusion_model.img_in.weight"}
+
+    for key in keys:
+        val = state_dict.get(key)
+        if val is not None:
+            return val.shape[1]
+
+    return None


### PR DESCRIPTION
## Summary

Before FLUX Fill was merged, we didn't do any checks for the model variant. We always returned "normal".

To determine if a model is a FLUX Fill model, we need to check the state dict for a specific key. Initially, this logic was too strict and rejected quantized FLUX models. This issue was resolved, but it turns out there is another failure mode - some fine-tunes use a different key.

This change further reduces the strictness, handling the alternate key and also falling back to "normal" if we don't see either key. This effectively restores the previous probing behaviour for all FLUX models.

## Related Issues / Discussions

Closes #7856
Closes #7859

## QA Instructions

I have a variety of FLUX models already installed. My testing strategy:
- Set `use_memory_db: true` in `invokeai.yaml`
- Restart the server
- Scan my FLUX main models folder in MM tab of UI
- Install all

I tested these models, all of which install correctly and have the correct variant (normal vs inpaint for FLUX Fill):
- FLUX Dev.safetensors
- FLUX Schnell.safetensors
- FLUX Fill.safetensors
- FLUX Dev (Quantized).safetensors
- FLUX Schnell (Quantized).safetensors
- flux1-fill-dev-Q8_0.gguf
- midjourneyReplica_flux1Dev.safetensors

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
