### PR TITLE
fix(ui): do not switch between images when focused on a tab element

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/hooks/useGalleryHotkeys.ts
+++ b/invokeai/frontend/web/src/features/gallery/hooks/useGalleryHotkeys.ts
@@ -49,7 +49,11 @@ export const useGalleryHotkeys = () => {
   useRegisteredHotkeys({
     id: 'galleryNavLeft',
     category: 'gallery',
-    callback: () => {
+    callback: (e) => {
+      // Skip the hotkey if the user is focused on a tab element - the arrow keys are used to navigate between tabs.
+      if (e.target instanceof HTMLElement && e.target.getAttribute('role') === 'tab') {
+        return;
+      }
       if (isOnFirstImageOfView && isPrevEnabled && !queryResult.isFetching) {
         goPrev('arrow');
         return;
@@ -71,7 +75,11 @@ export const useGalleryHotkeys = () => {
   useRegisteredHotkeys({
     id: 'galleryNavRight',
     category: 'gallery',
-    callback: () => {
+    callback: (e) => {
+      // Skip the hotkey if the user is focused on a tab element - the arrow keys are used to navigate between tabs.
+      if (e.target instanceof HTMLElement && e.target.getAttribute('role') === 'tab') {
+        return;
+      }
       if (isOnLastImageOfView && isNextEnabled && !queryResult.isFetching) {
         goNext('arrow');
         return;


### PR DESCRIPTION
## Summary

Arrow keys should only navigate between tabs, not gallery images.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
