### PR TITLE
Update flux_redux.py with downsampling and weight options

### DIFF
--- a/invokeai/app/invocations/flux_redux.py
+++ b/invokeai/app/invocations/flux_redux.py
@@ -87,7 +87,7 @@ class FluxReduxInvocation(BaseInvocation):
 
         encoded_x = self._siglip_encode(context, image)
         redux_conditioning = self._flux_redux_encode(context, encoded_x)
-        if self.downsampling_factor > 1 and self.weight != 1.0:
+        if self.downsampling_factor > 1 or self.weight != 1.0:
             redux_conditioning = self._downsample_weight(context, redux_conditioning)
 
         tensor_name = context.tensors.save(redux_conditioning)

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -2020,6 +2020,14 @@
             "composition": "Composition Only",
             "compositionDesc": "Replicates layout & structure while ignoring the reference's style."
         },
+        "fluxReduxImageInfluence": {
+            "imageInfluence": "Image Influence",
+            "lowest": "Lowest",
+            "low": "Low",
+            "medium": "Medium",
+            "high": "High",
+            "highest": "Highest"
+        },
         "fill": {
             "fillColor": "Fill Color",
             "fillStyle": "Fill Style",

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/FLUXReduxImageInfluence.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/FLUXReduxImageInfluence.tsx
@@ -1,0 +1,60 @@
+import type { ComboboxOnChange } from '@invoke-ai/ui-library';
+import { Combobox, FormControl, FormLabel } from '@invoke-ai/ui-library';
+import type { FLUXReduxImageInfluence as FLUXReduxImageInfluenceType } from 'features/controlLayers/store/types';
+import { isFLUXReduxImageInfluence } from 'features/controlLayers/store/types';
+import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { assert } from 'tsafe';
+
+type Props = {
+  imageInfluence: FLUXReduxImageInfluenceType;
+  onChange: (imageInfluence: FLUXReduxImageInfluenceType) => void;
+};
+
+export const FLUXReduxImageInfluence = memo(({ imageInfluence, onChange }: Props) => {
+  const { t } = useTranslation();
+
+  const options = useMemo(
+    () =>
+      [
+        {
+          label: t('controlLayers.fluxReduxImageInfluence.lowest'),
+          value: 'lowest',
+        },
+        {
+          label: t('controlLayers.fluxReduxImageInfluence.low'),
+          value: 'low',
+        },
+        {
+          label: t('controlLayers.fluxReduxImageInfluence.medium'),
+          value: 'medium',
+        },
+        {
+          label: t('controlLayers.fluxReduxImageInfluence.high'),
+          value: 'high',
+        },
+        {
+          label: t('controlLayers.fluxReduxImageInfluence.highest'),
+          value: 'highest',
+        },
+      ] satisfies { label: string; value: FLUXReduxImageInfluenceType }[],
+    [t]
+  );
+  const _onChange = useCallback<ComboboxOnChange>(
+    (v) => {
+      assert(isFLUXReduxImageInfluence(v?.value));
+      onChange(v.value);
+    },
+    [onChange]
+  );
+  const value = useMemo(() => options.find((o) => o.value === imageInfluence), [options, imageInfluence]);
+
+  return (
+    <FormControl>
+      <FormLabel m={0}>{t('controlLayers.fluxReduxImageInfluence.imageInfluence')}</FormLabel>
+      <Combobox value={value} options={options} onChange={_onChange} />
+    </FormControl>
+  );
+});
+
+FLUXReduxImageInfluence.displayName = 'FLUXReduxImageInfluence';

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterImagePreview.tsx
@@ -61,7 +61,7 @@ export const IPAdapterImagePreview = memo(
         )}
         {imageDTO && (
           <>
-            <DndImage imageDTO={imageDTO} />
+            <DndImage imageDTO={imageDTO} borderWidth={1} borderStyle='solid' />
             <Flex position="absolute" flexDir="column" top={2} insetInlineEnd={2} gap={1}>
               <DndImageIcon
                 onClick={handleResetControlImage}

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterImagePreview.tsx
@@ -61,7 +61,7 @@ export const IPAdapterImagePreview = memo(
         )}
         {imageDTO && (
           <>
-            <DndImage imageDTO={imageDTO} borderWidth={1} borderStyle='solid' />
+            <DndImage imageDTO={imageDTO} borderWidth={1} borderStyle="solid" />
             <Flex position="absolute" flexDir="column" top={2} insetInlineEnd={2} gap={1}>
               <DndImageIcon
                 onClick={handleResetControlImage}

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsx
@@ -50,7 +50,7 @@ export const IPAdapterMethod = memo(({ method, onChange }: Props) => {
   return (
     <FormControl>
       <InformationalPopover feature="ipAdapterMethod">
-        <FormLabel>{t('controlLayers.ipAdapterMethod.ipAdapterMethod')}</FormLabel>
+        <FormLabel m={0}>{t('controlLayers.ipAdapterMethod.ipAdapterMethod')}</FormLabel>
       </InformationalPopover>
       <Combobox value={value} options={options} onChange={_onChange} />
     </FormControl>

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterSettings.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterSettings.tsx
@@ -130,7 +130,7 @@ const IPAdapterSettingsContent = memo(() => {
             icon={<PiBoundingBoxBold />}
           />
         </Flex>
-        <Flex gap={2} w="full" alignItems="center">
+        <Flex gap={2} w="full">
           {ipAdapter.type === 'ip_adapter' && (
             <Flex flexDir="column" gap={2} w="full">
               {!isFLUX && <IPAdapterMethod method={ipAdapter.method} onChange={onChangeIPMethod} />}

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterSettings.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterSettings.tsx
@@ -5,6 +5,7 @@ import { BeginEndStepPct } from 'features/controlLayers/components/common/BeginE
 import { CanvasEntitySettingsWrapper } from 'features/controlLayers/components/common/CanvasEntitySettingsWrapper';
 import { Weight } from 'features/controlLayers/components/common/Weight';
 import { CLIPVisionModel } from 'features/controlLayers/components/IPAdapter/CLIPVisionModel';
+import { FLUXReduxImageInfluence } from 'features/controlLayers/components/IPAdapter/FLUXReduxImageInfluence';
 import { IPAdapterMethod } from 'features/controlLayers/components/IPAdapter/IPAdapterMethod';
 import { IPAdapterSettingsEmptyState } from 'features/controlLayers/components/IPAdapter/IPAdapterSettingsEmptyState';
 import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
@@ -13,6 +14,7 @@ import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import {
   referenceImageIPAdapterBeginEndStepPctChanged,
   referenceImageIPAdapterCLIPVisionModelChanged,
+  referenceImageIPAdapterFLUXReduxImageInfluenceChanged,
   referenceImageIPAdapterImageChanged,
   referenceImageIPAdapterMethodChanged,
   referenceImageIPAdapterModelChanged,
@@ -20,7 +22,12 @@ import {
 } from 'features/controlLayers/store/canvasSlice';
 import { selectIsFLUX } from 'features/controlLayers/store/paramsSlice';
 import { selectCanvasSlice, selectEntity, selectEntityOrThrow } from 'features/controlLayers/store/selectors';
-import type { CanvasEntityIdentifier, CLIPVisionModelV2, IPMethodV2 } from 'features/controlLayers/store/types';
+import type {
+  CanvasEntityIdentifier,
+  CLIPVisionModelV2,
+  FLUXReduxImageInfluence as FLUXReduxImageInfluenceType,
+  IPMethodV2,
+} from 'features/controlLayers/store/types';
 import type { SetGlobalReferenceImageDndTargetData } from 'features/dnd/dnd';
 import { setGlobalReferenceImageDndTarget } from 'features/dnd/dnd';
 import { memo, useCallback, useMemo } from 'react';
@@ -61,6 +68,13 @@ const IPAdapterSettingsContent = memo(() => {
   const onChangeIPMethod = useCallback(
     (method: IPMethodV2) => {
       dispatch(referenceImageIPAdapterMethodChanged({ entityIdentifier, method }));
+    },
+    [dispatch, entityIdentifier]
+  );
+
+  const onChangeFLUXReduxImageInfluence = useCallback(
+    (imageInfluence: FLUXReduxImageInfluenceType) => {
+      dispatch(referenceImageIPAdapterFLUXReduxImageInfluenceChanged({ entityIdentifier, imageInfluence }));
     },
     [dispatch, entityIdentifier]
   );
@@ -122,6 +136,14 @@ const IPAdapterSettingsContent = memo(() => {
               {!isFLUX && <IPAdapterMethod method={ipAdapter.method} onChange={onChangeIPMethod} />}
               <Weight weight={ipAdapter.weight} onChange={onChangeWeight} />
               <BeginEndStepPct beginEndStepPct={ipAdapter.beginEndStepPct} onChange={onChangeBeginEndStepPct} />
+            </Flex>
+          )}
+          {ipAdapter.type === 'flux_redux' && (
+            <Flex flexDir="column" gap={2} w="full" alignItems="flex-start">
+              <FLUXReduxImageInfluence
+                imageInfluence={ipAdapter.imageInfluence ?? 'lowest'}
+                onChange={onChangeFLUXReduxImageInfluence}
+              />
             </Flex>
           )}
           <Flex alignItems="center" justifyContent="center" h={32} w={32} aspectRatio="1/1" flexGrow={1}>

--- a/invokeai/frontend/web/src/features/controlLayers/components/RegionalGuidance/RegionalGuidanceIPAdapterSettings.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RegionalGuidance/RegionalGuidanceIPAdapterSettings.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { BeginEndStepPct } from 'features/controlLayers/components/common/BeginEndStepPct';
 import { Weight } from 'features/controlLayers/components/common/Weight';
 import { CLIPVisionModel } from 'features/controlLayers/components/IPAdapter/CLIPVisionModel';
+import { FLUXReduxImageInfluence } from 'features/controlLayers/components/IPAdapter/FLUXReduxImageInfluence';
 import { IPAdapterImagePreview } from 'features/controlLayers/components/IPAdapter/IPAdapterImagePreview';
 import { IPAdapterMethod } from 'features/controlLayers/components/IPAdapter/IPAdapterMethod';
 import { IPAdapterModel } from 'features/controlLayers/components/IPAdapter/IPAdapterModel';
@@ -15,13 +16,19 @@ import {
   rgIPAdapterBeginEndStepPctChanged,
   rgIPAdapterCLIPVisionModelChanged,
   rgIPAdapterDeleted,
+  rgIPAdapterFLUXReduxImageInfluenceChanged,
   rgIPAdapterImageChanged,
   rgIPAdapterMethodChanged,
   rgIPAdapterModelChanged,
   rgIPAdapterWeightChanged,
 } from 'features/controlLayers/store/canvasSlice';
 import { selectCanvasSlice, selectRegionalGuidanceReferenceImage } from 'features/controlLayers/store/selectors';
-import type { CanvasEntityIdentifier, CLIPVisionModelV2, IPMethodV2 } from 'features/controlLayers/store/types';
+import type {
+  CanvasEntityIdentifier,
+  CLIPVisionModelV2,
+  FLUXReduxImageInfluence as FLUXReduxImageInfluenceType,
+  IPMethodV2,
+} from 'features/controlLayers/store/types';
 import type { SetRegionalGuidanceReferenceImageDndTargetData } from 'features/dnd/dnd';
 import { setRegionalGuidanceReferenceImageDndTarget } from 'features/dnd/dnd';
 import { memo, useCallback, useMemo } from 'react';
@@ -69,6 +76,13 @@ const RegionalGuidanceIPAdapterSettingsContent = memo(({ referenceImageId }: Pro
   const onChangeIPMethod = useCallback(
     (method: IPMethodV2) => {
       dispatch(rgIPAdapterMethodChanged({ entityIdentifier, referenceImageId, method }));
+    },
+    [dispatch, entityIdentifier, referenceImageId]
+  );
+
+  const onChangeFLUXReduxImageInfluence = useCallback(
+    (imageInfluence: FLUXReduxImageInfluenceType) => {
+      dispatch(rgIPAdapterFLUXReduxImageInfluenceChanged({ entityIdentifier, referenceImageId, imageInfluence }));
     },
     [dispatch, entityIdentifier, referenceImageId]
   );
@@ -149,6 +163,14 @@ const RegionalGuidanceIPAdapterSettingsContent = memo(({ referenceImageId }: Pro
               <IPAdapterMethod method={ipAdapter.method} onChange={onChangeIPMethod} />
               <Weight weight={ipAdapter.weight} onChange={onChangeWeight} />
               <BeginEndStepPct beginEndStepPct={ipAdapter.beginEndStepPct} onChange={onChangeBeginEndStepPct} />
+            </Flex>
+          )}
+          {ipAdapter.type === 'flux_redux' && (
+            <Flex flexDir="column" gap={2} w="full">
+              <FLUXReduxImageInfluence
+                imageInfluence={ipAdapter.imageInfluence ?? 'lowest'}
+                onChange={onChangeFLUXReduxImageInfluence}
+              />
             </Flex>
           )}
           <Flex alignItems="center" justifyContent="center" h={32} w={32} aspectRatio="1/1" flexGrow={1}>

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -21,6 +21,7 @@ import type {
   ControlLoRAConfig,
   EntityMovedByPayload,
   FillStyle,
+  FLUXReduxImageInfluence,
   RegionalGuidanceReferenceImageState,
   RgbColor,
 } from 'features/controlLayers/store/types';
@@ -626,6 +627,20 @@ export const canvasSlice = createSlice({
       }
       entity.ipAdapter.method = method;
     },
+    referenceImageIPAdapterFLUXReduxImageInfluenceChanged: (
+      state,
+      action: PayloadAction<EntityIdentifierPayload<{ imageInfluence: FLUXReduxImageInfluence }, 'reference_image'>>
+    ) => {
+      const { entityIdentifier, imageInfluence } = action.payload;
+      const entity = selectEntity(state, entityIdentifier);
+      if (!entity) {
+        return;
+      }
+      if (entity.ipAdapter.type !== 'flux_redux') {
+        return;
+      }
+      entity.ipAdapter.imageInfluence = imageInfluence;
+    },
     referenceImageIPAdapterModelChanged: (
       state,
       action: PayloadAction<
@@ -925,6 +940,26 @@ export const canvasSlice = createSlice({
       }
 
       referenceImage.ipAdapter.method = method;
+    },
+    rgIPAdapterFLUXReduxImageInfluenceChanged: (
+      state,
+      action: PayloadAction<
+        EntityIdentifierPayload<
+          { referenceImageId: string; imageInfluence: FLUXReduxImageInfluence },
+          'regional_guidance'
+        >
+      >
+    ) => {
+      const { entityIdentifier, referenceImageId, imageInfluence } = action.payload;
+      const referenceImage = selectRegionalGuidanceReferenceImage(state, entityIdentifier, referenceImageId);
+      if (!referenceImage) {
+        return;
+      }
+      if (referenceImage.ipAdapter.type !== 'flux_redux') {
+        return;
+      }
+
+      referenceImage.ipAdapter.imageInfluence = imageInfluence;
     },
     rgIPAdapterModelChanged: (
       state,
@@ -1731,6 +1766,7 @@ export const {
   referenceImageIPAdapterCLIPVisionModelChanged,
   referenceImageIPAdapterWeightChanged,
   referenceImageIPAdapterBeginEndStepPctChanged,
+  referenceImageIPAdapterFLUXReduxImageInfluenceChanged,
   // Regions
   rgAdded,
   // rgRecalled,
@@ -1746,6 +1782,7 @@ export const {
   rgIPAdapterMethodChanged,
   rgIPAdapterModelChanged,
   rgIPAdapterCLIPVisionModelChanged,
+  rgIPAdapterFLUXReduxImageInfluenceChanged,
   // Inpaint mask
   inpaintMaskAdded,
   inpaintMaskConvertedToRegionalGuidance,

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -233,10 +233,15 @@ const zIPAdapterConfig = z.object({
 });
 export type IPAdapterConfig = z.infer<typeof zIPAdapterConfig>;
 
+const zFLUXReduxImageInfluence = z.enum(['lowest', 'low', 'medium', 'high', 'highest']);
+export const isFLUXReduxImageInfluence = (v: unknown): v is FLUXReduxImageInfluence =>
+  zFLUXReduxImageInfluence.safeParse(v).success;
+export type FLUXReduxImageInfluence = z.infer<typeof zFLUXReduxImageInfluence>;
 const zFLUXReduxConfig = z.object({
   type: z.literal('flux_redux'),
   image: zImageWithDims.nullable(),
   model: zServerValidatedModelIdentifierField.nullable(),
+  imageInfluence: zFLUXReduxImageInfluence.default('highest'),
 });
 export type FLUXReduxConfig = z.infer<typeof zFLUXReduxConfig>;
 

--- a/invokeai/frontend/web/src/features/controlLayers/store/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/util.ts
@@ -75,6 +75,7 @@ export const initialFLUXRedux: FLUXReduxConfig = {
   type: 'flux_redux',
   image: null,
   model: null,
+  imageInfluence: 'highest',
 };
 export const initialT2IAdapter: T2IAdapterConfig = {
   type: 't2i_adapter',

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addFLUXRedux.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addFLUXRedux.ts
@@ -48,7 +48,7 @@ export const addFLUXReduxes = ({ entities, g, collector, model }: AddFLUXReduxAr
  *
  * See invokeai/app/invocations/flux_redux.py for more details.
  */
-const IMAGE_INFLUENCE_TO_SETTINGS: Record<
+export const IMAGE_INFLUENCE_TO_SETTINGS: Record<
   FLUXReduxImageInfluence,
   Pick<Invocation<'flux_redux'>, 'downsampling_factor' | 'downsampling_function' | 'weight'>
 > = {

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addRegions.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addRegions.ts
@@ -5,6 +5,7 @@ import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
 import { getPrefixedId } from 'features/controlLayers/konva/util';
 import type { CanvasRegionalGuidanceState, Rect } from 'features/controlLayers/store/types';
 import { getRegionalGuidanceWarnings } from 'features/controlLayers/store/validators';
+import { IMAGE_INFLUENCE_TO_SETTINGS } from 'features/nodes/util/graph/generation/addFLUXRedux';
 import type { Graph } from 'features/nodes/util/graph/generation/Graph';
 import { serializeError } from 'serialize-error';
 import type { Invocation, MainModelConfig } from 'services/api/types';
@@ -313,6 +314,7 @@ export const addRegions = async ({
           image: {
             image_name: image.image_name,
           },
+          ...IMAGE_INFLUENCE_TO_SETTINGS[ipAdapter.imageInfluence ?? 'highest'],
         });
 
         // Connect the mask to the conditioning

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -7824,6 +7824,25 @@ export type components = {
              */
             redux_model?: components["schemas"]["ModelIdentifierField"];
             /**
+             * Downsampling Factor
+             * @description Redux Downsampling Factor (1-9)
+             * @default 1
+             */
+            downsampling_factor?: number;
+            /**
+             * Downsampling Function
+             * @description Redux Downsampling Function
+             * @default area
+             * @enum {string}
+             */
+            downsampling_function?: "nearest" | "bilinear" | "bicubic" | "area" | "nearest-exact";
+            /**
+             * Weight
+             * @description Redux weight (0.0-1.0)
+             * @default 1
+             */
+            weight?: number;
+            /**
              * type
              * @default flux_redux
              * @constant


### PR DESCRIPTION
Add downsampling and weight to Redux node - This should allow the main prompt conditioning to gain some traction over a Redux conditioning.

## Summary

The downsampling and weight idea is derived from https://github.com/kaibioinfo/ComfyUI_AdvancedRefluxControl
- Downsampling of 3-4 is where the main prompt starts to gain some traction. 
- Weight of 0.3-0.4 is where it weakens the redux conditioning enough for the main prompt to have an effect. 

Downsampling reduces the size of the redux conditioning
Weight reduces the intensity of the conditioning but not the size

## Related Issues / Discussions
N/A

## QA Instructions

Test defaults to work like the previous non-down-sampled redux

https://stable-diffusion-art.com/flux-redux/ - article on the original comfy node. 

## Merge Plan

Needs testing and reviewing and frontend consideration discussed 

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
