### PR TITLE
feat: workflow publish followups

### DIFF
--- a/invokeai/app/api/routers/session_queue.py
+++ b/invokeai/app/api/routers/session_queue.py
@@ -50,6 +50,10 @@ async def enqueue_batch(
         default=False,
         description="Whether or not this is a validation run.",
     ),
+    published_workflow_id: Optional[str] = Body(
+        default=None,
+        description="The ID of the published workflow associated with this queue item",
+    ),
     api_input_fields: Optional[list[FieldIdentifier]] = Body(
         default=None, description="The fields that were used as input to the API"
     ),

--- a/invokeai/app/api/routers/session_queue.py
+++ b/invokeai/app/api/routers/session_queue.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from fastapi import Body, Path, Query
 from fastapi.routing import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from invokeai.app.api.dependencies import ApiDependencies
 from invokeai.app.services.session_processor.session_processor_common import SessionProcessorStatus
@@ -35,6 +35,12 @@ class SessionQueueAndProcessorStatus(BaseModel):
     processor: SessionProcessorStatus
 
 
+class ValidationRunData(BaseModel):
+    workflow_id: str = Field(description="The id of the workflow being published.")
+    input_fields: list[FieldIdentifier] = Body(description="The input fields for the published workflow")
+    output_fields: list[FieldIdentifier] = Body(description="The output fields for the published workflow")
+
+
 @session_queue_router.post(
     "/{queue_id}/enqueue_batch",
     operation_id="enqueue_batch",
@@ -46,19 +52,9 @@ async def enqueue_batch(
     queue_id: str = Path(description="The queue id to perform this operation on"),
     batch: Batch = Body(description="Batch to process"),
     prepend: bool = Body(default=False, description="Whether or not to prepend this batch in the queue"),
-    is_api_validation_run: bool = Body(
-        default=False,
-        description="Whether or not this is a validation run.",
-    ),
-    published_workflow_id: Optional[str] = Body(
+    validation_run_data: Optional[ValidationRunData] = Body(
         default=None,
-        description="The ID of the published workflow associated with this queue item",
-    ),
-    api_input_fields: Optional[list[FieldIdentifier]] = Body(
-        default=None, description="The fields that were used as input to the API"
-    ),
-    api_output_fields: Optional[list[FieldIdentifier]] = Body(
-        default=None, description="The fields that were used as output from the API"
+        description="The validation run data to use for this batch. This is only used if this is a validation run.",
     ),
 ) -> EnqueueBatchResult:
     """Processes a batch and enqueues the output graphs for execution."""

--- a/invokeai/app/services/session_queue/session_queue_common.py
+++ b/invokeai/app/services/session_queue/session_queue_common.py
@@ -247,6 +247,10 @@ class SessionQueueItemWithoutGraph(BaseModel):
         default=False,
         description="Whether this queue item is an API validation run.",
     )
+    published_workflow_id: Optional[str] = Field(
+        default=None,
+        description="The ID of the published workflow associated with this queue item",
+    )
     api_input_fields: Optional[list[FieldIdentifier]] = Field(
         default=None, description="The fields that were used as input to the API"
     )

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1814,7 +1814,9 @@
             "publishedWorkflowIsLocked": "Published workflow is locked",
             "publishingValidationRun": "Publishing Validation Run",
             "publishingValidationRunInProgress": "Publishing validation run in progress.",
-            "publishedWorkflowsLocked": "Published workflows are locked and cannot be edited or run. Either unpublish the workflow or save a copy to edit or run this workflow."
+            "publishedWorkflowsLocked": "Published workflows are locked and cannot be edited or run. Either unpublish the workflow or save a copy to edit or run this workflow.",
+            "selectingOutputNode": "Selecting output node",
+            "selectingOutputNodeDesc": "Click a node to select it as the workflow's output node."
         }
     },
     "controlLayers": {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/TopLeftPanel.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/TopLeftPanel.tsx
@@ -3,7 +3,11 @@ import { useStore } from '@nanostores/react';
 import { useAppSelector } from 'app/store/storeHooks';
 import AddNodeButton from 'features/nodes/components/flow/panels/TopPanel/AddNodeButton';
 import UpdateNodesButton from 'features/nodes/components/flow/panels/TopPanel/UpdateNodesButton';
-import { $isInPublishFlow, useIsValidationRunInProgress } from 'features/nodes/components/sidePanel/workflow/publish';
+import {
+  $isInPublishFlow,
+  $isSelectingOutputNode,
+  useIsValidationRunInProgress,
+} from 'features/nodes/components/sidePanel/workflow/publish';
 import { useIsWorkflowEditorLocked } from 'features/nodes/hooks/useIsWorkflowEditorLocked';
 import { selectWorkflowIsPublished } from 'features/nodes/store/workflowSlice';
 import { memo } from 'react';
@@ -14,6 +18,7 @@ export const TopLeftPanel = memo(() => {
   const isInPublishFlow = useStore($isInPublishFlow);
   const isPublished = useAppSelector(selectWorkflowIsPublished);
   const isValidationRunInProgress = useIsValidationRunInProgress();
+  const isSelectingOutputNode = useStore($isSelectingOutputNode);
 
   const { t } = useTranslation();
   return (
@@ -34,9 +39,14 @@ export const TopLeftPanel = memo(() => {
                 {t('workflows.builder.publishingValidationRunInProgress')}
               </AlertDescription>
             )}
-            {isInPublishFlow && !isValidationRunInProgress && (
+            {isInPublishFlow && !isValidationRunInProgress && !isSelectingOutputNode && (
               <AlertDescription whiteSpace="pre-wrap">
                 {t('workflows.builder.workflowLockedDuringPublishing')}
+              </AlertDescription>
+            )}
+            {isInPublishFlow && !isValidationRunInProgress && isSelectingOutputNode && (
+              <AlertDescription whiteSpace="pre-wrap">
+                {t('workflows.builder.selectingOutputNodeDesc')}
               </AlertDescription>
             )}
             {isPublished && (

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/PublishWorkflowPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/PublishWorkflowPanelContent.tsx
@@ -1,3 +1,4 @@
+import type { ButtonProps } from '@invoke-ai/ui-library';
 import {
   Button,
   ButtonGroup,
@@ -43,7 +44,7 @@ import { toast } from 'features/toast/toast';
 import type { PropsWithChildren } from 'react';
 import { memo, useCallback, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { PiLightningFill, PiSignOutBold, PiXBold } from 'react-icons/pi';
+import { PiArrowLineRightBold, PiLightningFill, PiXBold } from 'react-icons/pi';
 import { serializeError } from 'serialize-error';
 import { assert } from 'tsafe';
 
@@ -53,7 +54,6 @@ export const PublishWorkflowPanelContent = memo(() => {
   return (
     <Flex flexDir="column" gap={2} h="full">
       <ButtonGroup isAttached={false} size="sm" variant="ghost">
-        <SelectOutputNodeButton />
         <Spacer />
         <CancelPublishButton />
         <PublishWorkflowButton />
@@ -74,32 +74,35 @@ const OutputFields = memo(() => {
   const { t } = useTranslation();
   const outputNodeId = useStore($outputNodeId);
 
-  if (!outputNodeId) {
-    return (
-      <Flex flexDir="column" borderWidth={1} borderRadius="base" gap={2} p={2}>
+  return (
+    <Flex flexDir="column" borderWidth={1} borderRadius="base" gap={2} p={2}>
+      <Flex alignItems="center">
+        <Text fontWeight="semibold">{t('workflows.builder.publishedWorkflowOutputs')}</Text>
+        <Spacer />
+        <SelectOutputNodeButton variant="link" size="sm" />
+      </Flex>
+
+      <Divider />
+      {!outputNodeId && (
         <Text fontWeight="semibold" color="error.300">
           {t('workflows.builder.noOutputNodeSelected')}
         </Text>
-      </Flex>
-    );
-  }
-
-  return <OutputFieldsContent outputNodeId={outputNodeId} />;
+      )}
+      {outputNodeId && <OutputFieldsContent outputNodeId={outputNodeId} />}
+    </Flex>
+  );
 });
 OutputFields.displayName = 'OutputFields';
 
 const OutputFieldsContent = memo(({ outputNodeId }: { outputNodeId: string }) => {
-  const { t } = useTranslation();
   const outputFieldNames = useOutputFieldNames(outputNodeId);
 
   return (
-    <Flex flexDir="column" borderWidth={1} borderRadius="base" gap={2} p={2}>
-      <Text fontWeight="semibold">{t('workflows.builder.publishedWorkflowOutputs')}</Text>
-      <Divider />
+    <>
       {outputFieldNames.map((fieldName) => (
         <NodeOutputFieldPreview key={`${outputNodeId}-${fieldName}`} nodeId={outputNodeId} fieldName={fieldName} />
       ))}
-    </Flex>
+    </>
   );
 });
 OutputFieldsContent.displayName = 'OutputFieldsContent';
@@ -152,7 +155,7 @@ const UnpublishableInputFields = memo(() => {
 });
 UnpublishableInputFields.displayName = 'UnpublishableInputFields';
 
-const SelectOutputNodeButton = memo(() => {
+const SelectOutputNodeButton = memo((props: ButtonProps) => {
   const { t } = useTranslation();
   const outputNodeId = useStore($outputNodeId);
   const isSelectingOutputNode = useStore($isSelectingOutputNode);
@@ -161,8 +164,18 @@ const SelectOutputNodeButton = memo(() => {
     $isSelectingOutputNode.set(true);
   }, []);
   return (
-    <Button leftIcon={<PiSignOutBold />} isDisabled={isSelectingOutputNode} onClick={onClick}>
-      {outputNodeId ? t('workflows.builder.changeOutputNode') : t('workflows.builder.selectOutputNode')}
+    <Button
+      leftIcon={<PiArrowLineRightBold />}
+      isDisabled={isSelectingOutputNode}
+      tooltip={isSelectingOutputNode ? t('workflows.builder.selectingOutputNodeDesc') : undefined}
+      onClick={onClick}
+      {...props}
+    >
+      {isSelectingOutputNode
+        ? t('workflows.builder.selectingOutputNode')
+        : outputNodeId
+          ? t('workflows.builder.changeOutputNode')
+          : t('workflows.builder.selectOutputNode')}
     </Button>
   );
 });

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/PublishWorkflowPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/PublishWorkflowPanelContent.tsx
@@ -192,6 +192,7 @@ const PublishWorkflowButton = memo(() => {
   const outputNodeId = useStore($outputNodeId);
   const isSelectingOutputNode = useStore($isSelectingOutputNode);
   const inputs = usePublishInputs();
+  const allowPublishWorkflows = useAppSelector(selectAllowPublishWorkflows);
 
   const projectUrl = useStore($projectUrl);
 
@@ -240,9 +241,11 @@ const PublishWorkflowButton = memo(() => {
       <Button
         leftIcon={<PiLightningFill />}
         isDisabled={
-          !isReadyToDoValidationRun ||
+          !allowPublishWorkflows ||
           !isReadyToEnqueue ||
+          !isWorkflowSaved ||
           hasBatchOrGeneratorNodes ||
+          !isReadyToDoValidationRun ||
           !(outputNodeId !== null && !isSelectingOutputNode)
         }
         onClick={onClick}
@@ -331,7 +334,7 @@ export const StartPublishFlowButton = memo(() => {
         leftIcon={<PiLightningFill />}
         variant="ghost"
         size="sm"
-        isDisabled={!allowPublishWorkflows || !isWorkflowSaved || hasBatchOrGeneratorNodes}
+        isDisabled={!allowPublishWorkflows || !isReadyToEnqueue || !isWorkflowSaved || hasBatchOrGeneratorNodes}
       >
         {t('workflows.builder.publish')}
       </Button>

--- a/invokeai/frontend/web/src/features/queue/hooks/useEnqueueWorkflows.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useEnqueueWorkflows.ts
@@ -136,10 +136,11 @@ export const useEnqueueWorkflows = () => {
 
         assert(workflow.id, 'Workflow without ID cannot be used for API validation run');
 
-        batchConfig.published_workflow_id = workflow.id;
-        batchConfig.is_api_validation_run = true;
-        batchConfig.api_input_fields = api_input_fields;
-        batchConfig.api_output_fields = api_output_fields;
+        batchConfig.validation_run_data = {
+          workflow_id: workflow.id,
+          input_fields: api_input_fields,
+          output_fields: api_output_fields,
+        };
 
         // If the batch is an API validation run, we only want to run it once
         batchConfig.batch.runs = 1;

--- a/invokeai/frontend/web/src/features/queue/hooks/useEnqueueWorkflows.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useEnqueueWorkflows.ts
@@ -134,6 +134,9 @@ export const useEnqueueWorkflows = () => {
           } as const;
         });
 
+        assert(workflow.id, 'Workflow without ID cannot be used for API validation run');
+
+        batchConfig.published_workflow_id = workflow.id;
         batchConfig.is_api_validation_run = true;
         batchConfig.api_input_fields = api_input_fields;
         batchConfig.api_output_fields = api_output_fields;

--- a/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromFile.tsx
+++ b/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromFile.tsx
@@ -29,7 +29,7 @@ export const useLoadWorkflowFromFile = () => {
           const { onSuccess, onError, onCompleted } = options;
           try {
             const unvalidatedWorkflow = JSON.parse(rawJSON as string);
-            const validatedWorkflow = await validatedAndLoadWorkflow(unvalidatedWorkflow);
+            const validatedWorkflow = await validatedAndLoadWorkflow(unvalidatedWorkflow, 'file');
 
             if (!validatedWorkflow) {
               reader.abort();

--- a/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromImage.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromImage.ts
@@ -41,7 +41,7 @@ export const useLoadWorkflowFromImage = () => {
 
         assert(unvalidatedWorkflow !== null, 'No workflow or graph provided');
 
-        const validatedWorkflow = await validateAndLoadWorkflow(unvalidatedWorkflow);
+        const validatedWorkflow = await validateAndLoadWorkflow(unvalidatedWorkflow, 'image');
 
         if (!validatedWorkflow) {
           onError?.();

--- a/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromLibrary.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromLibrary.ts
@@ -30,7 +30,7 @@ export const useLoadWorkflowFromLibrary = () => {
       try {
         const res = await getWorkflow(workflowId).unwrap();
 
-        const validatedWorkflow = await validateAndLoadWorkflow(res.workflow);
+        const validatedWorkflow = await validateAndLoadWorkflow(res.workflow, 'library');
 
         if (!validatedWorkflow) {
           onError?.();

--- a/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromObject.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/hooks/useLoadWorkflowFromObject.ts
@@ -21,7 +21,7 @@ export const useLoadWorkflowFromObject = () => {
     ) => {
       const { onSuccess, onError, onCompleted } = options;
       try {
-        const validatedWorkflow = await validateAndLoadWorkflow(unvalidatedWorkflow);
+        const validatedWorkflow = await validateAndLoadWorkflow(unvalidatedWorkflow, 'object');
 
         if (!validatedWorkflow) {
           onError?.();

--- a/invokeai/frontend/web/src/features/workflowLibrary/hooks/useValidateAndLoadWorkflow.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/hooks/useValidateAndLoadWorkflow.ts
@@ -43,7 +43,10 @@ export const useValidateAndLoadWorkflow = () => {
      *
      * This function catches all errors. It toasts and logs on success and error.
      */
-    async (unvalidatedWorkflow: unknown): Promise<WorkflowV3 | null> => {
+    async (
+      unvalidatedWorkflow: unknown,
+      origin: 'file' | 'image' | 'object' | 'library'
+    ): Promise<WorkflowV3 | null> => {
       try {
         const templates = $templates.get();
         const { workflow, warnings } = await validateWorkflow({
@@ -53,6 +56,13 @@ export const useValidateAndLoadWorkflow = () => {
           checkBoardAccess,
           checkModelAccess,
         });
+
+        if (origin !== 'library') {
+          // Workflow IDs should always map directly to the workflow in the library. If the workflow is loaded from
+          // some other source, and has an ID, we should remove it to ensure the app does not treat it as a library workflow.
+          // For example, when saving a workflow, we might accidentally attempt to save instead of save-as.
+          delete workflow.id;
+        }
 
         $nodeExecutionStates.set({});
         dispatch(workflowLoaded(workflow));

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -2462,27 +2462,8 @@ export type components = {
              * @default false
              */
             prepend?: boolean;
-            /**
-             * Is Api Validation Run
-             * @description Whether or not this is a validation run.
-             * @default false
-             */
-            is_api_validation_run?: boolean;
-            /**
-             * Published Workflow Id
-             * @description The ID of the published workflow associated with this queue item
-             */
-            published_workflow_id?: string | null;
-            /**
-             * Api Input Fields
-             * @description The fields that were used as input to the API
-             */
-            api_input_fields?: components["schemas"]["FieldIdentifier"][] | null;
-            /**
-             * Api Output Fields
-             * @description The fields that were used as output from the API
-             */
-            api_output_fields?: components["schemas"]["FieldIdentifier"][] | null;
+            /** @description The validation run data to use for this batch. This is only used if this is a validation run. */
+            validation_run_data?: components["schemas"]["ValidationRunData"] | null;
         };
         /** Body_import_style_presets */
         Body_import_style_presets: {
@@ -21877,6 +21858,24 @@ export type components = {
             msg: string;
             /** Error Type */
             type: string;
+        };
+        /** ValidationRunData */
+        ValidationRunData: {
+            /**
+             * Workflow Id
+             * @description The id of the workflow being published.
+             */
+            workflow_id: string;
+            /**
+             * Input Fields
+             * @description The input fields for the published workflow
+             */
+            input_fields: components["schemas"]["FieldIdentifier"][];
+            /**
+             * Output Fields
+             * @description The output fields for the published workflow
+             */
+            output_fields: components["schemas"]["FieldIdentifier"][];
         };
         /** Workflow */
         Workflow: {

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -2469,6 +2469,11 @@ export type components = {
              */
             is_api_validation_run?: boolean;
             /**
+             * Published Workflow Id
+             * @description The ID of the published workflow associated with this queue item
+             */
+            published_workflow_id?: string | null;
+            /**
              * Api Input Fields
              * @description The fields that were used as input to the API
              */
@@ -19509,6 +19514,11 @@ export type components = {
              */
             is_api_validation_run?: boolean;
             /**
+             * Published Workflow Id
+             * @description The ID of the published workflow associated with this queue item
+             */
+            published_workflow_id?: string | null;
+            /**
              * Api Input Fields
              * @description The fields that were used as input to the API
              */
@@ -19619,6 +19629,11 @@ export type components = {
              * @default false
              */
             is_api_validation_run?: boolean;
+            /**
+             * Published Workflow Id
+             * @description The ID of the published workflow associated with this queue item
+             */
+            published_workflow_id?: string | null;
             /**
              * Api Input Fields
              * @description The fields that were used as input to the API


### PR DESCRIPTION
## Summary

- Add missing conditions to button that starts publish flow, so that it is disabled when the graph is invalid
- Improved UX for choosing output node
- Added safeguard when loading workflows to delete ID field if present, which prevents an issue where a non-library workflow might be treated as one, causing weird bugs
- Add optional `published_workflow_id` to queue item model and enqueue batch endpoint
- Ensure `published_workflow_id` is passed when queuing validation run

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
