### PR TITLE
fix(ui): normalize alpha value to 0-1 when picking color on canvas

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasColorPickerToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasColorPickerToolModule.ts
@@ -407,8 +407,7 @@ export class CanvasColorPickerToolModule extends CanvasModuleBase {
 
   onStagePointerUp = (_e: KonvaEventObject<PointerEvent>) => {
     const color = this.$colorUnderCursor.get();
-    const settings = this.manager.stateApi.getSettings();
-    this.manager.stateApi.setColor({ ...settings.color, ...color });
+    this.manager.stateApi.setColor({ ...color, a: color.a / 255 });
   };
 
   onStagePointerMove = (_e: KonvaEventObject<PointerEvent>) => {


### PR DESCRIPTION
## Summary

Alpha values are 0-1 in CSS but 0-255 in Canvas. Need to normalize to 0-1 when picking color else the alpha value gets borked.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1020123559831539744/1358840412546011431

## QA Instructions

Color picker should work for alpha 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
