### PR TITLE
feat(ui): safer use of drawImage

### DIFF
--- a/invokeai/frontend/web/src/common/util/convertImageUrlToBlob.ts
+++ b/invokeai/frontend/web/src/common/util/convertImageUrlToBlob.ts
@@ -11,17 +11,25 @@ export const convertImageUrlToBlob = (url: string) =>
   new Promise<Blob | null>((resolve, reject) => {
     const img = new Image();
     img.onload = () => {
+      if (img.width === 0 || img.height === 0) {
+        reject(new Error('Image has no dimensions. The URL may be invalid or the object may not exist.'));
+        return;
+      }
+
       const canvas = document.createElement('canvas');
+
       canvas.width = img.width;
       canvas.height = img.height;
 
       const context = canvas.getContext('2d');
       if (!context) {
+        canvas.remove();
         reject(new Error('Failed to get canvas context'));
         return;
       }
       context.drawImage(img, 0, 0);
       canvas.toBlob((blob) => {
+        canvas.remove();
         if (blob) {
           resolve(blob);
         } else {

--- a/invokeai/frontend/web/src/common/util/convertImageUrlToBlob.ts
+++ b/invokeai/frontend/web/src/common/util/convertImageUrlToBlob.ts
@@ -23,13 +23,11 @@ export const convertImageUrlToBlob = (url: string) =>
 
       const context = canvas.getContext('2d');
       if (!context) {
-        canvas.remove();
         reject(new Error('Failed to get canvas context'));
         return;
       }
       context.drawImage(img, 0, 0);
       canvas.toBlob((blob) => {
-        canvas.remove();
         if (blob) {
           resolve(blob);
         } else {

--- a/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityPreviewImage.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityPreviewImage.tsx
@@ -53,7 +53,13 @@ export const CanvasEntityPreviewImage = memo(() => {
         const nodeRect = adapter.transformer.$nodeRect.get();
         const canvasCache = adapter.$canvasCache.get();
 
-        if (!canvasCache || canvasCache.width === 0 || canvasCache.height === 0) {
+        if (
+          !canvasCache ||
+          canvasCache.width === 0 ||
+          canvasCache.height === 0 ||
+          pixelRect.width === 0 ||
+          pixelRect.height === 0
+        ) {
           // Draw an empty canvas
           ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
           return;
@@ -127,6 +133,12 @@ const TooltipContent = ({ canvasRef }: { canvasRef: React.RefObject<HTMLCanvasEl
     const ctx = canvasRef2.current.getContext('2d');
 
     if (!ctx) {
+      return;
+    }
+
+    if (canvasRef.current.width === 0 || canvasRef.current.height === 0) {
+      // If these are 0, drawImage will raise! Clear the canvas and bail
+      ctx.clearRect(0, 0, canvasRef2.current.width, canvasRef2.current.height);
       return;
     }
 

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useSaveLayerToAssets.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useSaveLayerToAssets.ts
@@ -1,3 +1,4 @@
+import { logger } from 'app/logging/logger';
 import { useAppSelector } from 'app/store/storeHooks';
 import type { CanvasEntityAdapterControlLayer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterControlLayer';
 import type { CanvasEntityAdapterInpaintMask } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterInpaintMask';
@@ -5,10 +6,16 @@ import type { CanvasEntityAdapterRasterLayer } from 'features/controlLayers/konv
 import type { CanvasEntityAdapterRegionalGuidance } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterRegionalGuidance';
 import { canvasToBlob } from 'features/controlLayers/konva/util';
 import { selectAutoAddBoardId } from 'features/gallery/store/gallerySelectors';
+import { toast } from 'features/toast/toast';
 import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { serializeError } from 'serialize-error';
 import { uploadImage } from 'services/api/endpoints/images';
 
+const log = logger('canvas');
+
 export const useSaveLayerToAssets = () => {
+  const { t } = useTranslation();
   const autoAddBoardId = useAppSelector(selectAutoAddBoardId);
 
   const saveLayerToAssets = useCallback(
@@ -23,17 +30,25 @@ export const useSaveLayerToAssets = () => {
       if (!adapter) {
         return;
       }
-      const canvas = adapter.getCanvas();
-      const blob = await canvasToBlob(canvas);
-      const file = new File([blob], `layer-${adapter.id}.png`, { type: 'image/png' });
-      uploadImage({
-        file,
-        image_category: 'user',
-        is_intermediate: false,
-        board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
-      });
+      try {
+        const canvas = adapter.getCanvas();
+        const blob = await canvasToBlob(canvas);
+        const file = new File([blob], `layer-${adapter.id}.png`, { type: 'image/png' });
+        uploadImage({
+          file,
+          image_category: 'user',
+          is_intermediate: false,
+          board_id: autoAddBoardId === 'none' ? undefined : autoAddBoardId,
+        });
+      } catch (error) {
+        log.error({ error: serializeError(error) }, 'Problem copying layer to clipboard');
+        toast({
+          status: 'error',
+          title: t('toast.problemSavingLayer'),
+        });
+      }
     },
-    [autoAddBoardId]
+    [autoAddBoardId, t]
   );
 
   return saveLayerToAssets;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
@@ -327,28 +327,40 @@ export const downloadBlob = (blob: Blob, fileName: string) => {
  */
 export const dataURLToImageData = (dataURL: string, width: number, height: number): Promise<ImageData> => {
   return new Promise((resolve, reject) => {
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-
-    if (!ctx) {
-      canvas.remove();
-      reject('Unable to get context');
-      return;
-    }
-
-    ctx.imageSmoothingEnabled = false;
-
     const image = new Image();
     image.onload = function () {
+      if (image.width === 0 || image.height === 0) {
+        reject(new Error('Image has no dimensions. The URL may be invalid or the object may not exist.'));
+        return;
+      }
+
+      if (width === 0 || height === 0) {
+        reject(new Error('Cannot create ImageData with zero width or height'));
+        return;
+      }
+
+      const canvas = document.createElement('canvas');
+
+      canvas.width = width;
+      canvas.height = height;
+
+      const ctx = canvas.getContext('2d');
+
+      if (!ctx) {
+        canvas.remove();
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+
+      ctx.imageSmoothingEnabled = false;
+
       ctx.drawImage(image, 0, 0);
+      const imageData = ctx.getImageData(0, 0, width, height);
       canvas.remove();
-      resolve(ctx.getImageData(0, 0, width, height));
+      resolve(imageData);
     };
 
     image.onerror = function (e) {
-      canvas.remove();
       reject(e);
     };
 

--- a/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
@@ -347,7 +347,6 @@ export const dataURLToImageData = (dataURL: string, width: number, height: numbe
       const ctx = canvas.getContext('2d');
 
       if (!ctx) {
-        canvas.remove();
         reject(new Error('Failed to get canvas context'));
         return;
       }
@@ -356,7 +355,6 @@ export const dataURLToImageData = (dataURL: string, width: number, height: numbe
 
       ctx.drawImage(image, 0, 0);
       const imageData = ctx.getImageData(0, 0, width, height);
-      canvas.remove();
       resolve(imageData);
     };
 


### PR DESCRIPTION
## Summary

When calling `ctx.drawImage()`, if the image to be drawn has a width of height of 0, the call will raise.

In this change, I have carefully reviewed the call hierarchy for all of our own code that calls this method and ensured that each call has error handling.

Well, with one exception - I'm not sure how to handle errors in `invokeai/frontend/web/src/common/hooks/useClientSideUpload.ts`. But this should never be an issue in that hook - it's a Canvas problem.

## Related Issues / Discussions

n/a

## QA Instructions

This is a pretty safe change. It only adds additional error handling for edge cases. 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
