### PR TITLE
fix(ui): canvas dnd drop indicator color

### DIFF
--- a/invokeai/frontend/web/src/features/dnd/DndListDropIndicator.tsx
+++ b/invokeai/frontend/web/src/features/dnd/DndListDropIndicator.tsx
@@ -9,8 +9,7 @@ import type { DndListTargetState } from 'features/dnd/types';
  */
 const line = {
   thickness: 2,
-  backgroundColor: 'red',
-  // backgroundColor: 'base.500',
+  backgroundColor: 'base.500',
 };
 
 type DropIndicatorProps = {


### PR DESCRIPTION
## Summary

Was set to bright red ages ago for troubleshooting but never reverted to be gray. Now its gray

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
