### PR TITLE
Add uv lock check to git pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,21 +4,29 @@ repos:
   hooks:
   - id: black
     name: black
-    stages: [commit]
+    stages: [pre-commit]
     language: system
     entry: black
     types: [python]
 
   - id: flake8
     name: flake8
-    stages: [commit]
+    stages: [pre-commit]
     language: system
     entry: flake8
     types: [python]
 
   - id: isort
     name: isort
-    stages: [commit]
+    stages: [pre-commit]
     language: system
     entry: isort
     types: [python]
+
+  - id: uvlock
+    name: uv lock
+    stages: [pre-commit]
+    language: system
+    entry: uv lock
+    files: ^pyproject\.toml$
+    pass_filenames: false


### PR DESCRIPTION
## Summary

- updates pre-commit syntax
- adds check for an outdated `uv.lock`, which will only run if `pyproject.toml` is being updated in the commit.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
