### PR TITLE
fix(ui): ensure query subs are reset in case of error

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/setDefaultSettings.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/setDefaultSettings.ts
@@ -39,9 +39,8 @@ export const addSetDefaultSettingsListener = (startAppListening: AppStartListeni
         return;
       }
 
-      const request = dispatch(modelsApi.endpoints.getModelConfigs.initiate());
+      const request = dispatch(modelsApi.endpoints.getModelConfigs.initiate(undefined, { subscribe: false }));
       const data = await request.unwrap();
-      request.unsubscribe();
       const models = modelConfigsAdapterSelectors.selectAll(data);
 
       const modelConfig = models.find((model) => model.key === currentModel.key);

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketConnected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/socketConnected.ts
@@ -29,11 +29,8 @@ export const addSocketConnectedEventListener = (startAppListening: AppStartListe
 
       // Bail on the recovery logic if this is the first connection - we don't need to recover anything
       if ($isFirstConnection.get()) {
-        // Populate the model configs on first connection. This query cache has a 24hr timeout, so we can immediately
-        // unsubscribe.
-        const request = dispatch(modelsApi.endpoints.getModelConfigs.initiate());
-        request.unsubscribe();
-
+        // Populate the model configs on first connection.
+        dispatch(modelsApi.endpoints.getModelConfigs.initiate(undefined, { subscribe: false }));
         $isFirstConnection.set(false);
         return;
       }
@@ -61,10 +58,10 @@ export const addSocketConnectedEventListener = (startAppListening: AppStartListe
         const queueStatusRequest = dispatch(
           await queueApi.endpoints.getQueueStatus.initiate(undefined, {
             forceRefetch: true,
+            subscribe: false,
           })
         );
         const nextQueueStatusData = await queueStatusRequest.unwrap();
-        queueStatusRequest.unsubscribe();
 
         // If the queue hasn't changed, we don't need to do anything.
         if (isEqual(prevQueueStatusData?.queue, nextQueueStatusData.queue)) {


### PR DESCRIPTION
## Summary

fix(ui): ensure query subs are reset in case of error

prevent memory leak-ish behaviour

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
