### PR TITLE
fix(app): remove accidentally committed tensor cache size

### DIFF
--- a/invokeai/app/api/dependencies.py
+++ b/invokeai/app/api/dependencies.py
@@ -113,7 +113,6 @@ class ApiDependencies:
                 safe_globals=[torch.Tensor],
                 ephemeral=True,
             ),
-            max_cache_size=0,
         )
         conditioning = ObjectSerializerForwardCache(
             ObjectSerializerDisk[ConditioningFieldData](


### PR DESCRIPTION
## Summary

I had set this to zero for testing udring the python 2.6.0 upgrade and neglected to remove it.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
