### PR TITLE
Add to overload for GGMLTensor, so calling to on the model moves the quantized data.

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/cached_model/cached_model_only_full_load.py
+++ b/invokeai/backend/model_manager/load/model_cache/cached_model/cached_model_only_full_load.py
@@ -106,10 +106,10 @@ class CachedModelOnlyFullLoad:
         if isinstance(check_for_gguf, GGMLTensor):
             old_value = torch.__future__.get_overwrite_module_params_on_conversion()
             torch.__future__.set_overwrite_module_params_on_conversion(True)
-            self._model.to(self._compute_device)
+            self._model.to(self._offload_device)
             torch.__future__.set_overwrite_module_params_on_conversion(old_value)
         else:
-            self._model.to(self._compute_device)
+            self._model.to(self._offload_device)
 
         self._is_in_vram = False
         return self._total_bytes

--- a/invokeai/backend/model_manager/load/model_cache/cached_model/cached_model_only_full_load.py
+++ b/invokeai/backend/model_manager/load/model_cache/cached_model/cached_model_only_full_load.py
@@ -1,7 +1,8 @@
-from invokeai.backend.quantization.gguf.ggml_tensor import GGMLTensor
 from typing import Any
 
 import torch
+
+from invokeai.backend.quantization.gguf.ggml_tensor import GGMLTensor
 
 
 class CachedModelOnlyFullLoad:
@@ -78,8 +79,7 @@ class CachedModelOnlyFullLoad:
                 new_state_dict[k] = v.to(self._compute_device, copy=True)
             self._model.load_state_dict(new_state_dict, assign=True)
 
-        
-        check_for_gguf = hasattr(self._model, 'state_dict') and self._model.state_dict().get("img_in.weight")
+        check_for_gguf = hasattr(self._model, "state_dict") and self._model.state_dict().get("img_in.weight")
         if isinstance(check_for_gguf, GGMLTensor):
             old_value = torch.__future__.get_overwrite_module_params_on_conversion()
             torch.__future__.set_overwrite_module_params_on_conversion(True)
@@ -103,7 +103,7 @@ class CachedModelOnlyFullLoad:
         if self._cpu_state_dict is not None:
             self._model.load_state_dict(self._cpu_state_dict, assign=True)
 
-        check_for_gguf = hasattr(self._model, 'state_dict') and self._model.state_dict().get("img_in.weight")
+        check_for_gguf = hasattr(self._model, "state_dict") and self._model.state_dict().get("img_in.weight")
         if isinstance(check_for_gguf, GGMLTensor):
             old_value = torch.__future__.get_overwrite_module_params_on_conversion()
             torch.__future__.set_overwrite_module_params_on_conversion(True)

--- a/invokeai/backend/model_manager/load/model_cache/cached_model/cached_model_only_full_load.py
+++ b/invokeai/backend/model_manager/load/model_cache/cached_model/cached_model_only_full_load.py
@@ -78,7 +78,8 @@ class CachedModelOnlyFullLoad:
                 new_state_dict[k] = v.to(self._compute_device, copy=True)
             self._model.load_state_dict(new_state_dict, assign=True)
 
-        check_for_gguf = self._model.state_dict().get("img_in.weight")
+        
+        check_for_gguf = hasattr(self._model, 'state_dict') and self._model.state_dict().get("img_in.weight")
         if isinstance(check_for_gguf, GGMLTensor):
             old_value = torch.__future__.get_overwrite_module_params_on_conversion()
             torch.__future__.set_overwrite_module_params_on_conversion(True)
@@ -102,7 +103,7 @@ class CachedModelOnlyFullLoad:
         if self._cpu_state_dict is not None:
             self._model.load_state_dict(self._cpu_state_dict, assign=True)
 
-        check_for_gguf = self._model.state_dict().get("img_in.weight")
+        check_for_gguf = hasattr(self._model, 'state_dict') and self._model.state_dict().get("img_in.weight")
         if isinstance(check_for_gguf, GGMLTensor):
             old_value = torch.__future__.get_overwrite_module_params_on_conversion()
             torch.__future__.set_overwrite_module_params_on_conversion(True)

--- a/invokeai/backend/quantization/gguf/ggml_tensor.py
+++ b/invokeai/backend/quantization/gguf/ggml_tensor.py
@@ -123,6 +123,12 @@ class GGMLTensor(torch.Tensor):
     def to(self, *args, **kwargs) -> torch.Tensor: ...
 
     def to(self, *args, **kwargs):
+        for func_arg in args:
+            if isinstance(func_arg, torch.dtype) and func_arg != self.quantized_data.dtype:
+                raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
+        if 'dtype' in kwargs.keys():
+            if kwargs['dtype'] != self.quantized_data.dtype:
+                raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly."
         self.quantized_data = self.quantized_data.to(*args, **kwargs)
         return self
 

--- a/invokeai/backend/quantization/gguf/ggml_tensor.py
+++ b/invokeai/backend/quantization/gguf/ggml_tensor.py
@@ -126,8 +126,8 @@ class GGMLTensor(torch.Tensor):
         for func_arg in args:
             if isinstance(func_arg, torch.dtype) and func_arg != self.quantized_data.dtype:
                 raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
-        if 'dtype' in kwargs.keys():
-            if kwargs['dtype'] != self.quantized_data.dtype:
+        if "dtype" in kwargs.keys():
+            if kwargs["dtype"] != self.quantized_data.dtype:
                 raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
         self.quantized_data = self.quantized_data.to(*args, **kwargs)
         return self

--- a/invokeai/backend/quantization/gguf/ggml_tensor.py
+++ b/invokeai/backend/quantization/gguf/ggml_tensor.py
@@ -128,7 +128,7 @@ class GGMLTensor(torch.Tensor):
                 raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
         if 'dtype' in kwargs.keys():
             if kwargs['dtype'] != self.quantized_data.dtype:
-                raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly."
+                raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
         self.quantized_data = self.quantized_data.to(*args, **kwargs)
         return self
 

--- a/invokeai/backend/quantization/gguf/ggml_tensor.py
+++ b/invokeai/backend/quantization/gguf/ggml_tensor.py
@@ -119,19 +119,6 @@ class GGMLTensor(torch.Tensor):
             return self.tensor_shape[dim]
         return self.tensor_shape
 
-    @overload
-    def to(self, *args, **kwargs) -> torch.Tensor: ...
-
-    def to(self, *args, **kwargs):
-        for func_arg in args:
-            if isinstance(func_arg, torch.dtype) and func_arg != self.quantized_data.dtype:
-                raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
-        if "dtype" in kwargs.keys():
-            if kwargs["dtype"] != self.quantized_data.dtype:
-                raise ValueError("Operation changed the dtype of GGMLTensor unexpectedly.")
-        self.quantized_data = self.quantized_data.to(*args, **kwargs)
-        return self
-
     @property
     def shape(self) -> torch.Size:  # pyright: ignore[reportIncompatibleVariableOverride] pyright doesn't understand this for some reason.
         """The shape of the tensor after dequantization. I.e. the shape that will be used in any math ops."""

--- a/invokeai/backend/quantization/gguf/ggml_tensor.py
+++ b/invokeai/backend/quantization/gguf/ggml_tensor.py
@@ -119,6 +119,13 @@ class GGMLTensor(torch.Tensor):
             return self.tensor_shape[dim]
         return self.tensor_shape
 
+    @overload
+    def to(self, *args, **kwargs) -> torch.Tensor: ...
+
+    def to(self, *args, **kwargs):
+        self.quantized_data = self.quantized_data.to(*args, **kwargs)
+        return self
+
     @property
     def shape(self) -> torch.Size:  # pyright: ignore[reportIncompatibleVariableOverride] pyright doesn't understand this for some reason.
         """The shape of the tensor after dequantization. I.e. the shape that will be used in any math ops."""


### PR DESCRIPTION
## Summary

If a user has not enabled partial loading, and disabled  keeping copies of the models state dict  in CPU VRAM (both likely for MPS users) then GGUF models state dicts are not moved to the compute device from cpu device that models are loaded into by default. This is due to the quantised data being stored in its own field instead of the inherited Tensors data field.
This PR uses an overload of the Tensor `to`  method to  load the quantised data to the compute device when the model is moved by calling is `to` method,

## Related Issues / Discussions

Closes #7939

## QA Instructions

Duplicate the failure by removing  `enable_partial_loading: true` and adding `keep_ram_copy_of_weights: false` to invokeai.yaml as necessary  and attempting to run a image generation using a GGUF quantised Flux model.
Note: enable_partial_loading: true needs to be removed it seems commenting stuff out in the yaml file doesn't work (sometimes ?)

You should get an error related to mixed compute devices, on MPS the error is s follows:
```
RuntimeError: Tensor for argument weight is on cpu but expected on mps
```

Apply the PR , restart Invokeai and attempt the same render, it should now work.

## Merge Plan

This is a small stand alone PR it should merge without issue.
## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [] _Updated `What's New` copy (if doing a release after this PR)_
