### PR TITLE
feat(ui): show unsupported gen mode toasts as warnings intead of errors

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1328,8 +1328,8 @@
         "unableToCopyDesc": "Your browser does not support clipboard access. Firefox users may be able to fix this by following ",
         "unableToCopyDesc_theseSteps": "these steps",
         "fluxFillIncompatibleWithT2IAndI2I": "FLUX Fill is not compatible with Text to Image or Image to Image. Use other FLUX models for these tasks.",
-        "imagen3IncompatibleGenerationMode": "Google Imagen3 supports Text to Image only. Ensure the bounding box is empty, or use other models for Image to Image, Inpainting and Outpainting tasks.",
-        "chatGPT4oIncompatibleGenerationMode": "ChatGPT 4o supports Text to Image and Image to Image. Use other models Inpainting and Outpainting tasks.",
+        "imagen3IncompatibleGenerationMode": "Google Imagen3 supports Text to Image only. Use other models for Image to Image, Inpainting and Outpainting tasks.",
+        "chatGPT4oIncompatibleGenerationMode": "ChatGPT 4o supports Text to Image and Image to Image only. Use other models Inpainting and Outpainting tasks.",
         "problemUnpublishingWorkflow": "Problem Unpublishing Workflow",
         "problemUnpublishingWorkflowDescription": "There was a problem unpublishing the workflow. Please try again.",
         "workflowUnpublished": "Workflow Unpublished"

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildChatGPT4oGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildChatGPT4oGraph.ts
@@ -13,7 +13,7 @@ import {
   getBoardField,
   selectPresetModifiedPrompts,
 } from 'features/nodes/util/graph/graphBuilderUtils';
-import type { GraphBuilderReturn } from 'features/nodes/util/graph/types';
+import { type GraphBuilderReturn, UnsupportedGenerationModeError } from 'features/nodes/util/graph/types';
 import { t } from 'i18next';
 import { selectMainModelConfig } from 'services/api/endpoints/models';
 import type { Equals } from 'tsafe';
@@ -24,7 +24,9 @@ const log = logger('system');
 export const buildChatGPT4oGraph = async (state: RootState, manager: CanvasManager): Promise<GraphBuilderReturn> => {
   const generationMode = await manager.compositor.getGenerationMode();
 
-  assert(generationMode === 'txt2img' || generationMode === 'img2img', t('toast.chatGPT4oIncompatibleGenerationMode'));
+  if (generationMode !== 'txt2img' && generationMode !== 'img2img') {
+    throw new UnsupportedGenerationModeError(t('toast.chatGPT4oIncompatibleGenerationMode'));
+  }
 
   log.debug({ generationMode }, 'Building GPT Image graph');
 

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
@@ -22,7 +22,11 @@ import {
   getSizes,
   selectPresetModifiedPrompts,
 } from 'features/nodes/util/graph/graphBuilderUtils';
-import type { GraphBuilderReturn, ImageOutputNodes } from 'features/nodes/util/graph/types';
+import {
+  type GraphBuilderReturn,
+  type ImageOutputNodes,
+  UnsupportedGenerationModeError,
+} from 'features/nodes/util/graph/types';
 import { t } from 'i18next';
 import { selectMainModelConfig } from 'services/api/endpoints/models';
 import type { Invocation } from 'services/api/types';
@@ -80,7 +84,9 @@ export const buildFLUXGraph = async (state: RootState, manager: CanvasManager): 
     //
     // The other asserts above are just for sanity & type check and should never be hit, so they do not have
     // translations.
-    assert(generationMode === 'inpaint' || generationMode === 'outpaint', t('toast.fluxFillIncompatibleWithT2IAndI2I'));
+    if (generationMode === 'txt2img' || generationMode === 'img2img') {
+      throw new UnsupportedGenerationModeError(t('toast.fluxFillIncompatibleWithT2IAndI2I'));
+    }
 
     // FLUX Fill wants much higher guidance values than normal FLUX - silently "fix" the value for the user.
     // TODO(psyche): Figure out a way to alert the user that this is happening - maybe return warnings from the graph

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildImagen3Graph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildImagen3Graph.ts
@@ -11,7 +11,7 @@ import {
   getBoardField,
   selectPresetModifiedPrompts,
 } from 'features/nodes/util/graph/graphBuilderUtils';
-import type { GraphBuilderReturn } from 'features/nodes/util/graph/types';
+import { type GraphBuilderReturn, UnsupportedGenerationModeError } from 'features/nodes/util/graph/types';
 import { t } from 'i18next';
 import type { Equals } from 'tsafe';
 import { assert } from 'tsafe';
@@ -21,7 +21,9 @@ const log = logger('system');
 export const buildImagen3Graph = async (state: RootState, manager: CanvasManager): Promise<GraphBuilderReturn> => {
   const generationMode = await manager.compositor.getGenerationMode();
 
-  assert(generationMode === 'txt2img', t('toast.imagen3IncompatibleGenerationMode'));
+  if (generationMode !== 'txt2img') {
+    throw new UnsupportedGenerationModeError(t('toast.imagen3IncompatibleGenerationMode'));
+  }
 
   log.debug({ generationMode }, 'Building Imagen3 graph');
 

--- a/invokeai/frontend/web/src/features/nodes/util/graph/types.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/types.ts
@@ -32,3 +32,10 @@ export type GraphBuilderReturn = {
   seedFieldIdentifier?: FieldIdentifier;
   positivePromptFieldIdentifier: FieldIdentifier;
 };
+
+export class UnsupportedGenerationModeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}


### PR DESCRIPTION
## Summary

Old:
<img width="582" alt="Screenshot 2025-05-01 at 7 07 37 pm" src="https://github.com/user-attachments/assets/604d10b1-d48a-445f-ba8a-d3b1f9828b3a" />

New:

<img width="587" alt="Screenshot 2025-05-01 at 7 06 31 pm" src="https://github.com/user-attachments/assets/ef0f74c7-de9f-4491-99bf-9e60b051fcf0" />
<img width="582" alt="Screenshot 2025-05-01 at 7 05 54 pm" src="https://github.com/user-attachments/assets/732fe203-7388-4275-8f29-b9fc2a3c962e" />

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
