### PR TITLE
feat(mm): support customizable cache key for `load_model_from_path()`

### DIFF
--- a/invokeai/app/services/model_load/model_load_base.py
+++ b/invokeai/app/services/model_load/model_load_base.py
@@ -30,7 +30,10 @@ class ModelLoadServiceBase(ABC):
 
     @abstractmethod
     def load_model_from_path(
-        self, model_path: Path, loader: Optional[Callable[[Path], AnyModel]] = None
+        self,
+        model_path: Path,
+        loader: Optional[Callable[[Path], AnyModel]] = None,
+        cache_key_extra: Optional[str] = None,
     ) -> LoadedModelWithoutConfig:
         """
         Load the model file or directory located at the indicated Path.
@@ -46,6 +49,8 @@ class ModelLoadServiceBase(ABC):
         Args:
           model_path: A pathlib.Path to a checkpoint-style models file
           loader: A Callable that expects a Path and returns a Dict[str, Tensor]
+          cache_key_extra: A string to append to the cache key. This is useful for
+            differentiating an instances of the same model with different parameters.
 
         Returns:
           A LoadedModel object.

--- a/invokeai/app/services/model_load/model_load_default.py
+++ b/invokeai/app/services/model_load/model_load_default.py
@@ -76,9 +76,12 @@ class ModelLoadService(ModelLoadServiceBase):
         return loaded_model
 
     def load_model_from_path(
-        self, model_path: Path, loader: Optional[Callable[[Path], AnyModel]] = None
+        self,
+        model_path: Path,
+        loader: Optional[Callable[[Path], AnyModel]] = None,
+        cache_key_extra: Optional[str] = None,
     ) -> LoadedModelWithoutConfig:
-        cache_key = str(model_path)
+        cache_key = f"{model_path}:{cache_key_extra}" if cache_key_extra else str(model_path)
         try:
             return LoadedModelWithoutConfig(cache_record=self._ram_cache.get(key=cache_key), cache=self._ram_cache)
         except IndexError:

--- a/invokeai/app/services/shared/invocation_context.py
+++ b/invokeai/app/services/shared/invocation_context.py
@@ -497,6 +497,7 @@ class ModelsInterface(InvocationContextInterface):
         self,
         model_path: Path,
         loader: Optional[Callable[[Path], AnyModel]] = None,
+        cache_key_extra: Optional[str] = None,
     ) -> LoadedModelWithoutConfig:
         """
         Load the model file located at the indicated path
@@ -509,18 +510,25 @@ class ModelsInterface(InvocationContextInterface):
         Args:
             path: A model Path
             loader: A Callable that expects a Path and returns a dict[str|int, Any]
+            cache_key_extra: A string to append to the cache key. This is useful for
+                differentiating an instances of the same model with different parameters.
 
         Returns:
             A LoadedModelWithoutConfig object.
         """
 
         self._util.signal_progress(f"Loading model {model_path.name}")
-        return self._services.model_manager.load.load_model_from_path(model_path=model_path, loader=loader)
+        return self._services.model_manager.load.load_model_from_path(
+            model_path=model_path,
+            loader=loader,
+            cache_key_extra=cache_key_extra,
+        )
 
     def load_remote_model(
         self,
         source: str | AnyHttpUrl,
         loader: Optional[Callable[[Path], AnyModel]] = None,
+        cache_key_extra: Optional[str] = None,
     ) -> LoadedModelWithoutConfig:
         """
         Download, cache, and load the model file located at the indicated URL or repo_id.
@@ -535,6 +543,8 @@ class ModelsInterface(InvocationContextInterface):
         Args:
             source: A URL or huggingface repoid.
             loader: A Callable that expects a Path and returns a dict[str|int, Any]
+            cache_key_extra: A string to append to the cache key. This is useful for
+                differentiating an instances of the same model with different parameters.
 
         Returns:
             A LoadedModelWithoutConfig object.
@@ -542,7 +552,11 @@ class ModelsInterface(InvocationContextInterface):
         model_path = self._services.model_manager.install.download_and_cache_model(source=str(source))
 
         self._util.signal_progress(f"Loading model {source}")
-        return self._services.model_manager.load.load_model_from_path(model_path=model_path, loader=loader)
+        return self._services.model_manager.load.load_model_from_path(
+            model_path=model_path,
+            loader=loader,
+            cache_key_extra=cache_key_extra,
+        )
 
     def get_absolute_path(self, config_or_path: AnyModelConfig | Path | str) -> Path:
         """Gets the absolute path for a given model config or path.


### PR DESCRIPTION
## Summary

When loading/caching a model, we use its file path as the cache key.

Some models are initialized with parameters, so the path is not a unique identifier for the model. For these models, the cache key needs to have some other unique data in it.

This PR adds a `cache_key_extra: str | None = None` arg to the internal model manager `load_model_from_path()` method. It also adds the arg to the public invocation context methods that wrap the internal method.

If provided, the string is appended to the model's path as its cache key.

Alternatives to this approach include:
1. Instead of a string, accept any `Hashable`. Use the hashable as the cache key when provided. Or create a new object that includes the model path and extra hashable, and use that as the key. This approach may require deeper changes, because there may be something that relies on the cache keys being strings.
2. Use the change in this PR for the internal method, but make the public API take a hashable of model parameters instead of a string. In the public wrapper methods, we would stringify the hashable and pass it on to the internal methods.
3. Use some fancy introspection to divine the cache key. @JPPhoto [shared a draft on discord.](https://discord.com/channels/1020123559063990373/1361450510812450907/1363703458544484545)

I'm sure there are other strategies that work.

Out of the 4 approaches (this PR + the alternatives), I like `Alternative 1` the most. However, I haven't reviewed the cache logic thoroughly yet and am not confident that changing the key to a hashable will not break something. It'll probably be fine - maybe require minor changes - just I haven't investigated yet.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1361450510812450907

## QA Instructions

There are no functional changes to existing code paths/nodes. This is purely in support of community nodes that want to load models and take advantage of the model manager's caching.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
