### PR TITLE
feat(ui): custom error toast support

### DIFF
--- a/invokeai/frontend/web/src/app/components/InvokeAIUI.tsx
+++ b/invokeai/frontend/web/src/app/components/InvokeAIUI.tsx
@@ -18,6 +18,7 @@ import { $openAPISchemaUrl } from 'app/store/nanostores/openAPISchemaUrl';
 import { $projectId, $projectName, $projectUrl } from 'app/store/nanostores/projectId';
 import { $queueId, DEFAULT_QUEUE_ID } from 'app/store/nanostores/queueId';
 import { $store } from 'app/store/nanostores/store';
+import { $toastMap } from 'app/store/nanostores/toastMap';
 import { createStore } from 'app/store/store';
 import type { PartialAppConfig } from 'app/types/invokeai';
 import Loading from 'common/components/Loading/Loading';
@@ -31,6 +32,7 @@ import {
   DEFAULT_WORKFLOW_LIBRARY_TAG_CATEGORIES,
 } from 'features/nodes/store/workflowLibrarySlice';
 import type { WorkflowCategory } from 'features/nodes/types/workflow';
+import type { ToastConfig } from 'features/toast/toast';
 import type { PropsWithChildren, ReactNode } from 'react';
 import React, { lazy, memo, useEffect, useLayoutEffect, useMemo } from 'react';
 import { Provider } from 'react-redux';
@@ -58,6 +60,7 @@ interface Props extends PropsWithChildren {
   socketOptions?: Partial<ManagerOptions & SocketOptions>;
   isDebugging?: boolean;
   logo?: ReactNode;
+  toastMap?: Record<string, ToastConfig>;
   workflowCategories?: WorkflowCategory[];
   workflowTagCategories?: WorkflowTagCategory[];
   workflowSortOptions?: WorkflowSortOption[];
@@ -85,6 +88,7 @@ const InvokeAIUI = ({
   socketOptions,
   isDebugging = false,
   logo,
+  toastMap,
   workflowCategories,
   workflowTagCategories,
   workflowSortOptions,
@@ -223,6 +227,16 @@ const InvokeAIUI = ({
       $logo.set(undefined);
     };
   }, [logo]);
+
+  useEffect(() => {
+    if (toastMap) {
+      $toastMap.set(toastMap);
+    }
+
+    return () => {
+      $toastMap.set(undefined);
+    };
+  }, [toastMap]);
 
   useEffect(() => {
     if (onClickGoToModelManager) {

--- a/invokeai/frontend/web/src/app/store/nanostores/toastMap.ts
+++ b/invokeai/frontend/web/src/app/store/nanostores/toastMap.ts
@@ -1,0 +1,4 @@
+import type { ToastConfig } from 'features/toast/toast';
+import { atom } from 'nanostores';
+
+export const $toastMap = atom<Record<string, ToastConfig> | undefined>(undefined);

--- a/invokeai/frontend/web/src/features/toast/toast.ts
+++ b/invokeai/frontend/web/src/features/toast/toast.ts
@@ -9,7 +9,7 @@ export const toastApi = createStandaloneToast({
 }).toast;
 
 // Slightly modified version of UseToastOptions
-type ToastConfig = Omit<UseToastOptions, 'id'> & {
+export type ToastConfig = Omit<UseToastOptions, 'id'> & {
   // Only string - Chakra allows numbers
   id?: string;
 };

--- a/invokeai/frontend/web/src/services/api/authToastMiddleware.ts
+++ b/invokeai/frontend/web/src/services/api/authToastMiddleware.ts
@@ -1,8 +1,12 @@
 import type { Middleware } from '@reduxjs/toolkit';
 import { isRejectedWithValue } from '@reduxjs/toolkit';
+import { $toastMap } from 'app/store/nanostores/toastMap';
 import { toast } from 'features/toast/toast';
 import { t } from 'i18next';
 import { z } from 'zod';
+
+const usageErrorSubstring = 'usage allotment';
+const usageErrorCode = 'USAGE_LIMIT';
 
 const zRejectedForbiddenAction = z.object({
   payload: z.object({
@@ -31,14 +35,21 @@ export const authToastMiddleware: Middleware = () => (next) => (action) => {
         // do not show toast if problem is image access
         return next(action);
       }
+      const toastMap = $toastMap.get();
+      const customToastConfig = toastMap?.[usageErrorCode]; //TODO: update using error code in response
 
       const customMessage = parsed.payload.data.detail !== 'Forbidden' ? parsed.payload.data.detail : undefined;
-      toast({
-        id: `auth-error-toast-${endpointName}`,
-        title: t('toast.somethingWentWrong'),
-        status: 'error',
-        description: customMessage,
-      });
+      //TODO: remove substring check and just use error code
+      if (customMessage?.includes(usageErrorSubstring) && customToastConfig) {
+        toast(customToastConfig);
+      } else {
+        toast({
+          id: `auth-error-toast-${endpointName}`,
+          title: t('toast.somethingWentWrong'),
+          status: 'error',
+          description: customMessage,
+        });
+      }
     } catch (error) {
       // no-op
     }


### PR DESCRIPTION
## Summary

This is Step 1 in introducing support for custom error toasts. This only works for our usage limit errors, but followup work will add more cases. The back-end is not yet updated to support error codes, so for not we are checking a substring of the error message and looking up in the map based on that.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
