### PR TITLE
Expanded IP Adapter modes.

### DIFF
--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -608,7 +608,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
                     end_step_percent=single_ip_adapter.end_step_percent,
                     ip_adapter_conditioning=IPAdapterConditioningInfo(image_prompt_embeds, uncond_image_prompt_embeds),
                     mask=mask,
-                    method=single_ip_adapter.method
+                    method=single_ip_adapter.method,
                 )
             )
 

--- a/invokeai/app/invocations/denoise_latents.py
+++ b/invokeai/app/invocations/denoise_latents.py
@@ -608,6 +608,7 @@ class DenoiseLatentsInvocation(BaseInvocation):
                     end_step_percent=single_ip_adapter.end_step_percent,
                     ip_adapter_conditioning=IPAdapterConditioningInfo(image_prompt_embeds, uncond_image_prompt_embeds),
                     mask=mask,
+                    method=single_ip_adapter.method
                 )
             )
 

--- a/invokeai/app/invocations/ip_adapter.py
+++ b/invokeai/app/invocations/ip_adapter.py
@@ -31,7 +31,7 @@ class IPAdapterField(BaseModel):
     image_encoder_model: ModelIdentifierField = Field(description="The name of the CLIP image encoder model.")
     weight: Union[float, List[float]] = Field(default=1, description="The weight given to the IP-Adapter.")
     target_blocks: List[str] = Field(default=[], description="The IP Adapter blocks to apply")
-    method: str = Field(default='full', description="Weight apply method")
+    method: str = Field(default="full", description="Weight apply method")
     begin_step_percent: float = Field(
         default=0, ge=0, le=1, description="When the IP-Adapter is first applied (% of total steps)"
     )
@@ -133,7 +133,6 @@ class IPAdapterInvocation(BaseInvocation):
             image_encoder_model_name = image_encoder_starter_model.name
 
         image_encoder_model = self.get_clip_image_encoder(context, image_encoder_model_id, image_encoder_model_name)
-        negative_blocks: List[str] = []
 
         if self.method == "style":
             if ip_adapter_info.base == "sd-1":
@@ -151,9 +150,9 @@ class IPAdapterInvocation(BaseInvocation):
                 raise ValueError(f"Unsupported IP-Adapter base type: '{ip_adapter_info.base}'.")
         elif self.method == "style_precise":
             if ip_adapter_info.base == "sd-1":
-                target_blocks = ["up_blocks.1","down_blocks.2","mid_block"]
+                target_blocks = ["up_blocks.1", "down_blocks.2", "mid_block"]
             elif ip_adapter_info.base == "sdxl":
-                target_blocks = ["up_blocks.0.attentions.1","down_blocks.2.attentions.1"]
+                target_blocks = ["up_blocks.0.attentions.1", "down_blocks.2.attentions.1"]
             else:
                 raise ValueError(f"Unsupported IP-Adapter base type: '{ip_adapter_info.base}'.")
         elif self.method == "style_strong":
@@ -196,7 +195,7 @@ class IPAdapterInvocation(BaseInvocation):
                 begin_step_percent=self.begin_step_percent,
                 end_step_percent=self.end_step_percent,
                 mask=self.mask,
-                method=self.method
+                method=self.method,
             ),
         )
 

--- a/invokeai/app/invocations/ip_adapter.py
+++ b/invokeai/app/invocations/ip_adapter.py
@@ -31,6 +31,7 @@ class IPAdapterField(BaseModel):
     image_encoder_model: ModelIdentifierField = Field(description="The name of the CLIP image encoder model.")
     weight: Union[float, List[float]] = Field(default=1, description="The weight given to the IP-Adapter.")
     target_blocks: List[str] = Field(default=[], description="The IP Adapter blocks to apply")
+    method: str = Field(default='full', description="Weight apply method")
     begin_step_percent: float = Field(
         default=0, ge=0, le=1, description="When the IP-Adapter is first applied (% of total steps)"
     )
@@ -137,7 +138,7 @@ class IPAdapterInvocation(BaseInvocation):
             if ip_adapter_info.base == "sd-1":
                 target_blocks = ["up_blocks.1"]
             elif ip_adapter_info.base == "sdxl":
-                target_blocks = ["up_blocks.0.attentions.1"]
+                target_blocks = ["up_blocks.0.attentions.1", "down_blocks.2.attentions.1"]
             else:
                 raise ValueError(f"Unsupported IP-Adapter base type: '{ip_adapter_info.base}'.")
         elif self.method == "composition":
@@ -162,6 +163,7 @@ class IPAdapterInvocation(BaseInvocation):
                 begin_step_percent=self.begin_step_percent,
                 end_step_percent=self.end_step_percent,
                 mask=self.mask,
+                method=self.method
             ),
         )
 

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -371,7 +371,7 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
 
         if use_ip_adapter or use_regional_prompting:
             ip_adapters: Optional[List[UNetIPAdapterData]] = (
-                [{"ip_adapter": ipa.ip_adapter_model, "target_blocks": ipa.target_blocks} for ipa in ip_adapter_data]
+                [{"ip_adapter": ipa.ip_adapter_model, "target_blocks": ipa.target_blocks, "method": ipa.method} for ipa in ip_adapter_data]
                 if use_ip_adapter
                 else None
             )

--- a/invokeai/backend/stable_diffusion/diffusers_pipeline.py
+++ b/invokeai/backend/stable_diffusion/diffusers_pipeline.py
@@ -371,7 +371,10 @@ class StableDiffusionGeneratorPipeline(StableDiffusionPipeline):
 
         if use_ip_adapter or use_regional_prompting:
             ip_adapters: Optional[List[UNetIPAdapterData]] = (
-                [{"ip_adapter": ipa.ip_adapter_model, "target_blocks": ipa.target_blocks, "method": ipa.method} for ipa in ip_adapter_data]
+                [
+                    {"ip_adapter": ipa.ip_adapter_model, "target_blocks": ipa.target_blocks, "method": ipa.method}
+                    for ipa in ip_adapter_data
+                ]
                 if use_ip_adapter
                 else None
             )

--- a/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
@@ -104,12 +104,24 @@ class IPAdapterConditioningInfo:
 
 @dataclass
 class IPAdapterData:
+    """Data class for IP-Adapter configuration.
+
+    Attributes:
+        ip_adapter_model: The IP-Adapter model to use.
+        ip_adapter_conditioning: The IP-Adapter conditioning data.
+        mask: The mask to apply to the IP-Adapter conditioning.
+        target_blocks: List of target attention block names to apply IP-Adapter to.
+        negative_blocks: List of target attention block names that should use negative attention.
+        weight: The weight to apply to the IP-Adapter conditioning.
+        begin_step_percent: The percentage of steps at which to start applying the IP-Adapter.
+        end_step_percent: The percentage of steps at which to stop applying the IP-Adapter.
+        method: The method to use for applying the IP-Adapter ('full', 'style', 'composition').
+    """
     ip_adapter_model: IPAdapter
     ip_adapter_conditioning: IPAdapterConditioningInfo
     mask: torch.Tensor
     target_blocks: List[str]
-
-    # Either a single weight applied to all steps, or a list of weights for each step.
+    negative_blocks: List[str] = field(default_factory=list)
     weight: Union[float, List[float]] = 1.0
     begin_step_percent: float = 0.0
     end_step_percent: float = 1.0

--- a/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
@@ -117,6 +117,7 @@ class IPAdapterData:
         end_step_percent: The percentage of steps at which to stop applying the IP-Adapter.
         method: The method to use for applying the IP-Adapter ('full', 'style', 'composition').
     """
+
     ip_adapter_model: IPAdapter
     ip_adapter_conditioning: IPAdapterConditioningInfo
     mask: torch.Tensor
@@ -125,7 +126,7 @@ class IPAdapterData:
     weight: Union[float, List[float]] = 1.0
     begin_step_percent: float = 0.0
     end_step_percent: float = 1.0
-    method: str = 'full'
+    method: str = "full"
 
     def scale_for_step(self, step_index: int, total_steps: int) -> float:
         first_adapter_step = math.floor(self.begin_step_percent * total_steps)

--- a/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
+++ b/invokeai/backend/stable_diffusion/diffusion/conditioning_data.py
@@ -113,6 +113,7 @@ class IPAdapterData:
     weight: Union[float, List[float]] = 1.0
     begin_step_percent: float = 0.0
     end_step_percent: float = 1.0
+    method: str = 'full'
 
     def scale_for_step(self, step_index: int, total_steps: int) -> float:
         first_adapter_step = math.floor(self.begin_step_percent * total_steps)

--- a/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
+++ b/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
@@ -14,7 +14,7 @@ from invokeai.backend.stable_diffusion.diffusion.regional_prompt_data import Reg
 class IPAdapterAttentionWeights:
     ip_adapter_weights: IPAttentionProcessorWeights
     skip: bool
-
+    negative: bool
 
 class CustomAttnProcessor2_0(AttnProcessor2_0):
     """A custom implementation of AttnProcessor2_0 that supports additional Invoke features.
@@ -134,6 +134,7 @@ class CustomAttnProcessor2_0(AttnProcessor2_0):
         # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         # End unmodified block from AttnProcessor2_0.
 
+
         # Apply IP-Adapter conditioning.
         if is_cross_attention:
             if self._ip_adapter_attention_weights:
@@ -162,6 +163,10 @@ class CustomAttnProcessor2_0(AttnProcessor2_0):
                     # Expected ip_hidden_state shape: (batch_size, num_ip_images, ip_seq_len, ip_image_embedding)
 
                     if not self._ip_adapter_attention_weights[ipa_index].skip:
+                        # apply the IP-Adapter weights to the negative embeds
+                        if self._ip_adapter_attention_weights[ipa_index].negative:
+                            ip_hidden_states = torch.cat([ip_hidden_states[1], ip_hidden_states[0]*0], dim=0)
+
                         ip_key = ipa_weights.to_k_ip(ip_hidden_states)
                         ip_value = ipa_weights.to_v_ip(ip_hidden_states)
 

--- a/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
+++ b/invokeai/backend/stable_diffusion/diffusion/custom_atttention.py
@@ -16,6 +16,7 @@ class IPAdapterAttentionWeights:
     skip: bool
     negative: bool
 
+
 class CustomAttnProcessor2_0(AttnProcessor2_0):
     """A custom implementation of AttnProcessor2_0 that supports additional Invoke features.
     This implementation is based on
@@ -134,7 +135,6 @@ class CustomAttnProcessor2_0(AttnProcessor2_0):
         # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         # End unmodified block from AttnProcessor2_0.
 
-
         # Apply IP-Adapter conditioning.
         if is_cross_attention:
             if self._ip_adapter_attention_weights:
@@ -165,7 +165,7 @@ class CustomAttnProcessor2_0(AttnProcessor2_0):
                     if not self._ip_adapter_attention_weights[ipa_index].skip:
                         # apply the IP-Adapter weights to the negative embeds
                         if self._ip_adapter_attention_weights[ipa_index].negative:
-                            ip_hidden_states = torch.cat([ip_hidden_states[1], ip_hidden_states[0]*0], dim=0)
+                            ip_hidden_states = torch.cat([ip_hidden_states[1], ip_hidden_states[0] * 0], dim=0)
 
                         ip_key = ipa_weights.to_k_ip(ip_hidden_states)
                         ip_value = ipa_weights.to_v_ip(ip_hidden_states)

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -44,7 +44,7 @@ class UNetAttentionPatcher:
                     for block in ip_adapter["target_blocks"]:
                         if block in name:
                             skip = False
-                            negative = ip_adapter["method"] == "style_precise" and block == "down_blocks.2.attentions.1"
+                            negative = ip_adapter["method"] == "style_precise" and (block == "down_blocks.2.attentions.1" or block == "down_blocks.2" or block == "mid_block")
                             break
                     ip_adapter_attention_weights: IPAdapterAttentionWeights = IPAdapterAttentionWeights(
                         ip_adapter_weights=ip_adapter_weights, skip=skip, negative=negative

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -12,8 +12,8 @@ from invokeai.backend.stable_diffusion.diffusion.custom_atttention import (
 
 class UNetIPAdapterData(TypedDict):
     ip_adapter: IPAdapter
-    target_blocks: List[str]
-    method: str
+    target_blocks: List[str]  # Blocks where IP-Adapter should be applied
+    method: str  # Style or other method type
 
 
 class UNetAttentionPatcher:
@@ -44,7 +44,7 @@ class UNetAttentionPatcher:
                     for block in ip_adapter["target_blocks"]:
                         if block in name:
                             skip = False
-                            negative = (ip_adapter["method"] == 'style' and block == "down_blocks.2.attentions.1")
+                            negative = (ip_adapter["method"] == 'style_precise' and block == "down_blocks.2.attentions.1")
                             break
                     ip_adapter_attention_weights: IPAdapterAttentionWeights = IPAdapterAttentionWeights(
                         ip_adapter_weights=ip_adapter_weights, skip=skip, negative=negative

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -44,7 +44,7 @@ class UNetAttentionPatcher:
                     for block in ip_adapter["target_blocks"]:
                         if block in name:
                             skip = False
-                            negative = (ip_adapter["method"] == 'style_precise' and block == "down_blocks.2.attentions.1")
+                            negative = ip_adapter["method"] == "style_precise" and block == "down_blocks.2.attentions.1"
                             break
                     ip_adapter_attention_weights: IPAdapterAttentionWeights = IPAdapterAttentionWeights(
                         ip_adapter_weights=ip_adapter_weights, skip=skip, negative=negative

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -44,7 +44,11 @@ class UNetAttentionPatcher:
                     for block in ip_adapter["target_blocks"]:
                         if block in name:
                             skip = False
-                            negative = ip_adapter["method"] == "style_precise" and (block == "down_blocks.2.attentions.1" or block == "down_blocks.2" or block == "mid_block")
+                            negative = ip_adapter["method"] == "style_precise" and (
+                                block == "down_blocks.2.attentions.1"
+                                or block == "down_blocks.2"
+                                or block == "mid_block"
+                            )
                             break
                     ip_adapter_attention_weights: IPAdapterAttentionWeights = IPAdapterAttentionWeights(
                         ip_adapter_weights=ip_adapter_weights, skip=skip, negative=negative

--- a/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
+++ b/invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.py
@@ -13,6 +13,7 @@ from invokeai.backend.stable_diffusion.diffusion.custom_atttention import (
 class UNetIPAdapterData(TypedDict):
     ip_adapter: IPAdapter
     target_blocks: List[str]
+    method: str
 
 
 class UNetAttentionPatcher:
@@ -39,12 +40,14 @@ class UNetAttentionPatcher:
                 for ip_adapter in self._ip_adapters:
                     ip_adapter_weights = ip_adapter["ip_adapter"].attn_weights.get_attention_processor_weights(idx)
                     skip = True
+                    negative = False
                     for block in ip_adapter["target_blocks"]:
                         if block in name:
                             skip = False
+                            negative = (ip_adapter["method"] == 'style' and block == "down_blocks.2.attentions.1")
                             break
                     ip_adapter_attention_weights: IPAdapterAttentionWeights = IPAdapterAttentionWeights(
-                        ip_adapter_weights=ip_adapter_weights, skip=skip
+                        ip_adapter_weights=ip_adapter_weights, skip=skip, negative=negative
                     )
                     ip_adapter_attention_weights_collection.append(ip_adapter_attention_weights)
 

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -2045,7 +2045,11 @@
             "style": "Style Only",
             "styleDesc": "Applies visual style (colors, textures) without considering its layout.",
             "composition": "Composition Only",
-            "compositionDesc": "Replicates layout & structure while ignoring the reference's style."
+            "compositionDesc": "Replicates layout & structure while ignoring the reference's style.",
+            "styleStrong": "Style Strong",
+            "styleStrongDesc": "Applies a strong visual style, with a slightly reduced composition influence.",
+            "stylePrecise": "Style Precise",
+            "stylePreciseDesc": "Applies a precise visual style, eliminating subject influence."
         },
         "fluxReduxImageInfluence": {
             "imageInfluence": "Image Influence",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -2042,13 +2042,13 @@
             "ipAdapterMethod": "Mode",
             "full": "Style and Composition",
             "fullDesc": "Applies visual style (colors, textures) & composition (layout, structure).",
-            "style": "Style Only",
-            "styleDesc": "Applies visual style (colors, textures) without considering its layout.",
+            "style": "Style (Simple)",
+            "styleDesc": "Applies visual style (colors, textures) without considering its layout. Previously called Style Only.",
             "composition": "Composition Only",
             "compositionDesc": "Replicates layout & structure while ignoring the reference's style.",
-            "styleStrong": "Style Strong",
+            "styleStrong": "Style (Strong)",
             "styleStrongDesc": "Applies a strong visual style, with a slightly reduced composition influence.",
-            "stylePrecise": "Style Precise",
+            "stylePrecise": "Style (Precise)",
             "stylePreciseDesc": "Applies a precise visual style, eliminating subject influence."
         },
         "fluxReduxImageInfluence": {

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsx
@@ -35,6 +35,16 @@ export const IPAdapterMethod = memo(({ method, onChange }: Props) => {
         value: 'composition',
         description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.compositionDesc') : undefined,
       },
+      {
+        label: t('controlLayers.ipAdapterMethod.styleStrong'),
+        value: 'style_strong',
+        description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.styleStrongDesc') : undefined,
+      },
+      {
+        label: t('controlLayers.ipAdapterMethod.stylePrecise'),
+        value: 'style_precise',
+        description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.stylePreciseDesc') : undefined,
+      },
     ],
     [t, shouldShowModelDescriptions]
   );

--- a/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsx
@@ -31,11 +31,6 @@ export const IPAdapterMethod = memo(({ method, onChange }: Props) => {
         description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.styleDesc') : undefined,
       },
       {
-        label: t('controlLayers.ipAdapterMethod.composition'),
-        value: 'composition',
-        description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.compositionDesc') : undefined,
-      },
-      {
         label: t('controlLayers.ipAdapterMethod.styleStrong'),
         value: 'style_strong',
         description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.styleStrongDesc') : undefined,
@@ -44,6 +39,11 @@ export const IPAdapterMethod = memo(({ method, onChange }: Props) => {
         label: t('controlLayers.ipAdapterMethod.stylePrecise'),
         value: 'style_precise',
         description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.stylePreciseDesc') : undefined,
+      },
+      {
+        label: t('controlLayers.ipAdapterMethod.composition'),
+        value: 'composition',
+        description: shouldShowModelDescriptions ? t('controlLayers.ipAdapterMethod.compositionDesc') : undefined,
       },
     ],
     [t, shouldShowModelDescriptions]

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -50,7 +50,7 @@ const zCLIPVisionModelV2 = z.enum(['ViT-H', 'ViT-G', 'ViT-L']);
 export type CLIPVisionModelV2 = z.infer<typeof zCLIPVisionModelV2>;
 export const isCLIPVisionModelV2 = (v: unknown): v is CLIPVisionModelV2 => zCLIPVisionModelV2.safeParse(v).success;
 
-const zIPMethodV2 = z.enum(['full', 'style', 'composition']);
+const zIPMethodV2 = z.enum(['full', 'style', 'composition', 'style_strong', 'style_precise']);
 export type IPMethodV2 = z.infer<typeof zIPMethodV2>;
 export const isIPMethodV2 = (v: unknown): v is IPMethodV2 => zIPMethodV2.safeParse(v).success;
 

--- a/invokeai/frontend/web/src/features/nodes/types/common.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/common.ts
@@ -147,7 +147,7 @@ export const zIPAdapterField = z.object({
   image: zImageField,
   ip_adapter_model: zModelIdentifierField,
   weight: z.number(),
-  method: z.enum(['full', 'style', 'composition']),
+  method: z.enum(['full', 'style', 'composition', 'style_strong', 'style_precise']),
   begin_step_percent: z.number().optional(),
   end_step_percent: z.number().optional(),
 });

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -9164,6 +9164,12 @@ export type components = {
              */
             target_blocks?: string[];
             /**
+             * Method
+             * @description Weight apply method
+             * @default full
+             */
+            method?: string;
+            /**
              * Begin Step Percent
              * @description When the IP-Adapter is first applied (% of total steps)
              * @default 0
@@ -9234,7 +9240,7 @@ export type components = {
              * @default full
              * @enum {string}
              */
-            method?:  "full" | "style" | "style_strong" | "style_precise" | "composition";
+            method?: "full" | "style" | "composition" | "style_strong" | "style_precise";
             /**
              * Begin Step Percent
              * @description When the IP-Adapter is first applied (% of total steps)
@@ -9360,7 +9366,7 @@ export type components = {
              * @description Method to apply IP Weights with
              * @enum {string}
              */
-            method: "full" | "style" | "composition" | "style_strong" | "style_precise";
+            method: "full" | "style" | "composition";
             /**
              * Weight
              * @description The weight given to the IP-Adapter

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -9234,7 +9234,7 @@ export type components = {
              * @default full
              * @enum {string}
              */
-            method?: "full" | "style" | "composition";
+            method?:  "full" | "style" | "composition" | "style_strong" | "style_precise";
             /**
              * Begin Step Percent
              * @description When the IP-Adapter is first applied (% of total steps)

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -9360,7 +9360,7 @@ export type components = {
              * @description Method to apply IP Weights with
              * @enum {string}
              */
-            method: "full" | "style" | "composition";
+            method: "full" | "style" | "composition" | "style_strong" | "style_precise";
             /**
              * Weight
              * @description The weight given to the IP-Adapter

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -9234,7 +9234,7 @@ export type components = {
              * @default full
              * @enum {string}
              */
-            method?:  "full" | "style" | "composition" | "style_strong" | "style_precise";
+            method?:  "full" | "style" | "style_strong" | "style_precise" | "composition";
             /**
              * Begin Step Percent
              * @description When the IP-Adapter is first applied (% of total steps)


### PR DESCRIPTION
This pull request introduces enhancements to the IP-Adapter functionality, including the addition of two new methods (`style_strong` and `style_precise`) and corresponding updates across the backend and frontend to support these methods. Key changes include updates to data models, invocation logic, attention processing, and the user interface.

### Backend Enhancements to IP-Adapter:

* **New Methods and Logic:**
  - Added `style_strong` and `style_precise` methods to the `IPAdapterInvocation` class, with specific logic for determining target attention blocks based on the base type (e.g., `sd-1`, `sdxl`). (`[[1]](diffhunk://#diff-c63c2992c76f7ae765f25b13f9ecd2b8bb63eef5e5159dfa218a37926f95f980L97-R98)`, `[[2]](diffhunk://#diff-c63c2992c76f7ae765f25b13f9ecd2b8bb63eef5e5159dfa218a37926f95f980R151-R182)`)

* **Attention Processing Updates:**
  - With the help of matt3o, modified `CustomAttnProcessor2_0` to handle negative attention blocks for the `style_precise` method. This is, admittedly, less sophisticated than processing the entire negative block as a separate point of control, but the amount of work involved in that (and the likelihood of that being needed in the future, given this is for Diffusers/SDXL) seems low.  (`[invokeai/backend/stable_diffusion/diffusion/custom_atttention.pyR166-R169](diffhunk://#diff-2674cdb025f9eb53c71d878340376496d4f2cbf9d1ca77d7a048ea031124e8a2R166-R169)`)
  - Enhanced `UNetAttentionPatcher` to mark specific blocks as negative when using the `style_precise` method. (`[invokeai/backend/stable_diffusion/diffusion/unet_attention_patcher.pyR43-R50](diffhunk://#diff-500c7c7bdd4c31b28a0bea8009cd83b12ccb32813cfef4a0db0024607d8a9062R43-R50)`)


### Frontend Updates for IP-Adapter Configuration:

* **UI Enhancements:**
  - Added `style_strong` and `style_precise` options to the IP-Adapter method dropdown in the user interface, along with descriptions. (`[invokeai/frontend/web/src/features/controlLayers/components/IPAdapter/IPAdapterMethod.tsxR38-R47](diffhunk://#diff-a8e1c058bc6b8e47c2b9d696b5fff027d12f45d755977add5ad779ac00254630R38-R47)`)

* **Schema and Type Updates:**
  - Extended the `zIPMethodV2` and related schemas to include the new methods, ensuring validation and type safety. (`[[1]](diffhunk://#diff-41b99074662523f313cc66e9d6ce8fa9067ac0a87dbf8bcd374554dc533fbcf9L53-R53)`, `[[2]](diffhunk://#diff-21f94e3b560358a31df37b048dc4077c48c02f38c55068a6ffc4f11be239f07aL150-R150)`, `[[3]](diffhunk://#diff-7000f59d98ff3b216f5408fecd7c6ff301af310cd1f6d8301d08553fc696d4c4L9173-R9173)`, `[[4]](diffhunk://#diff-7000f59d98ff3b216f5408fecd7c6ff301af310cd1f6d8301d08553fc696d4c4L9299-R9299)`)## Summary

## QA Instructions

Should test all previous instances of IP Adapter vs new
**_Regression:_**
- SD1 Style
- SD1 Composition
- SD1 Full
- SDXL Style
- SDXL Composition
- SDXL Full
- Multiple IP Adapters

**_Functionality:_**
- SD1 Style Precise
- SD1 Style Strong
- SDXL Style Precise
- SDXL Style Strong

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
