### PR TITLE
fix(ui): only use client-side uploads if more than one image

### DIFF
--- a/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
+++ b/invokeai/frontend/web/src/common/hooks/useImageUploadButton.tsx
@@ -83,7 +83,7 @@ export const useImageUploadButton = ({ onUpload, isDisabled, allowMultiple }: Us
           }
         } else {
           let imageDTOs: ImageDTO[] = [];
-          if (isClientSideUploadEnabled) {
+          if (isClientSideUploadEnabled && files.length > 1) {
             imageDTOs = await Promise.all(files.map((file, i) => clientSideUpload(file, i)));
           } else {
             imageDTOs = await uploadImages(

--- a/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
+++ b/invokeai/frontend/web/src/features/dnd/FullscreenDropzone.tsx
@@ -109,7 +109,7 @@ export const FullscreenDropzone = memo(() => {
 
       const autoAddBoardId = selectAutoAddBoardId(getState());
 
-      if (isClientSideUploadEnabled) {
+      if (isClientSideUploadEnabled && files.length > 1) {
         for (const [i, file] of files.entries()) {
           await clientSideUpload(file, i);
         }


### PR DESCRIPTION
## Summary

Single image uploads should continue using the main /upload endpoint even if client-side uploads are enabled, so that users have a path to retain metadata on upload if they need to.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
