### PR TITLE
fix(nodes): better defaults parsing and error handling

### DIFF
--- a/invokeai/app/invocations/composition-nodes.py
+++ b/invokeai/app/invocations/composition-nodes.py
@@ -274,12 +274,12 @@ class InvokeAdjustImageHuePlusInvocation(BaseInvocation, WithMetadata, WithBoard
     title="Enhance Image",
     tags=["enhance", "image"],
     category="image",
-    version="1.2.0",
+    version="1.2.1",
 )
 class InvokeImageEnhanceInvocation(BaseInvocation, WithMetadata, WithBoard):
     """Applies processing from PIL's ImageEnhance module. Originally created by @dwringer"""
 
-    image: ImageField = InputField(default=None, description="The image for which to apply processing")
+    image: ImageField = InputField(description="The image for which to apply processing")
     invert: bool = InputField(default=False, description="Whether to invert the image colors")
     color: float = InputField(ge=0, default=1.0, description="Color enhancement factor")
     contrast: float = InputField(ge=0, default=1.0, description="Contrast enhancement factor")

--- a/invokeai/app/invocations/create_gradient_mask.py
+++ b/invokeai/app/invocations/create_gradient_mask.py
@@ -42,12 +42,12 @@ class GradientMaskOutput(BaseInvocationOutput):
     title="Create Gradient Mask",
     tags=["mask", "denoise"],
     category="latents",
-    version="1.2.0",
+    version="1.2.1",
 )
 class CreateGradientMaskInvocation(BaseInvocation):
     """Creates mask for denoising model run."""
 
-    mask: ImageField = InputField(default=None, description="Image which will be masked", ui_order=1)
+    mask: ImageField= InputField(description="Image which will be masked", ui_order=1)
     edge_radius: int = InputField(
         default=16, ge=0, description="How far to blur/expand the edges of the mask", ui_order=2
     )

--- a/invokeai/app/invocations/create_gradient_mask.py
+++ b/invokeai/app/invocations/create_gradient_mask.py
@@ -47,7 +47,7 @@ class GradientMaskOutput(BaseInvocationOutput):
 class CreateGradientMaskInvocation(BaseInvocation):
     """Creates mask for denoising model run."""
 
-    mask: ImageField= InputField(description="Image which will be masked", ui_order=1)
+    mask: ImageField = InputField(description="Image which will be masked", ui_order=1)
     edge_radius: int = InputField(
         default=16, ge=0, description="How far to blur/expand the edges of the mask", ui_order=2
     )

--- a/invokeai/app/invocations/fields.py
+++ b/invokeai/app/invocations/fields.py
@@ -400,8 +400,8 @@ class InputFieldJSONSchemaExtra(BaseModel):
     """
 
     input: Input
-    orig_required: bool
     field_kind: FieldKind
+    orig_required: bool = True
     default: Optional[Any] = None
     orig_default: Optional[Any] = None
     ui_hidden: bool = False
@@ -498,7 +498,7 @@ def InputField(
     input: Input = Input.Any,
     ui_type: Optional[UIType] = None,
     ui_component: Optional[UIComponent] = None,
-    ui_hidden: bool = False,
+    ui_hidden: Optional[bool] = None,
     ui_order: Optional[int] = None,
     ui_choice_labels: Optional[dict[str, str]] = None,
 ) -> Any:
@@ -534,14 +534,19 @@ def InputField(
 
     json_schema_extra_ = InputFieldJSONSchemaExtra(
         input=input,
-        ui_type=ui_type,
-        ui_component=ui_component,
-        ui_hidden=ui_hidden,
-        ui_order=ui_order,
-        ui_choice_labels=ui_choice_labels,
         field_kind=FieldKind.Input,
-        orig_required=True,
     )
+
+    if ui_type is not None:
+        json_schema_extra_.ui_type = ui_type
+    if ui_component is not None:
+        json_schema_extra_.ui_component = ui_component
+    if ui_hidden is not None:
+        json_schema_extra_.ui_hidden = ui_hidden
+    if ui_order is not None:
+        json_schema_extra_.ui_order = ui_order
+    if ui_choice_labels is not None:
+        json_schema_extra_.ui_choice_labels = ui_choice_labels
 
     """
     There is a conflict between the typing of invocation definitions and the typing of an invocation's
@@ -614,7 +619,7 @@ def InputField(
 
     return Field(
         **provided_args,
-        json_schema_extra=json_schema_extra_.model_dump(exclude_none=True),
+        json_schema_extra=json_schema_extra_.model_dump(exclude_unset=True),
     )
 
 

--- a/invokeai/app/invocations/ideal_size.py
+++ b/invokeai/app/invocations/ideal_size.py
@@ -21,14 +21,14 @@ class IdealSizeOutput(BaseInvocationOutput):
     "ideal_size",
     title="Ideal Size - SD1.5, SDXL",
     tags=["latents", "math", "ideal_size"],
-    version="1.0.5",
+    version="1.0.6",
 )
 class IdealSizeInvocation(BaseInvocation):
     """Calculates the ideal size for generation to avoid duplication"""
 
     width: int = InputField(default=1024, description="Final image width")
     height: int = InputField(default=576, description="Final image height")
-    unet: UNetField = InputField(default=None, description=FieldDescriptions.unet)
+    unet: UNetField = InputField(description=FieldDescriptions.unet)
     multiplier: float = InputField(
         default=1.0,
         description="Amount to multiply the model's dimensions by when calculating the ideal size (may result in "

--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -975,13 +975,13 @@ class SaveImageInvocation(BaseInvocation, WithMetadata, WithBoard):
     title="Canvas Paste Back",
     tags=["image", "combine"],
     category="image",
-    version="1.0.0",
+    version="1.0.1",
 )
 class CanvasPasteBackInvocation(BaseInvocation, WithMetadata, WithBoard):
     """Combines two images by using the mask provided. Intended for use on the Unified Canvas."""
 
     source_image: ImageField = InputField(description="The source image")
-    target_image: ImageField = InputField(default=None, description="The target image")
+    target_image: ImageField = InputField(description="The target image")
     mask: ImageField = InputField(
         description="The mask to use when pasting",
     )

--- a/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputTemplate.ts
@@ -682,7 +682,7 @@ const buildEnumFieldInputTemplate: FieldInputTemplateBuilder<EnumFieldInputTempl
     if (filteredAnyOf.length !== 1 || !isSchemaObject(firstAnyOf)) {
       options = [];
     } else {
-      options = firstAnyOf.enum ?? [];
+      options = firstAnyOf.const ? [firstAnyOf.const] : (firstAnyOf.enum ?? []);
     }
   } else if (schemaObject.const) {
     options = [schemaObject.const];

--- a/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/parseSchema.ts
@@ -161,8 +161,15 @@ export const parseSchema = (
           fieldType.batch = true;
         }
 
-        const fieldInputTemplate = buildFieldInputTemplate(property, propertyName, fieldType);
-        inputsAccumulator[propertyName] = fieldInputTemplate;
+        try {
+          const fieldInputTemplate = buildFieldInputTemplate(property, propertyName, fieldType);
+          inputsAccumulator[propertyName] = fieldInputTemplate;
+        } catch {
+          log.error(
+            { node: type, field: propertyName, schema: parseify(property) },
+            'Problem building input field template'
+          );
+        }
 
         return inputsAccumulator;
       },
@@ -226,9 +233,16 @@ export const parseSchema = (
           fieldType.batch = true;
         }
 
-        const fieldOutputTemplate = buildFieldOutputTemplate(property, propertyName, fieldType);
+        try {
+          const fieldOutputTemplate = buildFieldOutputTemplate(property, propertyName, fieldType);
+          outputsAccumulator[propertyName] = fieldOutputTemplate;
+        } catch {
+          log.error(
+            { node: type, field: propertyName, schema: parseify(property) },
+            'Problem building output field template'
+          );
+        }
 
-        outputsAccumulator[propertyName] = fieldOutputTemplate;
         return outputsAccumulator;
       },
       {} as Record<string, FieldOutputTemplate>

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -11165,9 +11165,12 @@ export type components = {
          */
         InputFieldJSONSchemaExtra: {
             input: components["schemas"]["Input"];
-            /** Orig Required */
-            orig_required: boolean;
             field_kind: components["schemas"]["FieldKind"];
+            /**
+             * Orig Required
+             * @default true
+             */
+            orig_required: boolean;
             /**
              * Default
              * @default null


### PR DESCRIPTION
## Summary

Fixes and better error handling for invalid invocation field default values.

## Related Issues / Discussions

Discord thread: https://discord.com/channels/1020123559063990373/1149506274971631688/1374029733423087636

## QA Instructions

Using this repo as a test https://github.com/mickr777/imagetoasciiimage

### Before

- No error in launcher/python terminal, just looks fine
- UI hangs at loading screen
- Error like this in the JS console of browser
  <img width="646" alt="image" src="https://github.com/user-attachments/assets/9cb669c1-1097-42a6-9ede-ec4236a8e81e" />

### After

- Big error in launcher/python terminal
- UI does not hang
- If, somehow, the invocation gets past the python safeguards, instead of hanging the UI, the error is logged and the UI loads.

Example terminal error:
```sh
[2025-05-20 08:30:45,802]::[InvokeAI]::ERROR --> Failed to load node pack imagetoasciiimage (may have partially loaded):
Traceback (most recent call last):
  File "/home/bat/Documents/Code/InvokeAI/invokeai/app/invocations/baseinvocation.py", line 530, in validate_field_default
    TempDefaultValidator.model_validate({field_name: orig_default})
  File "/home/bat/Documents/Code/InvokeAI/.venv/lib/python3.12/site-packages/pydantic/main.py", line 703, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for ImageToAAInvocation
local_font
  Input should be 'None' [type=literal_error, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/literal_error

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/bat/Documents/Code/InvokeAI/invokeai/app/invocations/load_custom_nodes.py", line 69, in load_custom_nodes
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/bat/invokeai-4.0.0/nodes/imagetoasciiimage/__init__.py", line 2, in <module>
    from .i2aa_anyfont import ImageToAAInvocation
  File "/home/bat/invokeai-4.0.0/nodes/imagetoasciiimage/i2aa_anyfont.py", line 116, in <module>
    @invocation(
     ^^^^^^^^^^^
  File "/home/bat/Documents/Code/InvokeAI/invokeai/app/invocations/baseinvocation.py", line 594, in wrapper
    validate_field_default(cls.__name__, field_name, invocation_type, annotation, field_info)
  File "/home/bat/Documents/Code/InvokeAI/invokeai/app/invocations/baseinvocation.py", line 532, in validate_field_default
    raise InvalidFieldError(
invokeai.app.invocations.baseinvocation.InvalidFieldError: Default value for field "local_font" on invocation "I2AA_AnyFont" is invalid, 1 validation error for ImageToAAInvocation
local_font
  Input should be 'None' [type=literal_error, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/literal_error
```

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
