### PR TITLE
fix: improve gguf performance with torch.compile

### DIFF
--- a/invokeai/backend/quantization/gguf/utils.py
+++ b/invokeai/backend/quantization/gguf/utils.py
@@ -5,7 +5,8 @@ from typing import Callable, Optional, Union
 import gguf
 import torch
 
-TORCH_COMPATIBLE_QTYPES = {None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16}
+# should not be a Set until this is resolved: https://github.com/pytorch/pytorch/issues/145761
+TORCH_COMPATIBLE_QTYPES = [None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16]
 
 # K Quants #
 QK_K = 256


### PR DESCRIPTION
## Summary

When using torch.compile with a Flux-type GGUF model, tlparse reports this error:

> Unsupported method call
>  Explanation: Dynamo does not know how to trace method `__contains__` of class `set`
>  Hint: Avoid calling `set.__contains__` in your code.
>  Hint: Please report an issue to PyTorch.

This is in `get_dequantized_tensor`, which gets called frequently enough for this to have a significant influence.

Changing the collection from a set to a list is sufficient to make it compatible.


## Related Issues / Discussions

See https://github.com/pytorch/pytorch/issues/145761


## QA Instructions

Run a GGUF.


## Merge Plan



## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
