### PR TITLE
Fix: Don't auto-scale away from SDXL training sizes

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/util/getScaledBoundingBoxDimensions.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/util/getScaledBoundingBoxDimensions.ts
@@ -1,7 +1,11 @@
 import { roundToMultiple } from 'common/util/roundDownToMultiple';
 import type { Dimensions } from 'features/controlLayers/store/types';
 import type { MainModelBase } from 'features/nodes/types/common';
-import { getGridSize, getOptimalDimension } from 'features/parameters/util/optimalDimension';
+import {
+  getGridSize,
+  getOptimalDimension,
+  isInSDXLTrainingDimensions,
+} from 'features/parameters/util/optimalDimension';
 
 /**
  * Scales the bounding box dimensions to the optimal dimension. The optimal dimensions should be the trained dimension
@@ -10,6 +14,11 @@ import { getGridSize, getOptimalDimension } from 'features/parameters/util/optim
  * @param modelBase The base model
  */
 export const getScaledBoundingBoxDimensions = (dimensions: Dimensions, modelBase: MainModelBase): Dimensions => {
+  // Special cases: Return original if SDXL and in training dimensions
+  if (modelBase === 'sdxl' && isInSDXLTrainingDimensions(dimensions.width, dimensions.height)) {
+    return { ...dimensions };
+  }
+
   const optimalDimension = getOptimalDimension(modelBase);
   const gridSize = getGridSize(modelBase);
   const width = roundToMultiple(dimensions.width, gridSize);

--- a/invokeai/frontend/web/src/features/parameters/util/optimalDimension.ts
+++ b/invokeai/frontend/web/src/features/parameters/util/optimalDimension.ts
@@ -26,6 +26,40 @@ export const getOptimalDimension = (base?: BaseModelType | null): number => {
   }
 };
 
+const SDXL_TRAINING_DIMENSIONS: [number, number][] = [
+  [512, 2048],
+  [512, 1984],
+  [512, 1920],
+  [512, 1856],
+  [576, 1792],
+  [576, 1728],
+  [576, 1664],
+  [640, 1600],
+  [640, 1536],
+  [704, 1472],
+  [704, 1408],
+  [704, 1344],
+  [768, 1344],
+  [768, 1280],
+  [832, 1216],
+  [832, 1152],
+  [896, 1152],
+  [896, 1088],
+  [960, 1088],
+  [960, 1024],
+  [1024, 1024],
+];
+
+/**
+ * Checks if the given width and height are in the SDXL training dimensions.
+ * @param width The width to check
+ * @param height The height to check
+ * @returns Whether the width and height are in the SDXL training dimensions (order agnostic)
+ */
+export const isInSDXLTrainingDimensions = (width: number, height: number): boolean => {
+  return SDXL_TRAINING_DIMENSIONS.some(([w, h]) => (w === width && h === height) || (w === height && h === width));
+};
+
 /**
  * Gets the grid size for a given base model. For Flux, the grid size is 16, otherwise it is 8.
  * - sd-1, sd-2, sdxl: 8


### PR DESCRIPTION
## Summary

This adds a quick check to the bbox auto scaling to leave the values alone when using an SDXL model and the dimensions are one of the standard sizes that SDXL was trained on. Scaling to nearby dimensions that do not play well with the Unet's internal downscaling results in edge artifacts.

All of the override dimensions are within 10% of the ~1MiP target size of the autoscaling code, and skipping the upscale will also avoid compression and reduce the number of saved intermediate images.

## Related Issues / Discussions

Previous discussion and suggestion of hard-coding fix:
https://discordapp.com/channels/1020123559063990373/1049495067846524939/1301654971254575175

Recent mention of the bug:
https://discordapp.com/channels/1020123559063990373/1020123559831539744/1375205214839115796

Original investigation about it a year ago (yikes):
https://discordapp.com/channels/1020123559063990373/1240001897814036562

## Merge Plan

ready to merge

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
