### PR TITLE
Enhancement: Relax Canvas Entity Restrctions during Staging.

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityEnabledToggle.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/common/CanvasEntityEnabledToggle.tsx
@@ -1,7 +1,6 @@
 import { IconButton } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
 import { useEntityIdentifierContext } from 'features/controlLayers/contexts/EntityIdentifierContext';
-import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useEntityIsEnabled } from 'features/controlLayers/hooks/useEntityIsEnabled';
 import { entityIsEnabledToggled } from 'features/controlLayers/store/canvasSlice';
 import { memo, useCallback } from 'react';
@@ -12,12 +11,14 @@ export const CanvasEntityEnabledToggle = memo(() => {
   const { t } = useTranslation();
   const entityIdentifier = useEntityIdentifierContext();
   const isEnabled = useEntityIsEnabled(entityIdentifier);
-  const isBusy = useCanvasIsBusy();
   const dispatch = useAppDispatch();
+
   const onClick = useCallback(() => {
     dispatch(entityIsEnabledToggled({ entityIdentifier }));
   }, [dispatch, entityIdentifier]);
 
+  // Following the existing pattern: parameter controls (like Weight, BeginEndStepPct sliders)
+  // don't use isBusy and work during staging. Enable/disable toggles should follow the same pattern.
   return (
     <IconButton
       size="sm"
@@ -27,7 +28,6 @@ export const CanvasEntityEnabledToggle = memo(() => {
       alignSelf="stretch"
       icon={isEnabled ? <PiCircleFill /> : <PiCircleBold />}
       onClick={onClick}
-      isDisabled={isBusy}
     />
   );
 });


### PR DESCRIPTION
## Summary
This pull request makes a small but significant change to the `CanvasEntityEnabledToggle` component in the `invokeai` frontend. The change removes the dependency on the `isBusy` state, aligning the behavior of the enable/disable toggles with other parameter controls.

This addresses a common user request to allow enabling/disabling layers in the process of using the staging area.

It also allows a user to turn a layer OFF while it is being actively transformed. While this is not ideal behavior, it's an already existing issue that users with a layer that is hidden or disabled can enter a filter state while still not being able to see it. Will address that in a different PR.

## Related Issues / Discussions

Various discord user requests, long standing feature request.

## QA Instructions

Tested toggling on/off during staging, filter, & transform functions.
Confirmed other actions like moving are still restricted.

## Merge Plan

good to go.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
