### PR TITLE
Revert "Update scaling math to land on 100% consistently."

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -31,7 +31,7 @@ type CanvasStageModuleConfig = {
 const DEFAULT_CONFIG: CanvasStageModuleConfig = {
   MIN_SCALE: 0.1,
   MAX_SCALE: 20,
-  SCALE_FACTOR: 0.9995,
+  SCALE_FACTOR: 0.999,
   FIT_LAYERS_TO_STAGE_PADDING_PX: 48,
 };
 
@@ -230,24 +230,7 @@ export class CanvasStageModule extends CanvasModuleBase {
    * Constrains a scale to be within the valid range
    */
   constrainScale = (scale: number): number => {
-    // Round to 2 decimal places to avoid floating point precision issues
-    const rounded = Math.round(scale * 100) / 100;
-    const clamped = clamp(rounded, this.config.MIN_SCALE, this.config.MAX_SCALE);
-
-    // Snap to 100% (scale = 1.0) with a more generous tolerance
-    if (Math.abs(clamped - 1) < 0.05) {
-      return 1;
-    }
-
-    // Snap to other common zoom levels for better UX
-    const commonScales = [0.25, 0.5, 0.75, 1.5, 2, 3, 4, 5];
-    for (const commonScale of commonScales) {
-      if (Math.abs(clamped - commonScale) < 0.03) {
-        return commonScale;
-      }
-    }
-
-    return clamped;
+    return clamp(Math.round(scale * 100) / 100, this.config.MIN_SCALE, this.config.MAX_SCALE);
   };
 
   /**


### PR DESCRIPTION
Reverts invoke-ai/InvokeAI#8043

I only tested this after merging. Unfortunately it breaks the canvas scaling for some input devices. How broken it is depends on magnitude and frequency of the input device's scroll events. 

As implemented in the PR, once the scale has snapped, you have to scroll more than the threshold _in a single scroll event_ to "break" the snap.

This interacts badly with certain input devices. For example, on a macOS touchpad, individual scroll events are very frequent with a small magnitude. It takes a really strong scroll for a single scroll event delta to be greater than the threshold.

So if you scroll hard enough to break the snap, it almost instantly jumps to the _next_ snap point, thanks to the inertial nature of macOS touchpad gestures. Even without the inertial touch stuff, on some input devices you would need to be _very_ agile and quick to not accidentally scroll directly from one snap point to the next.

One way to implement the snap behaviour might be to handle scrolling while snapped and not snapped differently:
- Track whether or not we are snapped.
- When scrolling, if un-snapped, scale until we snap. Current behaviour.
- When scrolling, if snapped, do not scale. Instead, track the cumulative distance scrolled. Once that reaches a snap break threshold, scale to just past the snap point and fall back to un-snapped scroll handling.