### PR TITLE
feat(ui): revised canvas scale snapping

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbarScale.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbarScale.tsx
@@ -122,7 +122,7 @@ export const CanvasToolbarScale = memo(() => {
   return (
     <Flex alignItems="center">
       <ZoomOutButton />
-      <Popover>
+      <Popover isLazy lazyBehavior="unmount">
         <PopoverAnchor>
           <NumberInput
             variant="outline"

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -241,11 +241,7 @@ export class CanvasStageModule extends CanvasModuleBase {
    * Constrains a scale to be within the valid range
    */
   constrainScale = (scale: number): number => {
-    // Round to 2 decimal places to avoid floating point precision issues
-    const rounded = Math.round(scale * 100) / 100;
-    const clamped = clamp(rounded, this.config.MIN_SCALE, this.config.MAX_SCALE);
-
-    return clamped;
+    return clamp(scale, this.config.MIN_SCALE, this.config.MAX_SCALE);
   };
 
   /**
@@ -264,8 +260,8 @@ export class CanvasStageModule extends CanvasModuleBase {
     const deltaX = (_center.x - x) / oldScale;
     const deltaY = (_center.y - y) / oldScale;
 
-    const newX = Math.floor(_center.x - deltaX * newScale);
-    const newY = Math.floor(_center.y - deltaY * newScale);
+    const newX = _center.x - deltaX * newScale;
+    const newY = _center.y - deltaY * newScale;
 
     this.konva.stage.setAttrs({
       x: newX,

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -39,9 +39,9 @@ type CanvasStageModuleConfig = {
 const DEFAULT_CONFIG: CanvasStageModuleConfig = {
   MIN_SCALE: 0.1,
   MAX_SCALE: 20,
-  SCALE_FACTOR: 0.9995,
+  SCALE_FACTOR: 0.999,
   FIT_LAYERS_TO_STAGE_PADDING_PX: 48,
-  SCALE_SNAP_POINTS: [0.25, 0.5, 0.75, 1.5, 2, 3, 4, 5],
+  SCALE_SNAP_POINTS: [0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5],
   SCALE_SNAP_TOLERANCE: 0.05,
 };
 
@@ -52,6 +52,11 @@ export class CanvasStageModule extends CanvasModuleBase {
   readonly parent: CanvasManager;
   readonly manager: CanvasManager;
   readonly log: Logger;
+
+  // State for scale snapping logic
+  private _intendedScale: number = 1;
+  private _activeSnapPoint: number | null = null;
+  private _snapTimeout: number | null = null;
 
   container: HTMLDivElement;
   konva: { stage: Konva.Stage };
@@ -87,6 +92,9 @@ export class CanvasStageModule extends CanvasModuleBase {
         container,
       }),
     };
+
+    // Initialize intended scale to the default stage scale
+    this._intendedScale = this.konva.stage.scaleX();
   }
 
   setContainer = (container: HTMLDivElement) => {
@@ -206,6 +214,10 @@ export class CanvasStageModule extends CanvasModuleBase {
       -rect.y * scale + this.config.FIT_LAYERS_TO_STAGE_PADDING_PX + (availableHeight - rect.height * scale) / 2
     );
 
+    // When fitting the stage, we update the intended scale and reset any active snap.
+    this._intendedScale = scale;
+    this._activeSnapPoint = null;
+
     this.konva.stage.setAttrs({
       x,
       y,
@@ -245,17 +257,31 @@ export class CanvasStageModule extends CanvasModuleBase {
   };
 
   /**
-   * Sets the scale of the stage. If center is provided, the stage will zoom in/out on that point.
-   * @param scale The new scale to set
-   * @param center The center of the stage to zoom in/out on
+   * Programmatically sets the scale of the stage, overriding any active snapping.
+   * If a center point is provided, the stage will zoom on that point.
+   * @param scale The new scale to set.
+   * @param center The center point for the zoom.
    */
   setScale = (scale: number, center?: Coordinate): void => {
-    this.log.trace('Setting scale');
-    const _center = center ?? this.getCenter(true);
+    this.log.trace({ scale }, 'Programmatically setting scale');
     const newScale = this.constrainScale(scale);
 
-    const { x, y } = this.getPosition();
+    // When scale is set programmatically, update the intended scale and reset any active snap.
+    this._intendedScale = newScale;
+    this._activeSnapPoint = null;
+
+    this._applyScale(newScale, center);
+  };
+
+  /**
+   * Applies a scale to the stage, adjusting the position to keep the given center point stationary.
+   * This internal method does NOT modify snapping state.
+   */
+  private _applyScale = (newScale: number, center?: Coordinate): void => {
     const oldScale = this.getScale();
+
+    const _center = center ?? this.getCenter(true);
+    const { x, y } = this.getPosition();
 
     const deltaX = (_center.x - x) / oldScale;
     const deltaY = (_center.y - y) / oldScale;
@@ -275,6 +301,7 @@ export class CanvasStageModule extends CanvasModuleBase {
 
   onStageMouseWheel = (e: KonvaEventObject<WheelEvent>) => {
     e.evt.preventDefault();
+    this._snapTimeout && window.clearTimeout(this._snapTimeout);
 
     if (e.evt.ctrlKey || e.evt.metaKey) {
       return;
@@ -289,8 +316,53 @@ export class CanvasStageModule extends CanvasModuleBase {
 
     // When wheeling on trackpad, e.evt.ctrlKey is true - in that case, let's reverse the direction
     const delta = e.evt.ctrlKey ? -e.evt.deltaY : e.evt.deltaY;
-    const scale = this.manager.stage.getScale() * this.config.SCALE_FACTOR ** delta;
-    this.manager.stage.setScale(scale, cursorPos);
+
+    // Update the intended scale based on the last intended scale, creating a continuous zoom feel
+    const newIntendedScale = this._intendedScale * this.config.SCALE_FACTOR ** delta;
+    this._intendedScale = this.constrainScale(newIntendedScale);
+
+    // Pass control to the snapping logic
+    this._updateScaleWithSnapping(cursorPos);
+
+    this._snapTimeout = window.setTimeout(() => {
+      // After a short delay, we can reset the intended scale to the current scale
+      // This allows for continuous zooming without snapping back to the last snapped scale
+      this._intendedScale = this.getScale();
+    }, 100);
+  };
+
+  /**
+   * Implements "sticky" snap logic.
+   * - If not snapped, checks if the intended scale is close enough to a snap point to engage the snap.
+   * - If snapped, checks if the intended scale has moved far enough away to break the snap.
+   * - Applies the resulting scale to the stage.
+   */
+  private _updateScaleWithSnapping = (center: Coordinate) => {
+    // If we are currently snapped, check if we should break out
+    if (this._activeSnapPoint !== null) {
+      const threshold = this._activeSnapPoint * this.config.SCALE_SNAP_TOLERANCE;
+      if (Math.abs(this._intendedScale - this._activeSnapPoint) > threshold) {
+        // User has scrolled far enough to break the snap
+        this._activeSnapPoint = null;
+        this._applyScale(this._intendedScale, center);
+      }
+      // Else, do nothing - we remain snapped at the current scale, creating a "dead zone"
+      return;
+    }
+
+    // If we are not snapped, check if we should snap to a point
+    for (const snapPoint of this.config.SCALE_SNAP_POINTS) {
+      const threshold = snapPoint * this.config.SCALE_SNAP_TOLERANCE;
+      if (Math.abs(this._intendedScale - snapPoint) < threshold) {
+        // Engage the snap
+        this._activeSnapPoint = snapPoint;
+        this._applyScale(snapPoint, center);
+        return;
+      }
+    }
+
+    // If we are not snapping and not breaking a snap, just update to the intended scale
+    this._applyScale(this._intendedScale, center);
   };
 
   onStagePointerDown = (e: KonvaEventObject<PointerEvent>) => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -6,7 +6,7 @@ import type { Coordinate, Dimensions, Rect, StageAttrs } from 'features/controlL
 import Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
 import { clamp } from 'lodash-es';
-import { atom } from 'nanostores';
+import { atom, computed } from 'nanostores';
 import type { Logger } from 'roarr';
 
 type CanvasStageModuleConfig = {
@@ -65,6 +65,7 @@ export class CanvasStageModule extends CanvasModuleBase {
     height: 0,
     scale: 0,
   });
+  $scale = computed(this.$stageAttrs, (attrs) => attrs.scale);
 
   subscriptions = new Set<() => void>();
   resizeObserver: ResizeObserver | null = null;


### PR DESCRIPTION
## Summary

Revised scale snapping on canvas.

Tracks the "intended" scale separately from "effective" scale to allow for snapping that does not inadvertently lock the scale to snap points, as described in #8048.

Also removed a couple constraints that were causing some jank:
- Canvas Scale is no longer rounded, allowing the scaling on touchpads to be smoother and get "stuck" less
- Canvas Position is no longer rounded, preventing the drift of canvas position while scaling in and out

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
