### PR TITLE
Fix: "Preserve Masked Region" for new mask compositing

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addInpaint.ts
@@ -69,10 +69,16 @@ export const addInpaint = async ({
   // Create a composite noise mask if we have any adapters with noise settings
   let noiseMaskImage: ImageDTO | null = null;
   if (noiseMaskAdapters.length > 0) {
-    noiseMaskImage = await manager.compositor.getGrayscaleMaskCompositeImageDTO(noiseMaskAdapters, rect, 'noiseLevel', {
-      is_intermediate: true,
-      silent: true,
-    });
+    noiseMaskImage = await manager.compositor.getGrayscaleMaskCompositeImageDTO(
+      noiseMaskAdapters,
+      rect,
+      'noiseLevel',
+      canvasSettings.preserveMask,
+      {
+        is_intermediate: true,
+        silent: true,
+      }
+    );
   }
 
   // Create a composite denoise limit mask
@@ -80,6 +86,7 @@ export const addInpaint = async ({
     inpaintMaskAdapters, // denoise limit defaults to 1 for masks that don't have it
     rect,
     'denoiseLimit',
+    canvasSettings.preserveMask,
     {
       is_intermediate: true,
       silent: true,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/addOutpaint.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/addOutpaint.ts
@@ -72,10 +72,16 @@ export const addOutpaint = async ({
   // Create a composite noise mask if we have any adapters with noise settings
   let noiseMaskImage: ImageDTO | null = null;
   if (noiseMaskAdapters.length > 0) {
-    noiseMaskImage = await manager.compositor.getGrayscaleMaskCompositeImageDTO(noiseMaskAdapters, rect, 'noiseLevel', {
-      is_intermediate: true,
-      silent: true,
-    });
+    noiseMaskImage = await manager.compositor.getGrayscaleMaskCompositeImageDTO(
+      noiseMaskAdapters,
+      rect,
+      'noiseLevel',
+      canvasSettings.preserveMask,
+      {
+        is_intermediate: true,
+        silent: true,
+      }
+    );
   }
 
   // Create a composite denoise limit mask
@@ -83,6 +89,7 @@ export const addOutpaint = async ({
     inpaintMaskAdapters, // denoise limit defaults to 1 for masks that don't have it
     rect,
     'denoiseLimit',
+    canvasSettings.preserveMask,
     {
       is_intermediate: true,
       silent: true,


### PR DESCRIPTION
## Summary

Broken in #8035 because mask inversion was previously handled by the alpha-to-mask node which is no longer used. 

Now addInpaint and addOutpaint will pass `canvasSettings.preserveMask`, and compositing includes this boolean in the caching.

## Merge Plan

ready to merge

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
