### PR TITLE
(Fix)(app) Delay Imports that require torch for app launch

### DIFF
--- a/invokeai/app/run_app.py
+++ b/invokeai/app/run_app.py
@@ -32,9 +32,9 @@ def run_app() -> None:
         configure_torch_cuda_allocator(app_config.pytorch_cuda_alloc_conf, logger)
 
     # This import must happen after configure_torch_cuda_allocator() is called, because the module imports torch.
-    from invokeai.backend.util.devices import TorchDevice
     from invokeai.app.invocations.baseinvocation import InvocationRegistry
     from invokeai.app.invocations.load_custom_nodes import load_custom_nodes
+    from invokeai.backend.util.devices import TorchDevice
 
     torch_device_name = TorchDevice.get_torch_device_name()
     logger.info(f"Using torch device: {torch_device_name}")

--- a/invokeai/app/run_app.py
+++ b/invokeai/app/run_app.py
@@ -17,8 +17,6 @@ def run_app() -> None:
 
     import uvicorn
 
-    from invokeai.app.invocations.baseinvocation import InvocationRegistry
-    from invokeai.app.invocations.load_custom_nodes import load_custom_nodes
     from invokeai.app.services.config.config_default import get_config
     from invokeai.app.util.torch_cuda_allocator import configure_torch_cuda_allocator
     from invokeai.backend.util.logging import InvokeAILogger
@@ -35,6 +33,8 @@ def run_app() -> None:
 
     # This import must happen after configure_torch_cuda_allocator() is called, because the module imports torch.
     from invokeai.backend.util.devices import TorchDevice
+    from invokeai.app.invocations.baseinvocation import InvocationRegistry
+    from invokeai.app.invocations.load_custom_nodes import load_custom_nodes
 
     torch_device_name = TorchDevice.get_torch_device_name()
     logger.info(f"Using torch device: {torch_device_name}")


### PR DESCRIPTION
## Summary

Fix for `RuntimeError: configure_torch_cuda_allocator() must be called before importing torch.` on app start

## Related Issues / Discussions

```
Traceback (most recent call last):
  File "D:\InvokeMain\InvokeAI\scripts\invokeai-web.py", line 20, in <module>
    main()
  File "D:\InvokeMain\InvokeAI\scripts\invokeai-web.py", line 16, in main
    run_app()
  File "D:\InvokeMain\InvokeAI\invokeai\app\run_app.py", line 33, in run_app
    configure_torch_cuda_allocator(app_config.pytorch_cuda_alloc_conf, logger)
  File "D:\InvokeMain\InvokeAI\invokeai\app\util\torch_cuda_allocator.py", line 13, in configure_torch_cuda_allocator
    raise RuntimeError("configure_torch_cuda_allocator() must be called before importing torch.")
RuntimeError: configure_torch_cuda_allocator() must be called before importing torch.
```


- [X] _The PR has a short but descriptive title, suitable for a changelog_

