### PR TITLE
feat(ui): canvas stage, zoom, and fit improvements

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasBusySpinner.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasBusySpinner.tsx
@@ -18,8 +18,9 @@ export const CanvasBusySpinner = memo(() => {
   );
   const isPendingRectCalculation = useStore($isPendingRectCalculation);
   const isRasterizing = useStore(canvasManager.stateApi.$isRasterizing);
+  const isCompositing = useStore(canvasManager.compositor.$isBusy);
 
-  if (isRasterizing || isPendingRectCalculation) {
+  if (isRasterizing || isCompositing || isPendingRectCalculation) {
     return <Spinner opacity={0.3} />;
   }
   return null;

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasBusySpinner.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasBusySpinner.tsx
@@ -1,0 +1,27 @@
+import { Spinner } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
+import { useAllEntityAdapters } from 'features/controlLayers/contexts/EntityAdapterContext';
+import { computed } from 'nanostores';
+import { memo, useMemo } from 'react';
+
+export const CanvasBusySpinner = memo(() => {
+  const canvasManager = useCanvasManager();
+  const allEntityAdapters = useAllEntityAdapters();
+  const $isPendingRectCalculation = useMemo(
+    () =>
+      computed(
+        allEntityAdapters.map(({ transformer }) => transformer.$isPendingRectCalculation),
+        (...values) => values.some((v) => v)
+      ),
+    [allEntityAdapters]
+  );
+  const isPendingRectCalculation = useStore($isPendingRectCalculation);
+  const isRasterizing = useStore(canvasManager.stateApi.$isRasterizing);
+
+  if (isRasterizing || isPendingRectCalculation) {
+    return <Spinner opacity={0.3} />;
+  }
+  return null;
+});
+CanvasBusySpinner.displayName = 'CanvasBusySpinner';

--- a/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/CanvasMainPanelContent.tsx
@@ -12,6 +12,7 @@ import { FocusRegionWrapper } from 'common/components/FocusRegionWrapper';
 import { CanvasAlertsPreserveMask } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsPreserveMask';
 import { CanvasAlertsSelectedEntityStatus } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsSelectedEntityStatus';
 import { CanvasAlertsSendingToGallery } from 'features/controlLayers/components/CanvasAlerts/CanvasAlertsSendingTo';
+import { CanvasBusySpinner } from 'features/controlLayers/components/CanvasBusySpinner';
 import { CanvasContextMenuGlobalMenuItems } from 'features/controlLayers/components/CanvasContextMenu/CanvasContextMenuGlobalMenuItems';
 import { CanvasContextMenuSelectedEntityMenuItems } from 'features/controlLayers/components/CanvasContextMenu/CanvasContextMenuSelectedEntityMenuItems';
 import { CanvasDropArea } from 'features/controlLayers/components/CanvasDropArea';
@@ -105,6 +106,9 @@ export const CanvasMainPanelContent = memo(() => {
                     <MenuButton as={IconButton} icon={<PiDotsThreeOutlineVerticalFill />} colorScheme="base" />
                     <MenuContent />
                   </Menu>
+                </Flex>
+                <Flex position="absolute" bottom={4} insetInlineEnd={4}>
+                  <CanvasBusySpinner />
                 </Flex>
               </CanvasManagerProviderGate>
             </Flex>

--- a/invokeai/frontend/web/src/features/controlLayers/contexts/EntityAdapterContext.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/contexts/EntityAdapterContext.tsx
@@ -168,3 +168,33 @@ export const useEntityAdapter = (
   assert(adapter, 'useEntityAdapter must be used within a EntityAdapterContext');
   return adapter;
 };
+
+export const useAllEntityAdapters = () => {
+  const canvasManager = useCanvasManager();
+  const regionalGuidanceAdapters = useSyncExternalStore(
+    canvasManager.adapters.regionMasks.subscribe,
+    canvasManager.adapters.regionMasks.getSnapshot
+  );
+  const rasterLayerAdapters = useSyncExternalStore(
+    canvasManager.adapters.rasterLayers.subscribe,
+    canvasManager.adapters.rasterLayers.getSnapshot
+  );
+  const controlLayerAdapters = useSyncExternalStore(
+    canvasManager.adapters.controlLayers.subscribe,
+    canvasManager.adapters.controlLayers.getSnapshot
+  );
+  const inpaintMaskAdapters = useSyncExternalStore(
+    canvasManager.adapters.inpaintMasks.subscribe,
+    canvasManager.adapters.inpaintMasks.getSnapshot
+  );
+  const allEntityAdapters = useMemo(() => {
+    return [
+      ...Array.from(rasterLayerAdapters.values()),
+      ...Array.from(controlLayerAdapters.values()),
+      ...Array.from(inpaintMaskAdapters.values()),
+      ...Array.from(regionalGuidanceAdapters.values()),
+    ];
+  }, [controlLayerAdapters, inpaintMaskAdapters, rasterLayerAdapters, regionalGuidanceAdapters]);
+
+  return allEntityAdapters;
+};

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityAdapterBase.ts
@@ -24,12 +24,13 @@ import {
   selectCanvasSlice,
   selectEntity,
 } from 'features/controlLayers/store/selectors';
-import {
-  type CanvasEntityIdentifier,
-  type CanvasRenderableEntityState,
-  isRasterLayerEntityIdentifier,
-  type Rect,
+import type {
+  CanvasEntityIdentifier,
+  CanvasRenderableEntityState,
+  LifecycleCallback,
+  Rect,
 } from 'features/controlLayers/store/types';
+import { isRasterLayerEntityIdentifier } from 'features/controlLayers/store/types';
 import { toast } from 'features/toast/toast';
 import Konva from 'konva';
 import { atom } from 'nanostores';
@@ -39,11 +40,6 @@ import type { ImageDTO } from 'services/api/types';
 import stableHash from 'stable-hash';
 import { assert } from 'tsafe';
 import type { Jsonifiable, JsonObject } from 'type-fest';
-
-// Ideally, we'd type `adapter` as `CanvasEntityAdapterBase`, but the generics make this tricky. `CanvasEntityAdapter`
-// is a union of all entity adapters and is functionally identical to `CanvasEntityAdapterBase`. We'll need to do a
-// type assertion below in the `onInit` method, which calls these callbacks.
-type InitCallback = (adapter: CanvasEntityAdapter) => Promise<boolean>;
 
 export abstract class CanvasEntityAdapterBase<
   T extends CanvasRenderableEntityState,
@@ -118,7 +114,7 @@ export abstract class CanvasEntityAdapterBase<
   /**
    * Callbacks that are executed when the module is initialized.
    */
-  private static initCallbacks = new Set<InitCallback>();
+  private static initCallbacks = new Set<LifecycleCallback>();
 
   /**
    * Register a callback to be run when an entity adapter is initialized.
@@ -165,7 +161,7 @@ export abstract class CanvasEntityAdapterBase<
    *   return false;
    * });
    */
-  static registerInitCallback = (callback: InitCallback) => {
+  static registerInitCallback = (callback: LifecycleCallback) => {
     const wrapped = async (adapter: CanvasEntityAdapter) => {
       const result = await callback(adapter);
       if (result) {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -1,7 +1,7 @@
 import type { Property } from 'csstype';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
 import { CanvasModuleBase } from 'features/controlLayers/konva/CanvasModuleBase';
-import { getKonvaNodeDebugAttrs, getPrefixedId } from 'features/controlLayers/konva/util';
+import { getKonvaNodeDebugAttrs, getPrefixedId, getRectUnion } from 'features/controlLayers/konva/util';
 import type { Coordinate, Dimensions, Rect, StageAttrs } from 'features/controlLayers/store/types';
 import Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
@@ -184,6 +184,18 @@ export class CanvasStageModule extends CanvasModuleBase {
       this.log.trace({ rect }, 'Fitting layers to stage');
       this.fitRect(rect);
     }
+  };
+
+  /**
+   * Fits the bbox and layers to the stage. The union of the bbox and the visible layers will be centered and scaled
+   * to fit the stage with some padding.
+   */
+  fitBboxAndLayersToStage = (): void => {
+    const layersRect = this.manager.compositor.getVisibleRectOfType();
+    const bboxRect = this.manager.stateApi.getBbox().rect;
+    const unionRect = getRectUnion(layersRect, bboxRect);
+    this.log.trace({ bboxRect, layersRect, unionRect }, 'Fitting bbox and layers to stage');
+    this.fitRect(unionRect);
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStageModule.ts
@@ -230,14 +230,23 @@ export class CanvasStageModule extends CanvasModuleBase {
     this._intendedScale = scale;
     this._activeSnapPoint = null;
 
-    this.konva.stage.setAttrs({
+    const tween = new Konva.Tween({
+      node: this.konva.stage,
+      duration: 0.15,
       x,
       y,
       scaleX: scale,
       scaleY: scale,
+      easing: Konva.Easings.EaseInOut,
+      onUpdate: () => {
+        this.syncStageAttrs();
+      },
+      onFinish: () => {
+        this.syncStageAttrs();
+        tween.destroy();
+      },
     });
-
-    this.syncStageAttrs({ x, y, scale });
+    tween.play();
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -1,3 +1,4 @@
+import type { CanvasEntityAdapter } from 'features/controlLayers/konva/CanvasEntity/types';
 import { fetchModelConfigByIdentifier } from 'features/metadata/util/modelFetchingHelpers';
 import { zMainModelBase, zModelIdentifierField } from 'features/nodes/types/common';
 import type { ParameterLoRAModel } from 'features/parameters/types/parameterSchemas';
@@ -611,3 +612,7 @@ export const isMaskEntityIdentifier = (
 ): entityIdentifier is CanvasEntityIdentifier<'inpaint_mask' | 'regional_guidance'> => {
   return isInpaintMaskEntityIdentifier(entityIdentifier) || isRegionalGuidanceEntityIdentifier(entityIdentifier);
 };
+
+// Ideally, we'd type `adapter` as `CanvasEntityAdapterBase`, but the generics make this tricky. `CanvasEntityAdapter`
+// is a union of all entity adapters and is functionally identical to `CanvasEntityAdapterBase`.
+export type LifecycleCallback = (adapter: CanvasEntityAdapter) => Promise<boolean>;

--- a/invokeai/frontend/web/src/features/imageActions/actions.ts
+++ b/invokeai/frontend/web/src/features/imageActions/actions.ts
@@ -173,14 +173,11 @@ export const newCanvasFromImage = async (arg: {
     imageObject = imageDTOToImageObject(imageDTO);
   }
 
-  const { x, y } = selectBboxRect(state);
-
   switch (type) {
     case 'raster_layer': {
       const overrides = {
         id: getPrefixedId('raster_layer'),
         objects: [imageObject],
-        position: { x, y },
       } satisfies Partial<CanvasRasterLayerState>;
       dispatch(canvasReset());
       // The `bboxChangedFromCanvas` reducer does no validation! Careful!
@@ -192,7 +189,6 @@ export const newCanvasFromImage = async (arg: {
       const overrides = {
         id: getPrefixedId('control_layer'),
         objects: [imageObject],
-        position: { x, y },
         controlAdapter: deepClone(initialControlNet),
       } satisfies Partial<CanvasControlLayerState>;
       dispatch(canvasReset());
@@ -205,7 +201,6 @@ export const newCanvasFromImage = async (arg: {
       const overrides = {
         id: getPrefixedId('inpaint_mask'),
         objects: [imageObject],
-        position: { x, y },
       } satisfies Partial<CanvasInpaintMaskState>;
       dispatch(canvasReset());
       // The `bboxChangedFromCanvas` reducer does no validation! Careful!
@@ -217,7 +212,6 @@ export const newCanvasFromImage = async (arg: {
       const overrides = {
         id: getPrefixedId('regional_guidance'),
         objects: [imageObject],
-        position: { x, y },
       } satisfies Partial<CanvasRegionalGuidanceState>;
       dispatch(canvasReset());
       // The `bboxChangedFromCanvas` reducer does no validation! Careful!


### PR DESCRIPTION
## Summary

- Fix issue where creating a new canvas from an image using one of the pictured buttons can result in the new layer being offset from the bbox, if the bbox had previously been moved.

![image](https://github.com/user-attachments/assets/af567521-c7d3-4e9f-b3b5-55cdf2c44159)

- Fix issue where canvas isn't always centered and zoomed correctly when creating new canvas from an image
- Add a spinner that renders when the canvas is busy rasterizing, compositing (the pause between clicking Invoke and the graph getting queued) or calculating the bbox rect. Just a subtle hint that "we are doing something right now, don't be alarmed that nothing is happening"
- Add quick animation when fitting canvas view to make it less jarring

## Related Issues / Discussions

Reported somewhere in discord. I think the two issues have existed for a long time and are not new.

## QA Instructions

Demo of new behaviours:

https://github.com/user-attachments/assets/c6943e78-2a4b-428b-82d0-9fa5e2cb2715

Note:
- Spinner in bottom right corner while we are calculating the bbox (same spinner shows during other operatiosn as described above)
- Things are centered and zoomed correctly when creating new layer
- Tweened position and scale when fitting

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
