### PR TITLE
Make image creation dates searchable in the gallery

### DIFF
--- a/invokeai/app/services/image_records/image_records_sqlite.py
+++ b/invokeai/app/services/image_records/image_records_sqlite.py
@@ -196,8 +196,12 @@ class SqliteImageRecordStorage(ImageRecordStorageBase):
         # Search term condition
         if search_term:
             query_conditions += """--sql
-            AND images.metadata LIKE ?
+            AND (
+                images.metadata LIKE ?
+                OR images.created_at LIKE ?
+            )
             """
+            query_params.append(f"%{search_term.lower()}%")
             query_params.append(f"%{search_term.lower()}%")
 
         if starred_first:


### PR DESCRIPTION
## Summary

This includes the `created_at` field in the gallery search. It does not do any smart parsing or before/after limits, but the user can follow the formatting in the Image Details viewer.

## QA Instructions

![image](https://github.com/user-attachments/assets/bb707de0-6758-4e62-bc27-8ea07d57ca0f)

## Merge Plan

Shouldn't interfere with anything, and I'm pretty sure the impact on the search time is negligible. 

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
