### PR TITLE
perf(app): reduce peak memory usage

### DIFF
--- a/invokeai/app/invocations/compel.py
+++ b/invokeai/app/invocations/compel.py
@@ -114,6 +114,13 @@ class CompelInvocation(BaseInvocation):
 
             c, _options = compel.build_conditioning_tensor_for_conjunction(conjunction)
 
+        del compel
+        del patched_tokenizer
+        del tokenizer
+        del ti_manager
+        del text_encoder
+        del text_encoder_info
+
         c = c.detach().to("cpu")
 
         conditioning_data = ConditioningFieldData(conditionings=[BasicConditioningInfo(embeds=c)])
@@ -222,7 +229,10 @@ class SDXLPromptInvocationBase:
             else:
                 c_pooled = None
 
+        del compel
+        del patched_tokenizer
         del tokenizer
+        del ti_manager
         del text_encoder
         del text_encoder_info
 

--- a/invokeai/backend/model_patcher.py
+++ b/invokeai/backend/model_patcher.py
@@ -46,6 +46,10 @@ class ModelPatcher:
         text_encoder: Union[CLIPTextModel, CLIPTextModelWithProjection],
         ti_list: List[Tuple[str, TextualInversionModelRaw]],
     ) -> Iterator[Tuple[CLIPTokenizer, TextualInversionManager]]:
+        if len(ti_list) == 0:
+            yield tokenizer, TextualInversionManager(tokenizer)
+            return
+
         init_tokens_count = None
         new_tokens_added = None
 


### PR DESCRIPTION
## Summary

Reduce peak memory usage by Invoke process. See commits for details.

TL;DR: We thought we had a memory leak. Not sure about that. I think we may just have a slowly climbing memory usage that eventually peaks and plateaus. Before we plateau, it looks like we have a memory leak.

Once the process allocates memory from the OS, it can never give it back, but it can re-use it. So the apparent memory leak is actually internal poor management of allocations, stemming frmo our usage patterns

### Changes

- `del` patched tokenizer and related objects in compel nodes so python can free up the arenas used by them
- Skip TI patching logic when there are no TIs to patch
- GC before each queue item

### Results

Sampled process memory usage after each queue item (SDXL t2i nothing extra). First column is memory at that time, second is delta from prev sample. Invocation cache is disabled for the testing bc that would really confound the results.

Top graph is usage, bottom is delta.
 
<img width="951" alt="image" src="https://github.com/user-attachments/assets/b8527101-bfc8-47c3-892c-4f09474b9a32" />

<img width="950" alt="image" src="https://github.com/user-attachments/assets/58acb824-9f09-4ee0-a67e-11b276c5d7f1" />

Notes
- Before the improvements, it takes ~100 queue items for mem to plateau. So for this test, if you didn't know any better, you'd think we have a memory leak unless you waited for the ~100 gens
- After the improvements, it takes ~15 queue items for mem to plateau.
- Plateau is ~900 MB greater without the fixes
- Before the fixes we are seeing ~20 to 30 mb increase per queue item
- We have some some caching internally - images, latents, conditioning tensors are all lru-cached. This contributes to the memory usage. I tried with these disabled and it reduced time to plateau bit a little bit.
- Even with the fixes, and the same graphs being executed, we sometimes need to allocate more memory. That's OK. It's the initial rapid climb that we want to reduce as much as possible. 

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
