### PR TITLE
fix: opencv dependency conflict

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
@@ -19,6 +19,7 @@ type Props = {
   withDownload?: boolean;
   withCopy?: boolean;
   extraCopyActions?: { label: string; getData: (data: unknown) => unknown }[];
+  wrapData?: boolean;
 } & FlexProps;
 
 const overlayscrollbarsOptions = getOverlayScrollbarsParams({
@@ -29,7 +30,16 @@ const overlayscrollbarsOptions = getOverlayScrollbarsParams({
 const ChakraPre = chakra('pre');
 
 const DataViewer = (props: Props) => {
-  const { label, data, fileName, withDownload = true, withCopy = true, extraCopyActions, ...rest } = props;
+  const {
+    label,
+    data,
+    fileName,
+    withDownload = true,
+    withCopy = true,
+    extraCopyActions,
+    wrapData = true,
+    ...rest
+  } = props;
   const dataString = useMemo(() => (isString(data) ? data : formatter.Serialize(data)) ?? '', [data]);
   const shift = useShiftModifier();
   const clipboard = useClipboard();
@@ -53,7 +63,7 @@ const DataViewer = (props: Props) => {
     <Flex bg="base.800" borderRadius="base" flexGrow={1} w="full" h="full" position="relative" {...rest}>
       <Box position="absolute" top={0} left={0} right={0} bottom={0} overflow="auto" p={2} fontSize="sm">
         <OverlayScrollbarsComponent defer style={overlayScrollbarsStyles} options={overlayscrollbarsOptions}>
-          <ChakraPre whiteSpace="pre-wrap">{dataString}</ChakraPre>
+          <ChakraPre whiteSpace={wrapData ? 'pre-wrap' : undefined}>{dataString}</ChakraPre>
         </OverlayScrollbarsComponent>
       </Box>
       <Flex position="absolute" top={0} insetInlineEnd={0} p={2}>

--- a/invokeai/frontend/web/src/features/system/components/AboutModal/AboutModal.tsx
+++ b/invokeai/frontend/web/src/features/system/components/AboutModal/AboutModal.tsx
@@ -58,7 +58,7 @@ const AboutModal = ({ children }: AboutModalProps) => {
       {cloneElement(children, {
         onClick: onOpen,
       })}
-      <Modal isOpen={isOpen} onClose={onClose} isCentered size="2xl" useInert={false}>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered size="5xl" useInert={false}>
         <ModalOverlay />
         <ModalContent maxH="80vh" h="34rem">
           <ModalHeader>{t('accessibility.about')}</ModalHeader>
@@ -66,7 +66,7 @@ const AboutModal = ({ children }: AboutModalProps) => {
           <ModalBody display="flex" flexDir="column" gap={4}>
             <Grid templateColumns="repeat(2, 1fr)" h="full">
               <GridItem backgroundColor="base.750" borderRadius="base" p="4" h="full">
-                <DataViewer label={t('common.systemInformation')} data={localData} />
+                <DataViewer label={t('common.systemInformation')} data={localData} wrapData={false} />
               </GridItem>
               <GridItem>
                 <Flex flexDir="column" gap={3} justifyContent="center" alignItems="center" h="full">

--- a/invokeai/frontend/web/src/services/api/endpoints/appInfo.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/appInfo.ts
@@ -1,7 +1,7 @@
 import { $openAPISchemaUrl } from 'app/store/nanostores/openAPISchemaUrl';
 import type { OpenAPIV3_1 } from 'openapi-types';
 import type { paths } from 'services/api/schema';
-import type { AppConfig, AppDependencyVersions, AppVersion } from 'services/api/types';
+import type { AppConfig, AppVersion } from 'services/api/types';
 
 import { api, buildV1Url } from '..';
 
@@ -22,7 +22,10 @@ export const appInfoApi = api.injectEndpoints({
       }),
       providesTags: ['FetchOnReconnect'],
     }),
-    getAppDeps: build.query<AppDependencyVersions, void>({
+    getAppDeps: build.query<
+      paths['/api/v1/app/app_deps']['get']['responses']['200']['content']['application/json'],
+      void
+    >({
       query: () => ({
         url: buildAppInfoUrl('app_deps'),
         method: 'GET',

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -1926,77 +1926,6 @@ export type components = {
             watermarking_methods: string[];
         };
         /**
-         * AppDependencyVersions
-         * @description App depencency Versions Response
-         */
-        AppDependencyVersions: {
-            /**
-             * Accelerate
-             * @description accelerate version
-             */
-            accelerate: string;
-            /**
-             * Compel
-             * @description compel version
-             */
-            compel: string;
-            /**
-             * Cuda
-             * @description CUDA version
-             */
-            cuda: string | null;
-            /**
-             * Diffusers
-             * @description diffusers version
-             */
-            diffusers: string;
-            /**
-             * Numpy
-             * @description Numpy version
-             */
-            numpy: string;
-            /**
-             * Opencv
-             * @description OpenCV version
-             */
-            opencv: string;
-            /**
-             * Onnx
-             * @description ONNX version
-             */
-            onnx: string;
-            /**
-             * Pillow
-             * @description Pillow (PIL) version
-             */
-            pillow: string;
-            /**
-             * Python
-             * @description Python version
-             */
-            python: string;
-            /**
-             * Torch
-             * @description PyTorch version
-             */
-            torch: string;
-            /**
-             * Torchvision
-             * @description PyTorch Vision version
-             */
-            torchvision: string;
-            /**
-             * Transformers
-             * @description transformers version
-             */
-            transformers: string;
-            /**
-             * Xformers
-             * @description xformers version
-             */
-            xformers: string | null;
-        };
-        /**
          * AppVersion
          * @description App Version Response
          */
@@ -24226,7 +24155,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AppDependencyVersions"];
+                    "application/json": {
+                        [key: string]: string;
+                    };
                 };
             };
         };

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -31,7 +31,6 @@ export type InvocationJSONSchemaExtra = S['UIConfigBase'];
 // App Info
 export type AppVersion = S['AppVersion'];
 export type AppConfig = S['AppConfig'];
-export type AppDependencyVersions = S['AppDependencyVersions'];
 
 // Images
 export type ImageDTO = S['ImageDTO'];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,12 @@ dependencies = [
   "humanize==4.12.1",
 ]
 
+[tool.uv]
+# Prevent opencv-python from ever being chosen during dependency resolution.
+# This prevents conflicts with opencv-contrib-python, which Invoke requires.
+override-dependencies = ["opencv-python; sys_platform=='never'"]
+
+
 [project.scripts]
 "invokeai-web" = "invokeai.app.run_app:run_app"
 


### PR DESCRIPTION
## Summary

[build: prevent opencv-python from being installed](https://github.com/invoke-ai/InvokeAI/commit/8d6eba887ce9a7e4663721a00c29fa9b66296dc0)

Fixes this error: `AttributeError: module 'cv2.ximgproc' has no attribute 'thinning'`

`opencv-contrib-python` supersedes `opencv-python`, providing the same API + additional features. The two packages should not be installed at the same time to avoid conflicts and/or errors.

The `invisible-watermark` package requires `opencv-python`, but we require the contrib variant.

This change updates `pyproject.toml` to prevent `opencv-python` from ever being installed using a `uv` features called dependency overrides.

---

Also update app dependency list endpoint to return _all_ dependencies. This indirectly fixes an issue where that endpoint would raise when attempting to get the version for something that is not installed (e.g. `opencv-python`). Could have just changed it to show `opencv-contrib-python` instead, but why not just show all deps. Better for troubleshooting.

## Related Issues / Discussions

Mentioned several times on discord but I didn't understand the issue until this thread w/ @joshistoast: https://discord.com/channels/1020123559063990373/1378131748856135811/1378131748856135811

## QA Instructions

`uv pip install -e .` _should_ fix it for manual installs and after updating via launcher to the next release version, should also be fixed.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
