### PR TITLE
Updated fracturedjsonjs to version 4.1.0 for friendlier comma placement

### DIFF
--- a/invokeai/frontend/web/package.json
+++ b/invokeai/frontend/web/package.json
@@ -68,7 +68,7 @@
     "cmdk": "^1.1.1",
     "compare-versions": "^6.1.1",
     "filesize": "^10.1.6",
-    "fracturedjsonjs": "^4.0.2",
+    "fracturedjsonjs": "^4.1.0",
     "framer-motion": "^11.10.0",
     "i18next": "^25.0.1",
     "i18next-http-backend": "^3.0.2",

--- a/invokeai/frontend/web/pnpm-lock.yaml
+++ b/invokeai/frontend/web/pnpm-lock.yaml
@@ -54,8 +54,8 @@ dependencies:
     specifier: ^10.1.6
     version: 10.1.6
   fracturedjsonjs:
-    specifier: ^4.0.2
-    version: 4.0.2
+    specifier: ^4.1.0
+    version: 4.1.0
   framer-motion:
     specifier: ^11.10.0
     version: 11.10.0(react-dom@18.3.1)(react@18.3.1)
@@ -5280,8 +5280,8 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /fracturedjsonjs@4.0.2:
-    resolution: {integrity: sha512-+vGJH9wK0EEhbbn50V2sOebLRaar1VL3EXr02kxchIwpkhQk0ItrPjIOtYPYuU9hNFpVzxjrPgzjtMJih+ae4A==}
+  /fracturedjsonjs@4.1.0:
+    resolution: {integrity: sha512-qy6LPA8OOiiyRHt5/sNKDayD7h5r3uHmHxSOLbBsgtU/hkt5vOVWOR51MdfDbeCNfj7k/dKCRbXYm8FBAJcgWQ==}
     dev: false
 
   /framer-motion@10.18.0(react-dom@18.3.1)(react@18.3.1):

--- a/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageMetadataViewer/DataViewer.tsx
@@ -2,7 +2,7 @@ import type { FlexProps } from '@invoke-ai/ui-library';
 import { Box, chakra, Flex, IconButton, Tooltip, useShiftModifier } from '@invoke-ai/ui-library';
 import { getOverlayScrollbarsParams } from 'common/components/OverlayScrollbars/constants';
 import { useClipboard } from 'common/hooks/useClipboard';
-import { Formatter } from 'fracturedjsonjs';
+import { Formatter, TableCommaPlacement } from 'fracturedjsonjs';
 import { isString } from 'lodash-es';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
 import type { CSSProperties } from 'react';
@@ -11,6 +11,8 @@ import { useTranslation } from 'react-i18next';
 import { PiCopyBold, PiDownloadSimpleBold } from 'react-icons/pi';
 
 const formatter = new Formatter();
+formatter.Options.TableCommaPlacement = TableCommaPlacement.BeforePadding;
+formatter.Options.OmitTrailingWhitespace = true;
 
 type Props = {
   label: string;


### PR DESCRIPTION
## Summary

The frontend metadata viewer uses fracturedjsonjs to format the JSON.  There are some cases where the commas look out of place and can cause unnecessary wrapping.  Updating to version 4.1.0 and setting two options fixes that.

## Related Issues / Discussions

Closes #8092 

## QA Instructions

Open an image in the viewer, click on the info icon, and select the metadata tab.  Look for the `model` property.  It should be an object whose values are all strings (at least, that's all I've seen).  If the code change worked, there should be no spaces between the strings' closing quotes and the commas that follow them.  (See issue #8092 for more clarification.)

## Merge Plan

N/A

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
