### PR TITLE
Flux Kontext UI support

### DIFF
--- a/invokeai/app/invocations/fields.py
+++ b/invokeai/app/invocations/fields.py
@@ -64,6 +64,7 @@ class UIType(str, Enum, metaclass=MetaEnum):
     Imagen3Model = "Imagen3ModelField"
     Imagen4Model = "Imagen4ModelField"
     ChatGPT4oModel = "ChatGPT4oModelField"
+    FluxKontextModel = "FluxKontextModelField"
     # endregion
 
     # region Misc Field Types

--- a/invokeai/backend/model_manager/taxonomy.py
+++ b/invokeai/backend/model_manager/taxonomy.py
@@ -29,6 +29,7 @@ class BaseModelType(str, Enum):
     Imagen3 = "imagen3"
     Imagen4 = "imagen4"
     ChatGPT4o = "chatgpt-4o"
+    FluxKontext = "flux-kontext"
 
 
 class ModelType(str, Enum):

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1147,6 +1147,7 @@
             "modelIncompatibleScaledBboxWidth": "Scaled bbox width is {{width}} but {{model}} requires multiple of {{multiple}}",
             "modelIncompatibleScaledBboxHeight": "Scaled bbox height is {{height}} but {{model}} requires multiple of {{multiple}}",
             "fluxModelMultipleControlLoRAs": "Can only use 1 Control LoRA at a time",
+            "fluxKontextMultipleReferenceImages": "Can only use 1 Reference Image at a time with Flux Kontext",
             "canvasIsFiltering": "Canvas is busy (filtering)",
             "canvasIsTransforming": "Canvas is busy (transforming)",
             "canvasIsRasterizing": "Canvas is busy (rasterizing)",
@@ -1337,6 +1338,7 @@
         "fluxFillIncompatibleWithT2IAndI2I": "FLUX Fill is not compatible with Text to Image or Image to Image. Use other FLUX models for these tasks.",
         "imagenIncompatibleGenerationMode": "Google {{model}} supports Text to Image only. Use other models for Image to Image, Inpainting and Outpainting tasks.",
         "chatGPT4oIncompatibleGenerationMode": "ChatGPT 4o supports Text to Image and Image to Image only. Use other models Inpainting and Outpainting tasks.",
+        "fluxKontextIncompatibleGenerationMode": "Flux Kontext supports Text to Image only. Use other models for Image to Image, Inpainting and Outpainting tasks.",
         "problemUnpublishingWorkflow": "Problem Unpublishing Workflow",
         "problemUnpublishingWorkflowDescription": "There was a problem unpublishing the workflow. Please try again.",
         "workflowUnpublished": "Workflow Unpublished"

--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedLinear.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/enqueueRequestedLinear.ts
@@ -10,6 +10,7 @@ import { prepareLinearUIBatch } from 'features/nodes/util/graph/buildLinearBatch
 import { buildChatGPT4oGraph } from 'features/nodes/util/graph/generation/buildChatGPT4oGraph';
 import { buildCogView4Graph } from 'features/nodes/util/graph/generation/buildCogView4Graph';
 import { buildFLUXGraph } from 'features/nodes/util/graph/generation/buildFLUXGraph';
+import { buildFluxKontextGraph } from 'features/nodes/util/graph/generation/buildFluxKontextGraph';
 import { buildImagen3Graph } from 'features/nodes/util/graph/generation/buildImagen3Graph';
 import { buildImagen4Graph } from 'features/nodes/util/graph/generation/buildImagen4Graph';
 import { buildSD1Graph } from 'features/nodes/util/graph/generation/buildSD1Graph';
@@ -59,6 +60,8 @@ export const addEnqueueRequestedLinear = (startAppListening: AppStartListening) 
             return await buildImagen4Graph(state, manager);
           case 'chatgpt-4o':
             return await buildChatGPT4oGraph(state, manager);
+          case 'flux-kontext':
+            return await buildFluxKontextGraph(state, manager);
           default:
             assert(false, `No graph builders for base ${base}`);
         }

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
@@ -29,6 +29,7 @@ import type {
 import {
   initialChatGPT4oReferenceImage,
   initialControlNet,
+  initialFluxKontextReferenceImage,
   initialIPAdapter,
   initialT2IAdapter,
 } from 'features/controlLayers/store/util';
@@ -81,8 +82,14 @@ export const selectDefaultRefImageConfig = createSelector(
   selectModelConfigsQuery,
   selectBase,
   (selectedMainModel, query, base): CanvasReferenceImageState['ipAdapter'] => {
-    if (selectedMainModel?.base === 'chatgpt-4o' || selectedMainModel?.base === 'flux-kontext') {
+    if (selectedMainModel?.base === 'chatgpt-4o') {
       const referenceImage = deepClone(initialChatGPT4oReferenceImage);
+      referenceImage.model = zModelIdentifierField.parse(selectedMainModel);
+      return referenceImage;
+    }
+
+    if (selectedMainModel?.base === 'flux-kontext') {
+      const referenceImage = deepClone(initialFluxKontextReferenceImage);
       referenceImage.model = zModelIdentifierField.parse(selectedMainModel);
       return referenceImage;
     }

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/addLayerHooks.ts
@@ -81,7 +81,7 @@ export const selectDefaultRefImageConfig = createSelector(
   selectModelConfigsQuery,
   selectBase,
   (selectedMainModel, query, base): CanvasReferenceImageState['ipAdapter'] => {
-    if (selectedMainModel?.base === 'chatgpt-4o') {
+    if (selectedMainModel?.base === 'chatgpt-4o' || selectedMainModel?.base === 'flux-kontext') {
       const referenceImage = deepClone(initialChatGPT4oReferenceImage);
       referenceImage.model = zModelIdentifierField.parse(selectedMainModel);
       return referenceImage;

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useIsEntityTypeEnabled.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useIsEntityTypeEnabled.ts
@@ -2,10 +2,12 @@ import { useAppSelector } from 'app/store/storeHooks';
 import {
   selectIsChatGTP4o,
   selectIsCogView4,
+  selectIsFluxKontext,
   selectIsImagen3,
   selectIsImagen4,
   selectIsSD3,
 } from 'features/controlLayers/store/paramsSlice';
+import { selectActiveReferenceImageEntities } from 'features/controlLayers/store/selectors';
 import type { CanvasEntityType } from 'features/controlLayers/store/types';
 import { useMemo } from 'react';
 import type { Equals } from 'tsafe';
@@ -17,23 +19,28 @@ export const useIsEntityTypeEnabled = (entityType: CanvasEntityType) => {
   const isImagen3 = useAppSelector(selectIsImagen3);
   const isImagen4 = useAppSelector(selectIsImagen4);
   const isChatGPT4o = useAppSelector(selectIsChatGTP4o);
+  const isFluxKontext = useAppSelector(selectIsFluxKontext);
+  const activeReferenceImageEntities = useAppSelector(selectActiveReferenceImageEntities);
 
   const isEntityTypeEnabled = useMemo<boolean>(() => {
     switch (entityType) {
       case 'reference_image':
+        if (isFluxKontext) {
+          return activeReferenceImageEntities.length === 0;
+        }
         return !isSD3 && !isCogView4 && !isImagen3 && !isImagen4;
       case 'regional_guidance':
-        return !isSD3 && !isCogView4 && !isImagen3 && !isImagen4 && !isChatGPT4o;
+        return !isSD3 && !isCogView4 && !isImagen3 && !isImagen4 && !isFluxKontext && !isChatGPT4o;
       case 'control_layer':
-        return !isSD3 && !isCogView4 && !isImagen3 && !isImagen4 && !isChatGPT4o;
+        return !isSD3 && !isCogView4 && !isImagen3 && !isImagen4 && !isFluxKontext && !isChatGPT4o;
       case 'inpaint_mask':
-        return !isImagen3 && !isImagen4 && !isChatGPT4o;
+        return !isImagen3 && !isImagen4 && !isFluxKontext && !isChatGPT4o;
       case 'raster_layer':
-        return !isImagen3 && !isImagen4 && !isChatGPT4o;
+        return !isImagen3 && !isImagen4 && !isFluxKontext && !isChatGPT4o;
       default:
         assert<Equals<typeof entityType, never>>(false);
     }
-  }, [entityType, isSD3, isCogView4, isImagen3, isImagen4, isChatGPT4o]);
+  }, [entityType, isSD3, isCogView4, isImagen3, isImagen4, isFluxKontext, isChatGPT4o, activeReferenceImageEntities]);
 
   return isEntityTypeEnabled;
 };

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -69,7 +69,13 @@ import type {
   IPMethodV2,
   T2IAdapterConfig,
 } from './types';
-import { getEntityIdentifier, isChatGPT4oAspectRatioID, isImagenAspectRatioID, isRenderableEntity } from './types';
+import {
+  getEntityIdentifier,
+  isChatGPT4oAspectRatioID,
+  isFluxKontextAspectRatioID,
+  isImagenAspectRatioID,
+  isRenderableEntity,
+} from './types';
 import {
   converters,
   getControlLayerState,
@@ -1330,6 +1336,26 @@ export const canvasSlice = createSlice({
         } else if (id === '2:3') {
           state.bbox.rect.width = 1024;
           state.bbox.rect.height = 1536;
+        }
+        state.bbox.aspectRatio.value = state.bbox.rect.width / state.bbox.rect.height;
+        state.bbox.aspectRatio.isLocked = true;
+      } else if (state.bbox.modelBase === 'flux-kontext' && isFluxKontextAspectRatioID(id)) {
+        // Flux Kontext has specific output sizes that are not exactly the same as the aspect ratio. Need special handling.
+        if (id === '1:1') {
+          state.bbox.rect.width = 1024;
+          state.bbox.rect.height = 1024;
+        } else if (id === '4:3') {
+          state.bbox.rect.width = 896;
+          state.bbox.rect.height = 1280;
+        } else if (id === '3:4') {
+          state.bbox.rect.width = 1280;
+          state.bbox.rect.height = 896;
+        } else if (id === '21:9') {
+          state.bbox.rect.width = 1408;
+          state.bbox.rect.height = 768;
+        } else if (id === '9:21') {
+          state.bbox.rect.width = 768;
+          state.bbox.rect.height = 1408;
         }
         state.bbox.aspectRatio.value = state.bbox.rect.width / state.bbox.rect.height;
         state.bbox.aspectRatio.isLocked = true;

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -81,6 +81,7 @@ import {
   initialChatGPT4oReferenceImage,
   initialControlLoRA,
   initialControlNet,
+  initialFluxKontextReferenceImage,
   initialFLUXRedux,
   initialIPAdapter,
   initialT2IAdapter,
@@ -680,6 +681,16 @@ export const canvasSlice = createSlice({
         // Switching to chatgpt-4o ref image
         entity.ipAdapter = {
           ...initialChatGPT4oReferenceImage,
+          image: entity.ipAdapter.image,
+          model: entity.ipAdapter.model,
+        };
+        return;
+      }
+
+      if (entity.ipAdapter.model.base === 'flux-kontext') {
+        // Switching to flux-kontext
+        entity.ipAdapter = {
+          ...initialFluxKontextReferenceImage,
           image: entity.ipAdapter.image,
           model: entity.ipAdapter.model,
         };

--- a/invokeai/frontend/web/src/features/controlLayers/store/paramsSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/paramsSlice.ts
@@ -383,6 +383,7 @@ export const selectIsCogView4 = createParamsSelector((params) => params.model?.b
 export const selectIsImagen3 = createParamsSelector((params) => params.model?.base === 'imagen3');
 export const selectIsImagen4 = createParamsSelector((params) => params.model?.base === 'imagen4');
 export const selectIsChatGTP4o = createParamsSelector((params) => params.model?.base === 'chatgpt-4o');
+export const selectIsFluxKontext = createParamsSelector((params) => params.model?.base === 'flux-kontext');
 
 export const selectModel = createParamsSelector((params) => params.model);
 export const selectModelKey = createParamsSelector((params) => params.model?.key);

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -258,6 +258,13 @@ const zChatGPT4oReferenceImageConfig = z.object({
 });
 export type ChatGPT4oReferenceImageConfig = z.infer<typeof zChatGPT4oReferenceImageConfig>;
 
+const zFluxKontextReferenceImageConfig = z.object({
+  type: z.literal('flux_kontext_reference_image'),
+  image: zImageWithDims.nullable(),
+  model: zServerValidatedModelIdentifierField.nullable(),
+});
+export type FluxKontextReferenceImageConfig = z.infer<typeof zFluxKontextReferenceImageConfig>;
+
 const zCanvasEntityBase = z.object({
   id: zId,
   name: zName,
@@ -268,7 +275,12 @@ const zCanvasEntityBase = z.object({
 const zCanvasReferenceImageState = zCanvasEntityBase.extend({
   type: z.literal('reference_image'),
   // This should be named `referenceImage` but we need to keep it as `ipAdapter` for backwards compatibility
-  ipAdapter: z.discriminatedUnion('type', [zIPAdapterConfig, zFLUXReduxConfig, zChatGPT4oReferenceImageConfig]),
+  ipAdapter: z.discriminatedUnion('type', [
+    zIPAdapterConfig,
+    zFLUXReduxConfig,
+    zChatGPT4oReferenceImageConfig,
+    zFluxKontextReferenceImageConfig,
+  ]),
 });
 export type CanvasReferenceImageState = z.infer<typeof zCanvasReferenceImageState>;
 
@@ -280,6 +292,9 @@ export const isFLUXReduxConfig = (config: CanvasReferenceImageState['ipAdapter']
 export const isChatGPT4oReferenceImageConfig = (
   config: CanvasReferenceImageState['ipAdapter']
 ): config is ChatGPT4oReferenceImageConfig => config.type === 'chatgpt_4o_reference_image';
+export const isFluxKontextReferenceImageConfig = (
+  config: CanvasReferenceImageState['ipAdapter']
+): config is FluxKontextReferenceImageConfig => config.type === 'flux_kontext_reference_image';
 
 const zFillStyle = z.enum(['solid', 'grid', 'crosshatch', 'diagonal', 'horizontal', 'vertical']);
 export type FillStyle = z.infer<typeof zFillStyle>;

--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -431,6 +431,10 @@ export const zChatGPT4oAspectRatioID = z.enum(['3:2', '1:1', '2:3']);
 export const isChatGPT4oAspectRatioID = (v: unknown): v is z.infer<typeof zChatGPT4oAspectRatioID> =>
   zChatGPT4oAspectRatioID.safeParse(v).success;
 
+export const zFluxKontextAspectRatioID = z.enum(['21:9', '4:3', '1:1', '3:4', '9:21']);
+export const isFluxKontextAspectRatioID = (v: unknown): v is z.infer<typeof zFluxKontextAspectRatioID> =>
+  zFluxKontextAspectRatioID.safeParse(v).success;
+
 export type AspectRatioID = z.infer<typeof zAspectRatioID>;
 export const isAspectRatioID = (v: unknown): v is AspectRatioID => zAspectRatioID.safeParse(v).success;
 

--- a/invokeai/frontend/web/src/features/controlLayers/store/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/util.ts
@@ -10,6 +10,7 @@ import type {
   ChatGPT4oReferenceImageConfig,
   ControlLoRAConfig,
   ControlNetConfig,
+  FluxKontextReferenceImageConfig,
   FLUXReduxConfig,
   ImageWithDims,
   IPAdapterConfig,
@@ -80,6 +81,11 @@ export const initialFLUXRedux: FLUXReduxConfig = {
 };
 export const initialChatGPT4oReferenceImage: ChatGPT4oReferenceImageConfig = {
   type: 'chatgpt_4o_reference_image',
+  image: null,
+  model: null,
+};
+export const initialFluxKontextReferenceImage: FluxKontextReferenceImageConfig = {
+  type: 'flux_kontext_reference_image',
   image: null,
   model: null,
 };

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelManagerPanel/ModelBaseBadge.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelManagerPanel/ModelBaseBadge.tsx
@@ -19,6 +19,7 @@ export const BASE_COLOR_MAP: Record<BaseModelType, string> = {
   imagen3: 'pink',
   imagen4: 'pink',
   'chatgpt-4o': 'pink',
+  'flux-kontext': 'pink',
 };
 
 const ModelBaseBadge = ({ base }: Props) => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldRenderer.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldRenderer.tsx
@@ -4,6 +4,7 @@ import { FloatFieldSlider } from 'features/nodes/components/flow/nodes/Invocatio
 import ChatGPT4oModelFieldInputComponent from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/ChatGPT4oModelFieldInputComponent';
 import { FloatFieldCollectionInputComponent } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/FloatFieldCollectionInputComponent';
 import { FloatGeneratorFieldInputComponent } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/FloatGeneratorFieldComponent';
+import FluxKontextModelFieldInputComponent from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/FluxKontextModelFieldInputComponent';
 import { ImageFieldCollectionInputComponent } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/ImageFieldCollectionInputComponent';
 import { ImageGeneratorFieldInputComponent } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/ImageGeneratorFieldComponent';
 import Imagen3ModelFieldInputComponent from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/Imagen3ModelFieldInputComponent';
@@ -50,6 +51,8 @@ import {
   isFloatFieldInputTemplate,
   isFloatGeneratorFieldInputInstance,
   isFloatGeneratorFieldInputTemplate,
+  isFluxKontextModelFieldInputInstance,
+  isFluxKontextModelFieldInputTemplate,
   isFluxMainModelFieldInputInstance,
   isFluxMainModelFieldInputTemplate,
   isFluxReduxModelFieldInputInstance,
@@ -415,6 +418,13 @@ export const InputFieldRenderer = memo(({ nodeId, fieldName, settings }: Props) 
       return null;
     }
     return <Imagen4ModelFieldInputComponent nodeId={nodeId} field={field} fieldTemplate={template} />;
+  }
+
+  if (isFluxKontextModelFieldInputTemplate(template)) {
+    if (!isFluxKontextModelFieldInputInstance(field)) {
+      return null;
+    }
+    return <FluxKontextModelFieldInputComponent nodeId={nodeId} field={field} fieldTemplate={template} />;
   }
 
   if (isChatGPT4oModelFieldInputTemplate(template)) {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/FluxKontextModelFieldInputComponent.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/FluxKontextModelFieldInputComponent.tsx
@@ -1,0 +1,49 @@
+import { useAppDispatch } from 'app/store/storeHooks';
+import { ModelFieldCombobox } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/ModelFieldCombobox';
+import { fieldFluxKontextModelValueChanged } from 'features/nodes/store/nodesSlice';
+import type {
+  FluxKontextModelFieldInputInstance,
+  FluxKontextModelFieldInputTemplate,
+} from 'features/nodes/types/field';
+import { memo, useCallback } from 'react';
+import { useFluxKontextModels } from 'services/api/hooks/modelsByType';
+import type { ApiModelConfig } from 'services/api/types';
+
+import type { FieldComponentProps } from './types';
+
+const FluxKontextModelFieldInputComponent = (
+  props: FieldComponentProps<FluxKontextModelFieldInputInstance, FluxKontextModelFieldInputTemplate>
+) => {
+  const { nodeId, field } = props;
+  const dispatch = useAppDispatch();
+
+  const [modelConfigs, { isLoading }] = useFluxKontextModels();
+
+  const onChange = useCallback(
+    (value: ApiModelConfig | null) => {
+      if (!value) {
+        return;
+      }
+      dispatch(
+        fieldFluxKontextModelValueChanged({
+          nodeId,
+          fieldName: field.name,
+          value,
+        })
+      );
+    },
+    [dispatch, field.name, nodeId]
+  );
+
+  return (
+    <ModelFieldCombobox
+      value={field.value}
+      modelConfigs={modelConfigs}
+      isLoadingConfigs={isLoading}
+      onChange={onChange}
+      required={props.fieldTemplate.required}
+    />
+  );
+};
+
+export default memo(FluxKontextModelFieldInputComponent);

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/publish.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/publish.ts
@@ -126,6 +126,7 @@ const NODE_TYPE_PUBLISH_DENYLIST = [
   'google_imagen4_generate',
   'chatgpt_create_image',
   'chatgpt_edit_image',
+  'flux_kontext_generate_image',
 ];
 
 export const selectHasUnpublishableNodes = createSelector(selectNodes, (nodes) => {

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -34,6 +34,7 @@ import type {
   FieldValue,
   FloatFieldValue,
   FloatGeneratorFieldValue,
+  FluxKontextModelFieldValue,
   FluxReduxModelFieldValue,
   FluxVAEModelFieldValue,
   ImageFieldCollectionValue,
@@ -75,6 +76,7 @@ import {
   zFloatFieldCollectionValue,
   zFloatFieldValue,
   zFloatGeneratorFieldValue,
+  zFluxKontextModelFieldValue,
   zFluxReduxModelFieldValue,
   zFluxVAEModelFieldValue,
   zImageFieldCollectionValue,
@@ -527,6 +529,9 @@ export const nodesSlice = createSlice({
     fieldChatGPT4oModelValueChanged: (state, action: FieldValueAction<ChatGPT4oModelFieldValue>) => {
       fieldValueReducer(state, action, zChatGPT4oModelFieldValue);
     },
+    fieldFluxKontextModelValueChanged: (state, action: FieldValueAction<FluxKontextModelFieldValue>) => {
+      fieldValueReducer(state, action, zFluxKontextModelFieldValue);
+    },
     fieldEnumModelValueChanged: (state, action: FieldValueAction<EnumFieldValue>) => {
       fieldValueReducer(state, action, zEnumFieldValue);
     },
@@ -697,6 +702,7 @@ export const {
   fieldImagen3ModelValueChanged,
   fieldImagen4ModelValueChanged,
   fieldChatGPT4oModelValueChanged,
+  fieldFluxKontextModelValueChanged,
   fieldFloatGeneratorValueChanged,
   fieldIntegerGeneratorValueChanged,
   fieldStringGeneratorValueChanged,

--- a/invokeai/frontend/web/src/features/nodes/types/common.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/common.ts
@@ -78,6 +78,7 @@ const zBaseModel = z.enum([
   'imagen3',
   'imagen4',
   'chatgpt-4o',
+  'flux-kontext',
 ]);
 export type BaseModelType = z.infer<typeof zBaseModel>;
 export const zMainModelBase = z.enum([
@@ -90,6 +91,7 @@ export const zMainModelBase = z.enum([
   'imagen3',
   'imagen4',
   'chatgpt-4o',
+  'flux-kontext',
 ]);
 export type MainModelBase = z.infer<typeof zMainModelBase>;
 export const isMainModelBase = (base: unknown): base is MainModelBase => zMainModelBase.safeParse(base).success;

--- a/invokeai/frontend/web/src/features/nodes/types/field.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/field.ts
@@ -260,6 +260,10 @@ const zChatGPT4oModelFieldType = zFieldTypeBase.extend({
   name: z.literal('ChatGPT4oModelField'),
   originalType: zStatelessFieldType.optional(),
 });
+const zFluxKontextModelFieldType = zFieldTypeBase.extend({
+  name: z.literal('FluxKontextModelField'),
+  originalType: zStatelessFieldType.optional(),
+});
 const zSchedulerFieldType = zFieldTypeBase.extend({
   name: z.literal('SchedulerField'),
   originalType: zStatelessFieldType.optional(),
@@ -313,6 +317,7 @@ const zStatefulFieldType = z.union([
   zImagen3ModelFieldType,
   zImagen4ModelFieldType,
   zChatGPT4oModelFieldType,
+  zFluxKontextModelFieldType,
   zColorFieldType,
   zSchedulerFieldType,
   zFloatGeneratorFieldType,
@@ -354,6 +359,7 @@ const modelFieldTypeNames = [
   zImagen3ModelFieldType.shape.name.value,
   zImagen4ModelFieldType.shape.name.value,
   zChatGPT4oModelFieldType.shape.name.value,
+  zFluxKontextModelFieldType.shape.name.value,
   // Stateless model fields
   'UNetField',
   'VAEField',
@@ -1231,6 +1237,24 @@ export const isImagen4ModelFieldInputTemplate =
   buildTemplateTypeGuard<Imagen4ModelFieldInputTemplate>('Imagen4ModelField');
 // #endregion
 
+// #region FluxKontextModelField
+export const zFluxKontextModelFieldValue = zModelIdentifierField.optional();
+const zFluxKontextModelFieldInputInstance = zFieldInputInstanceBase.extend({
+  value: zFluxKontextModelFieldValue,
+});
+const zFluxKontextModelFieldInputTemplate = zFieldInputTemplateBase.extend({
+  type: zFluxKontextModelFieldType,
+  originalType: zFieldType.optional(),
+  default: zFluxKontextModelFieldValue,
+});
+export type FluxKontextModelFieldValue = z.infer<typeof zFluxKontextModelFieldValue>;
+export type FluxKontextModelFieldInputInstance = z.infer<typeof zFluxKontextModelFieldInputInstance>;
+export type FluxKontextModelFieldInputTemplate = z.infer<typeof zFluxKontextModelFieldInputTemplate>;
+export const isFluxKontextModelFieldInputInstance = buildInstanceTypeGuard(zFluxKontextModelFieldInputInstance);
+export const isFluxKontextModelFieldInputTemplate =
+  buildTemplateTypeGuard<FluxKontextModelFieldInputTemplate>('FluxKontextModelField');
+// #endregion
+
 // #region ChatGPT4oModelField
 export const zChatGPT4oModelFieldValue = zModelIdentifierField.optional();
 const zChatGPT4oModelFieldInputInstance = zFieldInputInstanceBase.extend({
@@ -1882,6 +1906,7 @@ export const zStatefulFieldValue = z.union([
   zFluxReduxModelFieldValue,
   zImagen3ModelFieldValue,
   zImagen4ModelFieldValue,
+  zFluxKontextModelFieldValue,
   zChatGPT4oModelFieldValue,
   zColorFieldValue,
   zSchedulerFieldValue,
@@ -1976,6 +2001,7 @@ const zStatefulFieldInputTemplate = z.union([
   zImagen3ModelFieldInputTemplate,
   zImagen4ModelFieldInputTemplate,
   zChatGPT4oModelFieldInputTemplate,
+  zFluxKontextModelFieldInputTemplate,
   zColorFieldInputTemplate,
   zSchedulerFieldInputTemplate,
   zStatelessFieldInputTemplate,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
@@ -1,0 +1,91 @@
+import { logger } from 'app/logging/logger';
+import type { RootState } from 'app/store/store';
+import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
+import { getPrefixedId } from 'features/controlLayers/konva/util';
+import { selectCanvasSettingsSlice } from 'features/controlLayers/store/canvasSettingsSlice';
+import { selectCanvasSlice } from 'features/controlLayers/store/selectors';
+import { isFluxKontextReferenceImageConfig } from 'features/controlLayers/store/types';
+import { getGlobalReferenceImageWarnings } from 'features/controlLayers/store/validators';
+import type { ImageField } from 'features/nodes/types/common';
+import { zModelIdentifierField } from 'features/nodes/types/common';
+import { Graph } from 'features/nodes/util/graph/generation/Graph';
+import {
+  CANVAS_OUTPUT_PREFIX,
+  getBoardField,
+  selectPresetModifiedPrompts,
+} from 'features/nodes/util/graph/graphBuilderUtils';
+import { type GraphBuilderReturn, UnsupportedGenerationModeError } from 'features/nodes/util/graph/types';
+import { t } from 'i18next';
+import { selectMainModelConfig } from 'services/api/endpoints/models';
+import type { Equals } from 'tsafe';
+import { assert } from 'tsafe';
+
+const log = logger('system');
+
+export const buildFluxKontextGraph = async (state: RootState, manager: CanvasManager): Promise<GraphBuilderReturn> => {
+  const generationMode = await manager.compositor.getGenerationMode();
+
+  if (generationMode !== 'txt2img') {
+    throw new UnsupportedGenerationModeError(t('toast.fluxKontextIncompatibleGenerationMode'));
+  }
+
+  log.debug({ generationMode }, 'Building Flux Kontext graph');
+
+  const model = selectMainModelConfig(state);
+
+  const canvas = selectCanvasSlice(state);
+  const canvasSettings = selectCanvasSettingsSlice(state);
+
+  const { bbox } = canvas;
+  const { positivePrompt } = selectPresetModifiedPrompts(state);
+
+  assert(model, 'No model found in state');
+  assert(model.base === 'flux-kontext', 'Model is not a Flux Kontext model');
+
+  const is_intermediate = canvasSettings.sendToCanvas;
+  const board = canvasSettings.sendToCanvas ? undefined : getBoardField(state);
+
+  const validRefImages = canvas.referenceImages.entities
+    .filter((entity) => entity.isEnabled)
+    .filter((entity) => isFluxKontextReferenceImageConfig(entity.ipAdapter))
+    .filter((entity) => getGlobalReferenceImageWarnings(entity, model).length === 0);
+
+  let input_image: ImageField | undefined = undefined;
+
+  if (validRefImages[0]) {
+    assert(validRefImages.length === 1, 'Flux Kontext can have at most one reference image');
+
+    assert(validRefImages[0].ipAdapter.image, 'Image is required for reference image');
+    input_image = {
+      image_name: validRefImages[0].ipAdapter.image.image_name,
+    };
+  }
+
+  if (generationMode === 'txt2img') {
+    const g = new Graph(getPrefixedId('flux_kontext_txt2img_graph'));
+    const fluxKontextImage = g.addNode({
+      // @ts-expect-error: These nodes are not available in the OSS application
+      type: 'flux_kontext_generate_image',
+      id: getPrefixedId(CANVAS_OUTPUT_PREFIX),
+      model: zModelIdentifierField.parse(model),
+      positive_prompt: positivePrompt,
+      aspect_ratio: bbox.aspectRatio.id,
+      use_cache: false,
+      is_intermediate,
+      board,
+      input_image,
+    });
+    g.upsertMetadata({
+      positive_prompt: positivePrompt,
+      model: Graph.getModelMetadataField(model),
+      width: bbox.rect.width,
+      height: bbox.rect.height,
+    });
+    return {
+      g,
+      positivePromptFieldIdentifier: { nodeId: fluxKontextImage.id, fieldName: 'positive_prompt' },
+    };
+  }
+
+  assert<Equals<typeof generationMode, never>>(false, 'Invalid generation mode for Flux Kontext');
+};

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
@@ -45,7 +45,6 @@ export const buildFluxKontextGraph = async (state: RootState, manager: CanvasMan
   const is_intermediate = canvasSettings.sendToCanvas;
   const board = canvasSettings.sendToCanvas ? undefined : getBoardField(state);
 
-
   const validRefImages = canvas.referenceImages.entities
     .filter((entity) => entity.isEnabled)
     .filter((entity) => isFluxKontextReferenceImageConfig(entity.ipAdapter))

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
@@ -45,6 +45,7 @@ export const buildFluxKontextGraph = async (state: RootState, manager: CanvasMan
   const is_intermediate = canvasSettings.sendToCanvas;
   const board = canvasSettings.sendToCanvas ? undefined : getBoardField(state);
 
+
   const validRefImages = canvas.referenceImages.entities
     .filter((entity) => entity.isEnabled)
     .filter((entity) => isFluxKontextReferenceImageConfig(entity.ipAdapter))
@@ -65,7 +66,7 @@ export const buildFluxKontextGraph = async (state: RootState, manager: CanvasMan
     const g = new Graph(getPrefixedId('flux_kontext_txt2img_graph'));
     const fluxKontextImage = g.addNode({
       // @ts-expect-error: These nodes are not available in the OSS application
-      type: 'flux_kontext_generate_image',
+      type: input_image ? 'flux_kontext_edit_image' : 'flux_kontext_generate_image',
       id: getPrefixedId(CANVAS_OUTPUT_PREFIX),
       model: zModelIdentifierField.parse(model),
       positive_prompt: positivePrompt,
@@ -74,6 +75,7 @@ export const buildFluxKontextGraph = async (state: RootState, manager: CanvasMan
       is_intermediate,
       board,
       input_image,
+      prompt_upsampling: true,
     });
     g.upsertMetadata({
       positive_prompt: positivePrompt,

--- a/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputInstance.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputInstance.ts
@@ -36,6 +36,7 @@ const FIELD_VALUE_FALLBACK_MAP: Record<StatefulFieldType['name'], FieldValue> = 
   Imagen3ModelField: undefined,
   Imagen4ModelField: undefined,
   ChatGPT4oModelField: undefined,
+  FluxKontextModelField: undefined,
   FloatGeneratorField: undefined,
   IntegerGeneratorField: undefined,
   StringGeneratorField: undefined,

--- a/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputTemplate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/schema/buildFieldInputTemplate.ts
@@ -16,6 +16,7 @@ import type {
   FloatFieldCollectionInputTemplate,
   FloatFieldInputTemplate,
   FloatGeneratorFieldInputTemplate,
+  FluxKontextModelFieldInputTemplate,
   FluxMainModelFieldInputTemplate,
   FluxReduxModelFieldInputTemplate,
   FluxVAEModelFieldInputTemplate,
@@ -613,6 +614,20 @@ const buildImagen4ModelFieldInputTemplate: FieldInputTemplateBuilder<Imagen4Mode
   };
   return template;
 };
+
+const buildFluxKontextModelFieldInputTemplate: FieldInputTemplateBuilder<FluxKontextModelFieldInputTemplate> = ({
+  schemaObject,
+  baseField,
+  fieldType,
+}) => {
+  const template: FluxKontextModelFieldInputTemplate = {
+    ...baseField,
+    type: fieldType,
+    default: schemaObject.default ?? undefined,
+  };
+  return template;
+};
+
 const buildChatGPT4oModelFieldInputTemplate: FieldInputTemplateBuilder<ChatGPT4oModelFieldInputTemplate> = ({
   schemaObject,
   baseField,
@@ -835,6 +850,7 @@ export const TEMPLATE_BUILDER_MAP: Record<StatefulFieldType['name'], FieldInputT
   Imagen3ModelField: buildImagen3ModelFieldInputTemplate,
   Imagen4ModelField: buildImagen4ModelFieldInputTemplate,
   ChatGPT4oModelField: buildChatGPT4oModelFieldInputTemplate,
+  FluxKontextModelField: buildFluxKontextModelFieldInputTemplate,
   FloatGeneratorField: buildFloatGeneratorFieldInputTemplate,
   IntegerGeneratorField: buildIntegerGeneratorFieldInputTemplate,
   StringGeneratorField: buildStringGeneratorFieldInputTemplate,

--- a/invokeai/frontend/web/src/features/parameters/components/Bbox/BboxAspectRatioSelect.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Bbox/BboxAspectRatioSelect.tsx
@@ -3,12 +3,18 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
 import { bboxAspectRatioIdChanged } from 'features/controlLayers/store/canvasSlice';
 import { selectIsStaging } from 'features/controlLayers/store/canvasStagingAreaSlice';
-import { selectIsChatGTP4o, selectIsImagen3, selectIsImagen4 } from 'features/controlLayers/store/paramsSlice';
+import {
+  selectIsChatGTP4o,
+  selectIsFluxKontext,
+  selectIsImagen3,
+  selectIsImagen4,
+} from 'features/controlLayers/store/paramsSlice';
 import { selectAspectRatioID } from 'features/controlLayers/store/selectors';
 import {
   isAspectRatioID,
   zAspectRatioID,
   zChatGPT4oAspectRatioID,
+  zFluxKontextAspectRatioID,
   zImagen3AspectRatioID,
 } from 'features/controlLayers/store/types';
 import type { ChangeEventHandler } from 'react';
@@ -24,6 +30,7 @@ export const BboxAspectRatioSelect = memo(() => {
   const isImagen3 = useAppSelector(selectIsImagen3);
   const isChatGPT4o = useAppSelector(selectIsChatGTP4o);
   const isImagen4 = useAppSelector(selectIsImagen4);
+  const isFluxKontext = useAppSelector(selectIsFluxKontext);
   const options = useMemo(() => {
     // Imagen3 and ChatGPT4o have different aspect ratio options, and do not support freeform sizes
     if (isImagen3 || isImagen4) {
@@ -32,9 +39,12 @@ export const BboxAspectRatioSelect = memo(() => {
     if (isChatGPT4o) {
       return zChatGPT4oAspectRatioID.options;
     }
+    if (isFluxKontext) {
+      return zFluxKontextAspectRatioID.options;
+    }
     // All other models
     return zAspectRatioID.options;
-  }, [isImagen3, isChatGPT4o, isImagen4]);
+  }, [isImagen3, isChatGPT4o, isImagen4, isFluxKontext]);
 
   const onChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
     (e) => {

--- a/invokeai/frontend/web/src/features/parameters/hooks/useIsApiModel.ts
+++ b/invokeai/frontend/web/src/features/parameters/hooks/useIsApiModel.ts
@@ -1,10 +1,16 @@
 import { useAppSelector } from 'app/store/storeHooks';
-import { selectIsChatGTP4o, selectIsImagen3, selectIsImagen4 } from 'features/controlLayers/store/paramsSlice';
+import {
+  selectIsChatGTP4o,
+  selectIsFluxKontext,
+  selectIsImagen3,
+  selectIsImagen4,
+} from 'features/controlLayers/store/paramsSlice';
 
 export const useIsApiModel = () => {
   const isImagen3 = useAppSelector(selectIsImagen3);
   const isImagen4 = useAppSelector(selectIsImagen4);
   const isChatGPT4o = useAppSelector(selectIsChatGTP4o);
+  const isFluxKontext = useAppSelector(selectIsFluxKontext);
 
-  return isImagen3 || isImagen4 || isChatGPT4o;
+  return isImagen3 || isImagen4 || isChatGPT4o || isFluxKontext;
 };

--- a/invokeai/frontend/web/src/features/parameters/types/constants.ts
+++ b/invokeai/frontend/web/src/features/parameters/types/constants.ts
@@ -16,6 +16,7 @@ export const MODEL_TYPE_MAP: Record<BaseModelType, string> = {
   imagen3: 'Imagen3',
   imagen4: 'Imagen4',
   'chatgpt-4o': 'ChatGPT 4o',
+  'flux-kontext': 'Flux Kontext',
 };
 
 /**
@@ -33,6 +34,7 @@ export const MODEL_TYPE_SHORT_MAP: Record<BaseModelType, string> = {
   imagen3: 'Imagen3',
   imagen4: 'Imagen4',
   'chatgpt-4o': 'ChatGPT 4o',
+  'flux-kontext': 'Flux Kontext',
 };
 
 /**
@@ -83,6 +85,10 @@ export const CLIP_SKIP_MAP: Record<BaseModelType, { maxClip: number; markers: nu
     maxClip: 0,
     markers: [],
   },
+  'flux-kontext': {
+    maxClip: 0,
+    markers: [],
+  },
 };
 
 /**
@@ -124,4 +130,4 @@ export const SCHEDULER_OPTIONS: ComboboxOption[] = [
 /**
  * List of base models that make API requests
  */
-export const API_BASE_MODELS = ['imagen3', 'imagen4', 'chatgpt-4o'];
+export const API_BASE_MODELS = ['imagen3', 'imagen4', 'chatgpt-4o', 'flux-kontext'];

--- a/invokeai/frontend/web/src/features/parameters/util/optimalDimension.ts
+++ b/invokeai/frontend/web/src/features/parameters/util/optimalDimension.ts
@@ -21,6 +21,7 @@ export const getOptimalDimension = (base?: BaseModelType | null): number => {
     case 'imagen3':
     case 'imagen4':
     case 'chatgpt-4o':
+    case 'flux-kontext':
     default:
       return 1024;
   }
@@ -81,6 +82,7 @@ export const getGridSize = (base?: BaseModelType | null): number => {
     case 'sdxl':
     case 'imagen3':
     case 'chatgpt-4o':
+    case 'flux-kontext':
     default:
       return 8;
   }

--- a/invokeai/frontend/web/src/features/queue/store/readiness.ts
+++ b/invokeai/frontend/web/src/features/queue/store/readiness.ts
@@ -516,6 +516,17 @@ const getReasonsWhyCannotEnqueueCanvasTab = (arg: {
     }
   });
 
+  const enabledGlobalReferenceLayers = canvas.referenceImages.entities.filter(
+    (referenceImage) => referenceImage.isEnabled
+  );
+
+  // Flux Kontext only supports 1x Reference Image at a time.
+  const referenceImageCount = enabledGlobalReferenceLayers.length;
+
+  if (model?.base === 'flux-kontext' && referenceImageCount > 1) {
+    reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
+  }
+
   canvas.referenceImages.entities
     .filter((entity) => entity.isEnabled)
     .forEach((entity, i) => {

--- a/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
+++ b/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
@@ -38,6 +38,7 @@ import {
   isVAEModelConfig,
 } from 'services/api/types';
 
+
 type ModelHookArgs = { excludeSubmodels?: boolean };
 
 const buildModelsHook =
@@ -86,7 +87,11 @@ export const useCLIPVisionModels = buildModelsHook(isCLIPVisionModelConfig);
 export const useSigLipModels = buildModelsHook(isSigLipModelConfig);
 export const useFluxReduxModels = buildModelsHook(isFluxReduxModelConfig);
 export const useGlobalReferenceImageModels = buildModelsHook(
-  (config) => isIPAdapterModelConfig(config) || isFluxReduxModelConfig(config) || isChatGPT4oModelConfig(config)
+  (config) =>
+    isIPAdapterModelConfig(config) ||
+    isFluxReduxModelConfig(config) ||
+    isChatGPT4oModelConfig(config) ||
+    isFluxKontextModelConfig(config)
 );
 export const useRegionalReferenceImageModels = buildModelsHook(
   (config) => isIPAdapterModelConfig(config) || isFluxReduxModelConfig(config)

--- a/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
+++ b/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
@@ -16,6 +16,7 @@ import {
   isControlLayerModelConfig,
   isControlLoRAModelConfig,
   isControlNetModelConfig,
+  isFluxKontextModelConfig,
   isFluxMainModelModelConfig,
   isFluxReduxModelConfig,
   isFluxVAEModelConfig,
@@ -94,6 +95,7 @@ export const useLLaVAModels = buildModelsHook(isLLaVAModelConfig);
 export const useImagen3Models = buildModelsHook(isImagen3ModelConfig);
 export const useImagen4Models = buildModelsHook(isImagen4ModelConfig);
 export const useChatGPT4oModels = buildModelsHook(isChatGPT4oModelConfig);
+export const useFluxKontextModels = buildModelsHook(isFluxKontextModelConfig);
 
 // const buildModelsSelector =
 //   <T extends AnyModelConfig>(typeGuard: (config: AnyModelConfig) => config is T): Selector<RootState, T[]> =>

--- a/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
+++ b/invokeai/frontend/web/src/services/api/hooks/modelsByType.ts
@@ -38,7 +38,6 @@ import {
   isVAEModelConfig,
 } from 'services/api/types';
 
-
 type ModelHookArgs = { excludeSubmodels?: boolean };
 
 const buildModelsHook =

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -1765,6 +1765,7 @@ export type components = {
              * type
              * @default add
              * @constant
+             * @enum {string}
              */
             type: "add";
         };
@@ -1805,6 +1806,7 @@ export type components = {
              * type
              * @default alpha_mask_to_tensor
              * @constant
+             * @enum {string}
              */
             type: "alpha_mask_to_tensor";
         };
@@ -1842,12 +1844,14 @@ export type components = {
              * Type
              * @default main
              * @constant
+             * @enum {string}
              */
             type: "main";
             /**
              * Format
              * @default api
              * @constant
+             * @enum {string}
              */
             format: "api";
             /** @description The base model. */
@@ -1995,6 +1999,7 @@ export type components = {
              * type
              * @default apply_tensor_mask_to_image
              * @constant
+             * @enum {string}
              */
             type: "apply_tensor_mask_to_image";
         };
@@ -2051,6 +2056,7 @@ export type components = {
              * type
              * @default apply_mask_to_image
              * @constant
+             * @enum {string}
              */
             type: "apply_mask_to_image";
         };
@@ -2075,7 +2081,7 @@ export type components = {
          * @description Base model type.
          * @enum {string}
          */
-        BaseModelType: "any" | "sd-1" | "sd-2" | "sd-3" | "sdxl" | "sdxl-refiner" | "flux" | "cogview4" | "imagen3" | "imagen4" | "chatgpt-4o";
+        BaseModelType: "any" | "sd-1" | "sd-2" | "sd-3" | "sdxl" | "sdxl-refiner" | "flux" | "cogview4" | "imagen3" | "imagen4" | "chatgpt-4o" | "flux-kontext";
         /** Batch */
         Batch: {
             /**
@@ -2287,6 +2293,7 @@ export type components = {
              * type
              * @default blank_image
              * @constant
+             * @enum {string}
              */
             type: "blank_image";
         };
@@ -2338,6 +2345,7 @@ export type components = {
              * type
              * @default lblend
              * @constant
+             * @enum {string}
              */
             type: "lblend";
         };
@@ -2715,6 +2723,7 @@ export type components = {
              * type
              * @default boolean_collection
              * @constant
+             * @enum {string}
              */
             type: "boolean_collection";
         };
@@ -2732,6 +2741,7 @@ export type components = {
              * type
              * @default boolean_collection_output
              * @constant
+             * @enum {string}
              */
             type: "boolean_collection_output";
         };
@@ -2767,6 +2777,7 @@ export type components = {
              * type
              * @default boolean
              * @constant
+             * @enum {string}
              */
             type: "boolean";
         };
@@ -2784,6 +2795,7 @@ export type components = {
              * type
              * @default boolean_output
              * @constant
+             * @enum {string}
              */
             type: "boolean_output";
         };
@@ -2801,6 +2813,7 @@ export type components = {
              * type
              * @default bounding_box_collection_output
              * @constant
+             * @enum {string}
              */
             type: "bounding_box_collection_output";
         };
@@ -2886,6 +2899,7 @@ export type components = {
              * type
              * @default bounding_box
              * @constant
+             * @enum {string}
              */
             type: "bounding_box";
         };
@@ -2900,6 +2914,7 @@ export type components = {
              * type
              * @default bounding_box_output
              * @constant
+             * @enum {string}
              */
             type: "bounding_box_output";
         };
@@ -3037,12 +3052,14 @@ export type components = {
              * Type
              * @default clip_embed
              * @constant
+             * @enum {string}
              */
             type: "clip_embed";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -3087,6 +3104,7 @@ export type components = {
              * Variant
              * @default gigantic
              * @constant
+             * @enum {string}
              */
             variant?: "gigantic";
         };
@@ -3124,12 +3142,14 @@ export type components = {
              * Type
              * @default clip_embed
              * @constant
+             * @enum {string}
              */
             type: "clip_embed";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -3174,6 +3194,7 @@ export type components = {
              * Variant
              * @default large
              * @constant
+             * @enum {string}
              */
             variant?: "large";
         };
@@ -3191,6 +3212,7 @@ export type components = {
              * type
              * @default clip_output
              * @constant
+             * @enum {string}
              */
             type: "clip_output";
         };
@@ -3232,6 +3254,7 @@ export type components = {
              * type
              * @default clip_skip
              * @constant
+             * @enum {string}
              */
             type: "clip_skip";
         };
@@ -3250,6 +3273,7 @@ export type components = {
              * type
              * @default clip_skip_output
              * @constant
+             * @enum {string}
              */
             type: "clip_skip_output";
         };
@@ -3287,12 +3311,14 @@ export type components = {
              * Type
              * @default clip_vision
              * @constant
+             * @enum {string}
              */
             type: "clip_vision";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -3375,6 +3401,7 @@ export type components = {
              * type
              * @default infill_cv2
              * @constant
+             * @enum {string}
              */
             type: "infill_cv2";
         };
@@ -3471,6 +3498,7 @@ export type components = {
              * type
              * @default calculate_image_tiles_even_split
              * @constant
+             * @enum {string}
              */
             type: "calculate_image_tiles_even_split";
         };
@@ -3530,6 +3558,7 @@ export type components = {
              * type
              * @default calculate_image_tiles
              * @constant
+             * @enum {string}
              */
             type: "calculate_image_tiles";
         };
@@ -3589,6 +3618,7 @@ export type components = {
              * type
              * @default calculate_image_tiles_min_overlap
              * @constant
+             * @enum {string}
              */
             type: "calculate_image_tiles_min_overlap";
         };
@@ -3603,6 +3633,7 @@ export type components = {
              * type
              * @default calculate_image_tiles_output
              * @constant
+             * @enum {string}
              */
             type: "calculate_image_tiles_output";
         };
@@ -3692,6 +3723,7 @@ export type components = {
              * type
              * @default canny_edge_detection
              * @constant
+             * @enum {string}
              */
             type: "canny_edge_detection";
         };
@@ -3752,6 +3784,7 @@ export type components = {
              * type
              * @default canvas_paste_back
              * @constant
+             * @enum {string}
              */
             type: "canvas_paste_back";
         };
@@ -3812,6 +3845,7 @@ export type components = {
              * type
              * @default canvas_v2_mask_and_crop
              * @constant
+             * @enum {string}
              */
             type: "canvas_v2_mask_and_crop";
         };
@@ -3870,6 +3904,7 @@ export type components = {
              * type
              * @default img_pad_crop
              * @constant
+             * @enum {string}
              */
             type: "img_pad_crop";
         };
@@ -3924,6 +3959,7 @@ export type components = {
              * type
              * @default cogview4_conditioning_output
              * @constant
+             * @enum {string}
              */
             type: "cogview4_conditioning_output";
         };
@@ -4031,6 +4067,7 @@ export type components = {
              * type
              * @default cogview4_denoise
              * @constant
+             * @enum {string}
              */
             type: "cogview4_denoise";
         };
@@ -4080,6 +4117,7 @@ export type components = {
              * type
              * @default cogview4_i2l
              * @constant
+             * @enum {string}
              */
             type: "cogview4_i2l";
         };
@@ -4129,6 +4167,7 @@ export type components = {
              * type
              * @default cogview4_l2i
              * @constant
+             * @enum {string}
              */
             type: "cogview4_l2i";
         };
@@ -4160,6 +4199,7 @@ export type components = {
              * type
              * @default cogview4_model_loader
              * @constant
+             * @enum {string}
              */
             type: "cogview4_model_loader";
         };
@@ -4187,6 +4227,7 @@ export type components = {
              * type
              * @default cogview4_model_loader_output
              * @constant
+             * @enum {string}
              */
             type: "cogview4_model_loader_output";
         };
@@ -4228,6 +4269,7 @@ export type components = {
              * type
              * @default cogview4_text_encoder
              * @constant
+             * @enum {string}
              */
             type: "cogview4_text_encoder";
         };
@@ -4269,6 +4311,7 @@ export type components = {
              * type
              * @default collect
              * @constant
+             * @enum {string}
              */
             type: "collect";
         };
@@ -4283,6 +4326,7 @@ export type components = {
              * type
              * @default collect_output
              * @constant
+             * @enum {string}
              */
             type: "collect_output";
         };
@@ -4300,6 +4344,7 @@ export type components = {
              * type
              * @default color_collection_output
              * @constant
+             * @enum {string}
              */
             type: "color_collection_output";
         };
@@ -4361,6 +4406,7 @@ export type components = {
              * type
              * @default color_correct
              * @constant
+             * @enum {string}
              */
             type: "color_correct";
         };
@@ -4426,6 +4472,7 @@ export type components = {
              * type
              * @default color
              * @constant
+             * @enum {string}
              */
             type: "color";
         };
@@ -4476,6 +4523,7 @@ export type components = {
              * type
              * @default color_map
              * @constant
+             * @enum {string}
              */
             type: "color_map";
         };
@@ -4490,6 +4538,7 @@ export type components = {
              * type
              * @default color_output
              * @constant
+             * @enum {string}
              */
             type: "color_output";
         };
@@ -4536,6 +4585,7 @@ export type components = {
              * type
              * @default compel
              * @constant
+             * @enum {string}
              */
             type: "compel";
         };
@@ -4571,6 +4621,7 @@ export type components = {
              * type
              * @default conditioning_collection
              * @constant
+             * @enum {string}
              */
             type: "conditioning_collection";
         };
@@ -4588,6 +4639,7 @@ export type components = {
              * type
              * @default conditioning_collection_output
              * @constant
+             * @enum {string}
              */
             type: "conditioning_collection_output";
         };
@@ -4638,6 +4690,7 @@ export type components = {
              * type
              * @default conditioning
              * @constant
+             * @enum {string}
              */
             type: "conditioning";
         };
@@ -4652,6 +4705,7 @@ export type components = {
              * type
              * @default conditioning_output
              * @constant
+             * @enum {string}
              */
             type: "conditioning_output";
         };
@@ -4702,6 +4756,7 @@ export type components = {
              * type
              * @default content_shuffle
              * @constant
+             * @enum {string}
              */
             type: "content_shuffle";
         };
@@ -4783,12 +4838,14 @@ export type components = {
              * Type
              * @default control_lora
              * @constant
+             * @enum {string}
              */
             type: "control_lora";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -4881,12 +4938,14 @@ export type components = {
              * Type
              * @default control_lora
              * @constant
+             * @enum {string}
              */
             type: "control_lora";
             /**
              * Format
              * @default lycoris
              * @constant
+             * @enum {string}
              */
             format: "lycoris";
             /** @description The base model. */
@@ -4967,6 +5026,7 @@ export type components = {
              * Type
              * @default controlnet
              * @constant
+             * @enum {string}
              */
             type: "controlnet";
             /**
@@ -5059,12 +5119,14 @@ export type components = {
              * Type
              * @default controlnet
              * @constant
+             * @enum {string}
              */
             type: "controlnet";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -5176,6 +5238,7 @@ export type components = {
              * type
              * @default controlnet
              * @constant
+             * @enum {string}
              */
             type: "controlnet";
         };
@@ -5234,6 +5297,7 @@ export type components = {
              * type
              * @default control_output
              * @constant
+             * @enum {string}
              */
             type: "control_output";
         };
@@ -5464,6 +5528,7 @@ export type components = {
              * type
              * @default core_metadata
              * @constant
+             * @enum {string}
              */
             type: "core_metadata";
         } & {
@@ -5522,6 +5587,7 @@ export type components = {
              * type
              * @default create_denoise_mask
              * @constant
+             * @enum {string}
              */
             type: "create_denoise_mask";
         };
@@ -5604,6 +5670,7 @@ export type components = {
              * type
              * @default create_gradient_mask
              * @constant
+             * @enum {string}
              */
             type: "create_gradient_mask";
         };
@@ -5653,6 +5720,7 @@ export type components = {
              * type
              * @default crop_image_to_bounding_box
              * @constant
+             * @enum {string}
              */
             type: "crop_image_to_bounding_box";
         };
@@ -5712,6 +5780,7 @@ export type components = {
              * type
              * @default crop_latents
              * @constant
+             * @enum {string}
              */
             type: "crop_latents";
         };
@@ -5779,6 +5848,7 @@ export type components = {
              * type
              * @default cv_inpaint
              * @constant
+             * @enum {string}
              */
             type: "cv_inpaint";
         };
@@ -5838,6 +5908,7 @@ export type components = {
              * type
              * @default dw_openpose_detection
              * @constant
+             * @enum {string}
              */
             type: "dw_openpose_detection";
         };
@@ -5977,6 +6048,7 @@ export type components = {
              * type
              * @default denoise_latents
              * @constant
+             * @enum {string}
              */
             type: "denoise_latents";
         };
@@ -6095,6 +6167,7 @@ export type components = {
              * type
              * @default denoise_latents_meta
              * @constant
+             * @enum {string}
              */
             type: "denoise_latents_meta";
         };
@@ -6132,6 +6205,7 @@ export type components = {
              * type
              * @default denoise_mask_output
              * @constant
+             * @enum {string}
              */
             type: "denoise_mask_output";
         };
@@ -6183,6 +6257,7 @@ export type components = {
              * type
              * @default depth_anything_depth_estimation
              * @constant
+             * @enum {string}
              */
             type: "depth_anything_depth_estimation";
         };
@@ -6224,6 +6299,7 @@ export type components = {
              * type
              * @default div
              * @constant
+             * @enum {string}
              */
             type: "div";
         };
@@ -6479,6 +6555,7 @@ export type components = {
              * type
              * @default dynamic_prompt
              * @constant
+             * @enum {string}
              */
             type: "dynamic_prompt";
         };
@@ -6543,6 +6620,7 @@ export type components = {
              * type
              * @default esrgan
              * @constant
+             * @enum {string}
              */
             type: "esrgan";
         };
@@ -6647,6 +6725,7 @@ export type components = {
              * type
              * @default expand_mask_with_fade
              * @constant
+             * @enum {string}
              */
             type: "expand_mask_with_fade";
         };
@@ -6707,6 +6786,7 @@ export type components = {
              * type
              * @default flux_lora_collection_loader
              * @constant
+             * @enum {string}
              */
             type: "flux_lora_collection_loader";
         };
@@ -6763,6 +6843,7 @@ export type components = {
              * type
              * @default face_identifier
              * @constant
+             * @enum {string}
              */
             type: "face_identifier";
         };
@@ -6838,6 +6919,7 @@ export type components = {
              * type
              * @default face_mask_detection
              * @constant
+             * @enum {string}
              */
             type: "face_mask_detection";
         };
@@ -6862,6 +6944,7 @@ export type components = {
              * type
              * @default face_mask_output
              * @constant
+             * @enum {string}
              */
             type: "face_mask_output";
             /** @description The output mask */
@@ -6939,6 +7022,7 @@ export type components = {
              * type
              * @default face_off
              * @constant
+             * @enum {string}
              */
             type: "face_off";
         };
@@ -6963,6 +7047,7 @@ export type components = {
              * type
              * @default face_off_output
              * @constant
+             * @enum {string}
              */
             type: "face_off_output";
             /** @description The output mask */
@@ -7054,6 +7139,7 @@ export type components = {
              * type
              * @default float_batch
              * @constant
+             * @enum {string}
              */
             type: "float_batch";
         };
@@ -7089,6 +7175,7 @@ export type components = {
              * type
              * @default float_collection
              * @constant
+             * @enum {string}
              */
             type: "float_collection";
         };
@@ -7106,6 +7193,7 @@ export type components = {
              * type
              * @default float_collection_output
              * @constant
+             * @enum {string}
              */
             type: "float_collection_output";
         };
@@ -7140,6 +7228,7 @@ export type components = {
              * type
              * @default float_generator
              * @constant
+             * @enum {string}
              */
             type: "float_generator";
         };
@@ -7159,6 +7248,7 @@ export type components = {
              * type
              * @default float_generator_output
              * @constant
+             * @enum {string}
              */
             type: "float_generator_output";
         };
@@ -7194,6 +7284,7 @@ export type components = {
              * type
              * @default float
              * @constant
+             * @enum {string}
              */
             type: "float";
         };
@@ -7241,6 +7332,7 @@ export type components = {
              * type
              * @default float_range
              * @constant
+             * @enum {string}
              */
             type: "float_range";
         };
@@ -7289,6 +7381,7 @@ export type components = {
              * type
              * @default float_math
              * @constant
+             * @enum {string}
              */
             type: "float_math";
         };
@@ -7306,6 +7399,7 @@ export type components = {
              * type
              * @default float_output
              * @constant
+             * @enum {string}
              */
             type: "float_output";
         };
@@ -7354,6 +7448,7 @@ export type components = {
              * type
              * @default float_to_int
              * @constant
+             * @enum {string}
              */
             type: "float_to_int";
         };
@@ -7384,6 +7479,7 @@ export type components = {
              * type
              * @default flux_conditioning_output
              * @constant
+             * @enum {string}
              */
             type: "flux_conditioning_output";
         };
@@ -7430,6 +7526,7 @@ export type components = {
              * type
              * @default flux_control_lora_loader
              * @constant
+             * @enum {string}
              */
             type: "flux_control_lora_loader";
         };
@@ -7448,6 +7545,7 @@ export type components = {
              * type
              * @default flux_control_lora_loader_output
              * @constant
+             * @enum {string}
              */
             type: "flux_control_lora_loader_output";
         };
@@ -7556,6 +7654,7 @@ export type components = {
              * type
              * @default flux_controlnet
              * @constant
+             * @enum {string}
              */
             type: "flux_controlnet";
         };
@@ -7570,6 +7669,7 @@ export type components = {
              * type
              * @default flux_controlnet_output
              * @constant
+             * @enum {string}
              */
             type: "flux_controlnet_output";
         };
@@ -7737,6 +7837,7 @@ export type components = {
              * type
              * @default flux_denoise
              * @constant
+             * @enum {string}
              */
             type: "flux_denoise";
         };
@@ -7904,6 +8005,7 @@ export type components = {
              * type
              * @default flux_denoise_meta
              * @constant
+             * @enum {string}
              */
             type: "flux_denoise_meta";
         };
@@ -7953,6 +8055,7 @@ export type components = {
              * type
              * @default flux_fill
              * @constant
+             * @enum {string}
              */
             type: "flux_fill";
         };
@@ -7970,6 +8073,7 @@ export type components = {
              * type
              * @default flux_fill_output
              * @constant
+             * @enum {string}
              */
             type: "flux_fill_output";
         };
@@ -8011,6 +8115,7 @@ export type components = {
              * @description CLIP Vision model to use.
              * @default ViT-L
              * @constant
+             * @enum {string}
              */
             clip_vision_model?: "ViT-L";
             /**
@@ -8035,6 +8140,7 @@ export type components = {
              * type
              * @default flux_ip_adapter
              * @constant
+             * @enum {string}
              */
             type: "flux_ip_adapter";
         };
@@ -8094,6 +8200,7 @@ export type components = {
              * type
              * @default flux_lora_loader
              * @constant
+             * @enum {string}
              */
             type: "flux_lora_loader";
         };
@@ -8124,6 +8231,7 @@ export type components = {
              * type
              * @default flux_lora_loader_output
              * @constant
+             * @enum {string}
              */
             type: "flux_lora_loader_output";
         };
@@ -8171,6 +8279,7 @@ export type components = {
              * type
              * @default flux_model_loader
              * @constant
+             * @enum {string}
              */
             type: "flux_model_loader";
         };
@@ -8209,6 +8318,7 @@ export type components = {
              * type
              * @default flux_model_loader_output
              * @constant
+             * @enum {string}
              */
             type: "flux_model_loader_output";
         };
@@ -8259,12 +8369,14 @@ export type components = {
              * Type
              * @default flux_redux
              * @constant
+             * @enum {string}
              */
             type: "flux_redux";
             /**
              * Format
              * @default checkpoint
              * @constant
+             * @enum {string}
              */
             format: "checkpoint";
             /** @description The base model. */
@@ -8365,6 +8477,7 @@ export type components = {
              * type
              * @default flux_redux
              * @constant
+             * @enum {string}
              */
             type: "flux_redux";
         };
@@ -8382,6 +8495,7 @@ export type components = {
              * type
              * @default flux_redux_output
              * @constant
+             * @enum {string}
              */
             type: "flux_redux_output";
         };
@@ -8440,6 +8554,7 @@ export type components = {
              * type
              * @default flux_text_encoder
              * @constant
+             * @enum {string}
              */
             type: "flux_text_encoder";
         };
@@ -8489,6 +8604,7 @@ export type components = {
              * type
              * @default flux_vae_decode
              * @constant
+             * @enum {string}
              */
             type: "flux_vae_decode";
         };
@@ -8528,6 +8644,7 @@ export type components = {
              * type
              * @default flux_vae_encode
              * @constant
+             * @enum {string}
              */
             type: "flux_vae_encode";
         };
@@ -8632,6 +8749,7 @@ export type components = {
              * type
              * @default freeu
              * @constant
+             * @enum {string}
              */
             type: "freeu";
         };
@@ -8682,6 +8800,7 @@ export type components = {
              * type
              * @default get_image_mask_bounding_box
              * @constant
+             * @enum {string}
              */
             type: "get_image_mask_bounding_box";
         };
@@ -8705,6 +8824,7 @@ export type components = {
              * type
              * @default gradient_mask_output
              * @constant
+             * @enum {string}
              */
             type: "gradient_mask_output";
         };
@@ -8830,6 +8950,7 @@ export type components = {
              * type
              * @default grounding_dino
              * @constant
+             * @enum {string}
              */
             type: "grounding_dino";
         };
@@ -8880,6 +9001,7 @@ export type components = {
              * type
              * @default hed_edge_detection
              * @constant
+             * @enum {string}
              */
             type: "hed_edge_detection";
         };
@@ -8957,6 +9079,7 @@ export type components = {
              * type
              * @default heuristic_resize
              * @constant
+             * @enum {string}
              */
             type: "heuristic_resize";
         };
@@ -9049,12 +9172,14 @@ export type components = {
              * Type
              * @default ip_adapter
              * @constant
+             * @enum {string}
              */
             type: "ip_adapter";
             /**
              * Format
              * @default checkpoint
              * @constant
+             * @enum {string}
              */
             format: "checkpoint";
             /** @description The base model. */
@@ -9216,6 +9341,7 @@ export type components = {
              * type
              * @default ip_adapter
              * @constant
+             * @enum {string}
              */
             type: "ip_adapter";
         };
@@ -9253,12 +9379,14 @@ export type components = {
              * Type
              * @default ip_adapter
              * @constant
+             * @enum {string}
              */
             type: "ip_adapter";
             /**
              * Format
              * @default invokeai
              * @constant
+             * @enum {string}
              */
             format: "invokeai";
             /** @description The base model. */
@@ -9348,6 +9476,7 @@ export type components = {
              * type
              * @default ip_adapter_output
              * @constant
+             * @enum {string}
              */
             type: "ip_adapter_output";
         };
@@ -9400,6 +9529,7 @@ export type components = {
              * type
              * @default ideal_size
              * @constant
+             * @enum {string}
              */
             type: "ideal_size";
         };
@@ -9422,6 +9552,7 @@ export type components = {
              * type
              * @default ideal_size_output
              * @constant
+             * @enum {string}
              */
             type: "ideal_size_output";
         };
@@ -9464,6 +9595,7 @@ export type components = {
              * type
              * @default image_batch
              * @constant
+             * @enum {string}
              */
             type: "image_batch";
         };
@@ -9521,6 +9653,7 @@ export type components = {
              * type
              * @default img_blur
              * @constant
+             * @enum {string}
              */
             type: "img_blur";
         };
@@ -9584,6 +9717,7 @@ export type components = {
              * type
              * @default img_chan
              * @constant
+             * @enum {string}
              */
             type: "img_chan";
         };
@@ -9646,6 +9780,7 @@ export type components = {
              * type
              * @default img_channel_multiply
              * @constant
+             * @enum {string}
              */
             type: "img_channel_multiply";
         };
@@ -9702,6 +9837,7 @@ export type components = {
              * type
              * @default img_channel_offset
              * @constant
+             * @enum {string}
              */
             type: "img_channel_offset";
         };
@@ -9737,6 +9873,7 @@ export type components = {
              * type
              * @default image_collection
              * @constant
+             * @enum {string}
              */
             type: "image_collection";
         };
@@ -9754,6 +9891,7 @@ export type components = {
              * type
              * @default image_collection_output
              * @constant
+             * @enum {string}
              */
             type: "image_collection_output";
         };
@@ -9805,6 +9943,7 @@ export type components = {
              * type
              * @default img_conv
              * @constant
+             * @enum {string}
              */
             type: "img_conv";
         };
@@ -9873,6 +10012,7 @@ export type components = {
              * type
              * @default img_crop
              * @constant
+             * @enum {string}
              */
             type: "img_crop";
         };
@@ -9998,6 +10138,7 @@ export type components = {
              * type
              * @default image_generator
              * @constant
+             * @enum {string}
              */
             type: "image_generator";
         };
@@ -10017,6 +10158,7 @@ export type components = {
              * type
              * @default image_generator_output
              * @constant
+             * @enum {string}
              */
             type: "image_generator_output";
         };
@@ -10067,6 +10209,7 @@ export type components = {
              * type
              * @default img_hue_adjust
              * @constant
+             * @enum {string}
              */
             type: "img_hue_adjust";
         };
@@ -10123,6 +10266,7 @@ export type components = {
              * type
              * @default img_ilerp
              * @constant
+             * @enum {string}
              */
             type: "img_ilerp";
         };
@@ -10157,6 +10301,7 @@ export type components = {
              * type
              * @default image
              * @constant
+             * @enum {string}
              */
             type: "image";
         };
@@ -10213,6 +10358,7 @@ export type components = {
              * type
              * @default img_lerp
              * @constant
+             * @enum {string}
              */
             type: "img_lerp";
         };
@@ -10264,6 +10410,7 @@ export type components = {
              * type
              * @default image_mask_to_tensor
              * @constant
+             * @enum {string}
              */
             type: "image_mask_to_tensor";
         };
@@ -10313,6 +10460,7 @@ export type components = {
              * type
              * @default img_mul
              * @constant
+             * @enum {string}
              */
             type: "img_mul";
         };
@@ -10357,6 +10505,7 @@ export type components = {
              * type
              * @default img_nsfw
              * @constant
+             * @enum {string}
              */
             type: "img_nsfw";
         };
@@ -10437,6 +10586,7 @@ export type components = {
              * type
              * @default img_noise
              * @constant
+             * @enum {string}
              */
             type: "img_noise";
         };
@@ -10461,6 +10611,7 @@ export type components = {
              * type
              * @default image_output
              * @constant
+             * @enum {string}
              */
             type: "image_output";
         };
@@ -10490,6 +10641,7 @@ export type components = {
              * type
              * @default image_panel_coordinate_output
              * @constant
+             * @enum {string}
              */
             type: "image_panel_coordinate_output";
         };
@@ -10556,6 +10708,7 @@ export type components = {
              * type
              * @default image_panel_layout
              * @constant
+             * @enum {string}
              */
             type: "image_panel_layout";
         };
@@ -10628,6 +10781,7 @@ export type components = {
              * type
              * @default img_paste
              * @constant
+             * @enum {string}
              */
             type: "img_paste";
         };
@@ -10722,6 +10876,7 @@ export type components = {
              * type
              * @default img_resize
              * @constant
+             * @enum {string}
              */
             type: "img_resize";
         };
@@ -10779,6 +10934,7 @@ export type components = {
              * type
              * @default img_scale
              * @constant
+             * @enum {string}
              */
             type: "img_scale";
         };
@@ -10836,6 +10992,7 @@ export type components = {
              * type
              * @default i2l
              * @constant
+             * @enum {string}
              */
             type: "i2l";
         };
@@ -10917,6 +11074,7 @@ export type components = {
              * type
              * @default img_watermark
              * @constant
+             * @enum {string}
              */
             type: "img_watermark";
         };
@@ -10992,6 +11150,7 @@ export type components = {
              * type
              * @default infill_rgba
              * @constant
+             * @enum {string}
              */
             type: "infill_rgba";
         };
@@ -11049,6 +11208,7 @@ export type components = {
              * type
              * @default infill_patchmatch
              * @constant
+             * @enum {string}
              */
             type: "infill_patchmatch";
         };
@@ -11105,6 +11265,7 @@ export type components = {
              * type
              * @default infill_tile
              * @constant
+             * @enum {string}
              */
             type: "infill_tile";
         };
@@ -11207,6 +11368,7 @@ export type components = {
              * type
              * @default integer_batch
              * @constant
+             * @enum {string}
              */
             type: "integer_batch";
         };
@@ -11242,6 +11404,7 @@ export type components = {
              * type
              * @default integer_collection
              * @constant
+             * @enum {string}
              */
             type: "integer_collection";
         };
@@ -11259,6 +11422,7 @@ export type components = {
              * type
              * @default integer_collection_output
              * @constant
+             * @enum {string}
              */
             type: "integer_collection_output";
         };
@@ -11293,6 +11457,7 @@ export type components = {
              * type
              * @default integer_generator
              * @constant
+             * @enum {string}
              */
             type: "integer_generator";
         };
@@ -11309,6 +11474,7 @@ export type components = {
              * type
              * @default integer_generator_output
              * @constant
+             * @enum {string}
              */
             type: "integer_generator_output";
         };
@@ -11344,6 +11510,7 @@ export type components = {
              * type
              * @default integer
              * @constant
+             * @enum {string}
              */
             type: "integer";
         };
@@ -11392,6 +11559,7 @@ export type components = {
              * type
              * @default integer_math
              * @constant
+             * @enum {string}
              */
             type: "integer_math";
         };
@@ -11409,6 +11577,7 @@ export type components = {
              * type
              * @default integer_output
              * @constant
+             * @enum {string}
              */
             type: "integer_output";
         };
@@ -11443,6 +11612,7 @@ export type components = {
              * type
              * @default invert_tensor_mask
              * @constant
+             * @enum {string}
              */
             type: "invert_tensor_mask";
         };
@@ -12442,6 +12612,7 @@ export type components = {
              * type
              * @default invokeai_img_hue_adjust_plus
              * @constant
+             * @enum {string}
              */
             type: "invokeai_img_hue_adjust_plus";
         };
@@ -12486,6 +12657,7 @@ export type components = {
              * type
              * @default invokeai_ealightness
              * @constant
+             * @enum {string}
              */
             type: "invokeai_ealightness";
         };
@@ -12584,6 +12756,7 @@ export type components = {
              * type
              * @default invokeai_img_blend
              * @constant
+             * @enum {string}
              */
             type: "invokeai_img_blend";
         };
@@ -12669,6 +12842,7 @@ export type components = {
              * type
              * @default invokeai_img_composite
              * @constant
+             * @enum {string}
              */
             type: "invokeai_img_composite";
         };
@@ -12733,6 +12907,7 @@ export type components = {
              * type
              * @default invokeai_img_dilate_erode
              * @constant
+             * @enum {string}
              */
             type: "invokeai_img_dilate_erode";
         };
@@ -12807,6 +12982,7 @@ export type components = {
              * type
              * @default invokeai_img_enhance
              * @constant
+             * @enum {string}
              */
             type: "invokeai_img_enhance";
         };
@@ -12881,6 +13057,7 @@ export type components = {
              * type
              * @default invokeai_img_val_thresholds
              * @constant
+             * @enum {string}
              */
             type: "invokeai_img_val_thresholds";
         };
@@ -12922,6 +13099,7 @@ export type components = {
              * type
              * @default iterate
              * @constant
+             * @enum {string}
              */
             type: "iterate";
         };
@@ -12949,6 +13127,7 @@ export type components = {
              * type
              * @default iterate_output
              * @constant
+             * @enum {string}
              */
             type: "iterate_output";
         };
@@ -12994,6 +13173,7 @@ export type components = {
              * type
              * @default infill_lama
              * @constant
+             * @enum {string}
              */
             type: "infill_lama";
         };
@@ -13029,6 +13209,7 @@ export type components = {
              * type
              * @default latents_collection
              * @constant
+             * @enum {string}
              */
             type: "latents_collection";
         };
@@ -13046,6 +13227,7 @@ export type components = {
              * type
              * @default latents_collection_output
              * @constant
+             * @enum {string}
              */
             type: "latents_collection_output";
         };
@@ -13097,6 +13279,7 @@ export type components = {
              * type
              * @default latents
              * @constant
+             * @enum {string}
              */
             type: "latents";
         };
@@ -13111,6 +13294,7 @@ export type components = {
              * type
              * @default latents_meta_output
              * @constant
+             * @enum {string}
              */
             type: "latents_meta_output";
             /** @description Latents tensor */
@@ -13147,6 +13331,7 @@ export type components = {
              * type
              * @default latents_output
              * @constant
+             * @enum {string}
              */
             type: "latents_output";
         };
@@ -13214,6 +13399,7 @@ export type components = {
              * type
              * @default l2i
              * @constant
+             * @enum {string}
              */
             type: "l2i";
         };
@@ -13258,6 +13444,7 @@ export type components = {
              * type
              * @default lineart_anime_edge_detection
              * @constant
+             * @enum {string}
              */
             type: "lineart_anime_edge_detection";
         };
@@ -13308,6 +13495,7 @@ export type components = {
              * type
              * @default lineart_edge_detection
              * @constant
+             * @enum {string}
              */
             type: "lineart_edge_detection";
         };
@@ -13345,12 +13533,14 @@ export type components = {
              * Type
              * @default llava_onevision
              * @constant
+             * @enum {string}
              */
             type: "llava_onevision";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -13436,6 +13626,7 @@ export type components = {
              * type
              * @default llava_onevision_vllm
              * @constant
+             * @enum {string}
              */
             type: "llava_onevision_vllm";
         };
@@ -13483,6 +13674,7 @@ export type components = {
              * type
              * @default lora_collection_loader
              * @constant
+             * @enum {string}
              */
             type: "lora_collection_loader";
         };
@@ -13520,12 +13712,14 @@ export type components = {
              * Type
              * @default lora
              * @constant
+             * @enum {string}
              */
             type: "lora";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -13630,6 +13824,7 @@ export type components = {
              * type
              * @default lora_loader
              * @constant
+             * @enum {string}
              */
             type: "lora_loader";
         };
@@ -13654,6 +13849,7 @@ export type components = {
              * type
              * @default lora_loader_output
              * @constant
+             * @enum {string}
              */
             type: "lora_loader_output";
         };
@@ -13691,12 +13887,14 @@ export type components = {
              * Type
              * @default lora
              * @constant
+             * @enum {string}
              */
             type: "lora";
             /**
              * Format
              * @default lycoris
              * @constant
+             * @enum {string}
              */
             format: "lycoris";
             /** @description The base model. */
@@ -13792,6 +13990,7 @@ export type components = {
              * type
              * @default lora_selector
              * @constant
+             * @enum {string}
              */
             type: "lora_selector";
         };
@@ -13809,6 +14008,7 @@ export type components = {
              * type
              * @default lora_selector_output
              * @constant
+             * @enum {string}
              */
             type: "lora_selector_output";
         };
@@ -13846,6 +14046,7 @@ export type components = {
              * type
              * @default md_control_list_output
              * @constant
+             * @enum {string}
              */
             type: "md_control_list_output";
         };
@@ -13860,6 +14061,7 @@ export type components = {
              * type
              * @default md_ip_adapter_list_output
              * @constant
+             * @enum {string}
              */
             type: "md_ip_adapter_list_output";
         };
@@ -13874,6 +14076,7 @@ export type components = {
              * type
              * @default md_ip_adapters_output
              * @constant
+             * @enum {string}
              */
             type: "md_ip_adapters_output";
         };
@@ -13930,6 +14133,7 @@ export type components = {
              * type
              * @default mlsd_detection
              * @constant
+             * @enum {string}
              */
             type: "mlsd_detection";
         };
@@ -13967,12 +14171,14 @@ export type components = {
              * Type
              * @default main
              * @constant
+             * @enum {string}
              */
             type: "main";
             /**
              * Format
              * @default bnb_quantized_nf4b
              * @constant
+             * @enum {string}
              */
             format: "bnb_quantized_nf4b";
             /** @description The base model. */
@@ -14075,6 +14281,7 @@ export type components = {
              * Type
              * @default main
              * @constant
+             * @enum {string}
              */
             type: "main";
             /**
@@ -14184,12 +14391,14 @@ export type components = {
              * Type
              * @default main
              * @constant
+             * @enum {string}
              */
             type: "main";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -14277,12 +14486,14 @@ export type components = {
              * Type
              * @default main
              * @constant
+             * @enum {string}
              */
             type: "main";
             /**
              * Format
              * @default gguf_quantized
              * @constant
+             * @enum {string}
              */
             format: "gguf_quantized";
             /** @description The base model. */
@@ -14430,6 +14641,7 @@ export type components = {
              * type
              * @default main_model_loader
              * @constant
+             * @enum {string}
              */
             type: "main_model_loader";
         };
@@ -14479,6 +14691,7 @@ export type components = {
              * type
              * @default mask_combine
              * @constant
+             * @enum {string}
              */
             type: "mask_combine";
         };
@@ -14547,6 +14760,7 @@ export type components = {
              * type
              * @default mask_edge
              * @constant
+             * @enum {string}
              */
             type: "mask_edge";
         };
@@ -14597,6 +14811,7 @@ export type components = {
              * type
              * @default tomask
              * @constant
+             * @enum {string}
              */
             type: "tomask";
         };
@@ -14658,6 +14873,7 @@ export type components = {
              * type
              * @default mask_from_id
              * @constant
+             * @enum {string}
              */
             type: "mask_from_id";
         };
@@ -14682,6 +14898,7 @@ export type components = {
              * type
              * @default mask_output
              * @constant
+             * @enum {string}
              */
             type: "mask_output";
         };
@@ -14726,6 +14943,7 @@ export type components = {
              * type
              * @default tensor_mask_to_image
              * @constant
+             * @enum {string}
              */
             type: "tensor_mask_to_image";
         };
@@ -14782,6 +15000,7 @@ export type components = {
              * type
              * @default mediapipe_face_detection
              * @constant
+             * @enum {string}
              */
             type: "mediapipe_face_detection";
         };
@@ -14817,6 +15036,7 @@ export type components = {
              * type
              * @default merge_metadata
              * @constant
+             * @enum {string}
              */
             type: "merge_metadata";
         };
@@ -14875,6 +15095,7 @@ export type components = {
              * type
              * @default merge_tiles_to_image
              * @constant
+             * @enum {string}
              */
             type: "merge_tiles_to_image";
         };
@@ -14922,6 +15143,7 @@ export type components = {
              * type
              * @default metadata_field_extractor
              * @constant
+             * @enum {string}
              */
             type: "metadata_field_extractor";
         };
@@ -14956,6 +15178,7 @@ export type components = {
              * type
              * @default metadata_from_image
              * @constant
+             * @enum {string}
              */
             type: "metadata_from_image";
         };
@@ -14991,6 +15214,7 @@ export type components = {
              * type
              * @default metadata
              * @constant
+             * @enum {string}
              */
             type: "metadata";
         };
@@ -15045,6 +15269,7 @@ export type components = {
              * type
              * @default metadata_item
              * @constant
+             * @enum {string}
              */
             type: "metadata_item";
         };
@@ -15098,6 +15323,7 @@ export type components = {
              * type
              * @default metadata_item_linked
              * @constant
+             * @enum {string}
              */
             type: "metadata_item_linked";
         };
@@ -15112,6 +15338,7 @@ export type components = {
              * type
              * @default metadata_item_output
              * @constant
+             * @enum {string}
              */
             type: "metadata_item_output";
         };
@@ -15123,6 +15350,7 @@ export type components = {
              * type
              * @default metadata_output
              * @constant
+             * @enum {string}
              */
             type: "metadata_output";
         };
@@ -15176,6 +15404,7 @@ export type components = {
              * type
              * @default metadata_to_bool_collection
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_bool_collection";
         };
@@ -15229,6 +15458,7 @@ export type components = {
              * type
              * @default metadata_to_bool
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_bool";
         };
@@ -15268,6 +15498,7 @@ export type components = {
              * type
              * @default metadata_to_controlnets
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_controlnets";
         };
@@ -15321,6 +15552,7 @@ export type components = {
              * type
              * @default metadata_to_float_collection
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_float_collection";
         };
@@ -15374,6 +15606,7 @@ export type components = {
              * type
              * @default metadata_to_float
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_float";
         };
@@ -15414,6 +15647,7 @@ export type components = {
              * type
              * @default metadata_to_ip_adapters
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_ip_adapters";
         };
@@ -15467,6 +15701,7 @@ export type components = {
              * type
              * @default metadata_to_integer_collection
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_integer_collection";
         };
@@ -15520,6 +15755,7 @@ export type components = {
              * type
              * @default metadata_to_integer
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_integer";
         };
@@ -15566,6 +15802,7 @@ export type components = {
              * type
              * @default metadata_to_lora_collection
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_lora_collection";
         };
@@ -15583,6 +15820,7 @@ export type components = {
              * type
              * @default metadata_to_lora_collection_output
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_lora_collection_output";
         };
@@ -15629,6 +15867,7 @@ export type components = {
              * type
              * @default metadata_to_loras
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_loras";
         };
@@ -15681,6 +15920,7 @@ export type components = {
              * type
              * @default metadata_to_model
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_model";
         };
@@ -15718,6 +15958,7 @@ export type components = {
              * type
              * @default metadata_to_model_output
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_model_output";
         };
@@ -15770,6 +16011,7 @@ export type components = {
              * type
              * @default metadata_to_sdlx_loras
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_sdlx_loras";
         };
@@ -15822,6 +16064,7 @@ export type components = {
              * type
              * @default metadata_to_sdxl_model
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_sdxl_model";
         };
@@ -15864,6 +16107,7 @@ export type components = {
              * type
              * @default metadata_to_sdxl_model_output
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_sdxl_model_output";
         };
@@ -15918,6 +16162,7 @@ export type components = {
              * type
              * @default metadata_to_scheduler
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_scheduler";
         };
@@ -15971,6 +16216,7 @@ export type components = {
              * type
              * @default metadata_to_string_collection
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_string_collection";
         };
@@ -16024,6 +16270,7 @@ export type components = {
              * type
              * @default metadata_to_string
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_string";
         };
@@ -16064,6 +16311,7 @@ export type components = {
              * type
              * @default metadata_to_t2i_adapters
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_t2i_adapters";
         };
@@ -16116,6 +16364,7 @@ export type components = {
              * type
              * @default metadata_to_vae
              * @constant
+             * @enum {string}
              */
             type: "metadata_to_vae";
         };
@@ -16186,6 +16435,7 @@ export type components = {
              * type
              * @default model_identifier
              * @constant
+             * @enum {string}
              */
             type: "model_identifier";
         };
@@ -16203,6 +16453,7 @@ export type components = {
              * type
              * @default model_identifier_output
              * @constant
+             * @enum {string}
              */
             type: "model_identifier_output";
         };
@@ -16550,6 +16801,7 @@ export type components = {
              * type
              * @default model_loader_output
              * @constant
+             * @enum {string}
              */
             type: "model_loader_output";
             /**
@@ -16738,6 +16990,7 @@ export type components = {
              * type
              * @default mul
              * @constant
+             * @enum {string}
              */
             type: "mul";
         };
@@ -16809,6 +17062,7 @@ export type components = {
              * type
              * @default noise
              * @constant
+             * @enum {string}
              */
             type: "noise";
         };
@@ -16833,6 +17087,7 @@ export type components = {
              * type
              * @default noise_output
              * @constant
+             * @enum {string}
              */
             type: "noise_output";
         };
@@ -16877,6 +17132,7 @@ export type components = {
              * type
              * @default normal_map
              * @constant
+             * @enum {string}
              */
             type: "normal_map";
         };
@@ -17003,6 +17259,7 @@ export type components = {
              * type
              * @default pair_tile_image
              * @constant
+             * @enum {string}
              */
             type: "pair_tile_image";
         };
@@ -17014,6 +17271,7 @@ export type components = {
              * type
              * @default pair_tile_image_output
              * @constant
+             * @enum {string}
              */
             type: "pair_tile_image_output";
         };
@@ -17070,6 +17328,7 @@ export type components = {
              * type
              * @default paste_image_into_bounding_box
              * @constant
+             * @enum {string}
              */
             type: "paste_image_into_bounding_box";
         };
@@ -17126,6 +17385,7 @@ export type components = {
              * type
              * @default pidi_edge_detection
              * @constant
+             * @enum {string}
              */
             type: "pidi_edge_detection";
         };
@@ -17224,6 +17484,7 @@ export type components = {
              * type
              * @default prompt_from_file
              * @constant
+             * @enum {string}
              */
             type: "prompt_from_file";
         };
@@ -17420,6 +17681,7 @@ export type components = {
              * type
              * @default rand_float
              * @constant
+             * @enum {string}
              */
             type: "rand_float";
         };
@@ -17461,6 +17723,7 @@ export type components = {
              * type
              * @default rand_int
              * @constant
+             * @enum {string}
              */
             type: "rand_int";
         };
@@ -17514,6 +17777,7 @@ export type components = {
              * type
              * @default random_range
              * @constant
+             * @enum {string}
              */
             type: "random_range";
         };
@@ -17561,6 +17825,7 @@ export type components = {
              * type
              * @default range
              * @constant
+             * @enum {string}
              */
             type: "range";
         };
@@ -17608,6 +17873,7 @@ export type components = {
              * type
              * @default range_of_size
              * @constant
+             * @enum {string}
              */
             type: "range_of_size";
         };
@@ -17678,6 +17944,7 @@ export type components = {
              * type
              * @default rectangle_mask
              * @constant
+             * @enum {string}
              */
             type: "rectangle_mask";
         };
@@ -17774,6 +18041,7 @@ export type components = {
              * type
              * @default lresize
              * @constant
+             * @enum {string}
              */
             type: "lresize";
         };
@@ -17838,6 +18106,7 @@ export type components = {
              * type
              * @default round_float
              * @constant
+             * @enum {string}
              */
             type: "round_float";
         };
@@ -17891,6 +18160,7 @@ export type components = {
              * type
              * @default sd3_conditioning_output
              * @constant
+             * @enum {string}
              */
             type: "sd3_conditioning_output";
         };
@@ -17998,6 +18268,7 @@ export type components = {
              * type
              * @default sd3_denoise
              * @constant
+             * @enum {string}
              */
             type: "sd3_denoise";
         };
@@ -18047,6 +18318,7 @@ export type components = {
              * type
              * @default sd3_i2l
              * @constant
+             * @enum {string}
              */
             type: "sd3_i2l";
         };
@@ -18096,6 +18368,7 @@ export type components = {
              * type
              * @default sd3_l2i
              * @constant
+             * @enum {string}
              */
             type: "sd3_l2i";
         };
@@ -18184,6 +18457,7 @@ export type components = {
              * type
              * @default sdxl_compel_prompt
              * @constant
+             * @enum {string}
              */
             type: "sdxl_compel_prompt";
         };
@@ -18237,6 +18511,7 @@ export type components = {
              * type
              * @default sdxl_lora_collection_loader
              * @constant
+             * @enum {string}
              */
             type: "sdxl_lora_collection_loader";
         };
@@ -18296,6 +18571,7 @@ export type components = {
              * type
              * @default sdxl_lora_loader
              * @constant
+             * @enum {string}
              */
             type: "sdxl_lora_loader";
         };
@@ -18326,6 +18602,7 @@ export type components = {
              * type
              * @default sdxl_lora_loader_output
              * @constant
+             * @enum {string}
              */
             type: "sdxl_lora_loader_output";
         };
@@ -18360,6 +18637,7 @@ export type components = {
              * type
              * @default sdxl_model_loader
              * @constant
+             * @enum {string}
              */
             type: "sdxl_model_loader";
         };
@@ -18392,6 +18670,7 @@ export type components = {
              * type
              * @default sdxl_model_loader_output
              * @constant
+             * @enum {string}
              */
             type: "sdxl_model_loader_output";
         };
@@ -18458,6 +18737,7 @@ export type components = {
              * type
              * @default sdxl_refiner_compel_prompt
              * @constant
+             * @enum {string}
              */
             type: "sdxl_refiner_compel_prompt";
         };
@@ -18492,6 +18772,7 @@ export type components = {
              * type
              * @default sdxl_refiner_model_loader
              * @constant
+             * @enum {string}
              */
             type: "sdxl_refiner_model_loader";
         };
@@ -18519,6 +18800,7 @@ export type components = {
              * type
              * @default sdxl_refiner_model_loader_output
              * @constant
+             * @enum {string}
              */
             type: "sdxl_refiner_model_loader_output";
         };
@@ -18568,6 +18850,7 @@ export type components = {
              * type
              * @default save_image
              * @constant
+             * @enum {string}
              */
             type: "save_image";
         };
@@ -18621,6 +18904,7 @@ export type components = {
              * type
              * @default lscale
              * @constant
+             * @enum {string}
              */
             type: "lscale";
         };
@@ -18657,6 +18941,7 @@ export type components = {
              * type
              * @default scheduler
              * @constant
+             * @enum {string}
              */
             type: "scheduler";
         };
@@ -18672,6 +18957,7 @@ export type components = {
              * type
              * @default scheduler_output
              * @constant
+             * @enum {string}
              */
             type: "scheduler_output";
         };
@@ -18733,6 +19019,7 @@ export type components = {
              * type
              * @default sd3_model_loader
              * @constant
+             * @enum {string}
              */
             type: "sd3_model_loader";
         };
@@ -18770,6 +19057,7 @@ export type components = {
              * type
              * @default sd3_model_loader_output
              * @constant
+             * @enum {string}
              */
             type: "sd3_model_loader_output";
         };
@@ -18823,6 +19111,7 @@ export type components = {
              * type
              * @default sd3_text_encoder
              * @constant
+             * @enum {string}
              */
             type: "sd3_text_encoder";
         };
@@ -18876,6 +19165,7 @@ export type components = {
              * type
              * @default seamless
              * @constant
+             * @enum {string}
              */
             type: "seamless";
         };
@@ -18900,6 +19190,7 @@ export type components = {
              * type
              * @default seamless_output
              * @constant
+             * @enum {string}
              */
             type: "seamless_output";
         };
@@ -18965,6 +19256,7 @@ export type components = {
              * type
              * @default segment_anything
              * @constant
+             * @enum {string}
              */
             type: "segment_anything";
         };
@@ -19354,6 +19646,7 @@ export type components = {
              * type
              * @default show_image
              * @constant
+             * @enum {string}
              */
             type: "show_image";
         };
@@ -19391,12 +19684,14 @@ export type components = {
              * Type
              * @default siglip
              * @constant
+             * @enum {string}
              */
             type: "siglip";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -19491,6 +19786,7 @@ export type components = {
              * type
              * @default spandrel_image_to_image_autoscale
              * @constant
+             * @enum {string}
              */
             type: "spandrel_image_to_image_autoscale";
             /**
@@ -19540,12 +19836,14 @@ export type components = {
              * Type
              * @default spandrel_image_to_image
              * @constant
+             * @enum {string}
              */
             type: "spandrel_image_to_image";
             /**
              * Format
              * @default checkpoint
              * @constant
+             * @enum {string}
              */
             format: "checkpoint";
             /** @description The base model. */
@@ -19638,6 +19936,7 @@ export type components = {
              * type
              * @default spandrel_image_to_image
              * @constant
+             * @enum {string}
              */
             type: "spandrel_image_to_image";
         };
@@ -19715,6 +20014,7 @@ export type components = {
              * type
              * @default string_2_output
              * @constant
+             * @enum {string}
              */
             type: "string_2_output";
         };
@@ -19757,6 +20057,7 @@ export type components = {
              * type
              * @default string_batch
              * @constant
+             * @enum {string}
              */
             type: "string_batch";
         };
@@ -19792,6 +20093,7 @@ export type components = {
              * type
              * @default string_collection
              * @constant
+             * @enum {string}
              */
             type: "string_collection";
         };
@@ -19809,6 +20111,7 @@ export type components = {
              * type
              * @default string_collection_output
              * @constant
+             * @enum {string}
              */
             type: "string_collection_output";
         };
@@ -19843,6 +20146,7 @@ export type components = {
              * type
              * @default string_generator
              * @constant
+             * @enum {string}
              */
             type: "string_generator";
         };
@@ -19862,6 +20166,7 @@ export type components = {
              * type
              * @default string_generator_output
              * @constant
+             * @enum {string}
              */
             type: "string_generator_output";
         };
@@ -19897,6 +20202,7 @@ export type components = {
              * type
              * @default string
              * @constant
+             * @enum {string}
              */
             type: "string";
         };
@@ -19938,6 +20244,7 @@ export type components = {
              * type
              * @default string_join
              * @constant
+             * @enum {string}
              */
             type: "string_join";
         };
@@ -19985,6 +20292,7 @@ export type components = {
              * type
              * @default string_join_three
              * @constant
+             * @enum {string}
              */
             type: "string_join_three";
         };
@@ -20002,6 +20310,7 @@ export type components = {
              * type
              * @default string_output
              * @constant
+             * @enum {string}
              */
             type: "string_output";
         };
@@ -20024,6 +20333,7 @@ export type components = {
              * type
              * @default string_pos_neg_output
              * @constant
+             * @enum {string}
              */
             type: "string_pos_neg_output";
         };
@@ -20077,6 +20387,7 @@ export type components = {
              * type
              * @default string_replace
              * @constant
+             * @enum {string}
              */
             type: "string_replace";
         };
@@ -20118,6 +20429,7 @@ export type components = {
              * type
              * @default string_split
              * @constant
+             * @enum {string}
              */
             type: "string_split";
         };
@@ -20153,6 +20465,7 @@ export type components = {
              * type
              * @default string_split_neg
              * @constant
+             * @enum {string}
              */
             type: "string_split_neg";
         };
@@ -20230,6 +20543,7 @@ export type components = {
              * type
              * @default sub
              * @constant
+             * @enum {string}
              */
             type: "sub";
         };
@@ -20267,12 +20581,14 @@ export type components = {
              * Type
              * @default t2i_adapter
              * @constant
+             * @enum {string}
              */
             type: "t2i_adapter";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -20410,6 +20726,7 @@ export type components = {
              * type
              * @default t2i_adapter
              * @constant
+             * @enum {string}
              */
             type: "t2i_adapter";
         };
@@ -20461,6 +20778,7 @@ export type components = {
              * type
              * @default t2i_adapter_output
              * @constant
+             * @enum {string}
              */
             type: "t2i_adapter_output";
         };
@@ -20495,12 +20813,14 @@ export type components = {
              * Type
              * @default t5_encoder
              * @constant
+             * @enum {string}
              */
             type: "t5_encoder";
             /**
              * Format
              * @default bnb_quantized_int8b
              * @constant
+             * @enum {string}
              */
             format: "bnb_quantized_int8b";
             /** @description The base model. */
@@ -20571,12 +20891,14 @@ export type components = {
              * Type
              * @default t5_encoder
              * @constant
+             * @enum {string}
              */
             type: "t5_encoder";
             /**
              * Format
              * @default t5_encoder
              * @constant
+             * @enum {string}
              */
             format: "t5_encoder";
             /** @description The base model. */
@@ -20684,12 +21006,14 @@ export type components = {
              * Type
              * @default embedding
              * @constant
+             * @enum {string}
              */
             type: "embedding";
             /**
              * Format
              * @default embedding_file
              * @constant
+             * @enum {string}
              */
             format: "embedding_file";
             /** @description The base model. */
@@ -20763,12 +21087,14 @@ export type components = {
              * Type
              * @default embedding
              * @constant
+             * @enum {string}
              */
             type: "embedding";
             /**
              * Format
              * @default embedding_folder
              * @constant
+             * @enum {string}
              */
             format: "embedding_folder";
             /** @description The base model. */
@@ -20846,6 +21172,7 @@ export type components = {
              * type
              * @default tile_to_properties
              * @constant
+             * @enum {string}
              */
             type: "tile_to_properties";
         };
@@ -20905,6 +21232,7 @@ export type components = {
              * type
              * @default tile_to_properties_output
              * @constant
+             * @enum {string}
              */
             type: "tile_to_properties_output";
         };
@@ -21032,6 +21360,7 @@ export type components = {
              * type
              * @default tiled_multi_diffusion_denoise_latents
              * @constant
+             * @enum {string}
              */
             type: "tiled_multi_diffusion_denoise_latents";
         };
@@ -21119,7 +21448,7 @@ export type components = {
          *     used, and the type will be ignored. They are included here for backwards compatibility.
          * @enum {string}
          */
-        UIType: "MainModelField" | "CogView4MainModelField" | "FluxMainModelField" | "SD3MainModelField" | "SDXLMainModelField" | "SDXLRefinerModelField" | "ONNXModelField" | "VAEModelField" | "FluxVAEModelField" | "LoRAModelField" | "ControlNetModelField" | "IPAdapterModelField" | "T2IAdapterModelField" | "T5EncoderModelField" | "CLIPEmbedModelField" | "CLIPLEmbedModelField" | "CLIPGEmbedModelField" | "SpandrelImageToImageModelField" | "ControlLoRAModelField" | "SigLipModelField" | "FluxReduxModelField" | "LLaVAModelField" | "Imagen3ModelField" | "Imagen4ModelField" | "ChatGPT4oModelField" | "SchedulerField" | "AnyField" | "CollectionField" | "CollectionItemField" | "DEPRECATED_Boolean" | "DEPRECATED_Color" | "DEPRECATED_Conditioning" | "DEPRECATED_Control" | "DEPRECATED_Float" | "DEPRECATED_Image" | "DEPRECATED_Integer" | "DEPRECATED_Latents" | "DEPRECATED_String" | "DEPRECATED_BooleanCollection" | "DEPRECATED_ColorCollection" | "DEPRECATED_ConditioningCollection" | "DEPRECATED_ControlCollection" | "DEPRECATED_FloatCollection" | "DEPRECATED_ImageCollection" | "DEPRECATED_IntegerCollection" | "DEPRECATED_LatentsCollection" | "DEPRECATED_StringCollection" | "DEPRECATED_BooleanPolymorphic" | "DEPRECATED_ColorPolymorphic" | "DEPRECATED_ConditioningPolymorphic" | "DEPRECATED_ControlPolymorphic" | "DEPRECATED_FloatPolymorphic" | "DEPRECATED_ImagePolymorphic" | "DEPRECATED_IntegerPolymorphic" | "DEPRECATED_LatentsPolymorphic" | "DEPRECATED_StringPolymorphic" | "DEPRECATED_UNet" | "DEPRECATED_Vae" | "DEPRECATED_CLIP" | "DEPRECATED_Collection" | "DEPRECATED_CollectionItem" | "DEPRECATED_Enum" | "DEPRECATED_WorkflowField" | "DEPRECATED_IsIntermediate" | "DEPRECATED_BoardField" | "DEPRECATED_MetadataItem" | "DEPRECATED_MetadataItemCollection" | "DEPRECATED_MetadataItemPolymorphic" | "DEPRECATED_MetadataDict";
+        UIType: "MainModelField" | "CogView4MainModelField" | "FluxMainModelField" | "SD3MainModelField" | "SDXLMainModelField" | "SDXLRefinerModelField" | "ONNXModelField" | "VAEModelField" | "FluxVAEModelField" | "LoRAModelField" | "ControlNetModelField" | "IPAdapterModelField" | "T2IAdapterModelField" | "T5EncoderModelField" | "CLIPEmbedModelField" | "CLIPLEmbedModelField" | "CLIPGEmbedModelField" | "SpandrelImageToImageModelField" | "ControlLoRAModelField" | "SigLipModelField" | "FluxReduxModelField" | "LLaVAModelField" | "Imagen3ModelField" | "Imagen4ModelField" | "ChatGPT4oModelField" | "FluxKontextModelField" | "SchedulerField" | "AnyField" | "CollectionField" | "CollectionItemField" | "DEPRECATED_Boolean" | "DEPRECATED_Color" | "DEPRECATED_Conditioning" | "DEPRECATED_Control" | "DEPRECATED_Float" | "DEPRECATED_Image" | "DEPRECATED_Integer" | "DEPRECATED_Latents" | "DEPRECATED_String" | "DEPRECATED_BooleanCollection" | "DEPRECATED_ColorCollection" | "DEPRECATED_ConditioningCollection" | "DEPRECATED_ControlCollection" | "DEPRECATED_FloatCollection" | "DEPRECATED_ImageCollection" | "DEPRECATED_IntegerCollection" | "DEPRECATED_LatentsCollection" | "DEPRECATED_StringCollection" | "DEPRECATED_BooleanPolymorphic" | "DEPRECATED_ColorPolymorphic" | "DEPRECATED_ConditioningPolymorphic" | "DEPRECATED_ControlPolymorphic" | "DEPRECATED_FloatPolymorphic" | "DEPRECATED_ImagePolymorphic" | "DEPRECATED_IntegerPolymorphic" | "DEPRECATED_LatentsPolymorphic" | "DEPRECATED_StringPolymorphic" | "DEPRECATED_UNet" | "DEPRECATED_Vae" | "DEPRECATED_CLIP" | "DEPRECATED_Collection" | "DEPRECATED_CollectionItem" | "DEPRECATED_Enum" | "DEPRECATED_WorkflowField" | "DEPRECATED_IsIntermediate" | "DEPRECATED_BoardField" | "DEPRECATED_MetadataItem" | "DEPRECATED_MetadataItemCollection" | "DEPRECATED_MetadataItemPolymorphic" | "DEPRECATED_MetadataDict";
         /** UNetField */
         UNetField: {
             /** @description Info to load unet submodel */
@@ -21156,6 +21485,7 @@ export type components = {
              * type
              * @default unet_output
              * @constant
+             * @enum {string}
              */
             type: "unet_output";
         };
@@ -21243,6 +21573,7 @@ export type components = {
              * type
              * @default unsharp_mask
              * @constant
+             * @enum {string}
              */
             type: "unsharp_mask";
         };
@@ -21293,6 +21624,7 @@ export type components = {
              * Type
              * @default vae
              * @constant
+             * @enum {string}
              */
             type: "vae";
             /**
@@ -21383,12 +21715,14 @@ export type components = {
              * Type
              * @default vae
              * @constant
+             * @enum {string}
              */
             type: "vae";
             /**
              * Format
              * @default diffusers
              * @constant
+             * @enum {string}
              */
             format: "diffusers";
             /** @description The base model. */
@@ -21470,6 +21804,7 @@ export type components = {
              * type
              * @default vae_loader
              * @constant
+             * @enum {string}
              */
             type: "vae_loader";
         };
@@ -21487,6 +21822,7 @@ export type components = {
              * type
              * @default vae_output
              * @constant
+             * @enum {string}
              */
             type: "vae_output";
         };

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -240,6 +240,10 @@ export const isImagen4ModelConfig = (config: AnyModelConfig): config is ApiModel
   return config.type === 'main' && config.base === 'imagen4';
 };
 
+export const isFluxKontextModelConfig = (config: AnyModelConfig): config is ApiModelConfig => {
+  return config.type === 'main' && config.base === 'flux-kontext';
+};
+
 export const isNonRefinerMainModelConfig = (config: AnyModelConfig): config is MainModelConfig => {
   return config.type === 'main' && config.base !== 'sdxl-refiner';
 };


### PR DESCRIPTION
## Summary

* add UI support for Flux Kontext nodes and canvas (commercial only)
* these graphs can only be text2image and have a limit of one global reference image
* while Flux Kontext aspect ratio can go up to 21:9/9:21, these are not currently available in our aspect ratio dropdown so are excluded from the canvas UI

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
