### PR TITLE
fix(nodes): ensure each invocation overrides _original_model_fields with own field data

### DIFF
--- a/invokeai/app/invocations/baseinvocation.py
+++ b/invokeai/app/invocations/baseinvocation.py
@@ -582,6 +582,8 @@ def invocation(
 
         fields: dict[str, tuple[Any, FieldInfo]] = {}
 
+        original_model_fields: dict[str, OriginalModelField] = {}
+
         for field_name, field_info in cls.model_fields.items():
             annotation = field_info.annotation
             assert annotation is not None, f"{field_name} on invocation {invocation_type} has no type annotation."
@@ -589,7 +591,7 @@ def invocation(
                 f"{field_name} on invocation {invocation_type} has a non-dict json_schema_extra, did you forget to use InputField?"
             )
 
-            cls._original_model_fields[field_name] = OriginalModelField(annotation=annotation, field_info=field_info)
+            original_model_fields[field_name] = OriginalModelField(annotation=annotation, field_info=field_info)
 
             validate_field_default(cls.__name__, field_name, invocation_type, annotation, field_info)
 
@@ -676,6 +678,7 @@ def invocation(
         docstring = cls.__doc__
         new_class = create_model(cls.__qualname__, __base__=cls, __module__=cls.__module__, **fields)  # type: ignore
         new_class.__doc__ = docstring
+        new_class._original_model_fields = original_model_fields
 
         InvocationRegistry.register_invocation(new_class)
 


### PR DESCRIPTION
## Summary

`_original_model_fields` is a dict `ClassVar` on `BaseInvocation`. It stores the original fields for an Invocation, before any modifications are made by the `@invocation` decorator.

Individual Invocations were _intended_ to override the whole dict, but instead they added their own fields to it. 

```py
# baseinvocation.py
cls._original_model_fields[field_name] = OriginalModelField(annotation=annotation, field_info=field_info)
```

The dict was therefore accidentally  **shared amongst all invocation classes**. Here's what it looks like for `IPAdapterInvocation`:

<img width="603" alt="Screenshot 2025-06-19 at 12 44 40 pm" src="https://github.com/user-attachments/assets/99cfac57-6e96-49d9-ac6e-35393276c4d5" />

Note that a ton of fields unrelated to IP Adapter are in there. It shouldn't have those! Here's what it should look like:

<img width="599" alt="Screenshot 2025-06-19 at 12 44 10 pm" src="https://github.com/user-attachments/assets/67f2733a-599b-4870-8197-b36171709d1d" />

Note that it only includes fields from the IP Adapter node.

---

This bug has a knock-on effect when two invocations share the same field name. The original model field data would be replaced/clobbered.

For example, both `IPAdapterInvocation` and `FloatToIntegerInvocation` have a `method` field:

```py
class IPAdapterInvocation(BaseInvocation):
    # ...
    method: Literal["full", "style", "composition", "style_strong", "style_precise"] = InputField(
        default="full", description="The method to apply the IP-Adapter"
    )

class FloatToIntegerInvocation(BaseInvocation):
    # ...
    method: Literal["Nearest", "Floor", "Ceiling", "Truncate"] = InputField(
        default="Nearest", description="The method to use for rounding"
    )
```

We can have this sequence of events:
- `IPAdapterInvocation` is registered, storing its field data in the dict.
  - `cls._original_model_fields["method"]` is set to `IPAdapterInvocation.method`'s field data.
- `FloatToIntegerInvocation` is registered, storing its field data in the dict.
  - `cls._original_model_fields["method"]` is set to `FloatToIntegerInvocation.method`'s field data.
  
So `IPAdapterInvocation._original_model_fields["method"]` ends up referring to `FloatToIntegerInvocation.method`:

![image](https://github.com/user-attachments/assets/eec0f24a-9107-44cc-9f21-0b287e6b9775)

But it _should_ refer to its own `IPAdapterInvocation.method`, like this:

![image](https://github.com/user-attachments/assets/b77bc0aa-dbf0-4f4e-9054-4adb5270a18d)

Anything that consumes `_original_model_fields` for `IPAdapterInvocation` would get the float node's method field instead of its own.

## Related Issues / Discussions

n/a

## QA Instructions

Run in the debugger to observe `_original_model_fields`. There is no OSS code that consumes it.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
