### PR TITLE
fix(app): prep of collect nodes can create invalid edges

### DIFF
--- a/invokeai/app/services/shared/graph.py
+++ b/invokeai/app/services/shared/graph.py
@@ -1007,10 +1007,11 @@ class GraphExecutionState(BaseModel):
         new_node_ids = []
         if isinstance(next_node, CollectInvocation):
             # Collapse all iterator input mappings and create a single execution node for the collect invocation
-            all_iteration_mappings = list(
-                itertools.chain(*(((s, p) for p in self.source_prepared_mapping[s]) for s in next_node_parents))
-            )
-            # all_iteration_mappings = list(set(itertools.chain(*prepared_parent_mappings)))
+            all_iteration_mappings = []
+            for source_node_id in next_node_parents:
+                prepared_nodes = self.source_prepared_mapping[source_node_id]
+                all_iteration_mappings.extend([(source_node_id, p) for p in prepared_nodes])
+
             create_results = self._create_execution_node(next_node_id, all_iteration_mappings)
             if create_results is not None:
                 new_node_ids.extend(create_results)

--- a/tests/test_node_graph.py
+++ b/tests/test_node_graph.py
@@ -37,7 +37,6 @@ from tests.test_nodes import (
     ListPassThroughInvocation,
     PolymorphicStringTestInvocation,
     PromptCollectionTestInvocation,
-    PromptCollectionTestInvocationOutput,
     PromptTestInvocation,
     PromptTestInvocationOutput,
     TextToImageTestInvocation,
@@ -764,6 +763,7 @@ def test_nodes_must_return_invocation_output():
             def invoke(self) -> str:
                 return "foo"
 
+
 def test_collector_different_incomers():
     """Tests an edge case where a collector has incoming edges from invocations with differently-named output fields."""
     g = Graph()
@@ -783,6 +783,184 @@ def test_collector_different_incomers():
     # The bug resulted in an error like this when calling session.next():
     #   Field types are incompatible (a0f9797b-1179-4200-81ae-6ef981660163.prompt -> ccc6af96-2a65-4bbe-a02f-4189bb4770ac.item)
     run_session_with_mock_context(session)
-    output= get_single_output_from_session(session, n3.id)
+    output = get_single_output_from_session(session, n3.id)
     assert isinstance(output, CollectInvocationOutput)
     assert output.collection == ["Banana", "Sushi"]  # Both inputs should be collected
+
+
+def test_iterator_collector_iterator_chain():
+    """Test basic Iterator -> Collector -> Iterator chain execution."""
+    g = Graph()
+    # Start with a collection of strings
+    n1 = PromptCollectionTestInvocation(id="1", collection=["apple", "banana", "cherry"])
+    # First iterator breaks down the collection
+    n2 = IterateInvocation(id="2")
+    # Process each item (pass-through for simplicity)
+    n3 = PromptTestInvocation(id="3")
+    # Collector reassembles the processed items
+    n4 = CollectInvocation(id="4")
+    # Second iterator breaks down the collected items again
+    n5 = IterateInvocation(id="5")
+    # Process each item again
+    n6 = PromptTestInvocation(id="6")
+    # Final collector
+    n7 = CollectInvocation(id="7")
+
+    for node in [n1, n2, n3, n4, n5, n6, n7]:
+        g.add_node(node)
+
+    # Chain the nodes together
+    g.add_edge(create_edge(n1.id, "collection", n2.id, "collection"))
+    g.add_edge(create_edge(n2.id, "item", n3.id, "prompt"))
+    g.add_edge(create_edge(n3.id, "prompt", n4.id, "item"))
+    g.add_edge(create_edge(n4.id, "collection", n5.id, "collection"))
+    g.add_edge(create_edge(n5.id, "item", n6.id, "prompt"))
+    g.add_edge(create_edge(n6.id, "prompt", n7.id, "item"))
+
+    # Execute the graph
+    session = GraphExecutionState(graph=g)
+    run_session_with_mock_context(session)
+
+    # Verify the final output contains all original items
+    output = get_single_output_from_session(session, n7.id)
+    assert isinstance(output, CollectInvocationOutput)
+    assert set(output.collection) == {"apple", "banana", "cherry"}
+
+
+def test_parallel_iterator_collector_iterator_chains():
+    """Test two parallel Iterator -> Collector -> Iterator chains."""
+    g = Graph()
+
+    # First chain
+    n1 = PromptCollectionTestInvocation(id="1", collection=["a", "b"])
+    n2 = IterateInvocation(id="2")
+    n3 = PromptTestInvocation(id="3")
+    n4 = CollectInvocation(id="4")
+    n5 = IterateInvocation(id="5")
+    n6 = PromptTestInvocation(id="6")
+    n7 = CollectInvocation(id="7")
+
+    # Second chain
+    n8 = PromptCollectionTestInvocation(id="8", collection=["x", "y", "z"])
+    n9 = IterateInvocation(id="9")
+    n10 = PromptTestInvocation(id="10")
+    n11 = CollectInvocation(id="11")
+    n12 = IterateInvocation(id="12")
+    n13 = PromptTestInvocation(id="13")
+    n14 = CollectInvocation(id="14")
+
+    for node in [n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14]:
+        g.add_node(node)
+
+    # First chain edges
+    g.add_edge(create_edge(n1.id, "collection", n2.id, "collection"))
+    g.add_edge(create_edge(n2.id, "item", n3.id, "prompt"))
+    g.add_edge(create_edge(n3.id, "prompt", n4.id, "item"))
+    g.add_edge(create_edge(n4.id, "collection", n5.id, "collection"))
+    g.add_edge(create_edge(n5.id, "item", n6.id, "prompt"))
+    g.add_edge(create_edge(n6.id, "prompt", n7.id, "item"))
+
+    # Second chain edges
+    g.add_edge(create_edge(n8.id, "collection", n9.id, "collection"))
+    g.add_edge(create_edge(n9.id, "item", n10.id, "prompt"))
+    g.add_edge(create_edge(n10.id, "prompt", n11.id, "item"))
+    g.add_edge(create_edge(n11.id, "collection", n12.id, "collection"))
+    g.add_edge(create_edge(n12.id, "item", n13.id, "prompt"))
+    g.add_edge(create_edge(n13.id, "prompt", n14.id, "item"))
+
+    # Execute the graph
+    session = GraphExecutionState(graph=g)
+    run_session_with_mock_context(session)
+
+    # Verify both chains executed correctly
+    output1 = get_single_output_from_session(session, n7.id)
+    output2 = get_single_output_from_session(session, n14.id)
+
+    assert isinstance(output1, CollectInvocationOutput)
+    assert isinstance(output2, CollectInvocationOutput)
+    assert set(output1.collection) == {"a", "b"}
+    assert set(output2.collection) == {"x", "y", "z"}
+
+
+def test_iterator_collector_iterator_chain_with_cross_dependency():
+    """Test Iterator -> Collector -> Iterator chain where the second iterator depends on both chains."""
+    g = Graph()
+
+    # First chain: process strings
+    n1 = PromptCollectionTestInvocation(id="1", collection=["hello", "world"])
+    n2 = IterateInvocation(id="2")
+    n3 = PromptTestInvocation(id="3")
+    n4 = CollectInvocation(id="4")
+
+    # Second chain: process the collected results
+    n5 = IterateInvocation(id="5")
+    n6 = PromptTestInvocation(id="6")
+
+    # Additional input that gets collected with the iterator results
+    n7 = PromptTestInvocation(id="7", prompt="extra")
+
+    # Collector that receives from both the iterator and the additional input
+    n8 = CollectInvocation(id="8")
+
+    for node in [n1, n2, n3, n4, n5, n6, n7, n8]:
+        g.add_node(node)
+
+    # First chain
+    g.add_edge(create_edge(n1.id, "collection", n2.id, "collection"))
+    g.add_edge(create_edge(n2.id, "item", n3.id, "prompt"))
+    g.add_edge(create_edge(n3.id, "prompt", n4.id, "item"))
+
+    # Second chain
+    g.add_edge(create_edge(n4.id, "collection", n5.id, "collection"))
+    g.add_edge(create_edge(n5.id, "item", n6.id, "prompt"))
+
+    # Cross-dependency: collector receives from both iterator and regular node
+    g.add_edge(create_edge(n6.id, "prompt", n8.id, "item"))
+    g.add_edge(create_edge(n7.id, "prompt", n8.id, "item"))
+
+    # Execute the graph
+    session = GraphExecutionState(graph=g)
+    run_session_with_mock_context(session)
+
+    # Verify the final output contains items from both sources
+    output = get_single_output_from_session(session, n8.id)
+    assert isinstance(output, CollectInvocationOutput)
+    # Should contain the processed items from the iterator plus the extra item
+    assert set(output.collection) == {"hello", "world", "extra"}
+
+
+def test_iterator_collector_iterator_chain_with_empty_collection():
+    """Test Iterator -> Collector -> Iterator chain with empty input collection."""
+    g = Graph()
+
+    # Start with empty collection
+    n1 = PromptCollectionTestInvocation(id="1", collection=[])
+    n2 = IterateInvocation(id="2")
+    n3 = PromptTestInvocation(id="3")
+    n4 = CollectInvocation(id="4")
+    n5 = IterateInvocation(id="5")
+    n6 = PromptTestInvocation(id="6")
+    n7 = CollectInvocation(id="7")
+
+    for node in [n1, n2, n3, n4, n5, n6, n7]:
+        g.add_node(node)
+
+    # Chain the nodes
+    g.add_edge(create_edge(n1.id, "collection", n2.id, "collection"))
+    g.add_edge(create_edge(n2.id, "item", n3.id, "prompt"))
+    g.add_edge(create_edge(n3.id, "prompt", n4.id, "item"))
+    g.add_edge(create_edge(n4.id, "collection", n5.id, "collection"))
+    g.add_edge(create_edge(n5.id, "item", n6.id, "prompt"))
+    g.add_edge(create_edge(n6.id, "prompt", n7.id, "item"))
+
+    # Execute the graph
+    session = GraphExecutionState(graph=g)
+    run_session_with_mock_context(session)
+
+    # With empty collection, iterators don't create execution nodes, so collectors don't execute
+    # Verify that the final collector was never prepared (which is correct behavior)
+    assert n7.id not in session.source_prepared_mapping
+
+    # Verify only the source collection node executed
+    assert n1.id in session.source_prepared_mapping
+    assert len(session.source_prepared_mapping[n1.id]) == 1


### PR DESCRIPTION
## Summary

A subtle python bug caused invalid edges to be created when handling collect nodes. Who knows what weirdness this was causing.

Fixed the root cause and added some tests for this case and some other iterate/collect test cases.

## Related Issues / Discussions

Fixes this issue - and possibly others related to collect nodes:
![image](https://github.com/user-attachments/assets/6742e3fb-0342-40e3-9d30-3803c50b9b5b)

@JPPhoto raised on discord: https://discord.com/channels/1020123559063990373/1083864753543331981/1389069903205634142

## QA Instructions

Should fix JP's issue.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
