### PR TITLE
fix(ui): Upscale creativity bug

### DIFF
--- a/invokeai/app/util/step_callback.py
+++ b/invokeai/app/util/step_callback.py
@@ -123,7 +123,11 @@ def calc_percentage(intermediate_state: PipelineIntermediateState) -> float:
     if total_steps == 0:
         return 0.0
     if order == 2:
-        return floor(step / 2) / floor(total_steps / 2)
+        # Prevent division by zero when total_steps is 1 or 2
+        denominator = floor(total_steps / 2)
+        if denominator == 0:
+            return 0.0
+        return floor(step / 2) / denominator
     # order == 1
     return step / total_steps
 


### PR DESCRIPTION
## Summary

When creativity was at -10, users could run into a div by zero error. This clamps the bottom range of creativity.

## Related Issues / Discussions
Bug reports

## QA Instructions
Run with Creativity at <10 in the UPscale tab.

## Merge Plan
Merge when ready

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
