### PR TITLE
fix(ui): button functionality in workflow tab

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/WorkflowViewEditToggleButton.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/WorkflowViewEditToggleButton.tsx
@@ -2,7 +2,7 @@ import { IconButton } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { selectWorkflowMode, workflowModeChanged } from 'features/nodes/store/workflowLibrarySlice';
 import { navigationApi } from 'features/ui/layouts/navigation-api';
-import { WORKSPACE_PANEL_ID } from 'features/ui/layouts/shared';
+import { VIEWER_PANEL_ID, WORKSPACE_PANEL_ID } from 'features/ui/layouts/shared';
 import { setActiveTab } from 'features/ui/store/uiSlice';
 import type { MouseEventHandler } from 'react';
 import { memo, useCallback } from 'react';
@@ -33,7 +33,7 @@ export const WorkflowViewEditToggleButton = memo(() => {
       dispatch(setActiveTab('workflows'));
       dispatch(workflowModeChanged('view'));
       // Focus the Image Viewer panel
-      navigationApi.focusPanelInTab('workflows', WORKSPACE_PANEL_ID);
+      navigationApi.focusPanelInTab('workflows', VIEWER_PANEL_ID);
     },
     [dispatch]
   );


### PR DESCRIPTION
Summary

Fix: The "use in linear view" button on the workflow tab now correctly switches to and focuses the Image Viewer panel.

Related Issues / Discussions

N/A

QA Instructions

1.  Navigate to the "Workflow" tab.
2.  Click the "Use in linear view" (eye icon) button in the side panel.
3.  Verify that the UI switches to the Image Viewer panel within the workflow tab.

Merge Plan

N/A

Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_