### PR TITLE
feat(ui):Automatically select brush tool on edit

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImageButtons.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImageButtons.tsx
@@ -1,6 +1,7 @@
 import { Button, Divider, IconButton, Menu, MenuButton, MenuList } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { useAppSelector, useAppStore } from 'app/store/storeHooks';
+import { useCanvasManagerSafe } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import { selectIsStaging } from 'features/controlLayers/store/canvasStagingAreaSlice';
 import { DeleteImageButton } from 'features/deleteImageModal/components/DeleteImageButton';
 import SingleSelectionMenuItems from 'features/gallery/components/ImageContextMenu/SingleSelectionMenuItems';
@@ -44,6 +45,7 @@ export const CurrentImageButtons = memo(() => {
   const isStaging = useAppSelector(selectIsStaging);
   const isUpscalingEnabled = useFeatureStatus('upscaling');
   const { getState, dispatch } = useAppStore();
+  const canvasManager = useCanvasManagerSafe();
 
   const handleEdit = useCallback(async () => {
     if (!imageDTO) {
@@ -58,12 +60,18 @@ export const CurrentImageButtons = memo(() => {
       dispatch,
     });
     navigationApi.focusPanelInTab('canvas', WORKSPACE_PANEL_ID);
+
+    // Automatically select the brush tool when editing an image
+    if (canvasManager) {
+      canvasManager.tool.$tool.set('brush');
+    }
+
     toast({
       id: 'SENT_TO_CANVAS',
       title: t('toast.sentToCanvas'),
       status: 'success',
     });
-  }, [imageDTO, getState, dispatch, t]);
+  }, [imageDTO, getState, dispatch, t, canvasManager]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

When a user clicks the "Edit" button from the Image Viewer, the "Brush" tool is now automatically selected on the canvas. This streamlines the workflow by immediately preparing the user for common editing tasks after sending an image to the canvas.


##   Related Issues / Discussions

N/A

## QA Instructions

1.  Navigate to the Image Viewer.
2.  Select any image.
3.  Click the "Edit" button.
4.  Observe that the canvas panel is focused and the "Brush" tool is automatically selected in the canvas toolbar.

##  Merge Plan

N/A

%23%23 Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_