### PR TITLE
fix(ui): Fix translation reference in models picker

### DIFF
--- a/invokeai/frontend/web/src/features/lora/components/LoRASelect.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/LoRASelect.tsx
@@ -55,7 +55,7 @@ const LoRASelect = () => {
     }
 
     if (compatibleLoRAs.length === 0) {
-      return currentBaseModel ? t('models.noCompatibleLoRAs') : t('models.selectModelFirst');
+      return currentBaseModel ? t('models.noCompatibleLoRAs') : t('models.selectModel');
     }
 
     return t('models.addLora');
@@ -88,7 +88,7 @@ const LoRASelect = () => {
         placeholder={placeholder}
         getIsOptionDisabled={getIsDisabled}
         initialGroupStates={initialGroupStates}
-        noOptionsText={currentBaseModel ? t('models.noCompatibleLoRAs') : t('models.selectModelFirst')}
+        noOptionsText={currentBaseModel ? t('models.noCompatibleLoRAs') : t('models.selectModel')}
       />
     </FormControl>
   );


### PR DESCRIPTION
## Summary

The fix replaces the incorrect `t('models.selectModelFirst')` with the correct and existing `t('models.selectModel')` in `invokeai/frontend/web/src/features/lora/components/LoRASelect.tsx`.

##  Related Issues / Discussions

N/A

##  QA Instructions

1.  Navigate to the LoRA/Concepts section in the UI.
2.  Ensure that no base model is currently selected.
3.  Verify that the LoRA select dropdown displays "Select a Model" (or its translated equivalent) as its placeholder text.
4.  Open the LoRA select dropdown and confirm that the "no options" text also displays "Select a Model" (or its translated equivalent).
5. Enjoy the fix. Luxuriate in the translation.

##  Merge Plan

N/A

##  Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_