### PR TITLE
fix(ui): Fix save to gallery image update issue from staging area.

### DIFF
--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -15,7 +15,7 @@ import type {
   SQLiteDirection,
   UploadImageArg,
 } from 'services/api/types';
-import { getCategories, getListImagesUrl } from 'services/api/util';
+import { getListImagesUrl } from 'services/api/util';
 import stableHash from 'stable-hash';
 import type { Param0 } from 'tsafe';
 import type { JsonObject } from 'type-fest';

--- a/invokeai/frontend/web/src/services/api/endpoints/images.ts
+++ b/invokeai/frontend/web/src/services/api/endpoints/images.ts
@@ -270,25 +270,13 @@ export const imagesApi = api.injectEndpoints({
           // Don't add it to anything
           return [];
         }
-        const categories = getCategories(result);
         const boardId = result.board_id ?? 'none';
 
         return [
-          {
-            type: 'ImageList',
-            id: getListImagesUrl({
-              board_id: boardId,
-              categories,
-            }),
-          },
-          {
-            type: 'Board',
-            id: boardId,
-          },
-          {
-            type: 'BoardImagesTotal',
-            id: boardId,
-          },
+          ...getTagsToInvalidateForImageMutation([result.image_name]),
+          ...getTagsToInvalidateForBoardAffectingMutation([boardId]),
+          'ImageCollectionCounts',
+          { type: 'ImageCollection', id: LIST_TAG },
         ];
       },
     }),


### PR DESCRIPTION
## Summary

Fixes an issue where the Gallery was not updating immediately after an image was uploaded or copied (e.g., from the Staging Area).

The `uploadImage` mutation's cache invalidation was incomplete, preventing the Gallery from reflecting new images without a manual refresh. This PR updates the `uploadImage` mutation to use a comprehensive set of cache invalidation tags, aligning it with other mutations that affect image collections and boards.

## QA Instructions

1.  Go to the Staging Area.
2.  Select an image.
3.  Click the "Save Selected to Gallery" button.
4.  Verify that the Gallery (left sidebar) updates immediately to show the newly saved image, without requiring a page refresh.

## Checklist

-   [x] _The PR has a short but descriptive title, suitable for a changelog_
-   [ ] _Tests added / updated (if applicable)_
-   [ ] _Documentation added / updated (if applicable)_
-   [ ] _Updated `What's New` copy (if doing a release after this PR)_