### PR TITLE
fix(ui): Reset canvas session when queue item is canceled 

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/SimpleSession/StagingAreaItemsList.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/SimpleSession/StagingAreaItemsList.tsx
@@ -17,8 +17,8 @@ export const StagingAreaItemsList = memo(() => {
       return;
     }
 
-    return canvasManager.stagingArea.connectToSession(ctx.$selectedItemId, ctx.$progressData);
-  }, [canvasManager, ctx.$progressData, ctx.$selectedItemId]);
+    return canvasManager.stagingArea.connectToSession(ctx.$selectedItemId, ctx.$progressData, ctx.$isPending);
+  }, [canvasManager, ctx.$progressData, ctx.$selectedItemId, ctx.$isPending]);
 
   return (
     <ScrollableContent overflowX="scroll" overflowY="hidden">

--- a/invokeai/frontend/web/src/features/controlLayers/components/SimpleSession/context.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/SimpleSession/context.tsx
@@ -92,6 +92,7 @@ type CanvasSessionContextValue = {
   $items: Atom<S['SessionQueueItem'][]>;
   $itemCount: Atom<number>;
   $hasItems: Atom<boolean>;
+  $isPending: Atom<boolean>;
   $progressData: ProgressDataMap;
   $selectedItemId: WritableAtom<number | null>;
   $selectedItem: Atom<S['SessionQueueItem'] | null>;
@@ -169,6 +170,13 @@ export const CanvasSessionContextProvider = memo(
      * Whether there are any items. Computed from the queue items array.
      */
     const $hasItems = useState(() => computed([$items], (items) => items.length > 0))[0];
+
+    /**
+     * Whether there are any pending or in-progress items. Computed from the queue items array.
+     */
+    const $isPending = useState(() =>
+      computed([$items], (items) => items.some((item) => item.status === 'pending' || item.status === 'in_progress'))
+    )[0];
 
     /**
      * The currently selected queue item, or null if one is not selected.
@@ -506,6 +514,7 @@ export const CanvasSessionContextProvider = memo(
         session,
         $items,
         $hasItems,
+        $isPending,
         $progressData,
         $selectedItemId,
         $autoSwitch,
@@ -523,6 +532,7 @@ export const CanvasSessionContextProvider = memo(
         $autoSwitch,
         $items,
         $hasItems,
+        $isPending,
         $progressData,
         $selectedItem,
         $selectedItemId,

--- a/invokeai/frontend/web/src/services/events/setEventListeners.tsx
+++ b/invokeai/frontend/web/src/services/events/setEventListeners.tsx
@@ -9,7 +9,6 @@ import { $queueId } from 'app/store/nanostores/queueId';
 import type { AppStore } from 'app/store/store';
 import { deepClone } from 'common/util/deepClone';
 import { forEach, isNil, round } from 'es-toolkit/compat';
-import { canvasSessionReset, selectCanvasSessionId } from 'features/controlLayers/store/canvasStagingAreaSlice';
 import {
   $isInPublishFlow,
   $outputNodeId,
@@ -347,15 +346,6 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     const { item_id, session_id, status, batch_status, error_type, error_message, destination } = data;
 
     log.debug({ data }, `Queue item ${item_id} status updated: ${status}`);
-
-    // If this queue item was canceled and it belongs to the current canvas session, reset the canvas session
-    if (status === 'canceled' && destination) {
-      const currentCanvasSessionId = selectCanvasSessionId(getState());
-      if (currentCanvasSessionId === destination) {
-        dispatch(canvasSessionReset());
-        log.debug(`Canvas session reset due to canceled queue item ${item_id}`);
-      }
-    }
 
     // Invalidate caches for things we cannot easily update
     const tagsToInvalidate: ApiTagDescription[] = [

--- a/invokeai/frontend/web/src/services/events/setEventListeners.tsx
+++ b/invokeai/frontend/web/src/services/events/setEventListeners.tsx
@@ -9,6 +9,7 @@ import { $queueId } from 'app/store/nanostores/queueId';
 import type { AppStore } from 'app/store/store';
 import { deepClone } from 'common/util/deepClone';
 import { forEach, isNil, round } from 'es-toolkit/compat';
+import { canvasSessionReset, selectCanvasSessionId } from 'features/controlLayers/store/canvasStagingAreaSlice';
 import {
   $isInPublishFlow,
   $outputNodeId,
@@ -346,6 +347,15 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     const { item_id, session_id, status, batch_status, error_type, error_message, destination } = data;
 
     log.debug({ data }, `Queue item ${item_id} status updated: ${status}`);
+
+    // If this queue item was canceled and it belongs to the current canvas session, reset the canvas session
+    if (status === 'canceled' && destination) {
+      const currentCanvasSessionId = selectCanvasSessionId(getState());
+      if (currentCanvasSessionId === destination) {
+        dispatch(canvasSessionReset());
+        log.debug(`Canvas session reset due to canceled queue item ${item_id}`);
+      }
+    }
 
     // Invalidate caches for things we cannot easily update
     const tagsToInvalidate: ApiTagDescription[] = [


### PR DESCRIPTION
## Summary

Fixes the waiting for image screen sticking around after a cancel.

## Related Issues / Discussions
N/A

## QA Instructions
Cancel an image

## Merge Plan

Merge the PR

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
