### PR TITLE
fix(ui): Adds related model support to embeddings

### DIFF
--- a/invokeai/frontend/web/src/features/prompt/PromptTriggerSelect.tsx
+++ b/invokeai/frontend/web/src/features/prompt/PromptTriggerSelect.tsx
@@ -42,19 +42,6 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
   const options = useMemo(() => {
     const _options: GroupBase<ComboboxOption>[] = [];
 
-    if (tiModels) {
-      const embeddingOptions = tiModels
-        .filter((ti) => ti.base === mainModelConfig?.base)
-        .map((model) => ({ label: model.name, value: `<${model.name}>` }));
-
-      if (embeddingOptions.length > 0) {
-        _options.push({
-          label: t('prompt.compatibleEmbeddings'),
-          options: embeddingOptions,
-        });
-      }
-    }
-
     if (loraModels) {
       const triggerPhraseOptions = loraModels
         .filter((lora) => map(addedLoRAs, (l) => l.model.key).includes(lora.key))
@@ -70,6 +57,19 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
         _options.push({
           label: t('modelManager.loraTriggerPhrases'),
           options: flatten(triggerPhraseOptions),
+        });
+      }
+    }
+
+    if (tiModels) {
+      const embeddingOptions = tiModels
+        .filter((ti) => ti.base === mainModelConfig?.base)
+        .map((model) => ({ label: model.name, value: `<${model.name}>` }));
+
+      if (embeddingOptions.length > 0) {
+        _options.push({
+          label: t('prompt.compatibleEmbeddings'),
+          options: embeddingOptions,
         });
       }
     }

--- a/invokeai/frontend/web/src/features/prompt/PromptTriggerSelect.tsx
+++ b/invokeai/frontend/web/src/features/prompt/PromptTriggerSelect.tsx
@@ -1,5 +1,5 @@
 import type { ChakraProps, ComboboxOnChange, ComboboxOption } from '@invoke-ai/ui-library';
-import { Combobox, FormControl, Icon } from '@invoke-ai/ui-library';
+import { Combobox, Flex, FormControl, Icon } from '@invoke-ai/ui-library';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useAppSelector } from 'app/store/storeHooks';
 import type { GroupBase } from 'chakra-react-select';
@@ -18,7 +18,7 @@ import { isNonRefinerMainModelConfig } from 'services/api/types';
 
 const noOptionsMessage = () => t('prompt.noMatchingTriggers');
 
-type RelatedEmbedding = ComboboxOption & { starred?: boolean };
+type ComboboxOptionWithStarred = ComboboxOption & { starred?: boolean };
 
 export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSelectProps) => {
   const { t } = useTranslation();
@@ -65,7 +65,7 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
   );
 
   const options = useMemo(() => {
-    const _options: GroupBase<ComboboxOption>[] = [];
+    const _options: GroupBase<ComboboxOptionWithStarred>[] = [];
 
     if (loraModels) {
       const triggerPhraseOptions = loraModels
@@ -88,7 +88,7 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
 
     if (tiModels) {
       // Create embedding options with starred property for related models
-      const embeddingOptions: RelatedEmbedding[] = tiModels
+      const embeddingOptions: ComboboxOptionWithStarred[] = tiModels
         .filter((ti) => ti.base === mainModelConfig?.base)
         .map((model) => ({
           label: model.name,
@@ -128,27 +128,26 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
     return _options;
   }, [tiModels, loraModels, mainModelConfig, t, addedLoRAs, relatedModelKeys]);
 
-  const formatOptionLabel = useCallback((option: ComboboxOption) => {
-    const embeddingOption = option as RelatedEmbedding;
-    if (embeddingOption.starred) {
-      return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <Icon as={PiLinkSimple} color="invokeYellow.500" boxSize={3} />
-          {option.label}
-        </div>
-      );
-    }
-    return option.label;
+  const formatOptionLabel = useCallback((option: ComboboxOptionWithStarred) => {
+    return (
+      <Flex alignItems="center" gap={2}>
+        {option.starred && <Icon as={PiLinkSimple} color="invokeYellow.500" boxSize={4} />}
+        {option.label}
+      </Flex>
+    );
   }, []);
+
+  const placeholder = useMemo(() => {
+    if (isLoadingLoRAs || isLoadingTIs || isLoadingMainModelConfig) {
+      return t('common.loading');
+    }
+    return t('prompt.addPromptTrigger');
+  }, [t, isLoadingLoRAs, isLoadingTIs, isLoadingMainModelConfig]);
 
   return (
     <FormControl>
       <Combobox
-        placeholder={
-          isLoadingLoRAs || isLoadingTIs || isLoadingMainModelConfig
-            ? t('common.loading')
-            : t('prompt.addPromptTrigger')
-        }
+        placeholder={placeholder}
         defaultMenuIsOpen
         autoFocus
         value={null}

--- a/invokeai/frontend/web/src/features/prompt/PromptTriggerSelect.tsx
+++ b/invokeai/frontend/web/src/features/prompt/PromptTriggerSelect.tsx
@@ -1,5 +1,5 @@
 import type { ChakraProps, ComboboxOnChange, ComboboxOption } from '@invoke-ai/ui-library';
-import { Combobox, FormControl } from '@invoke-ai/ui-library';
+import { Combobox, FormControl, Icon } from '@invoke-ai/ui-library';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useAppSelector } from 'app/store/storeHooks';
 import type { GroupBase } from 'chakra-react-select';
@@ -10,11 +10,15 @@ import type { PromptTriggerSelectProps } from 'features/prompt/types';
 import { t } from 'i18next';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PiLinkSimple } from 'react-icons/pi';
+import { useGetRelatedModelIdsBatchQuery } from 'services/api/endpoints/modelRelationships';
 import { useGetModelConfigQuery } from 'services/api/endpoints/models';
 import { useEmbeddingModels, useLoRAModels } from 'services/api/hooks/modelsByType';
 import { isNonRefinerMainModelConfig } from 'services/api/types';
 
 const noOptionsMessage = () => t('prompt.noMatchingTriggers');
+
+type RelatedEmbedding = ComboboxOption & { starred?: boolean };
 
 export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSelectProps) => {
   const { t } = useTranslation();
@@ -26,6 +30,27 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
   );
   const [loraModels, { isLoading: isLoadingLoRAs }] = useLoRAModels();
   const [tiModels, { isLoading: isLoadingTIs }] = useEmbeddingModels();
+
+  // Get related model keys for current selected models
+  const selectedModelKeys = useMemo(() => {
+    const keys: string[] = [];
+    if (mainModel) {
+      keys.push(mainModel.key);
+    }
+    for (const { model } of addedLoRAs) {
+      keys.push(model.key);
+    }
+    return keys;
+  }, [mainModel, addedLoRAs]);
+
+  const { relatedModelKeys } = useGetRelatedModelIdsBatchQuery(selectedModelKeys, {
+    selectFromResult: ({ data }) => {
+      if (!data) {
+        return { relatedModelKeys: [] };
+      }
+      return { relatedModelKeys: data };
+    },
+  });
 
   const _onChange = useCallback<ComboboxOnChange>(
     (v) => {
@@ -62,9 +87,25 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
     }
 
     if (tiModels) {
-      const embeddingOptions = tiModels
+      // Create embedding options with starred property for related models
+      const embeddingOptions: RelatedEmbedding[] = tiModels
         .filter((ti) => ti.base === mainModelConfig?.base)
-        .map((model) => ({ label: model.name, value: `<${model.name}>` }));
+        .map((model) => ({
+          label: model.name,
+          value: `<${model.name}>`,
+          starred: relatedModelKeys.includes(model.key),
+        }));
+
+      // Sort so related embeddings come first
+      embeddingOptions.sort((a, b) => {
+        if (a.starred && !b.starred) {
+          return -1;
+        }
+        if (!a.starred && b.starred) {
+          return 1;
+        }
+        return 0;
+      });
 
       if (embeddingOptions.length > 0) {
         _options.push({
@@ -85,7 +126,20 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
     }
 
     return _options;
-  }, [tiModels, loraModels, mainModelConfig, t, addedLoRAs]);
+  }, [tiModels, loraModels, mainModelConfig, t, addedLoRAs, relatedModelKeys]);
+
+  const formatOptionLabel = useCallback((option: ComboboxOption) => {
+    const embeddingOption = option as RelatedEmbedding;
+    if (embeddingOption.starred) {
+      return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <Icon as={PiLinkSimple} color="invokeYellow.500" boxSize={3} />
+          {option.label}
+        </div>
+      );
+    }
+    return option.label;
+  }, []);
 
   return (
     <FormControl>
@@ -104,6 +158,7 @@ export const PromptTriggerSelect = memo(({ onSelect, onClose }: PromptTriggerSel
         onMenuClose={onClose}
         data-testid="add-prompt-trigger"
         sx={selectStyles}
+        formatOptionLabel={formatOptionLabel}
       />
     </FormControl>
   );


### PR DESCRIPTION
```
## Summary

Adds related model support to embeddings. Also reorders the prompt trigger popover menu to display LoRA trigger phrases before compatible embeddings. 

## Related Issues / Discussions
Missing embedding related models.

## QA Instructions
1.  Open the prompt trigger popover menu (e.g., by typing `/` in the prompt input field).
2.  Verify that "LoRA Trigger Phrases" are listed before "Compatible Embeddings".
3. Verify related embeddings are styled correctly.

## Merge Plan
merge when good.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
```