### PR TITLE
fix(ui): Re-implement image comparison on drag

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewerPanel.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewerPanel.tsx
@@ -1,17 +1,41 @@
 import { Divider, Flex } from '@invoke-ai/ui-library';
-import { ImageViewer } from 'features/gallery/components/ImageViewer/ImageViewer';
-import { ViewerToolbar } from 'features/gallery/components/ImageViewer/ViewerToolbar';
-import { memo } from 'react';
+import { useAppSelector } from 'app/store/storeHooks';
+import type { SetComparisonImageDndTargetData } from 'features/dnd/dnd';
+import { setComparisonImageDndTarget } from 'features/dnd/dnd';
+import { DndDropTarget } from 'features/dnd/DndDropTarget';
+import { selectImageToCompare, selectLastSelectedImage } from 'features/gallery/store/gallerySelectors';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { ImageViewerContextProvider } from './context';
+import { ImageViewer } from './ImageViewer';
+import { ViewerToolbar } from './ViewerToolbar';
 
 export const ImageViewerPanel = memo(() => {
+  const { t } = useTranslation();
+  const lastSelectedImage = useAppSelector(selectLastSelectedImage);
+  const imageToCompare = useAppSelector(selectImageToCompare);
+
+  // Only show drop target when we have a selected image but no comparison image yet
+  const shouldShowDropTarget = lastSelectedImage && !imageToCompare;
+
+  const dndTargetData = useMemo<SetComparisonImageDndTargetData>(() => setComparisonImageDndTarget.getData(), []);
+
   return (
     <ImageViewerContextProvider>
-      <Flex flexDir="column" w="full" h="full" overflow="hidden" gap={2}>
+      <Flex flexDir="column" w="full" h="full" overflow="hidden" gap={2} position="relative">
         <ViewerToolbar />
         <Divider />
-        <ImageViewer />
+        <Flex w="full" h="full" position="relative">
+          <ImageViewer />
+          {shouldShowDropTarget && (
+            <DndDropTarget
+              dndTarget={setComparisonImageDndTarget}
+              dndTargetData={dndTargetData}
+              label={t('gallery.selectForCompare')}
+            />
+          )}
+        </Flex>
       </Flex>
     </ImageViewerContextProvider>
   );


### PR DESCRIPTION
## Summary

This PR reintroduces image comparison directly from the Image Viewer panel by dragging an image from the gallery onto the Image Viewer, which was lost to the sands of time in the Great Earthquake of '25.

## Related Issues / Discussions

Customer reports

## QA Instructions

1.  Select an image in the gallery.
2.  Open the Image Viewer panel.
3.  Drag a *different* image from the gallery onto the Image Viewer panel.
4.  Verify that the Image Viewer automatically switches to comparison mode, displaying both images side-by-side.
5.  Confirm that the "Select for compare" drop target overlay is only visible when an image is selected and no comparison image is currently active.

## Merge Plan

<!-- None -->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_