### PR TITLE
fix(ui): Fix gallery toggle button functionality

### DIFF
--- a/invokeai/frontend/web/src/features/ui/components/FloatingRightPanelButtons.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/FloatingRightPanelButtons.tsx
@@ -22,7 +22,7 @@ const ToggleRightPanelButton = memo(() => {
     if (navigationApi.tabApi?.getTab() !== tab) {
       return;
     }
-    navigationApi.toggleLeftPanelInTab(tab);
+    navigationApi.toggleRightPanelInTab(tab);
   }, [tab]);
 
   return (


### PR DESCRIPTION
## Summary

Fixes an issue where the gallery toggle button (right panel) incorrectly opened/closed the options panel (left panel). This is unintended behavior, as users often expect buttons on the right side of the screen to affect the panels on the right side of the image.

With this fix, we have achieved intuitive behavior and all is right with the world.

## Related Issues / Discussions

<!-- None -->

## QA Instructions

1.  Open the InvokeAI UI.
2.  Click the "Gallery" button (rightmost button in the floating panel on the right).
3.  Verify that the right-hand gallery panel opens/closes, and the left-hand options panel is unaffected.

## Merge Plan

<!-- None -->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_