### PR TITLE
fix(ui): sets cfg_rescale_multiplier to 0 if there is no default. Also fixes issue with truthiness check causing 0 value to be missed.

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/setDefaultSettings.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/setDefaultSettings.ts
@@ -1,4 +1,5 @@
 import type { AppStartListening } from 'app/store/middleware/listenerMiddleware';
+import { isNil } from 'es-toolkit';
 import { bboxHeightChanged, bboxWidthChanged } from 'features/controlLayers/store/canvasSlice';
 import { selectIsStaging } from 'features/controlLayers/store/canvasStagingAreaSlice';
 import {
@@ -86,10 +87,16 @@ export const addSetDefaultSettingsListener = (startAppListening: AppStartListeni
           }
         }
 
-        if (cfg_rescale_multiplier) {
+        if (!isNil(cfg_rescale_multiplier)) {
           if (isParameterCFGRescaleMultiplier(cfg_rescale_multiplier)) {
             dispatch(setCfgRescaleMultiplier(cfg_rescale_multiplier));
           }
+        } else {
+          // Set this to 0 if it doesn't have a default. This value is
+          // easy to miss in the UI when users are resetting defaults
+          // and leaving it non-zero could lead to detrimental
+          // effects.
+          dispatch(setCfgRescaleMultiplier(0));
         }
 
         if (steps) {


### PR DESCRIPTION
## Summary
Sets CFG Rescale Multiplier to 0 when the Set Model Defaults icon is clicked if the Model does not have a default value for CFG Rescale Multiplier. See issue https://github.com/invoke-ai/InvokeAI/issues/7584 for the "why".  

Also addresses a minor issue where if the default is enabled but set to 0, and the Reset Model Defaults is clicked, the value is not reset to 0. 

Both issues were fixed in the default settings middleware by checking for a null value in the same way it's checked in the UseDefaultSettingsButton logic, and by adding an else block to force the value to 0 if it is null.

## Related Issues / Discussions
Closes #7584

## QA Instructions

Disabled a models default CFG Rescale Multiplier and changed settings in the Canvas view including CFG Rescale Multiplier, then clicked on the Reset Defaults icon (PiSparkleFil) to verify the initially reported issue is fixed. 

Enabled a models default CFG Rescale Multipler, but left the value as 0. Changed other model settings in Canvas view including the CFG Rescale Multipler, then clicked on the Reset Defaults icon to verify the CFG Rescale Multiplier is set back to 0.

## Merge Plan

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
