### PR TITLE
feat(ui): Adds bbox to ref image button on Canvas

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageHeader.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageHeader.tsx
@@ -4,13 +4,17 @@ import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useRefImageEntity } from 'features/controlLayers/components/RefImage/useRefImageEntity';
 import { useRefImageIdContext } from 'features/controlLayers/contexts/RefImageIdContext';
+import { selectMainModelConfig } from 'features/controlLayers/store/paramsSlice';
 import {
   refImageDeleted,
   refImageIsEnabledToggled,
   selectRefImageEntityIds,
 } from 'features/controlLayers/store/refImagesSlice';
+import { getGlobalReferenceImageWarnings } from 'features/controlLayers/store/validators';
 import { memo, useCallback, useMemo } from 'react';
-import { PiCircleBold, PiCircleFill, PiTrashBold } from 'react-icons/pi';
+import { PiCircleBold, PiCircleFill, PiTrashBold, PiWarningBold } from 'react-icons/pi';
+
+import { RefImageWarningTooltipContent } from './RefImageWarningTooltipContent';
 
 const textSx: SystemStyleObject = {
   color: 'base.300',
@@ -28,6 +32,12 @@ export const RefImageHeader = memo(() => {
   );
   const refImageNumber = useAppSelector(selectRefImageNumber);
   const entity = useRefImageEntity(id);
+  const mainModelConfig = useAppSelector(selectMainModelConfig);
+
+  const warnings = useMemo(() => {
+    return getGlobalReferenceImageWarnings(entity, mainModelConfig);
+  }, [entity, mainModelConfig]);
+
   const deleteRefImage = useCallback(() => {
     dispatch(refImageDeleted({ id }));
   }, [dispatch, id]);
@@ -42,6 +52,18 @@ export const RefImageHeader = memo(() => {
         Reference Image #{refImageNumber}
       </Text>
       <Flex alignItems="center" gap={1}>
+        {warnings.length > 0 && (
+          <IconButton
+            as="span"
+            size="sm"
+            variant="link"
+            alignSelf="stretch"
+            aria-label="warnings"
+            tooltip={<RefImageWarningTooltipContent warnings={warnings} />}
+            icon={<PiWarningBold />}
+            colorScheme="warning"
+          />
+        )}
         {!entity.isEnabled && (
           <Text fontSize="xs" fontStyle="italic" color="base.400">
             Disabled

--- a/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageList.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageList.tsx
@@ -85,11 +85,9 @@ const MaxRefImages = memo(() => {
 MaxRefImages.displayName = 'MaxRefImages';
 
 const AddRefImageDropTargetAndButton = memo(() => {
-  const { t } = useTranslation();
   const { dispatch, getState } = useAppStore();
   const tab = useAppSelector(selectActiveTab);
   const canvasManager = useCanvasManagerSafe();
-  const isBusy = useCanvasIsBusySafe();
 
   const uploadOptions = useMemo(
     () =>

--- a/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageList.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageList.tsx
@@ -1,11 +1,8 @@
-import { Button, Collapse, Divider, Flex } from '@invoke-ai/ui-library';
+import { Button, Collapse, Divider, Flex, IconButton } from '@invoke-ai/ui-library';
 import { useAppSelector, useAppStore } from 'app/store/storeHooks';
 import { useImageUploadButton } from 'common/hooks/useImageUploadButton';
 import { RefImagePreview } from 'features/controlLayers/components/RefImage/RefImagePreview';
-import {
-  CanvasManagerProviderGate,
-  useCanvasManagerSafe,
-} from 'features/controlLayers/contexts/CanvasManagerProviderGate';
+import { CanvasManagerProviderGate } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import { RefImageIdContext } from 'features/controlLayers/contexts/RefImageIdContext';
 import { getDefaultRefImageConfig } from 'features/controlLayers/hooks/addLayerHooks';
 import { useNewGlobalReferenceImageFromBbox } from 'features/controlLayers/hooks/saveCanvasHooks';
@@ -87,7 +84,6 @@ MaxRefImages.displayName = 'MaxRefImages';
 const AddRefImageDropTargetAndButton = memo(() => {
   const { dispatch, getState } = useAppStore();
   const tab = useAppSelector(selectActiveTab);
-  const canvasManager = useCanvasManagerSafe();
 
   const uploadOptions = useMemo(
     () =>
@@ -122,7 +118,7 @@ const AddRefImageDropTargetAndButton = memo(() => {
         <input {...uploadApi.getUploadInputProps()} />
         <DndDropTarget label="Drop" dndTarget={addGlobalReferenceImageDndTarget} dndTargetData={dndTargetData} />
       </Button>
-      {tab === 'canvas' && canvasManager && (
+      {tab === 'canvas' && (
         <CanvasManagerProviderGate>
           <BboxButton />
         </CanvasManagerProviderGate>
@@ -137,22 +133,16 @@ const BboxButton = memo(() => {
   const newGlobalReferenceImageFromBbox = useNewGlobalReferenceImageFromBbox();
 
   return (
-    <Button
-      size="sm"
-      variant="ghost"
+    <IconButton
+      size="lg"
+      variant="outline"
       h="full"
-      minW="auto"
-      px={2}
-      borderWidth="2px !important"
-      borderStyle="solid !important"
-      borderRadius="base"
+      icon={<PiBoundingBoxBold />}
       onClick={newGlobalReferenceImageFromBbox}
       isDisabled={isBusy}
       aria-label={t('controlLayers.pullBboxIntoReferenceImage')}
       tooltip={t('controlLayers.pullBboxIntoReferenceImage')}
-    >
-      <PiBoundingBoxBold />
-    </Button>
+    />
   );
 });
 AddRefImageDropTargetAndButton.displayName = 'AddRefImageDropTargetAndButton';

--- a/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageWarningTooltipContent.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RefImage/RefImageWarningTooltipContent.tsx
@@ -1,0 +1,18 @@
+import { Flex, ListItem, Text, UnorderedList } from '@invoke-ai/ui-library';
+import { upperFirst } from 'es-toolkit/compat';
+import { useTranslation } from 'react-i18next';
+
+export const RefImageWarningTooltipContent = ({ warnings }: { warnings: string[] }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Flex flexDir="column">
+      <Text fontWeight="semibold">Invalid Reference Image:</Text>
+      <UnorderedList>
+        {warnings.map((tKey) => (
+          <ListItem key={tKey}>{upperFirst(t(tKey))}</ListItem>
+        ))}
+      </UnorderedList>
+    </Flex>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a button to pull the BBox into a new ref image on the canvas tab.
![image](https://github.com/user-attachments/assets/e5336858-d4b4-4461-872a-0ae90de68cab)

## Related Issues / Discussions

User requests

## QA Instructions

Try bringing the bbox into a ref image. It should work, including when images have transparency.

## Merge Plan
Merge when ready.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
