### PR TITLE
feat(ui): panel state persistence

### DIFF
--- a/invokeai/frontend/web/src/features/ui/layouts/auto-layout-context.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/auto-layout-context.tsx
@@ -1,22 +1,21 @@
 import type { FocusRegionName } from 'common/hooks/focus';
 import type { IDockviewPanelProps, IGridviewPanelProps } from 'dockview';
 import type { TabName } from 'features/ui/store/uiTypes';
-import type { FunctionComponent, PropsWithChildren, RefObject } from 'react';
+import type { FunctionComponent, PropsWithChildren } from 'react';
 import { createContext, memo, useContext, useMemo } from 'react';
 
 import { AutoLayoutPanelContainer } from './AutoLayoutPanelContainer';
 
 type AutoLayoutContextValue = {
   tab: TabName;
-  rootRef: RefObject<HTMLDivElement>;
 };
 
 const AutoLayoutContext = createContext<AutoLayoutContextValue | null>(null);
 
 export const AutoLayoutProvider = (props: PropsWithChildren<AutoLayoutContextValue>) => {
-  const { tab, rootRef, children } = props;
+  const { tab, children } = props;
 
-  const value = useMemo<AutoLayoutContextValue>(() => ({ tab, rootRef }), [tab, rootRef]);
+  const value = useMemo<AutoLayoutContextValue>(() => ({ tab }), [tab]);
   return <AutoLayoutContext.Provider value={value}>{children}</AutoLayoutContext.Provider>;
 };
 

--- a/invokeai/frontend/web/src/features/ui/layouts/canvas-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/canvas-tab-auto-layout.tsx
@@ -25,7 +25,7 @@ import { AutoLayoutProvider, useAutoLayoutContext, withPanelContainer } from 'fe
 import { TabWithoutCloseButton } from 'features/ui/layouts/TabWithoutCloseButton';
 import type { TabName } from 'features/ui/store/uiTypes';
 import { dockviewTheme } from 'features/ui/styles/theme';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { CanvasTabLeftPanel } from './CanvasTabLeftPanel';
 import { CanvasWorkspacePanel } from './CanvasWorkspacePanel';
@@ -326,30 +326,21 @@ const initializeRootPanelLayout = (api: GridviewApi) => {
 };
 
 export const CanvasTabAutoLayout = memo(() => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [rootApi, setRootApi] = useState<GridviewApi | null>(null);
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
-    setRootApi(api);
+    initializeRootPanelLayout(api);
+    navigationApi.onTabReady('canvas');
   }, []);
 
-  useEffect(() => {
-    if (!rootApi) {
-      return;
-    }
-
-    initializeRootPanelLayout(rootApi);
-
-    navigationApi.onSwitchedTab();
-
-    return () => {
+  useEffect(
+    () => () => {
       navigationApi.unregisterTab('canvas');
-    };
-  }, [rootApi]);
+    },
+    []
+  );
 
   return (
-    <AutoLayoutProvider tab="canvas" rootRef={rootRef}>
+    <AutoLayoutProvider tab="canvas">
       <GridviewReact
-        ref={rootRef}
         className="dockview-theme-invoke"
         components={rootPanelComponents}
         onReady={onReady}

--- a/invokeai/frontend/web/src/features/ui/layouts/canvas-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/canvas-tab-auto-layout.tsx
@@ -112,7 +112,8 @@ const initializeCenterPanelLayout = (tab: TabName, api: DockviewApi) => {
     },
   });
 
-  // Register panels with navigation API
+  launchpad.api.setActive();
+
   navigationApi.registerPanel(tab, LAUNCHPAD_PANEL_ID, launchpad);
   navigationApi.registerPanel(tab, WORKSPACE_PANEL_ID, workspace);
   navigationApi.registerPanel(tab, VIEWER_PANEL_ID, viewer);
@@ -125,23 +126,7 @@ const MainPanel = memo(() => {
 
   const onReady = useCallback<IDockviewReactProps['onReady']>(
     ({ api }) => {
-      const panels = initializeCenterPanelLayout(tab, api);
-      panels.launchpad.api.setActive();
-
-      const disposables = [
-        api.onWillShowOverlay((e) => {
-          if (e.kind === 'header_space' || e.kind === 'tab') {
-            return;
-          }
-          e.preventDefault();
-        }),
-      ];
-
-      return () => {
-        disposables.forEach((disposable) => {
-          disposable.dispose();
-        });
-      };
+      initializeCenterPanelLayout(tab, api);
     },
     [tab]
   );

--- a/invokeai/frontend/web/src/features/ui/layouts/generate-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/generate-tab-auto-layout.tsx
@@ -24,7 +24,7 @@ import { AutoLayoutProvider, useAutoLayoutContext, withPanelContainer } from 'fe
 import { TabWithoutCloseButton } from 'features/ui/layouts/TabWithoutCloseButton';
 import type { TabName } from 'features/ui/store/uiTypes';
 import { dockviewTheme } from 'features/ui/styles/theme';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { GenerateTabLeftPanel } from './GenerateTabLeftPanel';
 import { navigationApi } from './navigation-api';
@@ -288,30 +288,21 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 };
 
 export const GenerateTabAutoLayout = memo(() => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [rootApi, setRootApi] = useState<GridviewApi | null>(null);
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
-    setRootApi(api);
+    initializeRootPanelLayout(api);
+    navigationApi.onTabReady('generate');
   }, []);
 
-  useEffect(() => {
-    if (!rootApi) {
-      return;
-    }
-
-    initializeRootPanelLayout(rootApi);
-
-    navigationApi.onSwitchedTab();
-
-    return () => {
+  useEffect(
+    () => () => {
       navigationApi.unregisterTab('generate');
-    };
-  }, [rootApi]);
+    },
+    []
+  );
 
   return (
-    <AutoLayoutProvider tab="generate" rootRef={rootRef}>
+    <AutoLayoutProvider tab="generate">
       <GridviewReact
-        ref={rootRef}
         className="dockview-theme-invoke"
         components={rootPanelComponents}
         onReady={onReady}

--- a/invokeai/frontend/web/src/features/ui/layouts/generate-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/generate-tab-auto-layout.tsx
@@ -91,7 +91,8 @@ const initializeMainPanelLayout = (tab: TabName, api: DockviewApi) => {
     },
   });
 
-  // Register panels with navigation API
+  launchpad.api.setActive();
+
   navigationApi.registerPanel(tab, LAUNCHPAD_PANEL_ID, launchpad);
   navigationApi.registerPanel(tab, VIEWER_PANEL_ID, viewer);
 
@@ -103,23 +104,7 @@ const MainPanel = memo(() => {
 
   const onReady = useCallback<IDockviewReactProps['onReady']>(
     ({ api }) => {
-      const { launchpad } = initializeMainPanelLayout(tab, api);
-      launchpad.api.setActive();
-
-      const disposables = [
-        api.onWillShowOverlay((e) => {
-          if (e.kind === 'header_space' || e.kind === 'tab') {
-            return;
-          }
-          e.preventDefault();
-        }),
-      ];
-
-      return () => {
-        disposables.forEach((disposable) => {
-          disposable.dispose();
-        });
-      };
+      initializeMainPanelLayout(tab, api);
     },
     [tab]
   );

--- a/invokeai/frontend/web/src/features/ui/layouts/models-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/models-tab-auto-layout.tsx
@@ -3,7 +3,7 @@ import { GridviewReact, LayoutPriority, Orientation } from 'dockview';
 import ModelManagerTab from 'features/ui/components/tabs/ModelManagerTab';
 import type { RootLayoutGridviewComponents } from 'features/ui/layouts/auto-layout-context';
 import { AutoLayoutProvider } from 'features/ui/layouts/auto-layout-context';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { navigationApi } from './navigation-api';
 import { MODELS_PANEL_ID } from './shared';
@@ -25,30 +25,21 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 };
 
 export const ModelsTabAutoLayout = memo(() => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [rootApi, setRootApi] = useState<GridviewApi | null>(null);
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
-    setRootApi(api);
+    initializeRootPanelLayout(api);
+    navigationApi.onTabReady('models');
   }, []);
 
-  useEffect(() => {
-    if (!rootApi) {
-      return;
-    }
-
-    initializeRootPanelLayout(rootApi);
-
-    navigationApi.onSwitchedTab();
-
-    return () => {
+  useEffect(
+    () => () => {
       navigationApi.unregisterTab('models');
-    };
-  }, [rootApi]);
+    },
+    []
+  );
 
   return (
-    <AutoLayoutProvider tab="models" rootRef={rootRef}>
+    <AutoLayoutProvider tab="models">
       <GridviewReact
-        ref={rootRef}
         className="dockview-theme-invoke"
         components={rootPanelComponents}
         onReady={onReady}

--- a/invokeai/frontend/web/src/features/ui/layouts/navigation-api.test.ts
+++ b/invokeai/frontend/web/src/features/ui/layouts/navigation-api.test.ts
@@ -185,6 +185,95 @@ describe('AppNavigationApi', () => {
     });
   });
 
+  describe('Panel Storage', () => {
+    beforeEach(() => {
+      navigationApi.connectToApp(mockAppApi);
+    });
+
+    it('stores initial gridview state when none exists', () => {
+      const key = `generate:${LEFT_PANEL_ID}`;
+      mockGetPanelState.mockReturnValue(undefined);
+
+      const panel = createMockPanel();
+      // simulate real dimensions
+      panel.api.height = 200;
+      panel.api.width = 400;
+
+      navigationApi.registerPanel('generate', LEFT_PANEL_ID, panel);
+
+      expect(mockGetPanelState).toHaveBeenCalledWith(key);
+      expect(mockSetPanelState).toHaveBeenCalledWith(key, {
+        id: key,
+        type: 'gridview-panel',
+        dimensions: { height: 200, width: 400 },
+      });
+    });
+
+    it('restores gridview from stored state', () => {
+      const key = `generate:${LEFT_PANEL_ID}`;
+      const stored = { id: key, type: 'gridview-panel', dimensions: { height: 50, width: 75 } };
+      mockGetPanelState.mockReturnValue(stored);
+
+      const panel = createMockPanel();
+      navigationApi.registerPanel('generate', LEFT_PANEL_ID, panel);
+
+      expect(panel.api.setSize).toHaveBeenCalledWith({ height: 50, width: 75 });
+      expect(mockDeletePanelState).not.toHaveBeenCalled();
+    });
+
+    it('collapses gridview when stored dimensions are zero', () => {
+      const key = `generate:${LEFT_PANEL_ID}`;
+      const stored = { id: key, type: 'gridview-panel', dimensions: { height: 0, width: 0 } };
+      mockGetPanelState.mockReturnValue(stored);
+
+      const panel = createMockPanel();
+      navigationApi.registerPanel('generate', LEFT_PANEL_ID, panel);
+
+      expect(panel.api.setConstraints).toHaveBeenCalledWith({ minimumWidth: 0, maximumWidth: 0 });
+      expect(panel.api.setConstraints).toHaveBeenCalledWith({ minimumHeight: 0, maximumHeight: 0 });
+      expect(panel.api.setSize).toHaveBeenCalledWith({ height: 0, width: 0 });
+    });
+
+    it('stores initial dockview state when none exists', () => {
+      const key = `generate:${LAUNCHPAD_PANEL_ID}`;
+      mockGetPanelState.mockReturnValue(undefined);
+
+      const panel = createMockDockPanel();
+      Object.defineProperty(panel.api, 'isActive', { value: true });
+
+      navigationApi.registerPanel('generate', LAUNCHPAD_PANEL_ID, panel);
+
+      expect(mockGetPanelState).toHaveBeenCalledWith(key);
+      expect(mockSetPanelState).toHaveBeenCalledWith(key, {
+        id: key,
+        type: 'dockview-panel',
+        isActive: true,
+      });
+    });
+
+    it('restores dockview active state', () => {
+      const key = `generate:${LAUNCHPAD_PANEL_ID}`;
+      const stored = { id: key, type: 'dockview-panel', isActive: true };
+      mockGetPanelState.mockReturnValue(stored);
+
+      const panel = createMockDockPanel();
+      navigationApi.registerPanel('generate', LAUNCHPAD_PANEL_ID, panel);
+
+      expect(panel.api.setActive).toHaveBeenCalled();
+    });
+
+    it('deletes mismatched dockview state', () => {
+      const key = `generate:${LAUNCHPAD_PANEL_ID}`;
+      const stored = { id: key, type: 'gridview-panel', dimensions: { height: 5, width: 5 } };
+      mockGetPanelState.mockReturnValue(stored);
+
+      const panel = createMockDockPanel();
+      navigationApi.registerPanel('generate', LAUNCHPAD_PANEL_ID, panel);
+
+      expect(mockDeletePanelState).toHaveBeenCalledWith(key);
+    });
+  });
+
   describe('Panel Focus', () => {
     beforeEach(() => {
       navigationApi.connectToApp(mockAppApi);

--- a/invokeai/frontend/web/src/features/ui/layouts/navigation-api.test.ts
+++ b/invokeai/frontend/web/src/features/ui/layouts/navigation-api.test.ts
@@ -413,8 +413,10 @@ describe('AppNavigationApi', () => {
       await expect(waitPromise).rejects.toThrow('Panel generate:settings registration timed out after 200ms');
 
       const elapsed = Date.now() - start;
-      expect(elapsed).toBeGreaterThanOrEqual(200);
-      expect(elapsed).toBeLessThan(300); // Allow some margin
+      // TODO(psyche): Use vitest's fake timeres
+      // Allow some margin for timer resolution
+      expect(elapsed).toBeGreaterThanOrEqual(190);
+      expect(elapsed).toBeLessThan(210);
     });
   });
 

--- a/invokeai/frontend/web/src/features/ui/layouts/navigation-api.test.ts
+++ b/invokeai/frontend/web/src/features/ui/layouts/navigation-api.test.ts
@@ -436,7 +436,7 @@ describe('AppNavigationApi', () => {
       const mockPanel = createMockPanel();
       const width = 500;
 
-      navigationApi.expandPanel(mockPanel, width);
+      navigationApi._expandPanel(mockPanel, width);
 
       expect(mockPanel.api.setConstraints).toHaveBeenCalledWith({
         maximumWidth: Number.MAX_SAFE_INTEGER,
@@ -448,7 +448,7 @@ describe('AppNavigationApi', () => {
     it('should collapse panel with zero constraints and size', () => {
       const mockPanel = createMockPanel();
 
-      navigationApi.collapsePanel(mockPanel);
+      navigationApi._collapsePanel(mockPanel);
 
       expect(mockPanel.api.setConstraints).toHaveBeenCalledWith({
         maximumWidth: 0,

--- a/invokeai/frontend/web/src/features/ui/layouts/navigation-api.ts
+++ b/invokeai/frontend/web/src/features/ui/layouts/navigation-api.ts
@@ -147,6 +147,23 @@ export class NavigationApi {
       }
       log.debug({ storedState }, 'Found stored state for panel, restoring');
 
+      // If the panel's dimensions are 0, we assume it was collapsed by the user. But when panels are initialzed,
+      // by default they may have a minimize dimension greater than 0. If we attempt to set a size of 0, it will
+      // not work - dockview will instead set the size to the minimum size.
+      //
+      // The user-facing issue is that the panel will not remember if it was collapsed or not, and will always
+      // be expanded when navigating to the tab.
+      //
+      // To fix this, if we find a stored state with dimensions of 0, we set the constraints to 0 before setting the
+      // size.
+      if (storedState.dimensions.width === 0) {
+        panel.api.setConstraints({ minimumWidth: 0, maximumWidth: 0 });
+      }
+
+      if (storedState.dimensions.height === 0) {
+        panel.api.setConstraints({ minimumHeight: 0, maximumHeight: 0 });
+      }
+
       panel.api.setSize(storedState.dimensions);
     }
     const { dispose } = panel.api.onDidDimensionsChange(

--- a/invokeai/frontend/web/src/features/ui/layouts/navigation-api.ts
+++ b/invokeai/frontend/web/src/features/ui/layouts/navigation-api.ts
@@ -16,34 +16,82 @@ const log = logger('system');
 
 type PanelType = IGridviewPanel | IDockviewPanel;
 
+/**
+ * An object that represents a promise that is waiting for a panel to be registered and ready.
+ *
+ * It includes a deferred promise that can be resolved or rejected, and a timeout ID.
+ */
 type Waiter = {
   deferred: Deferred<void>;
   timeoutId: ReturnType<typeof setTimeout> | null;
 };
 
 export class NavigationApi {
+  /**
+   * Map of registered panels, keyed by tab and panel ID in this format:
+   * `${tab}:${panelId}`
+   */
   private panels: Map<string, PanelType> = new Map();
+
+  /**
+   * Map of waiters for panel registration.
+   */
   private waiters: Map<string, Waiter> = new Map();
 
+  /**
+   * A flag indicating if the application is currently switching tabs, which can take some time.
+   */
   $isSwitchingTabs = atom(false);
+  /**
+   * The timeout used to add a short additional delay when switching tabs.
+   *
+   * The time it takes to switch tabs varies depending on the tab, and sometimes it is very fast, resulting in a flicker
+   * of the loading screen. This timeout is used to artificially extend the time the loading screen is shown.
+   */
   switchingTabsTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Separator used to create unique keys for panels. Typo protection.
+   */
   KEY_SEPARATOR = ':';
 
+  /**
+   * Private imperative method to set the current app tab.
+   */
   _setAppTab: ((tab: TabName) => void) | null = null;
+
+  /**
+   * Private imperative method to get the current app tab.
+   */
   _getAppTab: (() => TabName) | null = null;
 
+  /**
+   * Connect to the application to manage tab switching.
+   * @param arg.setAppTab - Function to set the current app tab
+   * @param arg.getAppTab - Function to get the current app tab
+   */
   connectToApp = (arg: { setAppTab: (tab: TabName) => void; getAppTab: () => TabName }): void => {
     const { setAppTab, getAppTab } = arg;
     this._setAppTab = setAppTab;
     this._getAppTab = getAppTab;
   };
 
+  /**
+   * Disconnect from the application, clearing the tab management functions.
+   */
   disconnectFromApp = (): void => {
     this._setAppTab = null;
     this._getAppTab = null;
   };
 
+  /**
+   * Switch to a specific app tab.
+   *
+   * The loading screen will be shown while the tab is switching.
+   *
+   * @param tab - The tab to switch to
+   * @return True if the switch was successful, false otherwise
+   */
   switchToTab = (tab: TabName): boolean => {
     if (this.switchingTabsTimeout !== null) {
       clearTimeout(this.switchingTabsTimeout);
@@ -63,30 +111,35 @@ export class NavigationApi {
     }
   };
 
-  onSwitchedTab = (): void => {
-    log.debug('Tab switch completed');
+  /**
+   * Callback for when a tab is ready after switching.
+   *
+   * Hides the loading screen after a short delay.
+   */
+  onTabReady = (tab: TabName): void => {
     this.switchingTabsTimeout = setTimeout(() => {
       this.$isSwitchingTabs.set(false);
+      log.debug(`Tab ${tab} ready`);
     }, SWITCH_TABS_FAKE_DELAY_MS);
   };
 
   /**
-   * Register a panel with a unique ID
+   * Registers a panel with the navigation API.
+   *
    * @param tab - The tab this panel belongs to
    * @param panelId - Unique identifier for the panel
    * @param panel - The panel instance
    * @returns Cleanup function to unregister the panel
    */
   registerPanel = (tab: TabName, panelId: string, panel: PanelType): (() => void) => {
-    const key = this.getPanelKey(tab, panelId);
+    const key = this._getPanelKey(tab, panelId);
 
     this.panels.set(key, panel);
 
-    // Resolve any waiting promises
+    // Resolve any pending waiters for this panel, notifying them that the panel is now registered.
     const waiter = this.waiters.get(key);
     if (waiter) {
       if (waiter.timeoutId) {
-        // Clear the timeout if it exists
         clearTimeout(waiter.timeoutId);
       }
       waiter.deferred.resolve();
@@ -102,30 +155,42 @@ export class NavigationApi {
   };
 
   /**
-   * Wait for a panel to be ready
+   * Waits for a panel to be ready.
+   *
    * @param tab - The tab the panel belongs to
    * @param panelId - The panel ID to wait for
    * @param timeout - Timeout in milliseconds (default: 2000)
-   * @returns Promise that resolves when the panel is ready
+   * @returns Promise that resolves when the panel is ready or rejects if it times out
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   await navigationApi.waitForPanel('myTab', 'myPanelId');
+   *   console.log('Panel is ready');
+   * } catch (error) {
+   *   console.error('Panel registration timed out:', error);
+   * }
+   * ```
    */
   waitForPanel = (tab: TabName, panelId: string, timeout = 2000): Promise<void> => {
-    const key = this.getPanelKey(tab, panelId);
+    const key = this._getPanelKey(tab, panelId);
 
+    // If the panel is already registered, we can resolve immediately.
     if (this.panels.has(key)) {
       return Promise.resolve();
     }
 
-    // Check if we already have a promise for this panel
+    // If we already have a waiter for this panel, return its promise instead of creating a new one.
     const existing = this.waiters.get(key);
-
     if (existing) {
       return existing.deferred.promise;
     }
 
+    // We do not have any waiters; create one and set up the timeout.
     const deferred = createDeferredPromise<void>();
 
     const timeoutId = setTimeout(() => {
-      // Only reject if this deferred is still waiting
+      // If the timeout expires, reject the promise and clean up the waiter.
       const waiter = this.waiters.get(key);
       if (waiter) {
         this.waiters.delete(key);
@@ -137,29 +202,47 @@ export class NavigationApi {
     return deferred.promise;
   };
 
-  getTabPrefix = (tab: TabName): string => {
+  /**
+   * Get the prefix for a tab to create unique keys for panels.
+   */
+  _getTabPrefix = (tab: TabName): string => {
     return `${tab}${this.KEY_SEPARATOR}`;
   };
 
-  getPanelKey = (tab: TabName, panelId: string): string => {
-    return `${this.getTabPrefix(tab)}${panelId}`;
+  /**
+   * Get the unique key for a panel based on its tab and ID.
+   */
+  _getPanelKey = (tab: TabName, panelId: string): string => {
+    return `${this._getTabPrefix(tab)}${panelId}`;
   };
 
   /**
-   * Focus a specific panel in a specific tab
+   * Focuses a specific panel in a specific tab.
+   *
+   * This method does not throw; it returns a Promise that resolves to true if the panel was successfully focused,
+   * or false if it failed to focus the panel (e.g., if the panel was not found or the tab switch failed).
+   *
    * @param tab - The tab to switch to
    * @param panelId - The panel ID to focus
+   * @param timeout - Timeout in milliseconds (default: 2000)
    * @returns Promise that resolves to true if successful, false otherwise
+   *
+   * @example
+   * ```typescript
+   * const focused = await navigationApi.focusPanel('myTab', 'myPanelId');
+   * if (focused) {
+   *   console.log('Panel focused successfully');
+   * } else {
+   *   console.error('Failed to focus panel');
+   * }
+   * ```
    */
-  focusPanel = async (tab: TabName, panelId: string): Promise<boolean> => {
+  focusPanel = async (tab: TabName, panelId: string, timeout = 2000): Promise<boolean> => {
     try {
-      // Switch to the target tab if needed
       this.switchToTab(tab);
+      await this.waitForPanel(tab, panelId, timeout);
 
-      // Wait for the panel to be ready
-      await this.waitForPanel(tab, panelId);
-
-      const key = this.getPanelKey(tab, panelId);
+      const key = this._getPanelKey(tab, panelId);
       const panel = this.panels.get(key);
 
       if (!panel) {
@@ -167,7 +250,7 @@ export class NavigationApi {
         return false;
       }
 
-      // Focus the panel
+      // Dockview uses the term "active", but we use "focused" for consistency.
       panel.api.setActive();
       log.debug(`Focused panel ${key}`);
 
@@ -178,30 +261,70 @@ export class NavigationApi {
     }
   };
 
-  focusPanelInActiveTab = (panelId: string): Promise<boolean> => {
+  /**
+   * Focuses a specific panel in the currently active tab.
+   *
+   * If the panel does not exist in the active tab, it returns false after a timeout.
+   *
+   * @param panelId - The panel ID to focus
+   * @param timeout - Timeout in milliseconds (default: 2000)
+   * @return Promise that resolves to true if the panel was focused, false otherwise
+   *
+   * @example
+   * ```typescript
+   * const focused = await navigationApi.focusPanelInActiveTab('myPanelId');
+   * if (focused) {
+   *   console.log('Panel focused successfully in active tab');
+   * } else {
+   *   console.error('Failed to focus panel in active tab');
+   * }
+   */
+  focusPanelInActiveTab = (panelId: string, timeout = 2000): Promise<boolean> => {
     const activeTab = this._getAppTab ? this._getAppTab() : null;
     if (!activeTab) {
       log.error('No active tab found');
       return Promise.resolve(false);
     }
-    return this.focusPanel(activeTab, panelId);
+    return this.focusPanel(activeTab, panelId, timeout);
   };
 
-  expandPanel = (panel: IGridviewPanel, width: number) => {
+  /**
+   * Expand a panel to a specified width.
+   */
+  _expandPanel = (panel: IGridviewPanel, width: number) => {
     panel.api.setConstraints({ maximumWidth: Number.MAX_SAFE_INTEGER, minimumWidth: width });
     panel.api.setSize({ width: width });
   };
 
-  collapsePanel = (panel: IGridviewPanel) => {
+  /**
+   * Collapse a panel by setting its width to 0.
+   */
+  _collapsePanel = (panel: IGridviewPanel) => {
     panel.api.setConstraints({ maximumWidth: 0, minimumWidth: 0 });
     panel.api.setSize({ width: 0 });
   };
 
+  /**
+   * Get a panel by its tab and ID.
+   *
+   * This method will not wait for the panel to be registered.
+   *
+   * @param tab - The tab the panel belongs to
+   * @param panelId - The panel ID
+   * @returns The panel instance or undefined if not found
+   */
   getPanel = (tab: TabName, panelId: string): PanelType | undefined => {
-    const key = this.getPanelKey(tab, panelId);
+    const key = this._getPanelKey(tab, panelId);
     return this.panels.get(key);
   };
 
+  /**
+   * Toggle the left panel in the currently active tab.
+   *
+   * This method will not wait for the panel to be registered.
+   *
+   * @returns True if the panel was toggled, false if it was not found or an error occurred
+   */
   toggleLeftPanel = (): boolean => {
     const activeTab = this._getAppTab ? this._getAppTab() : null;
     if (!activeTab) {
@@ -221,13 +344,20 @@ export class NavigationApi {
 
     const isCollapsed = leftPanel.maximumWidth === 0;
     if (isCollapsed) {
-      this.expandPanel(leftPanel, LEFT_PANEL_MIN_SIZE_PX);
+      this._expandPanel(leftPanel, LEFT_PANEL_MIN_SIZE_PX);
     } else {
-      this.collapsePanel(leftPanel);
+      this._collapsePanel(leftPanel);
     }
     return true;
   };
 
+  /**
+   * Toggle the right panel in the currently active tab.
+   *
+   * This method will not wait for the panel to be registered.
+   *
+   * @returns True if the panel was toggled, false if it was not found or an error occurred
+   */
   toggleRightPanel = (): boolean => {
     const activeTab = this._getAppTab ? this._getAppTab() : null;
     if (!activeTab) {
@@ -247,13 +377,21 @@ export class NavigationApi {
 
     const isCollapsed = rightPanel.maximumWidth === 0;
     if (isCollapsed) {
-      this.expandPanel(rightPanel, RIGHT_PANEL_MIN_SIZE_PX);
+      this._expandPanel(rightPanel, RIGHT_PANEL_MIN_SIZE_PX);
     } else {
-      this.collapsePanel(rightPanel);
+      this._collapsePanel(rightPanel);
     }
     return true;
   };
 
+  /**
+   * Toggle the left and right panels in the currently active tab.
+   *
+   * This method will not wait for the panels to be registered. If either panel is not found, it will not toggle
+   * either panel.
+   *
+   * @returns True if the panels were toggled, false if they were not found or an error occurred
+   */
   toggleLeftAndRightPanels = (): boolean => {
     const activeTab = this._getAppTab ? this._getAppTab() : null;
     if (!activeTab) {
@@ -277,17 +415,22 @@ export class NavigationApi {
     const isRightCollapsed = rightPanel.maximumWidth === 0;
 
     if (isLeftCollapsed || isRightCollapsed) {
-      this.expandPanel(leftPanel, LEFT_PANEL_MIN_SIZE_PX);
-      this.expandPanel(rightPanel, RIGHT_PANEL_MIN_SIZE_PX);
+      this._expandPanel(leftPanel, LEFT_PANEL_MIN_SIZE_PX);
+      this._expandPanel(rightPanel, RIGHT_PANEL_MIN_SIZE_PX);
     } else {
-      this.collapsePanel(leftPanel);
-      this.collapsePanel(rightPanel);
+      this._collapsePanel(leftPanel);
+      this._collapsePanel(rightPanel);
     }
     return true;
   };
 
   /**
-   * Reset panels in a specific tab (expand both left and right)
+   * Reset both left and right panels in the currently active tab to their minimum sizes.
+   *
+   * This method will not wait for the panels to be registered. If either panel is not found, it will not reset
+   * either panel.
+   *
+   * @returns True if the panels were reset, false if they were not found or an error occurred
    */
   resetLeftAndRightPanels = (): boolean => {
     const activeTab = this._getAppTab ? this._getAppTab() : null;
@@ -318,46 +461,45 @@ export class NavigationApi {
   };
 
   /**
-   * Check if a panel is registered
+   * Check if a panel is registered.
    * @param tab - The tab the panel belongs to
    * @param panelId - The panel ID to check
    * @returns True if the panel is registered
    */
   isPanelRegistered = (tab: TabName, panelId: string): boolean => {
-    const key = this.getPanelKey(tab, panelId);
+    const key = this._getPanelKey(tab, panelId);
     return this.panels.has(key);
   };
 
   /**
-   * Get all registered panels for a tab
+   * Get all registered panels for a tab.
    * @param tab - The tab to get panels for
    * @returns Array of panel IDs
    */
   getRegisteredPanels = (tab: TabName): string[] => {
-    const prefix = this.getTabPrefix(tab);
+    const prefix = this._getTabPrefix(tab);
     return Array.from(this.panels.keys())
       .filter((key) => key.startsWith(prefix))
       .map((key) => key.substring(prefix.length));
   };
 
   /**
-   * Unregister all panels for a tab
+   * Unregister all panels for a tab. Any pending waiters for these panels will be rejected.
    * @param tab - The tab to unregister panels for
    */
   unregisterTab = (tab: TabName): void => {
-    const prefix = this.getTabPrefix(tab);
+    const prefix = this._getTabPrefix(tab);
     const keysToDelete = Array.from(this.panels.keys()).filter((key) => key.startsWith(prefix));
 
     for (const key of keysToDelete) {
       this.panels.delete(key);
     }
 
-    // Clean up any pending promises by rejecting them
     const promiseKeysToDelete = Array.from(this.waiters.keys()).filter((key) => key.startsWith(prefix));
     for (const key of promiseKeysToDelete) {
       const waiter = this.waiters.get(key);
       if (waiter) {
-        // Clear timeout before rejecting
+        // Clear timeout before rejecting to prevent multiple rejections
         if (waiter.timeoutId) {
           clearTimeout(waiter.timeoutId);
         }

--- a/invokeai/frontend/web/src/features/ui/layouts/queue-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/queue-tab-auto-layout.tsx
@@ -3,7 +3,7 @@ import { GridviewReact, LayoutPriority, Orientation } from 'dockview';
 import QueueTab from 'features/ui/components/tabs/QueueTab';
 import type { RootLayoutGridviewComponents } from 'features/ui/layouts/auto-layout-context';
 import { AutoLayoutProvider } from 'features/ui/layouts/auto-layout-context';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { navigationApi } from './navigation-api';
 import { QUEUE_PANEL_ID } from './shared';
@@ -25,30 +25,21 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 };
 
 export const QueueTabAutoLayout = memo(() => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [rootApi, setRootApi] = useState<GridviewApi | null>(null);
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
-    setRootApi(api);
+    initializeRootPanelLayout(api);
+    navigationApi.onTabReady('queue');
   }, []);
 
-  useEffect(() => {
-    if (!rootApi) {
-      return;
-    }
-
-    initializeRootPanelLayout(rootApi);
-
-    navigationApi.onSwitchedTab();
-
-    return () => {
+  useEffect(
+    () => () => {
       navigationApi.unregisterTab('queue');
-    };
-  }, [rootApi]);
+    },
+    []
+  );
 
   return (
-    <AutoLayoutProvider tab="queue" rootRef={rootRef}>
+    <AutoLayoutProvider tab="queue">
       <GridviewReact
-        ref={rootRef}
         className="dockview-theme-invoke"
         components={rootPanelComponents}
         onReady={onReady}

--- a/invokeai/frontend/web/src/features/ui/layouts/upscaling-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/upscaling-tab-auto-layout.tsx
@@ -91,7 +91,8 @@ const initializeCenterPanelLayout = (tab: TabName, api: DockviewApi) => {
     },
   });
 
-  // Register panels with navigation API
+  launchpad.api.setActive();
+
   navigationApi.registerPanel(tab, LAUNCHPAD_PANEL_ID, launchpad);
   navigationApi.registerPanel(tab, VIEWER_PANEL_ID, viewer);
 
@@ -102,23 +103,7 @@ const MainPanel = memo(() => {
   const { tab } = useAutoLayoutContext();
   const onReady = useCallback<IDockviewReactProps['onReady']>(
     ({ api }) => {
-      const panels = initializeCenterPanelLayout(tab, api);
-      panels.launchpad.api.setActive();
-
-      const disposables = [
-        api.onWillShowOverlay((e) => {
-          if (e.kind === 'header_space' || e.kind === 'tab') {
-            return;
-          }
-          e.preventDefault();
-        }),
-      ];
-
-      return () => {
-        disposables.forEach((disposable) => {
-          disposable.dispose();
-        });
-      };
+      initializeCenterPanelLayout(tab, api);
     },
     [tab]
   );

--- a/invokeai/frontend/web/src/features/ui/layouts/upscaling-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/upscaling-tab-auto-layout.tsx
@@ -24,7 +24,7 @@ import { AutoLayoutProvider, useAutoLayoutContext, withPanelContainer } from 'fe
 import { TabWithoutCloseButton } from 'features/ui/layouts/TabWithoutCloseButton';
 import type { TabName } from 'features/ui/store/uiTypes';
 import { dockviewTheme } from 'features/ui/styles/theme';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { navigationApi } from './navigation-api';
 import { PanelHotkeysLogical } from './PanelHotkeysLogical';
@@ -288,30 +288,21 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 };
 
 export const UpscalingTabAutoLayout = memo(() => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [rootApi, setRootApi] = useState<GridviewApi | null>(null);
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
-    setRootApi(api);
+    initializeRootPanelLayout(api);
+    navigationApi.onTabReady('upscaling');
   }, []);
 
-  useEffect(() => {
-    if (!rootApi) {
-      return;
-    }
-
-    initializeRootPanelLayout(rootApi);
-
-    navigationApi.onSwitchedTab();
-
-    return () => {
+  useEffect(
+    () => () => {
       navigationApi.unregisterTab('upscaling');
-    };
-  }, [rootApi]);
+    },
+    []
+  );
 
   return (
-    <AutoLayoutProvider tab="upscaling" rootRef={rootRef}>
+    <AutoLayoutProvider tab="upscaling">
       <GridviewReact
-        ref={rootRef}
         className="dockview-theme-invoke"
         components={rootPanelComponents}
         onReady={onReady}

--- a/invokeai/frontend/web/src/features/ui/layouts/workflows-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/workflows-tab-auto-layout.tsx
@@ -109,7 +109,8 @@ const initializeMainPanelLayout = (tab: TabName, api: DockviewApi) => {
     },
   });
 
-  // Register panels with navigation API
+  launchpad.api.setActive();
+
   navigationApi.registerPanel(tab, LAUNCHPAD_PANEL_ID, launchpad);
   navigationApi.registerPanel(tab, WORKSPACE_PANEL_ID, workspace);
   navigationApi.registerPanel(tab, VIEWER_PANEL_ID, viewer);
@@ -122,23 +123,7 @@ const MainPanel = memo(() => {
 
   const onReady = useCallback<IDockviewReactProps['onReady']>(
     ({ api }) => {
-      const panels = initializeMainPanelLayout(tab, api);
-      panels.launchpad.api.setActive();
-
-      const disposables = [
-        api.onWillShowOverlay((e) => {
-          if (e.kind === 'header_space' || e.kind === 'tab') {
-            return;
-          }
-          e.preventDefault();
-        }),
-      ];
-
-      return () => {
-        disposables.forEach((disposable) => {
-          disposable.dispose();
-        });
-      };
+      initializeMainPanelLayout(tab, api);
     },
     [tab]
   );

--- a/invokeai/frontend/web/src/features/ui/layouts/workflows-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/workflows-tab-auto-layout.tsx
@@ -26,7 +26,7 @@ import { AutoLayoutProvider, useAutoLayoutContext, withPanelContainer } from 'fe
 import { TabWithoutCloseButton } from 'features/ui/layouts/TabWithoutCloseButton';
 import type { TabName } from 'features/ui/store/uiTypes';
 import { dockviewTheme } from 'features/ui/styles/theme';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { navigationApi } from './navigation-api';
 import { PanelHotkeysLogical } from './PanelHotkeysLogical';
@@ -305,30 +305,21 @@ const initializeRootPanelLayout = (api: GridviewApi) => {
 };
 
 export const WorkflowsTabAutoLayout = memo(() => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [rootApi, setRootApi] = useState<GridviewApi | null>(null);
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
-    setRootApi(api);
+    initializeRootPanelLayout(api);
+    navigationApi.onTabReady('workflows');
   }, []);
 
-  useEffect(() => {
-    if (!rootApi) {
-      return;
-    }
-
-    initializeRootPanelLayout(rootApi);
-
-    navigationApi.onSwitchedTab();
-
-    return () => {
+  useEffect(
+    () => () => {
       navigationApi.unregisterTab('workflows');
-    };
-  }, [rootApi]);
+    },
+    []
+  );
 
   return (
-    <AutoLayoutProvider tab="workflows" rootRef={rootRef}>
+    <AutoLayoutProvider tab="workflows">
       <GridviewReact
-        ref={rootRef}
         className="dockview-theme-invoke"
         components={rootPanelComponents}
         onReady={onReady}

--- a/invokeai/frontend/web/src/features/ui/store/uiSlice.ts
+++ b/invokeai/frontend/web/src/features/ui/store/uiSlice.ts
@@ -51,6 +51,20 @@ export const uiSlice = createSlice({
       const { id, size } = action.payload;
       state.textAreaSizes[id] = size;
     },
+    panelStateChanged: (
+      state,
+      action: PayloadAction<{
+        id: keyof UIState['panels'];
+        state: UIState['panels'][keyof UIState['panels']] | undefined;
+      }>
+    ) => {
+      const { id, state: panelState } = action.payload;
+      if (panelState) {
+        state.panels[id] = panelState;
+      } else {
+        delete state.panels[id];
+      }
+    },
     shouldShowNotificationChanged: (state, action: PayloadAction<UIState['shouldShowNotificationV2']>) => {
       state.shouldShowNotificationV2 = action.payload;
     },
@@ -66,6 +80,7 @@ export const {
   expanderStateChanged,
   shouldShowNotificationChanged,
   textAreaSizesStateChanged,
+  panelStateChanged,
 } = uiSlice.actions;
 
 export const selectUiSlice = (state: RootState) => state.ui;

--- a/invokeai/frontend/web/src/features/ui/store/uiTypes.ts
+++ b/invokeai/frontend/web/src/features/ui/store/uiTypes.ts
@@ -10,6 +10,25 @@ const zPartialDimensions = z.object({
   height: z.number().optional(),
 });
 
+const zDimensions = z.object({
+  width: z.number(),
+  height: z.number(),
+});
+
+const zDockviewPanelState = z.object({
+  id: z.string(),
+  type: z.literal('dockview-panel'),
+  isActive: z.boolean(),
+});
+export type StoredDockviewPanelState = z.infer<typeof zDockviewPanelState>;
+
+const zGridviewPanelState = z.object({
+  id: z.string(),
+  type: z.literal('gridview-panel'),
+  dimensions: zDimensions,
+});
+export type StoredGridviewPanelState = z.infer<typeof zGridviewPanelState>;
+
 const zUIState = z.object({
   _version: z.literal(3).default(3),
   activeTab: zTabName.default('canvas'),
@@ -19,6 +38,7 @@ const zUIState = z.object({
   accordions: z.record(z.string(), z.boolean()).default(() => ({})),
   expanders: z.record(z.string(), z.boolean()).default(() => ({})),
   textAreaSizes: z.record(z.string(), zPartialDimensions).default({}),
+  panels: z.record(z.string(), z.discriminatedUnion('type', [zDockviewPanelState, zGridviewPanelState])).default({}),
   shouldShowNotificationV2: z.boolean().default(true),
 });
 const INITIAL_STATE = zUIState.parse({});


### PR DESCRIPTION
## Summary

Panel states persist (size and active status). Panels are per-tab. In other words, the boards panel on the Generate tab is a different entity than the boards panel on the Canvas tab, and their state is persisted separately.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
