### PR TITLE
fix(ui): Fixes Control Layer Resizing Logic for new DND entity

### DIFF
--- a/invokeai/frontend/web/src/features/imageActions/actions.ts
+++ b/invokeai/frontend/web/src/features/imageActions/actions.ts
@@ -87,32 +87,20 @@ export const createNewCanvasEntityFromImage = async (arg: {
   const state = getState();
   const { x, y } = selectBboxRect(state);
 
+  const base = selectBboxModelBase(state);
+  const ratio = imageDTO.width / imageDTO.height;
+  const optimalDimension = getOptimalDimension(base);
+  const { width, height } = calculateNewSize(ratio, optimalDimension ** 2, base);
+
   let imageObject: CanvasImageState;
-  let resizeWidth: number;
-  let resizeHeight: number;
 
-  if (withResize) {
-    // Use the same resizing logic as newCanvasFromImage
-    const base = selectBboxModelBase(state);
-    const ratio = imageDTO.width / imageDTO.height;
-    const optimalDimension = getOptimalDimension(base);
-    const { width, height } = calculateNewSize(ratio, optimalDimension ** 2, base);
-    resizeWidth = width;
-    resizeHeight = height;
-  } else {
-    // Use current bbox dimensions
-    const { width, height } = selectBboxRect(state);
-    resizeWidth = width;
-    resizeHeight = height;
-  }
-
-  if (withResize && (resizeWidth !== imageDTO.width || resizeHeight !== imageDTO.height)) {
+  if (withResize && (width !== imageDTO.width || height !== imageDTO.height)) {
     const resizedImageDTO = await uploadImage({
       file: await imageDTOToFile(imageDTO),
       image_category: 'general',
       is_intermediate: true,
       silent: true,
-      resize_to: { width: resizeWidth, height: resizeHeight },
+      resize_to: { width, height },
     });
     imageObject = imageDTOToImageObject(resizedImageDTO);
   } else {


### PR DESCRIPTION
## Summary

Fixes logic to resize the image correctly (instead of based on current BBOX size)

## Related Issues / Discussions
Testing discovery

## QA Instructions
Use an image different than current bbox size. Drag in as a resized control layer. Should be added as a correctly resized image.

## Merge Plan
Merge away.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
