### PR TITLE
fix(ui): remove ref image from upscale

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/components/Prompts/UpscalePrompts.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Prompts/UpscalePrompts.tsx
@@ -31,4 +31,4 @@ export const UpscalePrompts = memo(() => {
   );
 });
 
-UpscalePrompts.displayName = 'UpscalePrompts'; 
+UpscalePrompts.displayName = 'UpscalePrompts';

--- a/invokeai/frontend/web/src/features/parameters/components/Prompts/UpscalePrompts.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Prompts/UpscalePrompts.tsx
@@ -1,0 +1,34 @@
+import { Flex } from '@invoke-ai/ui-library';
+import { useAppSelector } from 'app/store/storeHooks';
+import {
+  createParamsSelector,
+  selectHasNegativePrompt,
+  selectModelSupportsNegativePrompt,
+} from 'features/controlLayers/store/paramsSlice';
+import { ParamNegativePrompt } from 'features/parameters/components/Core/ParamNegativePrompt';
+import { ParamPositivePrompt } from 'features/parameters/components/Core/ParamPositivePrompt';
+import { ParamSDXLNegativeStylePrompt } from 'features/sdxl/components/SDXLPrompts/ParamSDXLNegativeStylePrompt';
+import { ParamSDXLPositiveStylePrompt } from 'features/sdxl/components/SDXLPrompts/ParamSDXLPositiveStylePrompt';
+import { memo } from 'react';
+
+const selectWithStylePrompts = createParamsSelector((params) => {
+  const isSDXL = params.model?.base === 'sdxl';
+  const shouldConcatPrompts = params.shouldConcatPrompts;
+  return isSDXL && !shouldConcatPrompts;
+});
+
+export const UpscalePrompts = memo(() => {
+  const withStylePrompts = useAppSelector(selectWithStylePrompts);
+  const modelSupportsNegativePrompt = useAppSelector(selectModelSupportsNegativePrompt);
+  const hasNegativePrompt = useAppSelector(selectHasNegativePrompt);
+  return (
+    <Flex flexDir="column" gap={2}>
+      <ParamPositivePrompt />
+      {withStylePrompts && <ParamSDXLPositiveStylePrompt />}
+      {modelSupportsNegativePrompt && hasNegativePrompt && <ParamNegativePrompt />}
+      {withStylePrompts && <ParamSDXLNegativeStylePrompt />}
+    </Flex>
+  );
+});
+
+UpscalePrompts.displayName = 'UpscalePrompts'; 

--- a/invokeai/frontend/web/src/features/ui/components/ParametersPanels/ParametersPanelUpscale.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/ParametersPanels/ParametersPanelUpscale.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { overlayScrollbarsParams } from 'common/components/OverlayScrollbars/constants';
-import { Prompts } from 'features/parameters/components/Prompts/Prompts';
+import { UpscalePrompts } from 'features/parameters/components/Prompts/UpscalePrompts';
 import { UpscaleTabAdvancedSettingsAccordion } from 'features/settingsAccordions/components/AdvancedSettingsAccordion/UpscaleTabAdvancedSettingsAccordion';
 import { UpscaleTabGenerationSettingsAccordion } from 'features/settingsAccordions/components/GenerationSettingsAccordion/UpscaleTabGenerationSettingsAccordion';
 import { UpscaleSettingsAccordion } from 'features/settingsAccordions/components/UpscaleSettingsAccordion/UpscaleSettingsAccordion';
@@ -34,7 +34,7 @@ export const ParametersPanelUpscale = memo(() => {
           )}
           <OverlayScrollbarsComponent defer style={overlayScrollbarsStyles} options={overlayScrollbarsParams.options}>
             <Flex gap={2} flexDirection="column" h="full" w="full">
-              <Prompts />
+              <UpscalePrompts />
               <UpscaleSettingsAccordion />
               <UpscaleTabGenerationSettingsAccordion />
               <UpscaleTabAdvancedSettingsAccordion />


### PR DESCRIPTION
## Summary
Removes unused ref image box from the Upscale tab.

## Related Issues / Discussions
Discussion

## QA Instructions
Does it show up? Nope!

## Merge Plan
Merge at will


## Checklist
- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
