### PR TITLE
fix(ui): prevent getting stuck on tab loading screen

### DIFF
--- a/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
+++ b/invokeai/frontend/web/src/features/ui/components/AppContent.tsx
@@ -58,7 +58,7 @@ const TabContent = memo(() => {
 TabContent.displayName = 'TabContent';
 
 const SwitchingTabsLoader = memo(() => {
-  const isSwitchingTabs = useStore(navigationApi.$isSwitchingTabs);
+  const isSwitchingTabs = useStore(navigationApi.$isLoading);
 
   if (isSwitchingTabs) {
     return <Loading />;

--- a/invokeai/frontend/web/src/features/ui/layouts/canvas-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/canvas-tab-auto-layout.tsx
@@ -313,7 +313,6 @@ const initializeRootPanelLayout = (api: GridviewApi) => {
 export const CanvasTabAutoLayout = memo(() => {
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
     initializeRootPanelLayout(api);
-    navigationApi.onTabReady('canvas');
   }, []);
 
   useEffect(

--- a/invokeai/frontend/web/src/features/ui/layouts/generate-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/generate-tab-auto-layout.tsx
@@ -275,7 +275,6 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 export const GenerateTabAutoLayout = memo(() => {
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
     initializeRootPanelLayout(api);
-    navigationApi.onTabReady('generate');
   }, []);
 
   useEffect(

--- a/invokeai/frontend/web/src/features/ui/layouts/models-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/models-tab-auto-layout.tsx
@@ -27,7 +27,6 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 export const ModelsTabAutoLayout = memo(() => {
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
     initializeRootPanelLayout(api);
-    navigationApi.onTabReady('models');
   }, []);
 
   useEffect(

--- a/invokeai/frontend/web/src/features/ui/layouts/navigation-api.ts
+++ b/invokeai/frontend/web/src/features/ui/layouts/navigation-api.ts
@@ -28,11 +28,20 @@ type Waiter = {
   timeoutId: ReturnType<typeof setTimeout> | null;
 };
 
+/**
+ * The API exposed by the application to manage navigation and panel states.
+ */
 export type NavigationAppApi = {
+  /**
+   * API to manage the currently active tab in the application.
+   */
   activeTab: {
     get: () => TabName;
     set: (tab: TabName) => void;
   };
+  /**
+   * API to manage the storage of panel states.
+   */
   panelStorage: {
     get: (id: string) => StoredDockviewPanelState | StoredGridviewPanelState | undefined;
     set: (id: string, state: StoredDockviewPanelState | StoredGridviewPanelState) => void;
@@ -63,6 +72,9 @@ export class NavigationApi {
    */
   KEY_SEPARATOR = ':';
 
+  /**
+   * The application API that provides methods to set and get the current app tab and manage panel storage.
+   */
   _app: NavigationAppApi | null = null;
 
   /**
@@ -123,6 +135,13 @@ export class NavigationApi {
     return true;
   };
 
+  /**
+   * Initializes storage for Gridview panels.
+   *
+   * - If the panel has no stored state, it its current dimensions are saved.
+   * - If the panel has a stored state, it is restored to those dimensions.
+   * - If the stored state has dimensions of 0, it is assumed that the panel was collapsed by the user.
+   */
   _initGridviewPanelStorage = (key: string, panel: IGridviewPanel) => {
     if (!this._app) {
       log.error('App not connected');
@@ -182,6 +201,12 @@ export class NavigationApi {
     return dispose;
   };
 
+  /**
+   * Initializes storage for Dockview panels.
+   *
+   * - If the panel has no stored state, it saves its current active state.
+   * - If the panel has a stored state, it restores that state.
+   */
   _initDockviewPanelStorage = (key: string, panel: IDockviewPanel) => {
     if (!this._app) {
       log.error('App not connected');
@@ -223,6 +248,9 @@ export class NavigationApi {
     return dispose;
   };
 
+  /**
+   * Helper function to initialize storage for a panel based on its type.
+   */
   _initPanelStorage = (key: string, panel: PanelType) => {
     if (panel instanceof GridviewPanel) {
       return this._initGridviewPanelStorage(key, panel);

--- a/invokeai/frontend/web/src/features/ui/layouts/queue-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/queue-tab-auto-layout.tsx
@@ -27,7 +27,6 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 export const QueueTabAutoLayout = memo(() => {
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
     initializeRootPanelLayout(api);
-    navigationApi.onTabReady('queue');
   }, []);
 
   useEffect(

--- a/invokeai/frontend/web/src/features/ui/layouts/upscaling-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/upscaling-tab-auto-layout.tsx
@@ -275,7 +275,6 @@ const initializeRootPanelLayout = (layoutApi: GridviewApi) => {
 export const UpscalingTabAutoLayout = memo(() => {
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
     initializeRootPanelLayout(api);
-    navigationApi.onTabReady('upscaling');
   }, []);
 
   useEffect(

--- a/invokeai/frontend/web/src/features/ui/layouts/workflows-tab-auto-layout.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/workflows-tab-auto-layout.tsx
@@ -292,7 +292,6 @@ const initializeRootPanelLayout = (api: GridviewApi) => {
 export const WorkflowsTabAutoLayout = memo(() => {
   const onReady = useCallback<IGridviewReactProps['onReady']>(({ api }) => {
     initializeRootPanelLayout(api);
-    navigationApi.onTabReady('workflows');
   }, []);
 
   useEffect(


### PR DESCRIPTION
## Summary

Make the tab loading screen logic more resilient to getting stuck by using a proper debounce implementation.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
