### PR TITLE
fix(ui): ignore disalbed ref images in readiness checks

### DIFF
--- a/invokeai/frontend/web/src/features/queue/store/readiness.ts
+++ b/invokeai/frontend/web/src/features/queue/store/readiness.ts
@@ -277,9 +277,10 @@ const getReasonsWhyCannotEnqueueGenerateTab = (arg: {
     reasons.push({ content: i18n.t('parameters.invoke.promptExpansionResultPending') });
   }
 
-  // Flux Kontext only supports 1x Reference Image at a time.
-  const referenceImageCount = refImages.entities.length;
+  const enabledRefImages = refImages.entities.filter(({ isEnabled }) => isEnabled);
+  const referenceImageCount = enabledRefImages.length;
 
+  // Flux Kontext only supports 1x Reference Image at a time.
   if (
     (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
     referenceImageCount > 1
@@ -287,19 +288,17 @@ const getReasonsWhyCannotEnqueueGenerateTab = (arg: {
     reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
   }
 
-  refImages.entities
-    .filter(({ isEnabled }) => isEnabled)
-    .forEach((entity, i) => {
-      const layerNumber = i + 1;
-      const refImageLiteral = i18n.t(LAYER_TYPE_TO_TKEY['reference_image']);
-      const prefix = `${refImageLiteral} #${layerNumber}`;
-      const problems = getGlobalReferenceImageWarnings(entity, model);
+  enabledRefImages.forEach((entity, i) => {
+    const layerNumber = i + 1;
+    const refImageLiteral = i18n.t(LAYER_TYPE_TO_TKEY['reference_image']);
+    const prefix = `${refImageLiteral} #${layerNumber}`;
+    const problems = getGlobalReferenceImageWarnings(entity, model);
 
-      if (problems.length) {
-        const content = upperFirst(problems.map((p) => i18n.t(p)).join(', '));
-        reasons.push({ prefix, content });
-      }
-    });
+    if (problems.length) {
+      const content = upperFirst(problems.map((p) => i18n.t(p)).join(', '));
+      reasons.push({ prefix, content });
+    }
+  });
 
   return reasons;
 };
@@ -636,9 +635,10 @@ const getReasonsWhyCannotEnqueueCanvasTab = (arg: {
     }
   });
 
-  // Flux Kontext only supports 1x Reference Image at a time.
-  const referenceImageCount = refImages.entities.filter((entity) => entity.isEnabled).length;
+  const enabledRefImages = refImages.entities.filter(({ isEnabled }) => isEnabled);
+  const referenceImageCount = enabledRefImages.length;
 
+  // Flux Kontext only supports 1x Reference Image at a time.
   if (
     (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
     referenceImageCount > 1
@@ -646,7 +646,7 @@ const getReasonsWhyCannotEnqueueCanvasTab = (arg: {
     reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
   }
 
-  refImages.entities.forEach((entity, i) => {
+  enabledRefImages.forEach((entity, i) => {
     const layerNumber = i + 1;
     const refImageLiteral = i18n.t(LAYER_TYPE_TO_TKEY['reference_image']);
     const prefix = `${refImageLiteral} #${layerNumber}`;


### PR DESCRIPTION
## Summary

fix(ui): ignore disalbed ref images in readiness checks

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1393542903732633661

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
