### PR TITLE
fix(docker): switch to pnpm10.x

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,7 @@
 FROM docker.io/node:22-slim AS web-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack use pnpm@8.x
-RUN corepack enable
+RUN corepack use pnpm@10.x && corepack enable
 
 WORKDIR /build
 COPY invokeai/frontend/web/ ./


### PR DESCRIPTION
## Summary

Frontend was updated to use pnpm v10.x as package manager, but the Dockerfile was left at 8.x. This PR fixes the issue.

## Merge Plan

Merge at will

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
