### PR TITLE
fix(ui): context menu on staging area images

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/QueueItemPreviewMini.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/QueueItemPreviewMini.tsx
@@ -62,6 +62,10 @@ export const QueueItemPreviewMini = memo(({ item, index }: Props) => {
     }
   }, [autoSwitch, dispatch]);
 
+  const onLoad = useCallback(() => {
+    ctx.onImageLoaded(item.item_id);
+  }, [ctx, item.item_id]);
+
   return (
     <Flex
       id={getQueueItemElementId(index)}
@@ -71,7 +75,7 @@ export const QueueItemPreviewMini = memo(({ item, index }: Props) => {
       onDoubleClick={onDoubleClick}
     >
       <QueueItemStatusLabel item={item} position="absolute" margin="auto" />
-      {imageDTO && <DndImage imageDTO={imageDTO} asThumbnail position="absolute" />}
+      {imageDTO && <DndImage imageDTO={imageDTO} position="absolute" onLoad={onLoad} />}
       <QueueItemProgressImage itemId={item.item_id} position="absolute" />
       <QueueItemNumber number={index + 1} position="absolute" top={0} left={1} />
       <QueueItemCircularProgress itemId={item.item_id} status={item.status} position="absolute" top={1} right={2} />

--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/QueueItemProgressImage.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/QueueItemProgressImage.tsx
@@ -7,9 +7,9 @@ import { useProgressDatum } from './context';
 type Props = { itemId: number } & ImageProps;
 
 export const QueueItemProgressImage = memo(({ itemId, ...rest }: Props) => {
-  const { progressImage } = useProgressDatum(itemId);
+  const { progressImage, imageLoaded } = useProgressDatum(itemId);
 
-  if (!progressImage) {
+  if (!progressImage || imageLoaded) {
     return null;
   }
 

--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/__mocks__/mockStagingAreaApp.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/__mocks__/mockStagingAreaApp.ts
@@ -12,7 +12,6 @@ export const createMockStagingAreaApp = (): StagingAreaAppApi & {
   _triggerInvocationProgress: (data: S['InvocationProgressEvent']) => void;
   _setAutoSwitchMode: (mode: AutoSwitchMode) => void;
   _setImageDTO: (imageName: string, imageDTO: ImageDTO | null) => void;
-  _setLoadImageDelay: (delay: number) => void;
 } => {
   const itemsChangedHandlers = new Set<(items: S['SessionQueueItem'][]) => void>();
   const queueItemStatusChangedHandlers = new Set<(data: S['QueueItemStatusChangedEvent']) => void>();
@@ -20,7 +19,6 @@ export const createMockStagingAreaApp = (): StagingAreaAppApi & {
 
   let autoSwitchMode: AutoSwitchMode = 'switch_on_start';
   const imageDTOs = new Map<string, ImageDTO | null>();
-  let loadImageDelay = 0;
 
   return {
     onDiscard: vi.fn(),
@@ -35,22 +33,6 @@ export const createMockStagingAreaApp = (): StagingAreaAppApi & {
     onAutoSwitchChange: vi.fn(),
     getImageDTO: vi.fn((imageName: string) => {
       return Promise.resolve(imageDTOs.get(imageName) || null);
-    }),
-    loadImage: vi.fn(async (imageName: string) => {
-      if (loadImageDelay > 0) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, loadImageDelay);
-        });
-      }
-      // Mock HTMLImageElement for testing environment
-      const mockImage = {
-        src: imageName,
-        width: 512,
-        height: 512,
-        onload: null,
-        onerror: null,
-      } as HTMLImageElement;
-      return mockImage;
     }),
     onItemsChanged: vi.fn((handler) => {
       itemsChangedHandlers.add(handler);
@@ -80,9 +62,6 @@ export const createMockStagingAreaApp = (): StagingAreaAppApi & {
     },
     _setImageDTO: (imageName: string, imageDTO: ImageDTO | null) => {
       imageDTOs.set(imageName, imageDTO);
-    },
-    _setLoadImageDelay: (delay: number) => {
-      loadImageDelay = delay;
     },
   };
 };

--- a/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/context.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/StagingArea/context.tsx
@@ -1,6 +1,5 @@
 import { useStore } from '@nanostores/react';
 import { useAppStore } from 'app/store/storeHooks';
-import { loadImage } from 'features/controlLayers/konva/util';
 import {
   selectStagingAreaAutoSwitch,
   settingsStagingAreaAutoSwitchChanged,
@@ -36,7 +35,6 @@ export const StagingAreaContextProvider = memo(({ children, sessionId }: PropsWi
     const _stagingAreaAppApi: StagingAreaAppApi = {
       getAutoSwitch: () => selectStagingAreaAutoSwitch(store.getState()),
       getImageDTO: (imageName: string) => getImageDTOSafe(imageName),
-      loadImage: (imageUrl: string) => loadImage(imageUrl, true),
       onInvocationProgress: (handler) => {
         socket?.on('invocation_progress', handler);
         return () => {


### PR DESCRIPTION
## Summary

There was a subtle issue where the progress image wasn't ever cleared, preventing the context menu from working on staging area preview images.

The staging area preview images were displaying the last progress image _on top of_ the result image. Because the image elements were so small, you wouldn't notice that you were looking at a low-res progress image. Right clicking a progress image gets you no menu.

If you refresh the page or switch tabs, this would fix itself, because those actions clear out the progress images. The result image would then be the topmost element, and the context menu works.

Fixing this without introducing a flash of empty space as the progress image was hidden required a bit of refactoring. We have to wait for the result image element to load before clearing out the progress.

Result - progress images appear to "resolve" to result images in the staging area without any blips or jank, and the context menu works after that happens.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1396117765793906828

## QA Instructions

Staging area context menu should work without any janky flashes of emptiness as generations complete

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
