### PR TITLE
feat(ui): Add Star/Unstar Hotkey and fix hotkey translations

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -470,6 +470,11 @@
             "togglePanels": {
                 "title": "Toggle Panels",
                 "desc": "Show or hide both left and right panels at once."
+            },
+            "selectGenerateTab": {
+                "title": "Select the Generate Tab",
+                "desc": "Selects the Generate tab.",
+                "key": "1"
             }
         },
         "canvas": {
@@ -607,6 +612,16 @@
             "fitBboxToMasks": {
                 "title": "Fit Bbox To Masks",
                 "desc": "Automatically adjust the generation bounding box to fit visible inpaint masks"
+            },
+            "applySegmentAnything": {
+                "title": "Apply Segment Anything",
+                "desc": "Apply the current Segment Anything mask.",
+                "key": "enter"
+            },
+            "cancelSegmentAnything": {
+                "title": "Cancel Segment Anything",
+                "desc": "Cancel the current Segment Anything operation.",
+                "key": "esc"
             }
         },
         "workflows": {
@@ -736,6 +751,10 @@
             "deleteSelection": {
                 "title": "Delete",
                 "desc": "Delete all selected images. By default, you will be prompted to confirm deletion. If the images are currently in use in the app, you will be warned."
+            },
+            "starImage": {
+                "title": "Star/Unstar Image",
+                "desc": "Star or unstar the selected image."
             }
         }
     },

--- a/invokeai/frontend/web/src/features/gallery/components/NewGallery.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/NewGallery.tsx
@@ -24,10 +24,8 @@ import type {
   VirtuosoGridHandle,
 } from 'react-virtuoso';
 import { VirtuosoGrid } from 'react-virtuoso';
-import { imagesApi } from 'services/api/endpoints/images';
+import { imagesApi, useImageDTO, useStarImagesMutation, useUnstarImagesMutation } from 'services/api/endpoints/images';
 import { useDebounce } from 'use-debounce';
-import { useImageDTO } from 'services/api/endpoints/images';
-import { useStarImagesMutation, useUnstarImagesMutation } from 'services/api/endpoints/images';
 
 import { GalleryImage, GalleryImagePlaceholder } from './ImageGrid/GalleryImage';
 import { GallerySelectionCountTag } from './ImageGrid/GallerySelectionCountTag';
@@ -474,7 +472,9 @@ export const NewGallery = memo(() => {
   const [unstarImages] = useUnstarImagesMutation();
 
   const handleStarHotkey = useCallback(() => {
-    if (!imageDTO) return;
+    if (!imageDTO) {
+      return;
+    }
     if (imageDTO.starred) {
       unstarImages({ image_names: [imageDTO.image_name] });
     } else {

--- a/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
+++ b/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
@@ -160,6 +160,7 @@ export const useHotkeyData = (): HotkeysData => {
     addHotkey('gallery', 'galleryNavDownAlt', ['alt+down']);
     addHotkey('gallery', 'galleryNavLeftAlt', ['alt+left']);
     addHotkey('gallery', 'deleteSelection', ['delete', 'backspace']);
+    addHotkey('gallery', 'starImage', ['.']);
 
     return data;
   }, [isMacOS, isModelManagerEnabled, t]);


### PR DESCRIPTION
## Summary

This adds a gallery hotkey for star/unstar image (using the `.` key). It also includes some minor fixes for other translation strings for other hotkeys that were missing definition in the translation file.

## Related Issues / Discussions

Discord

## QA Instructions

Select image. Press . - See it star. See it unstar.

## Merge Plan

Merge at will.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
