### PR TITLE
Fix nodes ui:  Make nodes dot background to be the same as the snap to grid size and position

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/Flow.tsx
@@ -263,7 +263,7 @@ export const Flow = memo(() => {
         noWheelClassName={NO_WHEEL_CLASS}
         noPanClassName={NO_PAN_CLASS}
       >
-        <Background />
+        <Background gap={snapGrid} offset={snapGrid} />
       </ReactFlow>
       <HotkeyIsolator />
     </>


### PR DESCRIPTION
## Summary

Update to Flow.tsx

Changes the size and offset of the dots background to be the same size as the snap to grid, and also fix the background dot pattern alignment.

Currently, the snapGrid is 25x25, and the default background dot gap is 20x20, these do not align.  This is fixed by making the gap property of the background the same as the snapGrid.

Additionally, there is a bug in the rectFlow background code that incorrectly sets the offset to be the centre of the dot pattern with the default offset of 0.  To work around this issue, setting the background offset property to the snapGrid size will realign the dot pattern correctly. 

## Related Issues / Discussions

I have logged a bug for the rectFlow background issue in its repo.  https://github.com/xyflow/xyflow/issues/5405

## QA Instructions

Add a Node to the workflow editor.  Ensure snap to grid is enabled. move the node about the top left corner of the node should now correctly snap to the background dot positions. 

## Merge Plan

NA

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
