### PR TITLE
feat(ui): add default inpaint mask layer on canvas reset

### DIFF
--- a/invokeai/frontend/web/src/common/components/SessionMenuItems.tsx
+++ b/invokeai/frontend/web/src/common/components/SessionMenuItems.tsx
@@ -1,6 +1,8 @@
 import { MenuItem } from '@invoke-ai/ui-library';
 import { useAppDispatch } from 'app/store/storeHooks';
-import { allEntitiesDeleted } from 'features/controlLayers/store/canvasSlice';
+import { canvasReset } from 'features/controlLayers/store/actions';
+import { inpaintMaskAdded } from 'features/controlLayers/store/canvasSlice';
+import { $canvasManager } from 'features/controlLayers/store/ephemeral';
 import { paramsReset } from 'features/controlLayers/store/paramsSlice';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +13,9 @@ export const SessionMenuItems = memo(() => {
   const dispatch = useAppDispatch();
 
   const resetCanvasLayers = useCallback(() => {
-    dispatch(allEntitiesDeleted());
+    dispatch(canvasReset());
+    dispatch(inpaintMaskAdded({ isSelected: true, isBookmarked: true }));
+    $canvasManager.get()?.stage.fitBboxToStage();
   }, [dispatch]);
   const resetGenerationSettings = useCallback(() => {
     dispatch(paramsReset());

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -1618,7 +1618,6 @@ export const {
   entityArrangedToBack,
   entityOpacityChanged,
   entitiesReordered,
-  allEntitiesDeleted,
   allEntitiesOfTypeIsHiddenToggled,
   allNonRasterLayersIsHiddenToggled,
   // bbox

--- a/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewCanvasFromImageSubMenu.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageContextMenu/ImageMenuItemNewCanvasFromImageSubMenu.tsx
@@ -21,7 +21,14 @@ export const ImageMenuItemNewCanvasFromImageSubMenu = memo(() => {
   const onClickNewCanvasWithRasterLayerFromImage = useCallback(async () => {
     const { dispatch, getState } = store;
     await navigationApi.focusPanel('canvas', WORKSPACE_PANEL_ID);
-    await newCanvasFromImage({ imageDTO, withResize: false, type: 'raster_layer', dispatch, getState });
+    await newCanvasFromImage({
+      imageDTO,
+      withResize: false,
+      withInpaintMask: true,
+      type: 'raster_layer',
+      dispatch,
+      getState,
+    });
     toast({
       id: 'SENT_TO_CANVAS',
       title: t('toast.sentToCanvas'),
@@ -32,7 +39,14 @@ export const ImageMenuItemNewCanvasFromImageSubMenu = memo(() => {
   const onClickNewCanvasWithControlLayerFromImage = useCallback(async () => {
     const { dispatch, getState } = store;
     await navigationApi.focusPanel('canvas', WORKSPACE_PANEL_ID);
-    await newCanvasFromImage({ imageDTO, withResize: false, type: 'control_layer', dispatch, getState });
+    await newCanvasFromImage({
+      imageDTO,
+      withResize: false,
+      withInpaintMask: true,
+      type: 'control_layer',
+      dispatch,
+      getState,
+    });
     toast({
       id: 'SENT_TO_CANVAS',
       title: t('toast.sentToCanvas'),
@@ -43,7 +57,14 @@ export const ImageMenuItemNewCanvasFromImageSubMenu = memo(() => {
   const onClickNewCanvasWithRasterLayerFromImageWithResize = useCallback(async () => {
     const { dispatch, getState } = store;
     await navigationApi.focusPanel('canvas', WORKSPACE_PANEL_ID);
-    await newCanvasFromImage({ imageDTO, withResize: true, type: 'raster_layer', dispatch, getState });
+    await newCanvasFromImage({
+      imageDTO,
+      withResize: true,
+      withInpaintMask: true,
+      type: 'raster_layer',
+      dispatch,
+      getState,
+    });
     toast({
       id: 'SENT_TO_CANVAS',
       title: t('toast.sentToCanvas'),
@@ -54,7 +75,14 @@ export const ImageMenuItemNewCanvasFromImageSubMenu = memo(() => {
   const onClickNewCanvasWithControlLayerFromImageWithResize = useCallback(async () => {
     const { dispatch, getState } = store;
     await navigationApi.focusPanel('canvas', WORKSPACE_PANEL_ID);
-    await newCanvasFromImage({ imageDTO, withResize: true, type: 'control_layer', dispatch, getState });
+    await newCanvasFromImage({
+      imageDTO,
+      withResize: true,
+      withInpaintMask: true,
+      type: 'control_layer',
+      dispatch,
+      getState,
+    });
     toast({
       id: 'SENT_TO_CANVAS',
       title: t('toast.sentToCanvas'),


### PR DESCRIPTION
## Summary

- Restore default inpaint mask layer on canvas reset
- Fit canvas to bbox on canvas reset

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1396992336248049745

## QA Instructions

Try these buttons:
- <img width="286" height="133" alt="image" src="https://github.com/user-attachments/assets/209c56b6-19e0-4aaa-b3c2-5622500e50fc" />
- <img width="309" height="210" alt="image" src="https://github.com/user-attachments/assets/1eda90af-c2cd-4f81-b5fc-15557af7ed73" />
- <img width="523" height="389" alt="image" src="https://github.com/user-attachments/assets/56d043f6-7b69-484e-85fc-968fcd5883dc" />


## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
