### PR TITLE
fix(ui): connect metadata to output node for ext api nodes

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildChatGPT4oGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildChatGPT4oGraph.ts
@@ -133,6 +133,8 @@ export const buildChatGPT4oGraph = async (arg: GraphBuilderArg): Promise<GraphBu
       g.upsertMetadata(selectCanvasMetadata(state));
     }
 
+    g.setMetadataReceivingNode(gptImage);
+
     return {
       g,
       positivePrompt,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
@@ -76,11 +76,15 @@ export const buildFluxKontextGraph = (arg: GraphBuilderArg): GraphBuilderReturn 
     'positive_prompt'
   );
   g.addEdgeToMetadata(positivePrompt, 'value', 'positive_prompt');
+
   g.upsertMetadata({
     model: Graph.getModelMetadataField(model),
     width: originalSize.width,
     height: originalSize.height,
   });
+
+  g.setMetadataReceivingNode(fluxKontextImage);
+
   return {
     g,
     positivePrompt,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildImagen3Graph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildImagen3Graph.ts
@@ -67,6 +67,8 @@ export const buildImagen3Graph = (arg: GraphBuilderArg): GraphBuilderReturn => {
     model: Graph.getModelMetadataField(model),
   });
 
+  g.setMetadataReceivingNode(imagen3);
+
   return {
     g,
     positivePrompt,

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildImagen4Graph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildImagen4Graph.ts
@@ -66,6 +66,8 @@ export const buildImagen4Graph = (arg: GraphBuilderArg): GraphBuilderReturn => {
     model: Graph.getModelMetadataField(model),
   });
 
+  g.setMetadataReceivingNode(imagen4);
+
   return {
     g,
     positivePrompt,


### PR DESCRIPTION
## Summary

Metadata was being populated in the metadata node, but not connected to the image-outputting nodes, resulting in no metadata being saved to the image.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
