### PR TITLE
fix(ui): progress image does not hide on viewer with autoswitch disabled

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/context.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/context.tsx
@@ -78,7 +78,12 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
         // create the illusion of the progress image "resolving" into the final image. If we cleared the progress image
         // now, there would be a flicker where the progress image disappears before the final image appears, and the
         // last-selected gallery image should be shown for a brief moment.
-        if (data.status === 'canceled' || data.status === 'failed') {
+        //
+        // When gallery auto-switch is disabled, we do not need to create this illusion, because we are not going to
+        // switch to the final image automatically. In this case, we clear the progress image immediately.
+        //
+        // We also clear the progress image if the queue item is canceled or failed, as there is no final image to show.
+        if (data.status === 'canceled' || data.status === 'failed' || !autoSwitch) {
           $progressEvent.set(null);
           $progressImage.set(null);
         }


### PR DESCRIPTION
## Summary

Fix an issue where, when gallery auto-switch to new images is disabled, the viewer doesn't hide the final progress image when a generation completes.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1399574352940241088

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
