### PR TITLE
fix(ui): queue count badge renders when left panel collapsed

### DIFF
--- a/invokeai/frontend/web/src/features/queue/components/QueueCountBadge.tsx
+++ b/invokeai/frontend/web/src/features/queue/components/QueueCountBadge.tsx
@@ -28,13 +28,24 @@ export const QueueCountBadge = memo(({ targetRef }: Props) => {
     }
 
     const cb = () => {
-      const { x, y } = target.getBoundingClientRect();
-      if (x === 0 || y === 0) {
-        // If the target is not visible, do not show the badge
+      // If the parent element is not visible, we do not want to show the badge. This can be tricky to reliably
+      // determine. The best way I've found is to check the bounding rect of the target and its parent.
+      const badgeElRect = target.getBoundingClientRect();
+      const parentElRect = parent.getBoundingClientRect();
+      if (
+        badgeElRect.x === 0 ||
+        badgeElRect.y === 0 ||
+        badgeElRect.width === 0 ||
+        badgeElRect.height === 0 ||
+        parentElRect.x === 0 ||
+        parentElRect.y === 0 ||
+        parentElRect.width === 0 ||
+        parentElRect.height === 0
+      ) {
         setBadgePos(null);
         return;
       }
-      setBadgePos({ x: `${x - 7}px`, y: `${y - 5}px` });
+      setBadgePos({ x: `${badgeElRect.x - 7}px`, y: `${badgeElRect.y - 5}px` });
     };
 
     const resizeObserver = new ResizeObserver(cb);


### PR DESCRIPTION
## Summary

When the left panel is collapsed, the queue count badge didn't detect that it should be hidden.

The logic for showing and hiding this badge is rather unpleasant, thanks to CSS padding and absolute positioning rules. We have to render it in a portal and dynamically calculate its position to have it float over the queue actions menu button 😵‍💫 . This includes logic to determine if the queue actions menu button is visible, which broke with the change to `dockview` for layouts.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
