### PR TITLE
fix(app): move (not copy) models from install tmpdir to destination

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -7,7 +7,7 @@ import threading
 import time
 from pathlib import Path
 from queue import Empty, Queue
-from shutil import copyfile, copytree, move, rmtree
+from shutil import move, rmtree
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
@@ -193,7 +193,7 @@ class ModelInstallService(ModelInstallServiceBase):
             self.app_config.models_path / info.base.value / info.type.value / (preferred_name or model_path.name)
         )
         try:
-            new_path = self._copy_model(model_path, dest_path)
+            new_path = self._move_model(model_path, dest_path)
         except FileExistsError as excp:
             raise DuplicateModelException(
                 f"A model named {model_path.name} is already installed at {dest_path.as_posix()}"
@@ -617,16 +617,6 @@ class ModelInstallService(ModelInstallServiceBase):
         model.path = new_path.relative_to(models_dir).as_posix()
         self.record_store.update_model(key, ModelRecordChanges(path=model.path))
         return model
-
-    def _copy_model(self, old_path: Path, new_path: Path) -> Path:
-        if old_path == new_path:
-            return old_path
-        new_path.parent.mkdir(parents=True, exist_ok=True)
-        if old_path.is_dir():
-            copytree(old_path, new_path)
-        else:
-            copyfile(old_path, new_path)
-        return new_path
 
     def _move_model(self, old_path: Path, new_path: Path) -> Path:
         if old_path == new_path:


### PR DESCRIPTION
## Summary

It's not clear why we were copying downloaded models to the destination dir instead of moving them. I cannot find a reason for it, and I am able to install single-file and diffusers models just fine with the change.

This fixes an issue where model installation requires 2x the model's size (bc we were copying the model over).

## Related Issues / Discussions

CC @keturn who noticed this in #8268

## QA Instructions

Install a diffusers and single-file model. Should work and generation should succeed afterwards.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
