### PR TITLE
fix(app): handle model files with periods in their name

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -186,7 +186,8 @@ class ModelInstallService(ModelInstallServiceBase):
         info: AnyModelConfig = self._probe(Path(model_path), config)  # type: ignore
 
         if preferred_name := config.name:
-            preferred_name = Path(preferred_name).with_suffix(model_path.suffix)
+            # Careful! Don't use pathlib.Path(...).with_suffix - it can will strip everything after the first dot.
+            preferred_name = f"{preferred_name}{model_path.suffix}"
 
         dest_path = (
             self.app_config.models_path / info.base.value / info.type.value / (preferred_name or model_path.name)


### PR DESCRIPTION
## Summary

Previously, we used pathlib's `with_suffix()` method to change add a suffix (e.g. ".safetensors") to a model when installing it.

The intention is to add a suffix to the model's name - but that method actually replaces everything after the first period.

This can cause different models to be installed under the same name!

For example, the FLUX models all end up with the same name:
- "FLUX.1 schnell.safetensors" -> "FLUX.safetensors"
- "FLUX.1 dev.safetensors" -> "FLUX.safetensors"

The fix is easy - append the suffix using string formatting instead of using pathlib.

This issue has existed for a long time, but was exacerbated in 075345bffd51704b217bdd41968812b523382610 in which I updated the names of our starter models, adding ".1" to the FLUX model names. Whoops!

## Related Issues / Discussions

- Closes #8276
- Closes #8346
- Closes #8310 

## QA Instructions

Install two different FLUX models. Both should install, and the filenames should not be correct (i.e. not "FLUX.safetensors").

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
