### PR TITLE
Add temporary snapping while Snap to Grid is off by holding CTRL for 64px snap or CTRL+SHIFT for 8px snap

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStateApiModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasStateApiModule.ts
@@ -319,6 +319,14 @@ export class CanvasStateApiModule extends CanvasModuleBase {
   getPositionGridSize = (): number => {
     const snapToGrid = this.getSettings().snapToGrid;
     if (!snapToGrid) {
+      const overrideSnap = this.$ctrlKey.get() || this.$metaKey.get();
+      if (overrideSnap) {
+        const useFine = this.$shiftKey.get();
+        if (useFine) {
+          return 8;
+        }
+        return 64;
+      }
       return 1;
     }
     const useFine = this.$ctrlKey.get() || this.$metaKey.get();


### PR DESCRIPTION
## Summary

Added a QoL feature to canvas grid snapping. While Snap to Grid is off, you can now:
- Hold CTRL key to temporarily enable snapping
- Hold CTRL+SHIFT to temporarily enable small step snapping

## Related Issues / Discussions


## QA Instructions

Simply load up the canvas and turn off Snap to Grid in canvas settings. Moving objects on the canvas will of course move by 1px increments. Hold CTRL and now it will snap to 64px increments. Hold CTRL+SHIFT and now it will snap to 8px increments.

## Merge Plan
???

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
