### PR TITLE
feat: support multiple ref images for flux kontext

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1235,7 +1235,7 @@
             "modelIncompatibleScaledBboxWidth": "Scaled bbox width is {{width}} but {{model}} requires multiple of {{multiple}}",
             "modelIncompatibleScaledBboxHeight": "Scaled bbox height is {{height}} but {{model}} requires multiple of {{multiple}}",
             "fluxModelMultipleControlLoRAs": "Can only use 1 Control LoRA at a time",
-            "fluxKontextMultipleReferenceImages": "Can only use 1 Reference Image at a time with Flux Kontext",
+            "fluxKontextMultipleReferenceImages": "Can only use 1 Reference Image at a time with FLUX Kontext via BFL API",
             "canvasIsFiltering": "Canvas is busy (filtering)",
             "canvasIsTransforming": "Canvas is busy (transforming)",
             "canvasIsRasterizing": "Canvas is busy (rasterizing)",

--- a/invokeai/frontend/web/src/features/queue/store/readiness.ts
+++ b/invokeai/frontend/web/src/features/queue/store/readiness.ts
@@ -280,12 +280,8 @@ const getReasonsWhyCannotEnqueueGenerateTab = (arg: {
   const enabledRefImages = refImages.entities.filter(({ isEnabled }) => isEnabled);
   const referenceImageCount = enabledRefImages.length;
 
-  // Flux Kontext only supports 1x Reference Image at a time.
-  if (
-    model?.base === 'flux-kontext' &&
-    // (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
-    referenceImageCount > 1
-  ) {
+  // FLUX Kontext via BFL API only supports 1x Reference Image at a time.
+  if (model?.base === 'flux-kontext' && referenceImageCount > 1) {
     reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
   }
 
@@ -639,12 +635,8 @@ const getReasonsWhyCannotEnqueueCanvasTab = (arg: {
   const enabledRefImages = refImages.entities.filter(({ isEnabled }) => isEnabled);
   const referenceImageCount = enabledRefImages.length;
 
-  // Flux Kontext only supports 1x Reference Image at a time.
-  if (
-    model?.base === 'flux-kontext' &&
-    // (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
-    referenceImageCount > 1
-  ) {
+  // FLUX Kontext via BFL API only supports 1x Reference Image at a time.
+  if (model?.base === 'flux-kontext' && referenceImageCount > 1) {
     reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
   }
 

--- a/invokeai/frontend/web/src/features/queue/store/readiness.ts
+++ b/invokeai/frontend/web/src/features/queue/store/readiness.ts
@@ -282,7 +282,8 @@ const getReasonsWhyCannotEnqueueGenerateTab = (arg: {
 
   // Flux Kontext only supports 1x Reference Image at a time.
   if (
-    (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
+    model?.base === 'flux-kontext' &&
+    // (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
     referenceImageCount > 1
   ) {
     reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
@@ -640,7 +641,8 @@ const getReasonsWhyCannotEnqueueCanvasTab = (arg: {
 
   // Flux Kontext only supports 1x Reference Image at a time.
   if (
-    (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
+    model?.base === 'flux-kontext' &&
+    // (model?.base === 'flux-kontext' || (model?.base === 'flux' && model?.name?.toLowerCase().includes('kontext'))) &&
     referenceImageCount > 1
   ) {
     reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -7921,10 +7921,11 @@ export type components = {
              */
             ip_adapter?: components["schemas"]["IPAdapterField"] | components["schemas"]["IPAdapterField"][] | null;
             /**
+             * Kontext Conditioning
              * @description FLUX Kontext conditioning (reference image).
              * @default null
              */
-            kontext_conditioning?: components["schemas"]["FluxKontextConditioningField"] | null;
+            kontext_conditioning?: components["schemas"]["FluxKontextConditioningField"] | components["schemas"]["FluxKontextConditioningField"][] | null;
             /**
              * type
              * @default flux_denoise
@@ -8088,10 +8089,11 @@ export type components = {
              */
             ip_adapter?: components["schemas"]["IPAdapterField"] | components["schemas"]["IPAdapterField"][] | null;
             /**
+             * Kontext Conditioning
              * @description FLUX Kontext conditioning (reference image).
              * @default null
              */
-            kontext_conditioning?: components["schemas"]["FluxKontextConditioningField"] | null;
+            kontext_conditioning?: components["schemas"]["FluxKontextConditioningField"] | components["schemas"]["FluxKontextConditioningField"][] | null;
             /**
              * type
              * @default flux_denoise_meta


### PR DESCRIPTION
## Summary

Support multiple ref images for FLUX Kontext (local model only). Images are concatenated in latent space. 

- FLUX Kontext extension updated to handle list of Kontext cond fields
- FLUX Denoise node updated (backwards-compatible change), version bumped
- Studio readiness checks updated to allow multiple ref images for _local_ Kontext
  - BFL API still only supports a single image. For BFL API, we could do image-space concatenation I suppose - but it's a bit hairy when the image sizes are different. I think it's safest to just say multiple ref images for BFL API Kontext is not supported. The Invoke button tooltip warning message is updated to refer to BFL API specifically.

### Example Output

(I used the first images in my gallery, clearly not particularly high quality inputs! but it still works)

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/675f2c0a-c037-4089-b918-5aa5e99dae26" />

plus

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/8078e726-5417-410a-97fc-4823d04e8c9a" />

"place the foxes on the man's shoulders"

equals

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/a15fda7a-7cee-47fa-bbff-6ca7f306b22c" />

how about "place the foxes on the man's shoulders, but give the foxes green alien eyes"

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/8b004b77-58c0-47bb-8a1d-aa41b7c5c175" />


## Related Issues / Discussions

Plenty of requests for this scattered about discord.

## QA Instructions

I compared single ref image Kontext before/after to ensure no regressions. Outputs are identical.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
