### PR TITLE
bugfix(docker-builder) add another cleaning step

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -45,11 +45,13 @@ jobs:
     steps:
       - name: Free up more disk space on the runner
         # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+        # https://github.com/orgs/community/discussions/25678#discussioncomment-9017167
         run: |
           echo "----- Free space before cleanup"
           df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo sh -c cd /opt && find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
           sudo swapoff /mnt/swapfile
           sudo rm -rf /mnt/swapfile
           echo "----- Free space after cleanup"


### PR DESCRIPTION
## Summary

[rocm builder](https://github.com/invoke-ai/InvokeAI/actions/runs/16606028926/job/46977909881) is failing for docker as it runs out of storage space in the VM.

In the failing log I see:
```
----- Free space before cleanup
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   45G   28G  62% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   60M  760M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
----- Free space after cleanup
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   40G   33G  56% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   60M  760M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G   28K   70G   1% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

Meaning the current clean up steps are only cleaning up about 5GBs of storage.

Looked into posts and found another set of steps for cleaning up the VM.

## TODOs

- [ ] Test this in production somehow... @ebr maybe you know how to force trigger?
