### PR TITLE
Add reset bbox to canvas hotkey

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -610,6 +610,10 @@
                 "title": "Toggle Non-Raster Layers",
                 "desc": "Show or hide all non-raster layer categories (Control Layers, Inpaint Masks, Regional Guidance)."
             },
+            "fitBboxToLayers": {
+                "title": "Fit Bbox To Layers",
+                "desc": "Automatically adjust the generation bounding box to fit visible layers"
+            },
             "fitBboxToMasks": {
                 "title": "Fit Bbox To Masks",
                 "desc": "Automatically adjust the generation bounding box to fit visible inpaint masks"

--- a/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbarFitBboxToLayersButton.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbarFitBboxToLayersButton.tsx
@@ -1,6 +1,8 @@
 import { IconButton } from '@invoke-ai/ui-library';
+import { useIsRegionFocused } from 'common/hooks/focus';
 import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
+import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/useHotkeyData';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PiResizeBold } from 'react-icons/pi';
@@ -9,9 +11,23 @@ export const CanvasToolbarFitBboxToLayersButton = memo(() => {
   const { t } = useTranslation();
   const canvasManager = useCanvasManager();
   const isBusy = useCanvasIsBusy();
+  const isCanvasFocused = useIsRegionFocused('canvas');
+
   const onClick = useCallback(() => {
     canvasManager.tool.tools.bbox.fitToLayers();
-  }, [canvasManager.tool.tools.bbox]);
+    canvasManager.stage.fitLayersToStage();
+  }, [canvasManager.tool.tools.bbox, canvasManager.stage]);
+
+  useRegisteredHotkeys({
+    id: 'fitBboxToLayers',
+    category: 'canvas',
+    callback: () => {
+      canvasManager.tool.tools.bbox.fitToLayers();
+      canvasManager.stage.fitLayersToStage();
+    },
+    options: { enabled: isCanvasFocused && !isBusy, preventDefault: true },
+    dependencies: [isCanvasFocused, isBusy],
+  });
 
   return (
     <IconButton

--- a/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
+++ b/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
@@ -102,7 +102,8 @@ export const useHotkeyData = (): HotkeysData => {
     addHotkey('canvas', 'selectColorPickerTool', ['i']);
     addHotkey('canvas', 'setFillToWhite', ['d']);
     addHotkey('canvas', 'fitLayersToCanvas', ['mod+0']);
-    addHotkey('canvas', 'fitBboxToCanvas', ['mod+shift+0', 'shift+s']);
+    addHotkey('canvas', 'fitBboxToCanvas', ['mod+shift+0']);
+    addHotkey('canvas', 'fitBboxToLayers', ['shift+n']);
     addHotkey('canvas', 'setZoomTo100Percent', ['mod+1']);
     addHotkey('canvas', 'setZoomTo200Percent', ['mod+2']);
     addHotkey('canvas', 'setZoomTo400Percent', ['mod+3']);

--- a/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
+++ b/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
@@ -102,7 +102,7 @@ export const useHotkeyData = (): HotkeysData => {
     addHotkey('canvas', 'selectColorPickerTool', ['i']);
     addHotkey('canvas', 'setFillToWhite', ['d']);
     addHotkey('canvas', 'fitLayersToCanvas', ['mod+0']);
-    addHotkey('canvas', 'fitBboxToCanvas', ['mod+shift+0']);
+    addHotkey('canvas', 'fitBboxToCanvas', ['mod+shift+0', 'shift+s']);
     addHotkey('canvas', 'setZoomTo100Percent', ['mod+1']);
     addHotkey('canvas', 'setZoomTo200Percent', ['mod+2']);
     addHotkey('canvas', 'setZoomTo400Percent', ['mod+3']);


### PR DESCRIPTION
## Summary

This PR adds a new hotkey, `Shift+N`, for the "Fit Bbox to Layers" action. It also resets the canvas view to the newly fit layers.

This provides an ergonomic and consistent hotkey, aligning with existing canvas hotkeys like `Shift+C` (Reset Inpaint Mask), `Shift+V` (Invert Mask), and `Shift+B` (Fit BBox to Masks). 

## Related Issues / Discussions

N/A

## QA Instructions

1.  Open the canvas.
2.  Select an image or create a bounding box.
3.  Resize the BBox and move the canvas view away from the bounding box.
4.  Press `Shift+N` to confirm the bounding box is fit to layers and is centered in the staging area
5.  Open the Hotkeys Modal (`?` hotkey) and verify "Fit Bbox to Canvas" lists both `Mod+Shift+0` and `Shift+S`.

## Merge Plan

N/A

## Checklist

-   [x] _The PR has a short but descriptive title, suitable for a changelog_
-   [ ] _Tests added / updated (if applicable)_
-   [ ] _Documentation added / updated (if applicable)_
-   [ ] _Updated `What's New` copy (if doing a release after this PR)_
