### PR TITLE
multi-ref image support for flux kontext API

### DIFF
--- a/invokeai/frontend/web/src/features/queue/store/readiness.ts
+++ b/invokeai/frontend/web/src/features/queue/store/readiness.ts
@@ -278,12 +278,6 @@ const getReasonsWhyCannotEnqueueGenerateTab = (arg: {
   }
 
   const enabledRefImages = refImages.entities.filter(({ isEnabled }) => isEnabled);
-  const referenceImageCount = enabledRefImages.length;
-
-  // FLUX Kontext via BFL API only supports 1x Reference Image at a time.
-  if (model?.base === 'flux-kontext' && referenceImageCount > 1) {
-    reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
-  }
 
   enabledRefImages.forEach((entity, i) => {
     const layerNumber = i + 1;
@@ -633,12 +627,6 @@ const getReasonsWhyCannotEnqueueCanvasTab = (arg: {
   });
 
   const enabledRefImages = refImages.entities.filter(({ isEnabled }) => isEnabled);
-  const referenceImageCount = enabledRefImages.length;
-
-  // FLUX Kontext via BFL API only supports 1x Reference Image at a time.
-  if (model?.base === 'flux-kontext' && referenceImageCount > 1) {
-    reasons.push({ content: i18n.t('parameters.invoke.fluxKontextMultipleReferenceImages') });
-  }
 
   enabledRefImages.forEach((entity, i) => {
     const layerNumber = i + 1;


### PR DESCRIPTION
## Summary

Update graph building for Flux Kontext API to allow multiple reference images with the support of image concatenation node

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
