### PR TITLE
fix(ui): overflow w/ long board names

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardEditableTitle.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardEditableTitle.tsx
@@ -53,6 +53,7 @@ export const BoardEditableTitle = memo(({ board, isSelected }: Props) => {
           color={isSelected ? 'base.100' : 'base.300'}
           onDoubleClick={editable.startEditing}
           cursor="text"
+          noOfLines={1}
         >
           {editable.value}
         </Text>

--- a/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardTooltip.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Boards/BoardsList/BoardTooltip.tsx
@@ -37,6 +37,7 @@ export const BoardTooltip = ({ board }: Props) => {
         />
       )}
       <Flex flexDir="column" alignItems="center">
+        {board && <Text fontWeight="semibold">{board.board_name}</Text>}
         <Text noOfLines={1}>
           {t('boards.imagesWithCount', { count: imagesTotal })}, {t('boards.assetsWithCount', { count: assetsTotal })}
         </Text>

--- a/invokeai/frontend/web/src/features/gallery/components/Gallery.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/Gallery.tsx
@@ -75,6 +75,7 @@ export const GalleryPanel = memo(() => {
           variant="ghost"
           onClick={collapsibleApi.toggle}
           leftIcon={isCollapsed ? <PiCaretDownBold /> : <PiCaretUpBold />}
+          noOfLines={1}
         >
           {boardName}
         </Button>


### PR DESCRIPTION
## Summary

Fix overflow for long board names

Before:
<img width="440" height="234" alt="image" src="https://github.com/user-attachments/assets/6e6015b4-5938-4b68-ba26-1959c46c451b" />


After:
<img width="443" height="192" alt="image" src="https://github.com/user-attachments/assets/cc9c871b-89be-4ef6-9467-8f73d0b6fc84" />


## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
