### PR TITLE
fix(ui): same field cannot be added to form multiple times in workflow editor

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldAddToFormRoot.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/InputFieldAddToFormRoot.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export const InputFieldAddToFormRoot = memo(({ nodeId, fieldName }: Props) => {
   const { t } = useTranslation();
-  const addToRoot = useAddNodeFieldToRoot(nodeId, fieldName);
+  const { isAddedToRoot, addNodeFieldToRoot } = useAddNodeFieldToRoot(nodeId, fieldName);
 
   return (
     <IconButton
@@ -21,7 +21,8 @@ export const InputFieldAddToFormRoot = memo(({ nodeId, fieldName }: Props) => {
       icon={<PiPlusBold />}
       pointerEvents="auto"
       size="xs"
-      onClick={addToRoot}
+      onClick={addNodeFieldToRoot}
+      isDisabled={isAddedToRoot}
     />
   );
 });

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/use-add-node-field-to-root.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/use-add-node-field-to-root.ts
@@ -2,15 +2,20 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useInputFieldInstance } from 'features/nodes/hooks/useInputFieldInstance';
 import { useInputFieldTemplateOrThrow } from 'features/nodes/hooks/useInputFieldTemplateOrThrow';
 import { formElementAdded } from 'features/nodes/store/nodesSlice';
-import { selectFormRootElementId } from 'features/nodes/store/selectors';
+import { buildSelectWorkflowFormNodeExists, selectFormRootElementId } from 'features/nodes/store/selectors';
 import { buildNodeFieldElement } from 'features/nodes/types/workflow';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export const useAddNodeFieldToRoot = (nodeId: string, fieldName: string) => {
   const dispatch = useAppDispatch();
   const rootElementId = useAppSelector(selectFormRootElementId);
   const fieldTemplate = useInputFieldTemplateOrThrow(fieldName);
   const field = useInputFieldInstance(fieldName);
+  const selectWorkflowFormNodeExists = useMemo(
+    () => buildSelectWorkflowFormNodeExists(nodeId, fieldName),
+    [nodeId, fieldName]
+  );
+  const isAddedToRoot = useAppSelector(selectWorkflowFormNodeExists);
 
   const addNodeFieldToRoot = useCallback(() => {
     const element = buildNodeFieldElement(nodeId, fieldName, fieldTemplate.type);
@@ -23,5 +28,5 @@ export const useAddNodeFieldToRoot = (nodeId: string, fieldName: string) => {
     );
   }, [nodeId, fieldName, fieldTemplate.type, dispatch, rootElementId, field.value]);
 
-  return addNodeFieldToRoot;
+  return { isAddedToRoot, addNodeFieldToRoot };
 };

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/publish.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/publish.ts
@@ -6,7 +6,7 @@ import { $templates } from 'features/nodes/store/nodesSlice';
 import {
   selectNodes,
   selectNodesSlice,
-  selectWorkflowFormNodeFieldFieldIdentifiers,
+  selectWorkflowFormNodeFieldFieldIdentifiersDeduped,
   selectWorkflowId,
 } from 'features/nodes/store/selectors';
 import type { Templates } from 'features/nodes/store/types';
@@ -54,7 +54,7 @@ export const useIsValidationRunInProgress = () => {
 };
 
 export const selectFieldIdentifiersWithInvocationTypes = createSelector(
-  selectWorkflowFormNodeFieldFieldIdentifiers,
+  selectWorkflowFormNodeFieldFieldIdentifiersDeduped,
   selectNodesSlice,
   (fieldIdentifiers, nodes) => {
     const result: FieldIdentiferWithLabelAndType[] = [];

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/publish.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/publish.ts
@@ -6,7 +6,7 @@ import { $templates } from 'features/nodes/store/nodesSlice';
 import {
   selectNodes,
   selectNodesSlice,
-  selectWorkflowFormNodeFieldFieldIdentifiersDeduped,
+  selectWorkflowFormNodeFieldFieldIdentifiers,
   selectWorkflowId,
 } from 'features/nodes/store/selectors';
 import type { Templates } from 'features/nodes/store/types';
@@ -54,7 +54,7 @@ export const useIsValidationRunInProgress = () => {
 };
 
 export const selectFieldIdentifiersWithInvocationTypes = createSelector(
-  selectWorkflowFormNodeFieldFieldIdentifiersDeduped,
+  selectWorkflowFormNodeFieldFieldIdentifiers,
   selectNodesSlice,
   (fieldIdentifiers, nodes) => {
     const result: FieldIdentiferWithLabelAndType[] = [];

--- a/invokeai/frontend/web/src/features/nodes/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/selectors.ts
@@ -1,7 +1,6 @@
 import type { Selector } from '@reduxjs/toolkit';
 import { createSelector } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/store';
-import { uniqBy } from 'es-toolkit/compat';
 import { getElement } from 'features/nodes/components/sidePanel/builder/form-manipulation';
 import type { NodesState } from 'features/nodes/store/types';
 import type { FieldInputInstance } from 'features/nodes/types/field';
@@ -94,12 +93,13 @@ export const selectFormInitialValues = createNodesSelector((workflow) => workflo
 export const selectNodeFieldElements = createNodesSelector((workflow) =>
   Object.values(workflow.form.elements).filter(isNodeFieldElement)
 );
-export const selectWorkflowFormNodeFieldFieldIdentifiersDeduped = createSelector(
+export const selectWorkflowFormNodeFieldFieldIdentifiers = createSelector(
   selectNodeFieldElements,
-  (nodeFieldElements) =>
-    uniqBy(nodeFieldElements, (el) => `${el.data.fieldIdentifier.nodeId}-${el.data.fieldIdentifier.fieldName}`).map(
-      (el) => el.data.fieldIdentifier
-    )
+  (nodeFieldElements) => nodeFieldElements.map((el) => el.data.fieldIdentifier)
 );
 
 export const buildSelectElement = (id: string) => createNodesSelector((workflow) => workflow.form?.elements[id]);
+export const buildSelectWorkflowFormNodeExists = (nodeId: string, fieldName: string) =>
+  createSelector(selectWorkflowFormNodeFieldFieldIdentifiers, (identifiers) =>
+    identifiers.some((identifier) => identifier.nodeId === nodeId && identifier.fieldName === fieldName)
+  );

--- a/invokeai/frontend/web/src/features/nodes/store/selectors.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/selectors.ts
@@ -1,6 +1,7 @@
 import type { Selector } from '@reduxjs/toolkit';
 import { createSelector } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/store';
+import { uniqBy } from 'es-toolkit/compat';
 import { getElement } from 'features/nodes/components/sidePanel/builder/form-manipulation';
 import type { NodesState } from 'features/nodes/store/types';
 import type { FieldInputInstance } from 'features/nodes/types/field';
@@ -93,13 +94,16 @@ export const selectFormInitialValues = createNodesSelector((workflow) => workflo
 export const selectNodeFieldElements = createNodesSelector((workflow) =>
   Object.values(workflow.form.elements).filter(isNodeFieldElement)
 );
-export const selectWorkflowFormNodeFieldFieldIdentifiers = createSelector(
+export const selectWorkflowFormNodeFieldFieldIdentifiersDeduped = createSelector(
   selectNodeFieldElements,
-  (nodeFieldElements) => nodeFieldElements.map((el) => el.data.fieldIdentifier)
+  (nodeFieldElements) =>
+    uniqBy(nodeFieldElements, (el) => `${el.data.fieldIdentifier.nodeId}-${el.data.fieldIdentifier.fieldName}`).map(
+      (el) => el.data.fieldIdentifier
+    )
 );
 
 export const buildSelectElement = (id: string) => createNodesSelector((workflow) => workflow.form?.elements[id]);
 export const buildSelectWorkflowFormNodeExists = (nodeId: string, fieldName: string) =>
-  createSelector(selectWorkflowFormNodeFieldFieldIdentifiers, (identifiers) =>
+  createSelector(selectWorkflowFormNodeFieldFieldIdentifiersDeduped, (identifiers) =>
     identifiers.some((identifier) => identifier.nodeId === nodeId && identifier.fieldName === fieldName)
   );


### PR DESCRIPTION
## Summary

A bug fix was implemented to avoid adding the same field to the form in the workflow editor.

- A new selector builder, `buildSelectWorkflowFormNodeExists`, was added to `selectors.ts`, which builds new node specific selectors to be able to decide if the node has already been added to the form.
- A new field, `isAddedToRoot`, is returned by `useAddNodeFieldToRoot` hook, which can be used to decide if the node has already been added to the form.
- `InputFieldAddToFormRoot` is disabled when the node has already been added to the form.

## Related Issues / Discussions

Closes #8400

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
