### PR TITLE
fix(mm): only add suffix to model paths when path is file

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -186,8 +186,9 @@ class ModelInstallService(ModelInstallServiceBase):
         info: AnyModelConfig = self._probe(Path(model_path), config)  # type: ignore
 
         if preferred_name := config.name:
-            # Careful! Don't use pathlib.Path(...).with_suffix - it can will strip everything after the first dot.
-            preferred_name = f"{preferred_name}{model_path.suffix}"
+            if Path(model_path).is_file():
+                # Careful! Don't use pathlib.Path(...).with_suffix - it can will strip everything after the first dot.
+                preferred_name = f"{preferred_name}{model_path.suffix}"
 
         dest_path = (
             self.app_config.models_path / info.base.value / info.type.value / (preferred_name or model_path.name)


### PR DESCRIPTION
## Summary

I noticed that diffusers/folder models with a `.` in the model source had everything after the `.` appended to their destination path.

Example model:
```py
depth_sdxl = StarterModel(
    name="Depth Map",
    base=BaseModelType.StableDiffusionXL,
    source="diffusers/controlNet-depth-sdxl-1.0",
    description="Uses depth information in the image to control the depth in the generation.",
    type=ModelType.ControlNet,
    previous_names=["depth-sdxl"],
)
```

This model's source ends with `.0`. It was installed into `sdxl/controlnet/Depth Map.0`, when it should be installed to `sdxl/controlnet/Depth Map`.

I added an extra check to only add the suffix to the destination path when the model is a file. Single-file models still get the correct file extension and folders use the preferred name.

## Related Issues / Discussions

This is a follow-on to #8352. It's been an issue for a long time.

## QA Instructions

I used the SDXL Depth Map and CyberRealistic models as tests for this. They isntall to the correct locations.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
