### PR TITLE
fix(ui): update board totals when generation completes

### DIFF
--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -5,6 +5,7 @@ import {
   selectAutoSwitch,
   selectGalleryView,
   selectGetImageNamesQueryArgs,
+  selectListBoardsQueryArgs,
   selectSelectedBoardId,
 } from 'features/gallery/store/gallerySelectors';
 import { boardIdSelected, galleryViewChanged, imageSelected } from 'features/gallery/store/gallerySlice';
@@ -75,6 +76,14 @@ export const buildOnInvocationComplete = (
       });
     }
     dispatch(boardsApi.util.upsertQueryEntries(entries));
+
+    dispatch(
+      boardsApi.util.updateQueryData('listAllBoards', selectListBoardsQueryArgs(getState()), (draft) => {
+        for (const board of draft) {
+          board.image_count = board.image_count + (boardTotalAdditions[board.board_id] ?? 0);
+        }
+      })
+    );
 
     /**
      * Optimistic update and cache invalidation for image names queries that match this image's board and categories.


### PR DESCRIPTION
## Summary

Optimistic updates for images total as each image is generated

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
