### PR TITLE
feat(ui): layer behaviour after merging

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
@@ -372,6 +372,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
         position: { x: Math.floor(rect.x), y: Math.floor(rect.y) },
       },
       mergedEntitiesToDelete: deleteMergedEntities ? entityIdentifiers.map(mapId) : [],
+      insertAfterEntity: entityIdentifiers.map(mapId).at(-1)
     };
 
     switch (type) {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasCompositorModule.ts
@@ -372,7 +372,7 @@ export class CanvasCompositorModule extends CanvasModuleBase {
         position: { x: Math.floor(rect.x), y: Math.floor(rect.y) },
       },
       mergedEntitiesToDelete: deleteMergedEntities ? entityIdentifiers.map(mapId) : [],
-      insertAfterEntity: entityIdentifiers.map(mapId).at(-1)
+      insertAfterEntity: entityIdentifiers.map(mapId).at(-1),
     };
 
     switch (type) {

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -117,7 +117,7 @@ const slice = createSlice({
         const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
         const entityState = getRasterLayerState(id, overrides);
 
-        const index = insertAfterEntity ? state.rasterLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        const index = insertAfterEntity ? state.rasterLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.rasterLayers.entities.length;
         state.rasterLayers.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
@@ -282,7 +282,7 @@ const slice = createSlice({
 
         const entityState = getControlLayerState(id, overrides);
 
-        const index = insertAfterEntity ? state.controlLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        const index = insertAfterEntity ? state.controlLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.controlLayers.entities.length;
         state.controlLayers.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
@@ -583,7 +583,7 @@ const slice = createSlice({
 
         const entityState = getRegionalGuidanceState(id, overrides);
 
-        const index = insertAfterEntity ? state.regionalGuidance.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        const index = insertAfterEntity ? state.regionalGuidance.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.regionalGuidance.entities.length;
         state.regionalGuidance.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
@@ -890,7 +890,7 @@ const slice = createSlice({
 
         const entityState = getInpaintMaskState(id, overrides);
 
-        const index = insertAfterEntity ? state.inpaintMasks.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        const index = insertAfterEntity ? state.inpaintMasks.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.inpaintMasks.entities.length;
         state.inpaintMasks.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -114,10 +114,19 @@ const slice = createSlice({
           insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
+        const {
+          id,
+          overrides,
+          isSelected,
+          isBookmarked,
+          mergedEntitiesToDelete = [],
+          insertAfterEntity,
+        } = action.payload;
         const entityState = getRasterLayerState(id, overrides);
 
-        const index = insertAfterEntity ? state.rasterLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.rasterLayers.entities.length;
+        const index = insertAfterEntity
+          ? state.rasterLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1
+          : state.rasterLayers.entities.length;
         state.rasterLayers.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
@@ -278,11 +287,20 @@ const slice = createSlice({
           insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
+        const {
+          id,
+          overrides,
+          isSelected,
+          isBookmarked,
+          mergedEntitiesToDelete = [],
+          insertAfterEntity,
+        } = action.payload;
 
         const entityState = getControlLayerState(id, overrides);
 
-        const index = insertAfterEntity ? state.controlLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.controlLayers.entities.length;
+        const index = insertAfterEntity
+          ? state.controlLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1
+          : state.controlLayers.entities.length;
         state.controlLayers.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
@@ -579,11 +597,20 @@ const slice = createSlice({
           insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
+        const {
+          id,
+          overrides,
+          isSelected,
+          isBookmarked,
+          mergedEntitiesToDelete = [],
+          insertAfterEntity,
+        } = action.payload;
 
         const entityState = getRegionalGuidanceState(id, overrides);
 
-        const index = insertAfterEntity ? state.regionalGuidance.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.regionalGuidance.entities.length;
+        const index = insertAfterEntity
+          ? state.regionalGuidance.entities.findIndex((e) => e.id === insertAfterEntity) + 1
+          : state.regionalGuidance.entities.length;
         state.regionalGuidance.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
@@ -886,11 +913,20 @@ const slice = createSlice({
           insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
+        const {
+          id,
+          overrides,
+          isSelected,
+          isBookmarked,
+          mergedEntitiesToDelete = [],
+          insertAfterEntity,
+        } = action.payload;
 
         const entityState = getInpaintMaskState(id, overrides);
 
-        const index = insertAfterEntity ? state.inpaintMasks.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : state.inpaintMasks.entities.length;
+        const index = insertAfterEntity
+          ? state.inpaintMasks.entities.findIndex((e) => e.id === insertAfterEntity) + 1
+          : state.inpaintMasks.entities.length;
         state.inpaintMasks.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -1261,25 +1261,33 @@ const slice = createSlice({
         newEntity.name = `${newEntity.name} (Copy)`;
       }
       switch (newEntity.type) {
-        case 'raster_layer':
+        case 'raster_layer': {
           newEntity.id = getPrefixedId('raster_layer');
-          state.rasterLayers.entities.push(newEntity);
+          const newEntityIndex = state.rasterLayers.entities.findIndex((e) => e.id === entityIdentifier.id) + 1;
+          state.rasterLayers.entities.splice(newEntityIndex, 0, newEntity);
           break;
-        case 'control_layer':
+        }
+        case 'control_layer': {
           newEntity.id = getPrefixedId('control_layer');
-          state.controlLayers.entities.push(newEntity);
+          const newEntityIndex = state.controlLayers.entities.findIndex((e) => e.id === entityIdentifier.id) + 1;
+          state.controlLayers.entities.splice(newEntityIndex, 0, newEntity);
           break;
-        case 'regional_guidance':
+        }
+        case 'regional_guidance': {
           newEntity.id = getPrefixedId('regional_guidance');
           for (const refImage of newEntity.referenceImages) {
             refImage.id = getPrefixedId('regional_guidance_ip_adapter');
           }
-          state.regionalGuidance.entities.push(newEntity);
+          const newEntityIndex = state.regionalGuidance.entities.findIndex((e) => e.id === entityIdentifier.id) + 1;
+          state.regionalGuidance.entities.splice(newEntityIndex, 0, newEntity);
           break;
-        case 'inpaint_mask':
+        }
+        case 'inpaint_mask': {
           newEntity.id = getPrefixedId('inpaint_mask');
-          state.inpaintMasks.entities.push(newEntity);
+          const newEntityIndex = state.inpaintMasks.entities.findIndex((e) => e.id === entityIdentifier.id) + 1;
+          state.inpaintMasks.entities.splice(newEntityIndex, 0, newEntity);
           break;
+        }
       }
 
       state.selectedEntityIdentifier = getEntityIdentifier(newEntity);

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSlice.ts
@@ -111,12 +111,14 @@ const slice = createSlice({
           isSelected?: boolean;
           isBookmarked?: boolean;
           mergedEntitiesToDelete?: string[];
+          insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [] } = action.payload;
+        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
         const entityState = getRasterLayerState(id, overrides);
 
-        state.rasterLayers.entities.push(entityState);
+        const index = insertAfterEntity ? state.rasterLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        state.rasterLayers.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
           state.rasterLayers.entities = state.rasterLayers.entities.filter(
@@ -139,6 +141,7 @@ const slice = createSlice({
         isSelected?: boolean;
         isBookmarked?: boolean;
         mergedEntitiesToDelete?: string[];
+        insertAfterEntity?: string;
       }) => ({
         payload: { ...payload, id: getPrefixedId('raster_layer') },
       }),
@@ -272,13 +275,15 @@ const slice = createSlice({
           isSelected?: boolean;
           isBookmarked?: boolean;
           mergedEntitiesToDelete?: string[];
+          insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [] } = action.payload;
+        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
 
         const entityState = getControlLayerState(id, overrides);
 
-        state.controlLayers.entities.push(entityState);
+        const index = insertAfterEntity ? state.controlLayers.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        state.controlLayers.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
           state.controlLayers.entities = state.controlLayers.entities.filter(
@@ -300,6 +305,7 @@ const slice = createSlice({
         isSelected?: boolean;
         isBookmarked?: boolean;
         mergedEntitiesToDelete?: string[];
+        insertAfterEntity?: string;
       }) => ({
         payload: { ...payload, id: getPrefixedId('control_layer') },
       }),
@@ -570,13 +576,15 @@ const slice = createSlice({
           isSelected?: boolean;
           isBookmarked?: boolean;
           mergedEntitiesToDelete?: string[];
+          insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [] } = action.payload;
+        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
 
         const entityState = getRegionalGuidanceState(id, overrides);
 
-        state.regionalGuidance.entities.push(entityState);
+        const index = insertAfterEntity ? state.regionalGuidance.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        state.regionalGuidance.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
           state.regionalGuidance.entities = state.regionalGuidance.entities.filter(
@@ -598,6 +606,7 @@ const slice = createSlice({
         isSelected?: boolean;
         isBookmarked?: boolean;
         mergedEntitiesToDelete?: string[];
+        insertAfterEntity?: string;
       }) => ({
         payload: { ...payload, id: getPrefixedId('regional_guidance') },
       }),
@@ -874,13 +883,15 @@ const slice = createSlice({
           isSelected?: boolean;
           isBookmarked?: boolean;
           mergedEntitiesToDelete?: string[];
+          insertAfterEntity?: string;
         }>
       ) => {
-        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [] } = action.payload;
+        const { id, overrides, isSelected, isBookmarked, mergedEntitiesToDelete = [], insertAfterEntity } = action.payload;
 
         const entityState = getInpaintMaskState(id, overrides);
 
-        state.inpaintMasks.entities.push(entityState);
+        const index = insertAfterEntity ? state.inpaintMasks.entities.findIndex((e) => e.id === insertAfterEntity) + 1 : 0;
+        state.inpaintMasks.entities.splice(index, 0, entityState);
 
         if (mergedEntitiesToDelete.length > 0) {
           state.inpaintMasks.entities = state.inpaintMasks.entities.filter(
@@ -902,6 +913,7 @@ const slice = createSlice({
         isSelected?: boolean;
         isBookmarked?: boolean;
         mergedEntitiesToDelete?: string[];
+        insertAfterEntity?: string;
       }) => ({
         payload: { ...payload, id: getPrefixedId('inpaint_mask') },
       }),


### PR DESCRIPTION
## Summary

A new feature was implemented to refine layer behaviour.

- `CanvasCompositorModule.mergeByEntityIdentifiers` was modified to define `insertAfterEntity` when the new merged layer is created
- `rasterLayerAdded`, `controlLayerAdded`, `rgAdded` and `inpaintMaskAdded` were modified in `canvasSlice.ts` to insert the merged layer after `insertAfterEntity`
- `entityDuplicated` was modified in `canvasSlice.ts` to insert the duplicated layer after the original one

## Related Issues / Discussions

Closes https://github.com/invoke-ai/InvokeAI/issues/8002

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
