### PR TITLE
fix(nodes) paste_image paste mask transparency and img_scale add multiple of

### DIFF
--- a/invokeai/app/invocations/image.py
+++ b/invokeai/app/invocations/image.py
@@ -177,10 +177,13 @@ class ImagePasteInvocation(BaseInvocation, WithMetadata, WithBoard):
         max_x = max(base_image.width, image.width + self.x)
         max_y = max(base_image.height, image.height + self.y)
 
+        new_image = Image.new(mode="RGBA", size=(max_x - min_x, max_y - min_y), color=(0, 0, 0, 0))
+        new_image.paste(base_image, (abs(min_x), abs(min_y)))
+
         # Create a temporary image to paste the image with transparency
-        temp_image = base_image
+        temp_image = new_image
         temp_image.paste(image, (max(0, self.x), max(0, self.y)), mask=mask)
-        new_image = Image.alpha_composite(base_image, temp_image)
+        new_image = Image.alpha_composite(new_image, temp_image)
 
         if self.crop:
             base_w, base_h = base_image.size


### PR DESCRIPTION
## Summary
fix(nodes): paste_image, paste mask operation doesn't want a black backdrop. Black should translate to transparent and the hack here is to used the reference image instead. Thus, acting as transparent but it's technically not. + img_scale, add "multiple of" for convenience

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
