### PR TITLE
tests: skip flaky MPS tests on CI

### DIFF
--- a/tests/backend/model_manager/load/model_cache/cached_model/utils.py
+++ b/tests/backend/model_manager/load/model_cache/cached_model/utils.py
@@ -21,13 +21,18 @@ class DummyModule(torch.nn.Module):
         x = x + self.buffer2
         return x
 
-is_github_ci = os.getenv('GITHUB_ACTIONS') == 'true'
+
+is_github_ci = os.getenv("GITHUB_ACTIONS") == "true"
 
 parameterize_mps_and_cuda = pytest.mark.parametrize(
     ("device"),
     [
         pytest.param(
-            "mps", marks=pytest.mark.skipif(is_github_ci or not torch.backends.mps.is_available(), reason="MPS is very flaky in CI" if is_github_ci else "MPS is not available.")
+            "mps",
+            marks=pytest.mark.skipif(
+                is_github_ci or not torch.backends.mps.is_available(),
+                reason="MPS is very flaky in CI" if is_github_ci else "MPS is not available.",
+            ),
         ),
         pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available.")),
     ],


### PR DESCRIPTION
## Summary

I don't know what changed but at some point recently, MPS partial model loading tests have been getting flakier and flakier in CI, to the point that today not a single one has finished (have tried many times). We are OOMing in the tests. 

I tried a few different things (clear torch caches before and after every model caching/loading test, clear GC, call torch.synchronize everywhere). Nothing worked. To unblock dev I've just marked these tests to skip in CI.

It's weird. If a change in our codebase broke CI, we'd expect that PR's CI to have never passed, preventing the offending change from getting into the codebase. Maybe it's a GH runner issue or upstream dependency change.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

This needs to merge ASAP so that other changes that alter python code can pass CI and themselves get merged.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
