### PR TITLE
feat(ui): shuffle  button on workflows

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1948,6 +1948,8 @@
             "addToForm": "Add to Form",
             "label": "Label",
             "showDescription": "Show Description",
+            "showShuffle": "Show Shuffle",
+            "shuffle": "Shuffle",
             "component": "Component",
             "numberInput": "Number Input",
             "singleLine": "Single Line",

--- a/invokeai/frontend/web/src/common/util/randomFloat.ts
+++ b/invokeai/frontend/web/src/common/util/randomFloat.ts
@@ -1,0 +1,5 @@
+const randomFloat = (min: number, max: number): number => {
+  return Math.random() * (max - min + Number.EPSILON) + min;
+};
+
+export default randomFloat;

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInput.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInput.tsx
@@ -13,7 +13,7 @@ export const FloatFieldInput = memo(
     props: FieldComponentProps<FloatFieldInputInstance, FloatFieldInputTemplate, { settings?: NodeFieldFloatSettings }>
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, handleClickRandomizeValue } =
+    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, randomizeValue } =
       useFloatField(nodeId, field.name, fieldTemplate, settings);
 
     const { t } = useTranslation();
@@ -33,13 +33,7 @@ export const FloatFieldInput = memo(
           constrainValue={constrainValue}
         />
         {showShuffle && (
-          <Button
-            size="sm"
-            isDisabled={false}
-            onClick={handleClickRandomizeValue}
-            leftIcon={<PiShuffleBold />}
-            flexShrink={0}
-          >
+          <Button size="sm" isDisabled={false} onClick={randomizeValue} leftIcon={<PiShuffleBold />} flexShrink={0}>
             {t('workflows.builder.shuffle')}
           </Button>
         )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInput.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInput.tsx
@@ -1,35 +1,49 @@
-import { CompositeNumberInput } from '@invoke-ai/ui-library';
+import { Button, CompositeNumberInput } from '@invoke-ai/ui-library';
 import { useFloatField } from 'features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField';
 import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
 import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { FloatFieldInputInstance, FloatFieldInputTemplate } from 'features/nodes/types/field';
 import type { NodeFieldFloatSettings } from 'features/nodes/types/workflow';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiShuffleBold } from 'react-icons/pi';
 
 export const FloatFieldInput = memo(
   (
     props: FieldComponentProps<FloatFieldInputInstance, FloatFieldInputTemplate, { settings?: NodeFieldFloatSettings }>
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep } = useFloatField(
-      nodeId,
-      field.name,
-      fieldTemplate,
-      settings
-    );
+    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, handleClickRandomizeValue } =
+      useFloatField(nodeId, field.name, fieldTemplate, settings);
+
+    const { t } = useTranslation();
 
     return (
-      <CompositeNumberInput
-        defaultValue={defaultValue}
-        onChange={onChange}
-        value={field.value}
-        min={min}
-        max={max}
-        step={step}
-        fineStep={fineStep}
-        className={NO_DRAG_CLASS}
-        flex="1 1 0"
-      />
+      <>
+        <CompositeNumberInput
+          defaultValue={defaultValue}
+          onChange={onChange}
+          value={field.value}
+          min={min}
+          max={max}
+          step={step}
+          fineStep={fineStep}
+          className={NO_DRAG_CLASS}
+          flex="1 1 0"
+          constrainValue={constrainValue}
+        />
+        {showShuffle && (
+          <Button
+            size="sm"
+            isDisabled={false}
+            onClick={handleClickRandomizeValue}
+            leftIcon={<PiShuffleBold />}
+            flexShrink={0}
+          >
+            {t('workflows.builder.shuffle')}
+          </Button>
+        )}
+      </>
     );
   }
 );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInputAndSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInputAndSlider.tsx
@@ -13,7 +13,7 @@ export const FloatFieldInputAndSlider = memo(
     props: FieldComponentProps<FloatFieldInputInstance, FloatFieldInputTemplate, { settings?: NodeFieldFloatSettings }>
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, handleClickRandomizeValue } =
+    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, randomizeValue } =
       useFloatField(nodeId, field.name, fieldTemplate, settings);
 
     const { t } = useTranslation();
@@ -46,13 +46,7 @@ export const FloatFieldInputAndSlider = memo(
           constrainValue={constrainValue}
         />
         {showShuffle && (
-          <Button
-            size="sm"
-            isDisabled={false}
-            onClick={handleClickRandomizeValue}
-            leftIcon={<PiShuffleBold />}
-            flexShrink={0}
-          >
+          <Button size="sm" isDisabled={false} onClick={randomizeValue} leftIcon={<PiShuffleBold />} flexShrink={0}>
             {t('workflows.builder.shuffle')}
           </Button>
         )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInputAndSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldInputAndSlider.tsx
@@ -1,22 +1,22 @@
-import { CompositeNumberInput, CompositeSlider } from '@invoke-ai/ui-library';
+import { Button, CompositeNumberInput, CompositeSlider } from '@invoke-ai/ui-library';
 import { useFloatField } from 'features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField';
 import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
 import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { FloatFieldInputInstance, FloatFieldInputTemplate } from 'features/nodes/types/field';
 import type { NodeFieldFloatSettings } from 'features/nodes/types/workflow';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiShuffleBold } from 'react-icons/pi';
 
 export const FloatFieldInputAndSlider = memo(
   (
     props: FieldComponentProps<FloatFieldInputInstance, FloatFieldInputTemplate, { settings?: NodeFieldFloatSettings }>
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep } = useFloatField(
-      nodeId,
-      field.name,
-      fieldTemplate,
-      settings
-    );
+    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, handleClickRandomizeValue } =
+      useFloatField(nodeId, field.name, fieldTemplate, settings);
+
+    const { t } = useTranslation();
 
     return (
       <>
@@ -43,7 +43,19 @@ export const FloatFieldInputAndSlider = memo(
           fineStep={fineStep}
           className={NO_DRAG_CLASS}
           flex="1 1 0"
+          constrainValue={constrainValue}
         />
+        {showShuffle && (
+          <Button
+            size="sm"
+            isDisabled={false}
+            onClick={handleClickRandomizeValue}
+            leftIcon={<PiShuffleBold />}
+            flexShrink={0}
+          >
+            {t('workflows.builder.shuffle')}
+          </Button>
+        )}
       </>
     );
   }

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldSlider.tsx
@@ -13,7 +13,7 @@ export const FloatFieldSlider = memo(
     props: FieldComponentProps<FloatFieldInputInstance, FloatFieldInputTemplate, { settings?: NodeFieldFloatSettings }>
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep, showShuffle, handleClickRandomizeValue } = useFloatField(
+    const { defaultValue, onChange, min, max, step, fineStep, showShuffle, randomizeValue } = useFloatField(
       nodeId,
       field.name,
       fieldTemplate,
@@ -38,13 +38,7 @@ export const FloatFieldSlider = memo(
           flex="1 1 0"
         />
         {showShuffle && (
-          <Button
-            size="sm"
-            isDisabled={false}
-            onClick={handleClickRandomizeValue}
-            leftIcon={<PiShuffleBold />}
-            flexShrink={0}
-          >
+          <Button size="sm" isDisabled={false} onClick={randomizeValue} leftIcon={<PiShuffleBold />} flexShrink={0}>
             {t('workflows.builder.shuffle')}
           </Button>
         )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/FloatFieldSlider.tsx
@@ -1,37 +1,54 @@
-import { CompositeSlider } from '@invoke-ai/ui-library';
+import { Button, CompositeSlider } from '@invoke-ai/ui-library';
 import { useFloatField } from 'features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField';
 import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
 import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { FloatFieldInputInstance, FloatFieldInputTemplate } from 'features/nodes/types/field';
 import type { NodeFieldFloatSettings } from 'features/nodes/types/workflow';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiShuffleBold } from 'react-icons/pi';
 
 export const FloatFieldSlider = memo(
   (
     props: FieldComponentProps<FloatFieldInputInstance, FloatFieldInputTemplate, { settings?: NodeFieldFloatSettings }>
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep } = useFloatField(
+    const { defaultValue, onChange, min, max, step, fineStep, showShuffle, handleClickRandomizeValue } = useFloatField(
       nodeId,
       field.name,
       fieldTemplate,
       settings
     );
 
+    const { t } = useTranslation();
+
     return (
-      <CompositeSlider
-        defaultValue={defaultValue}
-        onChange={onChange}
-        value={field.value}
-        min={min}
-        max={max}
-        step={step}
-        fineStep={fineStep}
-        className={NO_DRAG_CLASS}
-        marks
-        withThumbTooltip
-        flex="1 1 0"
-      />
+      <>
+        <CompositeSlider
+          defaultValue={defaultValue}
+          onChange={onChange}
+          value={field.value}
+          min={min}
+          max={max}
+          step={step}
+          fineStep={fineStep}
+          className={NO_DRAG_CLASS}
+          marks
+          withThumbTooltip
+          flex="1 1 0"
+        />
+        {showShuffle && (
+          <Button
+            size="sm"
+            isDisabled={false}
+            onClick={handleClickRandomizeValue}
+            leftIcon={<PiShuffleBold />}
+            flexShrink={0}
+          >
+            {t('workflows.builder.shuffle')}
+          </Button>
+        )}
+      </>
     );
   }
 );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField.ts
@@ -1,5 +1,6 @@
 import { NUMPY_RAND_MAX } from 'app/constants';
 import { useAppDispatch } from 'app/store/storeHooks';
+import randomFloat from 'common/util/randomFloat';
 import { roundDownToMultiple, roundUpToMultiple } from 'common/util/roundDownToMultiple';
 import { isNil } from 'es-toolkit/compat';
 import { fieldFloatValueChanged } from 'features/nodes/store/nodesSlice';
@@ -11,9 +12,9 @@ export const useFloatField = (
   nodeId: string,
   fieldName: string,
   fieldTemplate: FloatFieldInputTemplate,
-  overrides: { min?: number; max?: number; step?: number } = {}
+  overrides: { showShuffle?: boolean; min?: number; max?: number; step?: number } = {}
 ) => {
-  const { min: overrideMin, max: overrideMax, step: overrideStep } = overrides;
+  const { showShuffle, min: overrideMin, max: overrideMax, step: overrideStep } = overrides;
   const dispatch = useAppDispatch();
 
   const step = useMemo(() => {
@@ -77,6 +78,11 @@ export const useFloatField = (
     [dispatch, fieldName, nodeId]
   );
 
+  const handleClickRandomizeValue = useCallback(() => {
+    const value = Number((Math.round(randomFloat(min, max) / step) * step).toFixed(10));
+    dispatch(fieldFloatValueChanged({ nodeId, fieldName, value }));
+  }, [dispatch, fieldName, nodeId, min, max, step]);
+
   return {
     defaultValue: fieldTemplate.default,
     onChange,
@@ -85,5 +91,7 @@ export const useFloatField = (
     step,
     fineStep,
     constrainValue,
+    showShuffle,
+    handleClickRandomizeValue,
   };
 };

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField.ts
@@ -78,7 +78,7 @@ export const useFloatField = (
     [dispatch, fieldName, nodeId]
   );
 
-  const handleClickRandomizeValue = useCallback(() => {
+  const randomizeValue = useCallback(() => {
     const value = Number((Math.round(randomFloat(min, max) / step) * step).toFixed(10));
     dispatch(fieldFloatValueChanged({ nodeId, fieldName, value }));
   }, [dispatch, fieldName, nodeId, min, max, step]);
@@ -92,6 +92,6 @@ export const useFloatField = (
     fineStep,
     constrainValue,
     showShuffle,
-    handleClickRandomizeValue,
+    randomizeValue,
   };
 };

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInput.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInput.tsx
@@ -1,10 +1,12 @@
-import { CompositeNumberInput } from '@invoke-ai/ui-library';
+import { Button, CompositeNumberInput } from '@invoke-ai/ui-library';
 import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
 import { useIntegerField } from 'features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField';
 import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { IntegerFieldInputInstance, IntegerFieldInputTemplate } from 'features/nodes/types/field';
 import type { NodeFieldIntegerSettings } from 'features/nodes/types/workflow';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiShuffleBold } from 'react-icons/pi';
 
 export const IntegerFieldInput = memo(
   (
@@ -15,26 +17,46 @@ export const IntegerFieldInput = memo(
     >
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep, constrainValue } = useIntegerField(
-      nodeId,
-      field.name,
-      fieldTemplate,
-      settings
-    );
+    const {
+      defaultValue,
+      onValueChange,
+      min,
+      max,
+      step,
+      fineStep,
+      constrainValue,
+      showShuffle,
+      handleClickRandomizeValue,
+    } = useIntegerField(nodeId, field.name, fieldTemplate, settings);
+
+    const { t } = useTranslation();
 
     return (
-      <CompositeNumberInput
-        defaultValue={defaultValue}
-        onChange={onChange}
-        value={field.value}
-        min={min}
-        max={max}
-        step={step}
-        fineStep={fineStep}
-        className={NO_DRAG_CLASS}
-        flex="1 1 0"
-        constrainValue={constrainValue}
-      />
+      <>
+        <CompositeNumberInput
+          defaultValue={defaultValue}
+          onChange={onValueChange}
+          value={field.value}
+          min={min}
+          max={max}
+          step={step}
+          fineStep={fineStep}
+          className={NO_DRAG_CLASS}
+          flex="1 1 0"
+          constrainValue={constrainValue}
+        />
+        {showShuffle && (
+          <Button
+            size="sm"
+            isDisabled={false}
+            onClick={handleClickRandomizeValue}
+            leftIcon={<PiShuffleBold />}
+            flexShrink={0}
+          >
+            {t('workflows.builder.shuffle')}
+          </Button>
+        )}
+      </>
     );
   }
 );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInput.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInput.tsx
@@ -17,17 +17,8 @@ export const IntegerFieldInput = memo(
     >
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const {
-      defaultValue,
-      onValueChange,
-      min,
-      max,
-      step,
-      fineStep,
-      constrainValue,
-      showShuffle,
-      handleClickRandomizeValue,
-    } = useIntegerField(nodeId, field.name, fieldTemplate, settings);
+    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, randomizeValue } =
+      useIntegerField(nodeId, field.name, fieldTemplate, settings);
 
     const { t } = useTranslation();
 
@@ -35,7 +26,7 @@ export const IntegerFieldInput = memo(
       <>
         <CompositeNumberInput
           defaultValue={defaultValue}
-          onChange={onValueChange}
+          onChange={onChange}
           value={field.value}
           min={min}
           max={max}
@@ -46,13 +37,7 @@ export const IntegerFieldInput = memo(
           constrainValue={constrainValue}
         />
         {showShuffle && (
-          <Button
-            size="sm"
-            isDisabled={false}
-            onClick={handleClickRandomizeValue}
-            leftIcon={<PiShuffleBold />}
-            flexShrink={0}
-          >
+          <Button size="sm" isDisabled={false} onClick={randomizeValue} leftIcon={<PiShuffleBold />} flexShrink={0}>
             {t('workflows.builder.shuffle')}
           </Button>
         )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInputAndSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInputAndSlider.tsx
@@ -17,17 +17,8 @@ export const IntegerFieldInputAndSlider = memo(
     >
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const {
-      defaultValue,
-      onValueChange,
-      min,
-      max,
-      step,
-      fineStep,
-      constrainValue,
-      showShuffle,
-      handleClickRandomizeValue,
-    } = useIntegerField(nodeId, field.name, fieldTemplate, settings);
+    const { defaultValue, onChange, min, max, step, fineStep, constrainValue, showShuffle, randomizeValue } =
+      useIntegerField(nodeId, field.name, fieldTemplate, settings);
 
     const { t } = useTranslation();
 
@@ -35,7 +26,7 @@ export const IntegerFieldInputAndSlider = memo(
       <>
         <CompositeSlider
           defaultValue={defaultValue}
-          onChange={onValueChange}
+          onChange={onChange}
           value={field.value}
           min={min}
           max={max}
@@ -48,7 +39,7 @@ export const IntegerFieldInputAndSlider = memo(
         />
         <CompositeNumberInput
           defaultValue={defaultValue}
-          onChange={onValueChange}
+          onChange={onChange}
           value={field.value}
           min={min}
           max={max}
@@ -59,13 +50,7 @@ export const IntegerFieldInputAndSlider = memo(
           constrainValue={constrainValue}
         />
         {showShuffle && (
-          <Button
-            size="sm"
-            isDisabled={false}
-            onClick={handleClickRandomizeValue}
-            leftIcon={<PiShuffleBold />}
-            flexShrink={0}
-          >
+          <Button size="sm" isDisabled={false} onClick={randomizeValue} leftIcon={<PiShuffleBold />} flexShrink={0}>
             {t('workflows.builder.shuffle')}
           </Button>
         )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInputAndSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldInputAndSlider.tsx
@@ -1,10 +1,12 @@
-import { CompositeNumberInput, CompositeSlider } from '@invoke-ai/ui-library';
+import { Button, CompositeNumberInput, CompositeSlider } from '@invoke-ai/ui-library';
 import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
 import { useIntegerField } from 'features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField';
 import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { IntegerFieldInputInstance, IntegerFieldInputTemplate } from 'features/nodes/types/field';
 import type { NodeFieldIntegerSettings } from 'features/nodes/types/workflow';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiShuffleBold } from 'react-icons/pi';
 
 export const IntegerFieldInputAndSlider = memo(
   (
@@ -15,18 +17,25 @@ export const IntegerFieldInputAndSlider = memo(
     >
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep } = useIntegerField(
-      nodeId,
-      field.name,
-      fieldTemplate,
-      settings
-    );
+    const {
+      defaultValue,
+      onValueChange,
+      min,
+      max,
+      step,
+      fineStep,
+      constrainValue,
+      showShuffle,
+      handleClickRandomizeValue,
+    } = useIntegerField(nodeId, field.name, fieldTemplate, settings);
+
+    const { t } = useTranslation();
 
     return (
       <>
         <CompositeSlider
           defaultValue={defaultValue}
-          onChange={onChange}
+          onChange={onValueChange}
           value={field.value}
           min={min}
           max={max}
@@ -39,7 +48,7 @@ export const IntegerFieldInputAndSlider = memo(
         />
         <CompositeNumberInput
           defaultValue={defaultValue}
-          onChange={onChange}
+          onChange={onValueChange}
           value={field.value}
           min={min}
           max={max}
@@ -47,7 +56,19 @@ export const IntegerFieldInputAndSlider = memo(
           fineStep={fineStep}
           className={NO_DRAG_CLASS}
           flex="1 1 0"
+          constrainValue={constrainValue}
         />
+        {showShuffle && (
+          <Button
+            size="sm"
+            isDisabled={false}
+            onClick={handleClickRandomizeValue}
+            leftIcon={<PiShuffleBold />}
+            flexShrink={0}
+          >
+            {t('workflows.builder.shuffle')}
+          </Button>
+        )}
       </>
     );
   }

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldSlider.tsx
@@ -17,8 +17,12 @@ export const IntegerFieldSlider = memo(
     >
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onValueChange, min, max, step, fineStep, showShuffle, handleClickRandomizeValue } =
-      useIntegerField(nodeId, field.name, fieldTemplate, settings);
+    const { defaultValue, onChange, min, max, step, fineStep, showShuffle, randomizeValue } = useIntegerField(
+      nodeId,
+      field.name,
+      fieldTemplate,
+      settings
+    );
 
     const { t } = useTranslation();
 
@@ -26,7 +30,7 @@ export const IntegerFieldSlider = memo(
       <>
         <CompositeSlider
           defaultValue={defaultValue}
-          onChange={onValueChange}
+          onChange={onChange}
           value={field.value}
           min={min}
           max={max}
@@ -38,13 +42,7 @@ export const IntegerFieldSlider = memo(
           flex="1 1 0"
         />
         {showShuffle && (
-          <Button
-            size="sm"
-            isDisabled={false}
-            onClick={handleClickRandomizeValue}
-            leftIcon={<PiShuffleBold />}
-            flexShrink={0}
-          >
+          <Button size="sm" isDisabled={false} onClick={randomizeValue} leftIcon={<PiShuffleBold />} flexShrink={0}>
             {t('workflows.builder.shuffle')}
           </Button>
         )}

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldSlider.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/IntegerFieldSlider.tsx
@@ -1,10 +1,12 @@
-import { CompositeSlider } from '@invoke-ai/ui-library';
+import { Button, CompositeSlider } from '@invoke-ai/ui-library';
 import type { FieldComponentProps } from 'features/nodes/components/flow/nodes/Invocation/fields/inputs/types';
 import { useIntegerField } from 'features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField';
 import { NO_DRAG_CLASS } from 'features/nodes/types/constants';
 import type { IntegerFieldInputInstance, IntegerFieldInputTemplate } from 'features/nodes/types/field';
 import type { NodeFieldIntegerSettings } from 'features/nodes/types/workflow';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiShuffleBold } from 'react-icons/pi';
 
 export const IntegerFieldSlider = memo(
   (
@@ -15,27 +17,38 @@ export const IntegerFieldSlider = memo(
     >
   ) => {
     const { nodeId, field, fieldTemplate, settings } = props;
-    const { defaultValue, onChange, min, max, step, fineStep } = useIntegerField(
-      nodeId,
-      field.name,
-      fieldTemplate,
-      settings
-    );
+    const { defaultValue, onValueChange, min, max, step, fineStep, showShuffle, handleClickRandomizeValue } =
+      useIntegerField(nodeId, field.name, fieldTemplate, settings);
+
+    const { t } = useTranslation();
 
     return (
-      <CompositeSlider
-        defaultValue={defaultValue}
-        onChange={onChange}
-        value={field.value}
-        min={min}
-        max={max}
-        step={step}
-        fineStep={fineStep}
-        className={NO_DRAG_CLASS}
-        marks
-        withThumbTooltip
-        flex="1 1 0"
-      />
+      <>
+        <CompositeSlider
+          defaultValue={defaultValue}
+          onChange={onValueChange}
+          value={field.value}
+          min={min}
+          max={max}
+          step={step}
+          fineStep={fineStep}
+          className={NO_DRAG_CLASS}
+          marks
+          withThumbTooltip
+          flex="1 1 0"
+        />
+        {showShuffle && (
+          <Button
+            size="sm"
+            isDisabled={false}
+            onClick={handleClickRandomizeValue}
+            leftIcon={<PiShuffleBold />}
+            flexShrink={0}
+          >
+            {t('workflows.builder.shuffle')}
+          </Button>
+        )}
+      </>
     );
   }
 );

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField.ts
@@ -70,27 +70,27 @@ export const useIntegerField = (
     [max, min, overrideMax, overrideMin, overrideStep, step]
   );
 
-  const onValueChange = useCallback(
+  const onChange = useCallback(
     (value: number) => {
       dispatch(fieldIntegerValueChanged({ nodeId, fieldName, value }));
     },
     [dispatch, fieldName, nodeId]
   );
 
-  const handleClickRandomizeValue = useCallback(() => {
+  const randomizeValue = useCallback(() => {
     const value = Math.round(randomInt(min, max) / step) * step;
     dispatch(fieldIntegerValueChanged({ nodeId, fieldName, value }));
   }, [dispatch, fieldName, nodeId, min, max, step]);
 
   return {
     defaultValue: fieldTemplate.default,
-    onValueChange,
+    onChange,
     min,
     max,
     step,
     fineStep,
     constrainValue,
     showShuffle,
-    handleClickRandomizeValue,
+    randomizeValue,
   };
 };

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/IntegerField/useIntegerField.ts
@@ -1,5 +1,6 @@
 import { NUMPY_RAND_MAX } from 'app/constants';
 import { useAppDispatch } from 'app/store/storeHooks';
+import randomInt from 'common/util/randomInt';
 import { roundDownToMultiple, roundUpToMultiple } from 'common/util/roundDownToMultiple';
 import { isNil } from 'es-toolkit/compat';
 import { fieldIntegerValueChanged } from 'features/nodes/store/nodesSlice';
@@ -11,9 +12,9 @@ export const useIntegerField = (
   nodeId: string,
   fieldName: string,
   fieldTemplate: IntegerFieldInputTemplate,
-  overrides: { min?: number; max?: number; step?: number } = {}
+  overrides: { showShuffle?: boolean; min?: number; max?: number; step?: number } = {}
 ) => {
-  const { min: overrideMin, max: overrideMax, step: overrideStep } = overrides;
+  const { showShuffle, min: overrideMin, max: overrideMax, step: overrideStep } = overrides;
   const dispatch = useAppDispatch();
 
   const step = useMemo(() => {
@@ -65,25 +66,31 @@ export const useIntegerField = (
   }, [fieldTemplate.exclusiveMaximum, fieldTemplate.maximum, overrideMax, step]);
 
   const constrainValue = useCallback(
-    (v: number) =>
-      constrainNumber(v, { min, max, step: step }, { min: overrideMin, max: overrideMax, step: overrideStep }),
+    (v: number) => constrainNumber(v, { min, max, step }, { min: overrideMin, max: overrideMax, step: overrideStep }),
     [max, min, overrideMax, overrideMin, overrideStep, step]
   );
 
-  const onChange = useCallback(
+  const onValueChange = useCallback(
     (value: number) => {
       dispatch(fieldIntegerValueChanged({ nodeId, fieldName, value }));
     },
     [dispatch, fieldName, nodeId]
   );
 
+  const handleClickRandomizeValue = useCallback(() => {
+    const value = Math.round(randomInt(min, max) / step) * step;
+    dispatch(fieldIntegerValueChanged({ nodeId, fieldName, value }));
+  }, [dispatch, fieldName, nodeId, min, max, step]);
+
   return {
     defaultValue: fieldTemplate.default,
-    onChange,
+    onValueChange,
     min,
     max,
     step,
     fineStep,
     constrainValue,
+    showShuffle,
+    handleClickRandomizeValue,
   };
 };

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementFloatSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementFloatSettings.tsx
@@ -20,6 +20,24 @@ type Props = {
 };
 
 export const NodeFieldElementFloatSettings = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
+  return (
+    <>
+      <SettingShuffle id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingComponent
+        id={id}
+        settings={settings}
+        nodeId={nodeId}
+        fieldName={fieldName}
+        fieldTemplate={fieldTemplate}
+      />
+      <SettingMin id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingMax id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+    </>
+  );
+});
+NodeFieldElementFloatSettings.displayName = 'NodeFieldElementFloatSettings';
+
+const SettingShuffle = memo(({ id, settings }: Props) => {
   const { showShuffle } = settings;
 
   const { t } = useTranslation();
@@ -34,24 +52,13 @@ export const NodeFieldElementFloatSettings = memo(({ id, settings, nodeId, field
   }, [dispatch, id, settings, showShuffle]);
 
   return (
-    <>
-      <FormControl>
-        <FormLabel flex={1}>{t('workflows.builder.showShuffle')}</FormLabel>
-        <Switch size="sm" isChecked={showShuffle} onChange={toggleShowShuffle} />
-      </FormControl>
-      <SettingComponent
-        id={id}
-        settings={settings}
-        nodeId={nodeId}
-        fieldName={fieldName}
-        fieldTemplate={fieldTemplate}
-      />
-      <SettingMin id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-      <SettingMax id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-    </>
+    <FormControl>
+      <FormLabel flex={1}>{t('workflows.builder.showShuffle')}</FormLabel>
+      <Switch size="sm" isChecked={showShuffle} onChange={toggleShowShuffle} />
+    </FormControl>
   );
 });
-NodeFieldElementFloatSettings.displayName = 'NodeFieldElementFloatSettings';
+SettingShuffle.displayName = 'SettingShuffle';
 
 const SettingComponent = memo(({ id, settings }: Props) => {
   const { t } = useTranslation();

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementFloatSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementFloatSettings.tsx
@@ -20,8 +20,25 @@ type Props = {
 };
 
 export const NodeFieldElementFloatSettings = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
+  const { showShuffle } = settings;
+
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  const toggleShowShuffle = useCallback(() => {
+    const newSettings: NodeFieldFloatSettings = {
+      ...settings,
+      showShuffle: !showShuffle,
+    };
+    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+  }, [dispatch, id, settings, showShuffle]);
+
   return (
     <>
+      <FormControl>
+        <FormLabel flex={1}>{t('workflows.builder.showShuffle')}</FormLabel>
+        <Switch size="sm" isChecked={showShuffle} onChange={toggleShowShuffle} />
+      </FormControl>
       <SettingComponent
         id={id}
         settings={settings}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementIntegerSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementIntegerSettings.tsx
@@ -21,8 +21,25 @@ type Props = {
 };
 
 export const NodeFieldElementIntegerSettings = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
+  const { showShuffle } = settings;
+
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  const toggleShowShuffle = useCallback(() => {
+    const newSettings: NodeFieldIntegerSettings = {
+      ...settings,
+      showShuffle: !showShuffle,
+    };
+    dispatch(formElementNodeFieldDataChanged({ id, changes: { settings: newSettings } }));
+  }, [dispatch, id, settings, showShuffle]);
+
   return (
     <>
+      <FormControl>
+        <FormLabel flex={1}>{t('workflows.builder.showShuffle')}</FormLabel>
+        <Switch size="sm" isChecked={showShuffle} onChange={toggleShowShuffle} />
+      </FormControl>
       <SettingComponent
         id={id}
         settings={settings}

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementIntegerSettings.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/builder/NodeFieldElementIntegerSettings.tsx
@@ -21,6 +21,24 @@ type Props = {
 };
 
 export const NodeFieldElementIntegerSettings = memo(({ id, settings, nodeId, fieldName, fieldTemplate }: Props) => {
+  return (
+    <>
+      <SettingShuffle id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingComponent
+        id={id}
+        settings={settings}
+        nodeId={nodeId}
+        fieldName={fieldName}
+        fieldTemplate={fieldTemplate}
+      />
+      <SettingMin id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+      <SettingMax id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
+    </>
+  );
+});
+NodeFieldElementIntegerSettings.displayName = 'NodeFieldElementIntegerSettings';
+
+const SettingShuffle = memo(({ id, settings }: Props) => {
   const { showShuffle } = settings;
 
   const { t } = useTranslation();
@@ -35,24 +53,13 @@ export const NodeFieldElementIntegerSettings = memo(({ id, settings, nodeId, fie
   }, [dispatch, id, settings, showShuffle]);
 
   return (
-    <>
-      <FormControl>
-        <FormLabel flex={1}>{t('workflows.builder.showShuffle')}</FormLabel>
-        <Switch size="sm" isChecked={showShuffle} onChange={toggleShowShuffle} />
-      </FormControl>
-      <SettingComponent
-        id={id}
-        settings={settings}
-        nodeId={nodeId}
-        fieldName={fieldName}
-        fieldTemplate={fieldTemplate}
-      />
-      <SettingMin id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-      <SettingMax id={id} settings={settings} nodeId={nodeId} fieldName={fieldName} fieldTemplate={fieldTemplate} />
-    </>
+    <FormControl>
+      <FormLabel flex={1}>{t('workflows.builder.showShuffle')}</FormLabel>
+      <Switch size="sm" isChecked={showShuffle} onChange={toggleShowShuffle} />
+    </FormControl>
   );
 });
-NodeFieldElementIntegerSettings.displayName = 'NodeFieldElementIntegerSettings';
+SettingShuffle.displayName = 'SettingShuffle';
 
 const SettingComponent = memo(({ id, settings }: Props) => {
   const { t } = useTranslation();

--- a/invokeai/frontend/web/src/features/nodes/types/workflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/types/workflow.ts
@@ -74,6 +74,7 @@ export const NODE_FIELD_CLASS_NAME = `form-builder-${NODE_FIELD_TYPE}`;
 const FLOAT_FIELD_SETTINGS_TYPE = 'float-field-config';
 const zNodeFieldFloatSettings = z.object({
   type: z.literal(FLOAT_FIELD_SETTINGS_TYPE).default(FLOAT_FIELD_SETTINGS_TYPE),
+  showShuffle: z.boolean().default(false),
   component: zNumberComponent.default('number-input'),
   min: z.number().optional(),
   max: z.number().optional(),
@@ -84,6 +85,7 @@ export type NodeFieldFloatSettings = z.infer<typeof zNodeFieldFloatSettings>;
 const INTEGER_FIELD_CONFIG_TYPE = 'integer-field-config';
 const zNodeFieldIntegerSettings = z.object({
   type: z.literal(INTEGER_FIELD_CONFIG_TYPE).default(INTEGER_FIELD_CONFIG_TYPE),
+  showShuffle: z.boolean().default(false),
   component: zNumberComponent.default('number-input'),
   min: z.number().optional(),
   max: z.number().optional(),


### PR DESCRIPTION
## Summary

A new feature was implemented to shuffle any number field in the workflow editor.

- `showShuffle` was added to the schemas of both integer and floating point field settings in `workflow.ts`
- a new utility function, `randomFloat`, was created in `randomFloat.ts` to be able to generate random floating point numbers
- `useIntegerField` and `useFloatField` were extended to generate a new random value and dispatch the changed value when the `Shuffle` button is clicked
- `Show Shuffle` toggle was added to `NodeFieldElementIntegerSettings` and `NodeFieldElementFloatSettings`
- `IntegerFieldInput`, `IntegerFieldSlider`, `IntegerFieldInputAndSlider`, `FloatFieldInput`, `FloatFieldSlider`, `FloatFieldInputAndSlider` were extended with the `Shuffle` button
- new tanslations, `showShuffle` and `shuffle`, were added to en.json

## Related Issues / Discussions

Closes #7788

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
