### PR TITLE
ci: add workflow to catch incorrect usage of git-lfs

### DIFF
--- a/.github/workflows/lfs-checks.yml
+++ b/.github/workflows/lfs-checks.yml
@@ -19,6 +19,9 @@ jobs:
   lfs-check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      # Required to label and comment on the PRs
+      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lfs-checks.yml
+++ b/.github/workflows/lfs-checks.yml
@@ -1,0 +1,27 @@
+# Checks that large files and LFS-tracked files are properly checked in with pointer format.
+# Uses https://github.com/ppremk/lfs-warning to detect LFS issues.
+
+name: 'lfs checks'
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types:
+      - 'ready_for_review'
+      - 'opened'
+      - 'synchronize'
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  lfs-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: check lfs files
+        uses: ppremk/lfs-warning@v3.3


### PR DESCRIPTION
## Summary

ci: add workflow to catch incorrect usage of git-lfs

## Related Issues / Discussions

#8433 inadvertently committed a non-LFS-tracked file to an LFS-tracked dir, causing a string of issues. #8446 fixed that file. This PR should prevent the issue from occurring again, catching the issue in CI.

## QA Instructions

n/a

## Merge Plan

Needs to be added to required workflows in repo settings

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
