### PR TITLE
fix(ui): float input precision

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/FloatField/useFloatField.ts
@@ -37,6 +37,13 @@ export const useFloatField = (
     return fieldTemplate.multipleOf;
   }, [fieldTemplate.multipleOf, overrideStep]);
 
+  const baseStep = useMemo(() => {
+    if (isNil(fieldTemplate.multipleOf)) {
+      return undefined;
+    }
+    return fieldTemplate.multipleOf;
+  }, [fieldTemplate.multipleOf]);
+
   const min = useMemo(() => {
     let min = -NUMPY_RAND_MAX;
 
@@ -67,8 +74,8 @@ export const useFloatField = (
 
   const constrainValue = useCallback(
     (v: number) =>
-      constrainNumber(v, { min, max, step: step }, { min: overrideMin, max: overrideMax, step: overrideStep }),
-    [max, min, overrideMax, overrideMin, overrideStep, step]
+      constrainNumber(v, { min, max, step: baseStep }, { min: overrideMin, max: overrideMax, step: overrideStep }),
+    [max, min, overrideMax, overrideMin, overrideStep, baseStep]
   );
 
   const onChange = useCallback(

--- a/invokeai/frontend/web/src/features/nodes/util/constrainNumber.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/constrainNumber.ts
@@ -1,6 +1,6 @@
 import type { PartialDeep } from 'type-fest';
 
-type NumberConstraints = { min: number; max: number; step: number };
+type NumberConstraints = { min: number; max: number; step?: number };
 
 /**
  * Constrain a number to a range and round to the nearest multiple of a given value.


### PR DESCRIPTION
## Summary

Determine the "base" step for floats. If no `multipleOf` is provided, the "base" step is `undefined`, meaning the float can have any number of decimal places.

The UI library does its own step constrains though and is rounding to 3 decimal places. Probably need to update the logic in the UI library to have truly arbitrary precision for float fields.

## Related Issues / Discussions

In #8450 a bug was fixed, the `constrainValue` prop wasn't added on float fields when it should have been. Adding it added more constraints to the fields, altering their precision. 

## QA Instructions

float fields should behave like they did before #8450 now

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
