### PR TITLE
fix(ui): race condition when setting hf token and downloading model

### DIFF
--- a/invokeai/frontend/web/src/services/events/onModelInstallError.tsx
+++ b/invokeai/frontend/web/src/services/events/onModelInstallError.tsx
@@ -173,7 +173,7 @@ const HFUnauthorizedToastDescription = () => {
   if (data === 'unknown') {
     return (
       <Text fontSize="md">
-        {t('modelManager.hfTokenUnableToErrorMessage')}{' '}
+        {t('modelManager.hfTokenUnableToVerifyErrorMessage')}{' '}
         <Button onClick={onClick} variant="link" color="base.50" flexGrow={0}>
           {t('modelManager.modelManager')}.
         </Button>
@@ -181,6 +181,13 @@ const HFUnauthorizedToastDescription = () => {
     );
   }
 
-  // data === 'valid' - should never happen!
-  assert(false, 'Unexpected valid HF token with unauthorized error');
+  // data === 'valid' - user may have a token but not authorized for model?
+  return (
+    <Text fontSize="md">
+      {t('modelManager.hfTokenForbiddenErrorMessage')}{' '}
+      <Button onClick={onClick} variant="link" color="base.50" flexGrow={0}>
+        {t('modelManager.modelManager')}.
+      </Button>
+    </Text>
+  );
 };


### PR DESCRIPTION
## Summary

I ran into a race condition where I set a HF token and it was valid, but somehow this error toast still appeared. The conditional feel through to an assertion that we never expected to get to, which crashed the UI.

Handled the unexpected case gracefully now.

## Related Issues / Discussions

n/a

## QA Instructions

Hard to repro given its a race condition between the HF hub library and our model manager. 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
