### PR TITLE
fix(ui): respect direction of selection in Gallery

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageGrid/GalleryImage.tsx
@@ -121,7 +121,7 @@ const buildOnClick =
         if (currentClickedIndex < lastClickedIndex) {
           imagesToSelect.reverse();
         }
-        dispatch(selectionChanged(imagesToSelect));
+        dispatch(selectionChanged(uniq(selection.concat(imagesToSelect))));
       }
     } else if (ctrlKey || metaKey) {
       if (selection.some((n) => n === imageName) && selection.length > 1) {


### PR DESCRIPTION
## Summary

A new bugfix was implemented to respect the direction of selection of multiple images in Gallery

- `buildOnClick` was modified in `GalleryImage.tsx` to respect the direction of the selection

## Related Issues / Discussions

Closes https://github.com/invoke-ai/InvokeAI/issues/8451

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
