### PR TITLE
feat(ui): change board - sorting order of boards alphabetical

### DIFF
--- a/invokeai/frontend/web/src/features/changeBoardModal/components/ChangeBoardModal.tsx
+++ b/invokeai/frontend/web/src/features/changeBoardModal/components/ChangeBoardModal.tsx
@@ -36,10 +36,12 @@ const ChangeBoardModal = () => {
 
   const options = useMemo<ComboboxOption[]>(() => {
     return [{ label: t('boards.uncategorized'), value: 'none' }].concat(
-      (boards ?? []).map((board) => ({
-        label: board.board_name,
-        value: board.board_id,
-      }))
+      (boards ?? [])
+        .map((board) => ({
+          label: board.board_name,
+          value: board.board_id,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label))
     );
   }, [boards, t]);
 
@@ -63,7 +65,6 @@ const ChangeBoardModal = () => {
         board_id: selectedBoard,
       });
     }
-    setSelectedBoard(null);
     dispatch(changeBoardReset());
   }, [addImagesToBoard, dispatch, imagesToChange, removeImagesFromBoard, selectedBoard]);
 
@@ -89,7 +90,6 @@ const ChangeBoardModal = () => {
           {t('boards.movingImagesToBoard', {
             count: imagesToChange.length,
           })}
-          :
         </Text>
         <FormControl isDisabled={isFetching}>
           <Combobox


### PR DESCRIPTION
## Summary

A new feature was implemented to alphabetically order boards in the `Change Board` dialog

- order of `boards` was changed to sort them alphabetically in `ChangeBoardModal`

## Related Issues / Discussions

Closes [#1234" format, so that the issue will be automatically closed when the PR merges.-->](https://github.com/invoke-ai/InvokeAI/issues/8341)

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
