### PR TITLE
feat(ui): respect aspect ratio when resizing bbox on canvas

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasBboxToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasBboxToolModule.ts
@@ -344,9 +344,9 @@ export class CanvasBboxToolModule extends CanvasModuleBase {
     let width = roundToMultipleMin(this.konva.proxyRect.width() * this.konva.proxyRect.scaleX(), gridSize);
     let height = roundToMultipleMin(this.konva.proxyRect.height() * this.konva.proxyRect.scaleY(), gridSize);
 
-    // If shift is held and we are resizing from a corner, retain aspect ratio - needs special handling. We skip this
-    // if alt/opt is held - this requires math too big for my brain.
-    if (shift && CORNER_ANCHORS.includes(anchor) && !alt) {
+    // If ratio is locked OR shift is held and we are resizing from a corner, retain aspect ratio - needs special
+    // handling. We skip this if alt/opt is held - this requires math too big for my brain.
+    if ((this.manager.stateApi.getBbox().aspectRatio.isLocked || (shift && CORNER_ANCHORS.includes(anchor))) && !alt) {
       // Fit the bbox to the last aspect ratio
       let fittedWidth = Math.sqrt(width * height * this.$aspectRatioBuffer.get());
       let fittedHeight = fittedWidth / this.$aspectRatioBuffer.get();


### PR DESCRIPTION
## Summary

If the aspect ratio is locked, transforming bbox from Canvas maintains the selected aspect ratio. This uses an existing codepath - previously this behaviour was used only when holding shift.

## Related Issues / Discussions

offline discussion

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
