### PR TITLE
fix(ui): progress image gets stuck on viewer when generating on canvas

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/context.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/context.tsx
@@ -83,7 +83,15 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
         // switch to the final image automatically. In this case, we clear the progress image immediately.
         //
         // We also clear the progress image if the queue item is canceled or failed, as there is no final image to show.
-        if (data.status === 'canceled' || data.status === 'failed' || !autoSwitch) {
+        if (
+          data.status === 'canceled' ||
+          data.status === 'failed' ||
+          !autoSwitch ||
+          // When the origin is 'canvas' and destination is 'canvas' (without a ':<session id>' suffix), that means the
+          // image is going to be added to the staging area. In this case, we need to clear the progress image else it
+          // will be stuck on the viewer.
+          (data.origin === 'canvas' && data.destination !== 'canvas')
+        ) {
           $progressEvent.set(null);
           $progressImage.set(null);
         }


### PR DESCRIPTION
## Summary

fix(ui): progress image gets stuck on viewer when generating on canvas

## Related Issues / Discussions

Reported on discord https://discord.com/channels/1020123559063990373/1149506274971631688/1409712164759015434

## QA Instructions

Reproduce issue:
- Generate on canvas
- Click Viewer tab
- When generation finishes, the last progress image is stuck in the viewer until you click another image in gallery

With the fix, the progress image should disappear after generation finishes.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
