### PR TITLE
feat(ui): LoRA default weight

### DIFF
--- a/invokeai/app/services/model_records/model_records_base.py
+++ b/invokeai/app/services/model_records/model_records_base.py
@@ -15,6 +15,7 @@ from invokeai.app.util.model_exclude_null import BaseModelExcludeNull
 from invokeai.backend.model_manager.config import (
     AnyModelConfig,
     ControlAdapterDefaultSettings,
+    LoraModelDefaultSettings,
     MainModelDefaultSettings,
 )
 from invokeai.backend.model_manager.taxonomy import (
@@ -83,7 +84,7 @@ class ModelRecordChanges(BaseModelExcludeNull):
     file_size: Optional[int] = Field(description="Size of model file", default=None)
     format: Optional[str] = Field(description="format of model file", default=None)
     trigger_phrases: Optional[set[str]] = Field(description="Set of trigger phrases for this model", default=None)
-    default_settings: Optional[MainModelDefaultSettings | ControlAdapterDefaultSettings] = Field(
+    default_settings: Optional[MainModelDefaultSettings | LoraModelDefaultSettings | ControlAdapterDefaultSettings] = Field(
         description="Default settings for this model", default=None
     )
 

--- a/invokeai/app/services/model_records/model_records_base.py
+++ b/invokeai/app/services/model_records/model_records_base.py
@@ -84,8 +84,8 @@ class ModelRecordChanges(BaseModelExcludeNull):
     file_size: Optional[int] = Field(description="Size of model file", default=None)
     format: Optional[str] = Field(description="format of model file", default=None)
     trigger_phrases: Optional[set[str]] = Field(description="Set of trigger phrases for this model", default=None)
-    default_settings: Optional[MainModelDefaultSettings | LoraModelDefaultSettings | ControlAdapterDefaultSettings] = Field(
-        description="Default settings for this model", default=None
+    default_settings: Optional[MainModelDefaultSettings | LoraModelDefaultSettings | ControlAdapterDefaultSettings] = (
+        Field(description="Default settings for this model", default=None)
     )
 
     # Checkpoint-specific changes

--- a/invokeai/backend/model_manager/config.py
+++ b/invokeai/backend/model_manager/config.py
@@ -94,6 +94,7 @@ class LoraModelDefaultSettings(BaseModel):
     weight: float | None = Field(default=None, ge=-1, le=2, description="Default weight for this model")
     model_config = ConfigDict(extra="forbid")
 
+
 class ControlAdapterDefaultSettings(BaseModel):
     # This could be narrowed to controlnet processor nodes, but they change. Leaving this a string is safer.
     preprocessor: str | None

--- a/invokeai/backend/model_manager/config.py
+++ b/invokeai/backend/model_manager/config.py
@@ -90,6 +90,10 @@ class MainModelDefaultSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class LoraModelDefaultSettings(BaseModel):
+    weight: float | None = Field(default=None, ge=-1, le=2, description="Default weight for this model")
+    model_config = ConfigDict(extra="forbid")
+
 class ControlAdapterDefaultSettings(BaseModel):
     # This could be narrowed to controlnet processor nodes, but they change. Leaving this a string is safer.
     preprocessor: str | None
@@ -287,6 +291,9 @@ class LoRAConfigBase(ABC, BaseModel):
 
     type: Literal[ModelType.LoRA] = ModelType.LoRA
     trigger_phrases: Optional[set[str]] = Field(description="Set of trigger phrases for this model", default=None)
+    default_settings: Optional[LoraModelDefaultSettings] = Field(
+        description="Default settings for this model", default=None
+    )
 
     @classmethod
     def flux_lora_format(cls, mod: ModelOnDisk):
@@ -748,7 +755,7 @@ AnyModelConfig = Annotated[
 ]
 
 AnyModelConfigValidator = TypeAdapter(AnyModelConfig)
-AnyDefaultSettings: TypeAlias = Union[MainModelDefaultSettings, ControlAdapterDefaultSettings]
+AnyDefaultSettings: TypeAlias = Union[MainModelDefaultSettings, LoraModelDefaultSettings, ControlAdapterDefaultSettings]
 
 
 class ModelConfigFactory:

--- a/invokeai/backend/model_manager/legacy_probe.py
+++ b/invokeai/backend/model_manager/legacy_probe.py
@@ -545,8 +545,10 @@ def get_default_settings_control_adapters(model_name: str) -> Optional[ControlAd
             return ControlAdapterDefaultSettings(preprocessor=v)
     return None
 
+
 def get_default_settings_lora() -> LoraModelDefaultSettings:
     return LoraModelDefaultSettings()
+
 
 def get_default_settings_main(model_base: BaseModelType) -> Optional[MainModelDefaultSettings]:
     if model_base is BaseModelType.StableDiffusion1 or model_base is BaseModelType.StableDiffusion2:

--- a/invokeai/backend/model_manager/legacy_probe.py
+++ b/invokeai/backend/model_manager/legacy_probe.py
@@ -23,6 +23,7 @@ from invokeai.backend.model_manager.config import (
     AnyModelConfig,
     ControlAdapterDefaultSettings,
     InvalidModelConfigException,
+    LoraModelDefaultSettings,
     MainModelDefaultSettings,
     ModelConfigFactory,
     SubmodelDefinition,
@@ -217,6 +218,8 @@ class ModelProbe(object):
         if not fields["default_settings"]:
             if fields["type"] in {ModelType.ControlNet, ModelType.T2IAdapter, ModelType.ControlLoRa}:
                 fields["default_settings"] = get_default_settings_control_adapters(fields["name"])
+            if fields["type"] in {ModelType.LoRA}:
+                fields["default_settings"] = get_default_settings_lora()
             elif fields["type"] is ModelType.Main:
                 fields["default_settings"] = get_default_settings_main(fields["base"])
 
@@ -542,6 +545,8 @@ def get_default_settings_control_adapters(model_name: str) -> Optional[ControlAd
             return ControlAdapterDefaultSettings(preprocessor=v)
     return None
 
+def get_default_settings_lora() -> LoraModelDefaultSettings:
+    return LoraModelDefaultSettings()
 
 def get_default_settings_main(model_base: BaseModelType) -> Optional[MainModelDefaultSettings]:
     if model_base is BaseModelType.StableDiffusion1 or model_base is BaseModelType.StableDiffusion2:

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -792,6 +792,9 @@
             }
         }
     },
+    "lora": {
+        "weight": "Weight"
+    },
     "metadata": {
         "allPrompts": "All Prompts",
         "cfgScale": "CFG scale",

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -127,6 +127,9 @@ export const zAppConfig = z.object({
   flux: z.object({
     guidance: zNumericalParameterConfig,
   }),
+  lora: z.object({
+    weight: zNumericalParameterConfig,
+  }),
 });
 
 export type AppConfig = z.infer<typeof zAppConfig>;
@@ -297,6 +300,17 @@ export const getDefaultAppConfig = (): AppConfig => ({
       numberInputMax: 20,
       fineStep: 0.1,
       coarseStep: 0.5,
+    },
+  },
+  lora: {
+    weight: {
+      initial: 0.75,
+      sliderMin: -1,
+      sliderMax: 2,
+      numberInputMin: -1,
+      numberInputMax: 2,
+      fineStep: 0.01,
+      coarseStep: 0.05,
     },
   },
 });

--- a/invokeai/frontend/web/src/app/types/invokeai.ts
+++ b/invokeai/frontend/web/src/app/types/invokeai.ts
@@ -127,9 +127,6 @@ export const zAppConfig = z.object({
   flux: z.object({
     guidance: zNumericalParameterConfig,
   }),
-  lora: z.object({
-    weight: zNumericalParameterConfig,
-  }),
 });
 
 export type AppConfig = z.infer<typeof zAppConfig>;
@@ -300,17 +297,6 @@ export const getDefaultAppConfig = (): AppConfig => ({
       numberInputMax: 20,
       fineStep: 0.1,
       coarseStep: 0.5,
-    },
-  },
-  lora: {
-    weight: {
-      initial: 0.75,
-      sliderMin: -1,
-      sliderMax: 2,
-      numberInputMin: -1,
-      numberInputMax: 2,
-      fineStep: 0.01,
-      coarseStep: 0.05,
     },
   },
 });

--- a/invokeai/frontend/web/src/features/controlLayers/store/lorasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/lorasSlice.ts
@@ -4,6 +4,7 @@ import type { SliceConfig } from 'app/store/types';
 import { paramsReset } from 'features/controlLayers/store/paramsSlice';
 import { type LoRA, zLoRA } from 'features/controlLayers/store/types';
 import { zModelIdentifierField } from 'features/nodes/types/common';
+import { DEFAULT_LORA_WEIGHT_CONFIG } from 'features/system/store/configSlice';
 import type { LoRAModelConfig } from 'services/api/types';
 import { v4 as uuidv4 } from 'uuid';
 import z from 'zod';
@@ -28,7 +29,7 @@ const slice = createSlice({
         const { model, id } = action.payload;
         const parsedModel = zModelIdentifierField.parse(model);
         const defaultLoRAConfig: Pick<LoRA, 'weight' | 'isEnabled'> = {
-          weight: model.default_settings?.weight ?? 0.75,
+          weight: model.default_settings?.weight ?? DEFAULT_LORA_WEIGHT_CONFIG.initial,
           isEnabled: true,
         };
         state.loras.push({ ...defaultLoRAConfig, model: parsedModel, id });

--- a/invokeai/frontend/web/src/features/controlLayers/store/lorasSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/lorasSlice.ts
@@ -13,11 +13,6 @@ const zLoRAsState = z.object({
 });
 type LoRAsState = z.infer<typeof zLoRAsState>;
 
-const defaultLoRAConfig: Pick<LoRA, 'weight' | 'isEnabled'> = {
-  weight: 0.75,
-  isEnabled: true,
-};
-
 const getInitialState = (): LoRAsState => ({
   loras: [],
 });
@@ -32,6 +27,10 @@ const slice = createSlice({
       reducer: (state, action: PayloadAction<{ model: LoRAModelConfig; id: string }>) => {
         const { model, id } = action.payload;
         const parsedModel = zModelIdentifierField.parse(model);
+        const defaultLoRAConfig: Pick<LoRA, 'weight' | 'isEnabled'> = {
+          weight: model.default_settings?.weight ?? 0.75,
+          isEnabled: true,
+        };
         state.loras.push({ ...defaultLoRAConfig, model: parsedModel, id });
       },
       prepare: (payload: { model: LoRAModelConfig }) => ({ payload: { ...payload, id: uuidv4() } }),
@@ -87,3 +86,7 @@ export const lorasSliceConfig: SliceConfig<typeof slice> = {
 
 export const selectLoRAsSlice = (state: RootState) => state.loras;
 export const selectAddedLoRAs = createSelector(selectLoRAsSlice, (loras) => loras.loras);
+export const buildSelectLoRA = (id: string) =>
+  createSelector([selectLoRAsSlice], (loras) => {
+    return selectLoRA(loras, id);
+  });

--- a/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
@@ -18,12 +18,10 @@ import {
   loraWeightChanged,
 } from 'features/controlLayers/store/lorasSlice';
 import type { LoRA } from 'features/controlLayers/store/types';
-import { selectLoRAWeightConfig } from 'features/system/store/configSlice';
+import { DEFAULT_LORA_WEIGHT_CONFIG } from 'features/system/store/configSlice';
 import { memo, useCallback, useMemo } from 'react';
 import { PiTrashSimpleBold } from 'react-icons/pi';
 import { useGetModelConfigQuery } from 'services/api/endpoints/models';
-
-const marks = [-1, 0, 1, 2];
 
 export const LoRACard = memo((props: { id: string }) => {
   const selectLoRA = useMemo(() => buildSelectLoRA(props.id), [props.id]);
@@ -39,7 +37,6 @@ LoRACard.displayName = 'LoRACard';
 
 const LoRAContent = memo(({ lora }: { lora: LoRA }) => {
   const dispatch = useAppDispatch();
-  const config = useAppSelector(selectLoRAWeightConfig);
   const { data: loraConfig } = useGetModelConfigQuery(lora.model.key);
 
   const handleChange = useCallback(
@@ -81,22 +78,22 @@ const LoRAContent = memo(({ lora }: { lora: LoRA }) => {
           <CompositeSlider
             value={lora.weight}
             onChange={handleChange}
-            min={config.sliderMin}
-            max={config.sliderMax}
-            step={config.coarseStep}
-            marks={marks}
-            defaultValue={config.initial}
+            min={DEFAULT_LORA_WEIGHT_CONFIG.sliderMin}
+            max={DEFAULT_LORA_WEIGHT_CONFIG.sliderMax}
+            step={DEFAULT_LORA_WEIGHT_CONFIG.coarseStep}
+            marks={DEFAULT_LORA_WEIGHT_CONFIG.marks.slice()}
+            defaultValue={DEFAULT_LORA_WEIGHT_CONFIG.initial}
             isDisabled={!lora.isEnabled}
           />
           <CompositeNumberInput
             value={lora.weight}
             onChange={handleChange}
-            min={config.numberInputMin}
-            max={config.numberInputMax}
-            step={config.coarseStep}
+            min={DEFAULT_LORA_WEIGHT_CONFIG.numberInputMin}
+            max={DEFAULT_LORA_WEIGHT_CONFIG.numberInputMax}
+            step={DEFAULT_LORA_WEIGHT_CONFIG.coarseStep}
             w={20}
             flexShrink={0}
-            defaultValue={config.initial}
+            defaultValue={DEFAULT_LORA_WEIGHT_CONFIG.initial}
             isDisabled={!lora.isEnabled}
           />
         </CardBody>

--- a/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
+++ b/invokeai/frontend/web/src/features/lora/components/LoRACard.tsx
@@ -9,16 +9,16 @@ import {
   Switch,
   Text,
 } from '@invoke-ai/ui-library';
-import { createSelector } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
 import {
+  buildSelectLoRA,
   loraDeleted,
   loraIsEnabledChanged,
   loraWeightChanged,
-  selectLoRAsSlice,
 } from 'features/controlLayers/store/lorasSlice';
 import type { LoRA } from 'features/controlLayers/store/types';
+import { selectLoRAWeightConfig } from 'features/system/store/configSlice';
 import { memo, useCallback, useMemo } from 'react';
 import { PiTrashSimpleBold } from 'react-icons/pi';
 import { useGetModelConfigQuery } from 'services/api/endpoints/models';
@@ -26,10 +26,7 @@ import { useGetModelConfigQuery } from 'services/api/endpoints/models';
 const marks = [-1, 0, 1, 2];
 
 export const LoRACard = memo((props: { id: string }) => {
-  const selectLoRA = useMemo(
-    () => createSelector(selectLoRAsSlice, ({ loras }) => loras.find(({ id }) => id === props.id)),
-    [props.id]
-  );
+  const selectLoRA = useMemo(() => buildSelectLoRA(props.id), [props.id]);
   const lora = useAppSelector(selectLoRA);
 
   if (!lora) {
@@ -42,6 +39,7 @@ LoRACard.displayName = 'LoRACard';
 
 const LoRAContent = memo(({ lora }: { lora: LoRA }) => {
   const dispatch = useAppDispatch();
+  const config = useAppSelector(selectLoRAWeightConfig);
   const { data: loraConfig } = useGetModelConfigQuery(lora.model.key);
 
   const handleChange = useCallback(
@@ -83,22 +81,22 @@ const LoRAContent = memo(({ lora }: { lora: LoRA }) => {
           <CompositeSlider
             value={lora.weight}
             onChange={handleChange}
-            min={-1}
-            max={2}
-            step={0.01}
+            min={config.sliderMin}
+            max={config.sliderMax}
+            step={config.coarseStep}
             marks={marks}
-            defaultValue={0.75}
+            defaultValue={config.initial}
             isDisabled={!lora.isEnabled}
           />
           <CompositeNumberInput
             value={lora.weight}
             onChange={handleChange}
-            min={-10}
-            max={10}
-            step={0.01}
+            min={config.numberInputMin}
+            max={config.numberInputMax}
+            step={config.coarseStep}
             w={20}
             flexShrink={0}
-            defaultValue={0.75}
+            defaultValue={config.initial}
             isDisabled={!lora.isEnabled}
           />
         </CardBody>

--- a/invokeai/frontend/web/src/features/modelManagerV2/hooks/useLoRAModelDefaultSettings.ts
+++ b/invokeai/frontend/web/src/features/modelManagerV2/hooks/useLoRAModelDefaultSettings.ts
@@ -1,29 +1,17 @@
-import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
-import { useAppSelector } from 'app/store/storeHooks';
 import { isNil } from 'es-toolkit/compat';
-import { selectConfigSlice } from 'features/system/store/configSlice';
+import { DEFAULT_LORA_WEIGHT_CONFIG } from 'features/system/store/configSlice';
 import { useMemo } from 'react';
 import type { LoRAModelConfig } from 'services/api/types';
 
-const initialStatesSelector = createMemoizedSelector(selectConfigSlice, (config) => {
-  const { weight } = config.lora;
-
-  return {
-    initialWeight: weight.initial,
-  };
-});
-
 export const useLoRAModelDefaultSettings = (modelConfig: LoRAModelConfig) => {
-  const { initialWeight } = useAppSelector(initialStatesSelector);
-
   const defaultSettingsDefaults = useMemo(() => {
     return {
       weight: {
         isEnabled: !isNil(modelConfig?.default_settings?.weight),
-        value: modelConfig?.default_settings?.weight || initialWeight,
+        value: modelConfig?.default_settings?.weight ?? DEFAULT_LORA_WEIGHT_CONFIG.initial,
       },
     };
-  }, [modelConfig?.default_settings, initialWeight]);
+  }, [modelConfig?.default_settings]);
 
   return defaultSettingsDefaults;
 };

--- a/invokeai/frontend/web/src/features/modelManagerV2/hooks/useLoRAModelDefaultSettings.ts
+++ b/invokeai/frontend/web/src/features/modelManagerV2/hooks/useLoRAModelDefaultSettings.ts
@@ -1,0 +1,29 @@
+import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
+import { useAppSelector } from 'app/store/storeHooks';
+import { isNil } from 'es-toolkit/compat';
+import { selectConfigSlice } from 'features/system/store/configSlice';
+import { useMemo } from 'react';
+import type { LoRAModelConfig } from 'services/api/types';
+
+const initialStatesSelector = createMemoizedSelector(selectConfigSlice, (config) => {
+  const { weight } = config.lora;
+
+  return {
+    initialWeight: weight.initial,
+  };
+});
+
+export const useLoRAModelDefaultSettings = (modelConfig: LoRAModelConfig) => {
+  const { initialWeight } = useAppSelector(initialStatesSelector);
+
+  const defaultSettingsDefaults = useMemo(() => {
+    return {
+      weight: {
+        isEnabled: !isNil(modelConfig?.default_settings?.weight),
+        value: modelConfig?.default_settings?.weight || initialWeight,
+      },
+    };
+  }, [modelConfig?.default_settings, initialWeight]);
+
+  return defaultSettingsDefaults;
+};

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
@@ -1,8 +1,7 @@
 import { CompositeNumberInput, CompositeSlider, Flex, FormControl, FormLabel } from '@invoke-ai/ui-library';
-import { useAppSelector } from 'app/store/storeHooks';
 import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
 import { SettingToggle } from 'features/modelManagerV2/subpanels/ModelPanel/SettingToggle';
-import { selectLoRAWeightConfig } from 'features/system/store/configSlice';
+import { DEFAULT_LORA_WEIGHT_CONFIG } from 'features/system/store/configSlice';
 import { memo, useCallback, useMemo } from 'react';
 import type { UseControllerProps } from 'react-hook-form';
 import { useController } from 'react-hook-form';
@@ -14,13 +13,7 @@ type DefaultWeight = LoRAModelDefaultSettingsFormData['weight'];
 
 export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSettingsFormData>) => {
   const { field } = useController(props);
-
-  const config = useAppSelector(selectLoRAWeightConfig);
   const { t } = useTranslation();
-  const marks = useMemo(
-    () => [config.sliderMin, Math.floor(config.sliderMax / 2), config.sliderMax],
-    [config.sliderMax, config.sliderMin]
-  );
 
   const onChange = useCallback(
     (v: number) => {
@@ -53,20 +46,20 @@ export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSet
       <Flex w="full" gap={4}>
         <CompositeSlider
           value={value}
-          min={config.sliderMin}
-          max={config.sliderMax}
-          step={config.coarseStep}
-          fineStep={config.fineStep}
+          min={DEFAULT_LORA_WEIGHT_CONFIG.sliderMin}
+          max={DEFAULT_LORA_WEIGHT_CONFIG.sliderMax}
+          step={DEFAULT_LORA_WEIGHT_CONFIG.coarseStep}
+          fineStep={DEFAULT_LORA_WEIGHT_CONFIG.fineStep}
           onChange={onChange}
-          marks={marks}
+          marks={DEFAULT_LORA_WEIGHT_CONFIG.marks.slice()}
           isDisabled={isDisabled}
         />
         <CompositeNumberInput
           value={value}
-          min={config.numberInputMin}
-          max={config.numberInputMax}
-          step={config.coarseStep}
-          fineStep={config.fineStep}
+          min={DEFAULT_LORA_WEIGHT_CONFIG.numberInputMin}
+          max={DEFAULT_LORA_WEIGHT_CONFIG.numberInputMax}
+          step={DEFAULT_LORA_WEIGHT_CONFIG.coarseStep}
+          fineStep={DEFAULT_LORA_WEIGHT_CONFIG.fineStep}
           onChange={onChange}
           isDisabled={isDisabled}
         />

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
@@ -11,14 +11,14 @@ import type { LoRAModelDefaultSettingsFormData } from './LoRAModelDefaultSetting
 
 type DefaultWeight = LoRAModelDefaultSettingsFormData['weight'];
 
-export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSettingsFormData>) => {
+export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSettingsFormData, 'weight'>) => {
   const { field } = useController(props);
   const { t } = useTranslation();
 
   const onChange = useCallback(
     (v: number) => {
       const updatedValue = {
-        ...(field.value as DefaultWeight),
+        ...(field.value),
         value: v,
       };
       field.onChange(updatedValue);
@@ -27,11 +27,11 @@ export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSet
   );
 
   const value = useMemo(() => {
-    return (field.value as DefaultWeight).value;
+    return (field.value).value;
   }, [field.value]);
 
   const isDisabled = useMemo(() => {
-    return !(field.value as DefaultWeight).isEnabled;
+    return !(field.value).isEnabled;
   }, [field.value]);
 
   return (

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
@@ -1,0 +1,78 @@
+import { CompositeNumberInput, CompositeSlider, Flex, FormControl, FormLabel } from '@invoke-ai/ui-library';
+import { useAppSelector } from 'app/store/storeHooks';
+import { InformationalPopover } from 'common/components/InformationalPopover/InformationalPopover';
+import { SettingToggle } from 'features/modelManagerV2/subpanels/ModelPanel/SettingToggle';
+import { selectLoRAWeightConfig } from 'features/system/store/configSlice';
+import { memo, useCallback, useMemo } from 'react';
+import type { UseControllerProps } from 'react-hook-form';
+import { useController } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import type { LoRAModelDefaultSettingsFormData } from './LoRAModelDefaultSettings';
+
+type DefaultWeight = LoRAModelDefaultSettingsFormData['weight'];
+
+export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSettingsFormData>) => {
+  const { field } = useController(props);
+
+  const config = useAppSelector(selectLoRAWeightConfig);
+  const { t } = useTranslation();
+  const marks = useMemo(
+    () => [config.sliderMin, Math.floor(config.sliderMax / 2), config.sliderMax],
+    [config.sliderMax, config.sliderMin]
+  );
+
+  const onChange = useCallback(
+    (v: number) => {
+      const updatedValue = {
+        ...(field.value as DefaultWeight),
+        value: v,
+      };
+      field.onChange(updatedValue);
+    },
+    [field]
+  );
+
+  const value = useMemo(() => {
+    return (field.value as DefaultWeight).value;
+  }, [field.value]);
+
+  const isDisabled = useMemo(() => {
+    return !(field.value as DefaultWeight).isEnabled;
+  }, [field.value]);
+
+  return (
+    <FormControl flexDir="column" gap={2} alignItems="flex-start">
+      <Flex justifyContent="space-between" w="full">
+        <InformationalPopover feature="loraWeight">
+          <FormLabel>{t('lora.weight')}</FormLabel>
+        </InformationalPopover>
+        <SettingToggle control={props.control} name="weight" />
+      </Flex>
+
+      <Flex w="full" gap={4}>
+        <CompositeSlider
+          value={value}
+          min={config.sliderMin}
+          max={config.sliderMax}
+          step={config.coarseStep}
+          fineStep={config.fineStep}
+          onChange={onChange}
+          marks={marks}
+          isDisabled={isDisabled}
+        />
+        <CompositeNumberInput
+          value={value}
+          min={config.numberInputMin}
+          max={config.numberInputMax}
+          step={config.coarseStep}
+          fineStep={config.fineStep}
+          onChange={onChange}
+          isDisabled={isDisabled}
+        />
+      </Flex>
+    </FormControl>
+  );
+});
+
+DefaultWeight.displayName = 'DefaultWeight';

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight.tsx
@@ -18,7 +18,7 @@ export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSet
   const onChange = useCallback(
     (v: number) => {
       const updatedValue = {
-        ...(field.value),
+        ...field.value,
         value: v,
       };
       field.onChange(updatedValue);
@@ -27,11 +27,11 @@ export const DefaultWeight = memo((props: UseControllerProps<LoRAModelDefaultSet
   );
 
   const value = useMemo(() => {
-    return (field.value).value;
+    return field.value.value;
   }, [field.value]);
 
   const isDisabled = useMemo(() => {
-    return !(field.value).isEnabled;
+    return !field.value.isEnabled;
   }, [field.value]);
 
   return (

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/LoRAModelDefaultSettings.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/LoRAModelDefaultSettings.tsx
@@ -1,0 +1,88 @@
+import { Button, Flex, Heading, SimpleGrid } from '@invoke-ai/ui-library';
+import { useLoRAModelDefaultSettings } from 'features/modelManagerV2/hooks/useLoraModelDefaultSettings';
+import { DefaultWeight } from 'features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight';
+import type { FormField } from 'features/modelManagerV2/subpanels/ModelPanel/MainModelDefaultSettings/MainModelDefaultSettings';
+import { toast } from 'features/toast/toast';
+import { memo, useCallback } from 'react';
+import type { SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { PiCheckBold } from 'react-icons/pi';
+import { useUpdateModelMutation } from 'services/api/endpoints/models';
+import type { LoRAModelConfig } from 'services/api/types';
+
+export type LoRAModelDefaultSettingsFormData = {
+  weight: FormField<number>;
+};
+
+type Props = {
+  modelConfig: LoRAModelConfig;
+};
+
+export const LoRAModelDefaultSettings = memo(({ modelConfig }: Props) => {
+  const { t } = useTranslation();
+
+  const defaultSettingsDefaults = useLoRAModelDefaultSettings(modelConfig);
+
+  const [updateModel, { isLoading: isLoadingUpdateModel }] = useUpdateModelMutation();
+
+  const { handleSubmit, control, formState, reset } = useForm<LoRAModelDefaultSettingsFormData>({
+    defaultValues: defaultSettingsDefaults,
+  });
+
+  const onSubmit = useCallback<SubmitHandler<LoRAModelDefaultSettingsFormData>>(
+    (data) => {
+      const body = {
+        weight: data.weight.isEnabled ? data.weight.value : null,
+      };
+
+      updateModel({
+        key: modelConfig.key,
+        body: { default_settings: body },
+      })
+        .unwrap()
+        .then((_) => {
+          toast({
+            id: 'DEFAULT_SETTINGS_SAVED',
+            title: t('modelManager.defaultSettingsSaved'),
+            status: 'success',
+          });
+          reset(data);
+        })
+        .catch((error) => {
+          if (error) {
+            toast({
+              id: 'DEFAULT_SETTINGS_SAVE_FAILED',
+              title: `${error.data.detail} `,
+              status: 'error',
+            });
+          }
+        });
+    },
+    [updateModel, modelConfig.key, t, reset]
+  );
+
+  return (
+    <>
+      <Flex gap="4" justifyContent="space-between" w="full" pb={4}>
+        <Heading fontSize="md">{t('modelManager.defaultSettings')}</Heading>
+        <Button
+          size="sm"
+          leftIcon={<PiCheckBold />}
+          colorScheme="invokeYellow"
+          isDisabled={!formState.isDirty}
+          onClick={handleSubmit(onSubmit)}
+          isLoading={isLoadingUpdateModel}
+        >
+          {t('common.save')}
+        </Button>
+      </Flex>
+
+      <SimpleGrid columns={2} gap={8}>
+        <DefaultWeight control={control} name="weight" />
+      </SimpleGrid>
+    </>
+  );
+});
+
+LoRAModelDefaultSettings.displayName = 'LoRAModelDefaultSettings';

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/LoRAModelDefaultSettings.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/LoRAModelDefaultSettings.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Heading, SimpleGrid } from '@invoke-ai/ui-library';
-import { useLoRAModelDefaultSettings } from 'features/modelManagerV2/hooks/useLoraModelDefaultSettings';
+import { useLoRAModelDefaultSettings } from 'features/modelManagerV2/hooks/useLoRAModelDefaultSettings';
 import { DefaultWeight } from 'features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/DefaultWeight';
 import type { FormField } from 'features/modelManagerV2/subpanels/ModelPanel/MainModelDefaultSettings/MainModelDefaultSettings';
 import { toast } from 'features/toast/toast';

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelView.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelView.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, SimpleGrid } from '@invoke-ai/ui-library';
 import { ControlAdapterModelDefaultSettings } from 'features/modelManagerV2/subpanels/ModelPanel/ControlAdapterModelDefaultSettings/ControlAdapterModelDefaultSettings';
+import { LoRAModelDefaultSettings } from 'features/modelManagerV2/subpanels/ModelPanel/LoRAModelDefaultSettings/LoRAModelDefaultSettings';
 import { ModelConvertButton } from 'features/modelManagerV2/subpanels/ModelPanel/ModelConvertButton';
 import { ModelEditButton } from 'features/modelManagerV2/subpanels/ModelPanel/ModelEditButton';
 import { ModelHeader } from 'features/modelManagerV2/subpanels/ModelPanel/ModelHeader';
@@ -79,9 +80,13 @@ export const ModelView = memo(({ modelConfig }: Props) => {
             {(modelConfig.type === 'controlnet' ||
               modelConfig.type === 't2i_adapter' ||
               modelConfig.type === 'control_lora') && <ControlAdapterModelDefaultSettings modelConfig={modelConfig} />}
-            {(modelConfig.type === 'main' || modelConfig.type === 'lora') && (
-              <TriggerPhrases modelConfig={modelConfig} />
+            {modelConfig.type === 'lora' && (
+              <>
+                <LoRAModelDefaultSettings modelConfig={modelConfig} />
+                <TriggerPhrases modelConfig={modelConfig} />
+              </>
             )}
+            {modelConfig.type === 'main' && <TriggerPhrases modelConfig={modelConfig} />}
           </Box>
         )}
         <Box overflowY="auto" layerStyle="second" borderRadius="base" p={4}>

--- a/invokeai/frontend/web/src/features/system/store/configSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/configSlice.ts
@@ -6,6 +6,17 @@ import { getDefaultAppConfig, type PartialAppConfig, zAppConfig } from 'app/type
 import { merge } from 'es-toolkit/compat';
 import z from 'zod';
 
+export const DEFAULT_LORA_WEIGHT_CONFIG = {
+  initial: 0.75,
+  sliderMin: -1,
+  sliderMax: 2,
+  marks: [-1, 0, 1, 2],
+  numberInputMin: -1,
+  numberInputMax: 2,
+  fineStep: 0.01,
+  coarseStep: 0.05,
+} as const;
+
 const zConfigState = z.object({
   ...zAppConfig.shape,
   didLoad: z.boolean(),
@@ -61,7 +72,6 @@ export const selectInfillTileSizeConfig = createConfigSelector((config) => confi
 export const selectImg2imgStrengthConfig = createConfigSelector((config) => config.sd.img2imgStrength);
 export const selectMaxPromptsConfig = createConfigSelector((config) => config.sd.dynamicPrompts.maxPrompts);
 export const selectIterationsConfig = createConfigSelector((config) => config.sd.iterations);
-export const selectLoRAWeightConfig = createConfigSelector((config) => config.lora.weight);
 
 export const selectMaxUpscaleDimension = createConfigSelector((config) => config.maxUpscaleDimension);
 export const selectAllowPrivateStylePresets = createConfigSelector((config) => config.allowPrivateStylePresets);

--- a/invokeai/frontend/web/src/features/system/store/configSlice.ts
+++ b/invokeai/frontend/web/src/features/system/store/configSlice.ts
@@ -61,6 +61,7 @@ export const selectInfillTileSizeConfig = createConfigSelector((config) => confi
 export const selectImg2imgStrengthConfig = createConfigSelector((config) => config.sd.img2imgStrength);
 export const selectMaxPromptsConfig = createConfigSelector((config) => config.sd.dynamicPrompts.maxPrompts);
 export const selectIterationsConfig = createConfigSelector((config) => config.sd.iterations);
+export const selectLoRAWeightConfig = createConfigSelector((config) => config.lora.weight);
 
 export const selectMaxUpscaleDimension = createConfigSelector((config) => config.maxUpscaleDimension);
 export const selectAllowPrivateStylePresets = createConfigSelector((config) => config.allowPrivateStylePresets);

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -12729,14 +12729,14 @@ export type components = {
              * Convert Cache Dir
              * Format: path
              * @description Path to the converted models cache directory (DEPRECATED, but do not delete because it is needed for migration from previous versions).
-             * @default models\.convert_cache
+             * @default models/.convert_cache
              */
             convert_cache_dir?: string;
             /**
              * Download Cache Dir
              * Format: path
              * @description Path to the directory that contains dynamically downloaded models.
-             * @default models\.download_cache
+             * @default models/.download_cache
              */
             download_cache_dir?: string;
             /**

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -12729,14 +12729,14 @@ export type components = {
              * Convert Cache Dir
              * Format: path
              * @description Path to the converted models cache directory (DEPRECATED, but do not delete because it is needed for migration from previous versions).
-             * @default models/.convert_cache
+             * @default models\.convert_cache
              */
             convert_cache_dir?: string;
             /**
              * Download Cache Dir
              * Format: path
              * @description Path to the directory that contains dynamically downloaded models.
-             * @default models/.download_cache
+             * @default models\.download_cache
              */
             download_cache_dir?: string;
             /**
@@ -14211,6 +14211,8 @@ export type components = {
              * @description Set of trigger phrases for this model
              */
             trigger_phrases?: string[] | null;
+            /** @description Default settings for this model */
+            default_settings?: components["schemas"]["LoraModelDefaultSettings"] | null;
         };
         /** LoRAField */
         LoRAField: {
@@ -14382,6 +14384,8 @@ export type components = {
              * @description Set of trigger phrases for this model
              */
             trigger_phrases?: string[] | null;
+            /** @description Default settings for this model */
+            default_settings?: components["schemas"]["LoraModelDefaultSettings"] | null;
         };
         /**
          * LoRAMetadataField
@@ -14476,6 +14480,8 @@ export type components = {
              * @description Set of trigger phrases for this model
              */
             trigger_phrases?: string[] | null;
+            /** @description Default settings for this model */
+            default_settings?: components["schemas"]["LoraModelDefaultSettings"] | null;
         };
         /**
          * Select LoRA
@@ -14558,6 +14564,14 @@ export type components = {
          * @enum {integer}
          */
         LogLevel: 0 | 10 | 20 | 30 | 40 | 50;
+        /** LoraModelDefaultSettings */
+        LoraModelDefaultSettings: {
+            /**
+             * Weight
+             * @description Default weight for this model
+             */
+            weight?: number | null;
+        };
         /** MDControlListOutput */
         MDControlListOutput: {
             /**
@@ -17351,7 +17365,7 @@ export type components = {
              * Default Settings
              * @description Default settings for this model
              */
-            default_settings?: components["schemas"]["MainModelDefaultSettings"] | components["schemas"]["ControlAdapterDefaultSettings"] | null;
+            default_settings?: components["schemas"]["MainModelDefaultSettings"] | components["schemas"]["LoraModelDefaultSettings"] | components["schemas"]["ControlAdapterDefaultSettings"] | null;
             /**
              * Variant
              * @description The variant of the model.


### PR DESCRIPTION
## Summary

A new feature was implemented to specify LoRA default weight per model

- `LoraModelDefaultSettings` was created in `config.py` to represent LoRA related default settings
- a new instance variable, `default_settings`, was added to `LoRAConfigBase` to persist LoRA related default settings in every kind of LoRA model instance
- a new function, `get_default_settings_lora`, was added to `legacy_probe.py` to populate default settings extracted from models
- `LoraModelDefaultSettings` was added as another option to `ModelRecordChanges.default_settings` in order to persist LoRA related default settings
- API model re-generated into `schema.ts` to make latest changes in backend API available in the frontend
- a new field, `lora.weight`, was added to the `zAppConfig` schema to store LoRA weight UI elements related default settings
- a new selector, `selectLoRAWeightConfig`, was added to `configSlice.ts` to retrieve LoRA weight UI elements related default settings
- `defaultLoRAConfig` is created per request and was moved into `loraAdded` reducer to set LoRA weight based on default settings
- `useLoRAModelDefaultSettings` custom hook was created to merge model and UI related default settings
- `DefaultWeight` component was created to represent and set the LoRA weight default setting
- `LoRAModelDefaultSettings` component was created to manage LoRA default settings
- `LoRAModelDefaultSettings` component was added to `ModelView` to be able to separately manage main models and LoRA models default settings
- default settings are queried to configure child components in `LoRACard` component
- new tanslation, `lora.weight`, was added to `en.json`

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1408129778996740167

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
