### PR TITLE
fix(ui): konva logging

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -214,7 +214,13 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
     const isVisible = this.parent.konva.layer.visible();
     const isCached = this.konva.objectGroup.isCached();
 
-    if (isVisible && (force || !isCached)) {
+    // We should also never cache if the entity has no dimensions. Konva will log an error to console like this:
+    // Konva error: Can not cache the node. Width or height of the node equals 0. Caching is skipped.
+    //
+    // It won't raise - just logs the error.
+    const hasContent = this.konva.objectGroup.width() > 0 && this.konva.objectGroup.height() > 0;
+
+    if (hasContent && isVisible && (force || !isCached)) {
       this.log.trace('Caching object group');
       this.konva.objectGroup.clearCache();
       this.konva.objectGroup.cache({ pixelRatio: 1, imageSmoothingEnabled: false });

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasModuleBase.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasModuleBase.ts
@@ -115,7 +115,7 @@ export abstract class CanvasModuleBase {
    * ```
    */
   destroy: () => void = () => {
-    this.log('Destroying module');
+    this.log.debug('Destroying module');
   };
 
   /**

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
@@ -162,7 +162,7 @@ export class CanvasObjectImage extends CanvasModuleBase {
   };
 
   onFailedToLoadImage = (message: string) => {
-    this.log({ image: this.state.image }, message);
+    this.log.error({ image: this.state.image }, message);
     this.konva.image?.visible(false);
     this.isLoading = false;
     this.isError = true;

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
@@ -15,7 +15,7 @@ import type { CanvasImageState, Dimensions } from 'features/controlLayers/store/
 import { t } from 'i18next';
 import Konva from 'konva';
 import type { Logger } from 'roarr';
-import { JsonObject } from 'roarr/dist/types';
+import type { JsonObject } from 'roarr/dist/types';
 import { getImageDTOSafe } from 'services/api/endpoints/images';
 
 type CanvasObjectImageConfig = {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasObject/CanvasObjectImage.ts
@@ -2,6 +2,7 @@ import { objectEquals } from '@observ33r/object-equals';
 import { Mutex } from 'async-mutex';
 import { deepClone } from 'common/util/deepClone';
 import { withResultAsync } from 'common/util/result';
+import { parseify } from 'common/util/serialize';
 import type { CanvasEntityBufferObjectRenderer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityBufferObjectRenderer';
 import type { CanvasEntityFilterer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityFilterer';
 import type { CanvasEntityObjectRenderer } from 'features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer';
@@ -14,6 +15,7 @@ import type { CanvasImageState, Dimensions } from 'features/controlLayers/store/
 import { t } from 'i18next';
 import Konva from 'konva';
 import type { Logger } from 'roarr';
+import { JsonObject } from 'roarr/dist/types';
 import { getImageDTOSafe } from 'services/api/endpoints/images';
 
 type CanvasObjectImageConfig = {
@@ -129,7 +131,10 @@ export class CanvasObjectImage extends CanvasModuleBase {
     const imageElementResult = await withResultAsync(() => loadImage(imageDTO.image_url, true));
     if (imageElementResult.isErr()) {
       // Image loading failed (e.g. the URL to the "physical" image is invalid)
-      this.onFailedToLoadImage(t('controlLayers.unableToLoadImage', 'Unable to load image'));
+      this.onFailedToLoadImage(
+        t('controlLayers.unableToLoadImage', 'Unable to load image'),
+        parseify(imageElementResult.error)
+      );
       return;
     }
 
@@ -152,7 +157,10 @@ export class CanvasObjectImage extends CanvasModuleBase {
     const imageElementResult = await withResultAsync(() => loadImage(dataURL, false));
     if (imageElementResult.isErr()) {
       // Image loading failed (e.g. the URL to the "physical" image is invalid)
-      this.onFailedToLoadImage(t('controlLayers.unableToLoadImage', 'Unable to load image'));
+      this.onFailedToLoadImage(
+        t('controlLayers.unableToLoadImage', 'Unable to load image'),
+        parseify(imageElementResult.error)
+      );
       return;
     }
 
@@ -161,8 +169,8 @@ export class CanvasObjectImage extends CanvasModuleBase {
     this.updateImageElement();
   };
 
-  onFailedToLoadImage = (message: string) => {
-    this.log.error({ image: this.state.image }, message);
+  onFailedToLoadImage = (message: string, error?: JsonObject) => {
+    this.log.error({ image: this.state.image, error }, message);
     this.konva.image?.visible(false);
     this.isLoading = false;
     this.isError = true;


### PR DESCRIPTION
## Summary

- Do not attempt to cache nodes without width or height. Prevents a console error from being logged by Konva. This particular error wasn't ever _raised_ - just logged. So this only reduces some noise.
- Log at error level when an image fails to load. Previously, this log was accidentally done without specifying a log level, which apparently results in no logs at all.
- Include the specific error when an image fails to load. Previously, only a message "unable to load image" was logged.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
