### PR TITLE
fix(ui): control layer transparency effect not working

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -216,11 +216,8 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
 
     // We should also never cache if the entity has no dimensions. Konva will log an error to console like this:
     // Konva error: Can not cache the node. Width or height of the node equals 0. Caching is skipped.
-    //
-    // It won't raise - just logs the error.
-    const hasContent = this.konva.objectGroup.width() > 0 && this.konva.objectGroup.height() > 0;
 
-    if (hasContent && isVisible && (force || !isCached)) {
+    if (isVisible && (force || !isCached)) {
       this.log.trace('Caching object group');
       this.konva.objectGroup.clearCache();
       this.konva.objectGroup.cache({ pixelRatio: 1, imageSmoothingEnabled: false });


### PR DESCRIPTION
## Summary

A change in #8493 intended to prevent konva from caching nodes that have no content (preventing errors about caching a node with 0 width or height) inadvertently is breaking the Control Layer transparency effect. There appears to be a bug (?) where konva doesn't reliably calculate the size of object groups which means my fix doesn't reliably do what it was intended to do.

## Related Issues / Discussions

Reported on discord

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
