### PR TITLE
fix(app): board count queries not getting categories as params

### DIFF
--- a/invokeai/app/services/board_image_records/board_image_records_sqlite.py
+++ b/invokeai/app/services/board_image_records/board_image_records_sqlite.py
@@ -165,7 +165,7 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
                     WHERE images.is_intermediate = FALSE AND images.image_category IN ( {placeholders} )
                     AND board_images.board_id = ?;
                     """,
-                (board_id),
+                (*category_strings, board_id),
             )
             count = cast(int, cursor.fetchone()[0])
         return count
@@ -184,7 +184,7 @@ class SqliteBoardImageRecordStorage(BoardImageRecordStorageBase):
                     WHERE images.is_intermediate = FALSE AND images.image_category IN ( {placeholders} )
                     AND board_images.board_id = ?;
                     """,
-                (board_id),
+                (*category_strings, board_id),
             )
             count = cast(int, cursor.fetchone()[0])
         return count


### PR DESCRIPTION
## Summary

```sh
    | sqlite3.ProgrammingError: Incorrect number of bindings supplied. The current statement uses 2, and there are 36 supplied.
```

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1410657037549043864

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
