### PR TITLE
feat(ui): add readiness checks for LoRAs

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1281,6 +1281,7 @@
             "modelIncompatibleScaledBboxWidth": "Scaled bbox width is {{width}} but {{model}} requires multiple of {{multiple}}",
             "modelIncompatibleScaledBboxHeight": "Scaled bbox height is {{height}} but {{model}} requires multiple of {{multiple}}",
             "fluxModelMultipleControlLoRAs": "Can only use 1 Control LoRA at a time",
+            "incompatibleLoRAs": "Incompatible LoRA(s) added",
             "canvasIsFiltering": "Canvas is busy (filtering)",
             "canvasIsTransforming": "Canvas is busy (transforming)",
             "canvasIsRasterizing": "Canvas is busy (rasterizing)",


### PR DESCRIPTION
## Summary

If incompatible LoRAs are added, prevent Invoking.

The logic to prevent adding incompatible LoRAs to graphs already existed. This does not fix any generation bugs; just a visual inconsistency where it looks like Invoke would use an incompatible LoRA.

---

I also slightly refactored how the readiness check args are passed in to use a single object. Much harder to accidentally pass the wrong thing in this way.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1410666884306571396

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
