### PR TITLE
fix(ui): remove LoRAs for recall use all

### DIFF
--- a/invokeai/frontend/web/src/features/metadata/parsing.tsx
+++ b/invokeai/frontend/web/src/features/metadata/parsing.tsx
@@ -802,7 +802,7 @@ const LoRAs: CollectionMetadataHandler<LoRA[]> = {
   parse: async (metadata, store) => {
     const rawArray = getProperty(metadata, 'loras');
 
-    if(!rawArray) {
+    if (!rawArray) {
       return [];
     }
 


### PR DESCRIPTION
## Summary

A new bugfix was implemented to remove LoRAs from parameters when restoring all metadata for images generated without any LoRA

- LoRA metadata check is added to `LoRAs` handler's parse method in `parsing.tsx` to avoid throwing an exception when there is no LoRA in the image metadata

## Related Issues / Discussions

Closes #8487

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
