### PR TITLE
fix(ui): gallery selection issues

### DIFF
--- a/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/boardIdSelected.ts
+++ b/invokeai/frontend/web/src/app/store/middleware/listenerMiddleware/listeners/boardIdSelected.ts
@@ -48,6 +48,8 @@ export const addBoardIdSelectedListener = (startAppListening: AppStartListening)
 
         if (imageToSelect) {
           dispatch(itemSelected({ type: 'image', id: imageToSelect }));
+        } else {
+          dispatch(itemSelected(null));
         }
       } else {
         const queryArgs = { ...selectGetVideoIdsQueryArgs(state), board_id };
@@ -70,6 +72,8 @@ export const addBoardIdSelectedListener = (startAppListening: AppStartListening)
 
         if (videoToSelect) {
           dispatch(itemSelected({ type: 'video', id: videoToSelect }));
+        } else {
+          dispatch(itemSelected(null));
         }
       }
     },

--- a/invokeai/frontend/web/src/features/deleteImageModal/store/state.ts
+++ b/invokeai/frontend/web/src/features/deleteImageModal/store/state.ts
@@ -89,15 +89,15 @@ const handleDeletions = async (image_names: string[], store: AppStore) => {
     const newImageNames = data?.image_names.filter((name) => !deleted_images.includes(name)) || [];
     const newSelectedImage = newImageNames[index ?? 0] || null;
 
-    if (
-      intersection(
-        state.gallery.selection.map((s) => s.id),
-        image_names
-      ).length > 0 &&
-      newSelectedImage
-    ) {
-      // Some selected images were deleted, clear selection
-      dispatch(itemSelected({ type: 'image', id: newSelectedImage }));
+    const galleryImageNames = state.gallery.selection.map((s) => s.id);
+
+    if (intersection(galleryImageNames, image_names).length > 0) {
+      if (newSelectedImage) {
+        // Some selected images were deleted, clear selection
+        dispatch(itemSelected({ type: 'image', id: newSelectedImage }));
+      } else {
+        dispatch(itemSelected(null));
+      }
     }
 
     // We need to reset the features where the image is in use - none of these work if their image(s) don't exist

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewerPanel.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageViewerPanel.tsx
@@ -19,6 +19,10 @@ export const ImageViewerPanel = memo(() => {
 
   return (
     <ImageViewerContextProvider>
+      {
+        // The image viewer renders progress images - if no image is selected, show the image viewer anyway
+        !isComparing && !lastSelectedItem && <ImageViewer />
+      }
       {!isComparing && lastSelectedItem?.type === 'image' && <ImageViewer />}
       {!isComparing && lastSelectedItem?.type === 'video' && <VideoViewer />}
       {isComparing && <ImageComparison />}


### PR DESCRIPTION
## Summary

- [fix(ui): clear gallery selection when last image on selected board is deleted](https://github.com/invoke-ai/InvokeAI/commit/f26590b44bba8228416a84ccff68a86fadc7f1d7)
- [fix(ui): clear gallery selection when switching boards and there are no items in the new board](https://github.com/invoke-ai/InvokeAI/commit/56c0ef01b0e5bbb514be02afa5a4167485b5e1ba)
- [fix(ui): show fallback when no image is selected](https://github.com/invoke-ai/InvokeAI/commit/778b5fb5c54807935f56cf9f9baf2bad2ace4c6f)

## Related Issues / Discussions

Reported on discord: https://discord.com/channels/1020123559063990373/1149506274971631688/1412820856169693297

## QA Instructions

- Create a board and add a single image to it
- Delete the image - the image should disappear from viewer, and viewer should show the fallback
- Switch to a different board - the viewer should show the first image in the newly-selected board
- Switch back to the board with no images - the viewer should show the fallback

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
