### PR TITLE
feat(ui): do not use thumbnail images as fallbacks

### DIFF
--- a/invokeai/frontend/web/src/features/dnd/DndImage.tsx
+++ b/invokeai/frontend/web/src/features/dnd/DndImage.tsx
@@ -75,7 +75,6 @@ export const DndImage = memo(
           role="button"
           ref={ref}
           src={asThumbnail ? imageDTO.thumbnail_url : imageDTO.image_url}
-          fallbackSrc={asThumbnail ? undefined : imageDTO.thumbnail_url}
           width={imageDTO.width}
           height={imageDTO.height}
           sx={sx}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonHover.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonHover.tsx
@@ -56,7 +56,6 @@ export const ImageComparisonHover = memo(({ firstImage, secondImage, rect }: Com
           <Image
             id="image-comparison-hover-first-image"
             src={firstImage.image_url}
-            fallbackSrc={firstImage.thumbnail_url}
             crossOrigin={crossOrigin}
             w={fittedDims.width}
             h={fittedDims.height}
@@ -93,7 +92,6 @@ export const ImageComparisonHover = memo(({ firstImage, secondImage, rect }: Com
               position="relative"
               id="image-comparison-hover-second-image"
               src={secondImage.image_url}
-              fallbackSrc={secondImage.thumbnail_url}
               crossOrigin={crossOrigin}
               w={compareImageDims.width}
               h={compareImageDims.height}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonSideBySide.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonSideBySide.tsx
@@ -55,7 +55,6 @@ const SideBySideImage = memo(({ imageDTO, type }: { imageDTO: ImageDTO; type: 'f
           maxW="full"
           maxH="full"
           src={imageDTO.image_url}
-          fallbackSrc={imageDTO.thumbnail_url}
           crossOrigin={crossOrigin}
           objectFit="contain"
           borderRadius="base"

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonSlider.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/ImageComparisonSlider.tsx
@@ -134,7 +134,6 @@ export const ImageComparisonSlider = memo(({ firstImage, secondImage, rect }: Co
             position="relative"
             id="image-comparison-second-image"
             src={secondImage.image_url}
-            fallbackSrc={secondImage.thumbnail_url}
             crossOrigin={crossOrigin}
             w={compareImageDims.width}
             h={compareImageDims.height}
@@ -157,7 +156,6 @@ export const ImageComparisonSlider = memo(({ firstImage, secondImage, rect }: Co
             <Image
               id="image-comparison-first-image"
               src={firstImage.image_url}
-              fallbackSrc={firstImage.thumbnail_url}
               crossOrigin={crossOrigin}
               w={fittedDims.width}
               h={fittedDims.height}


### PR DESCRIPTION
## Summary

Theoretically using thumbnail images as fallbacks provides a better user experience:

- Start loading both thumbnail and full image
- Render the thumbnail when it is ready
- Then render the full image when it is ready, typically _after_ the thumbnail

But this does make more network requests, and adds an extra render when we show images (== perf hit). In testing locally, it actually feels snappier without the thumbnail fallback (likely psychosomatic). It certainly does not feel any _worse_, so I think this is a good change.

## Related Issues / Discussions

n/a

## QA Instructions

This is kinda experimental. We've used thumbnails for fallbacks for a long time - it's possible that this negatively affects user experience.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
