### PR TITLE
fix(ui): route metadata to gemini node

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildGemini2_5Graph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildGemini2_5Graph.ts
@@ -73,6 +73,9 @@ export const buildGemini2_5Graph = (arg: GraphBuilderArg): GraphBuilderReturn =>
   g.upsertMetadata({
     model: Graph.getModelMetadataField(model),
   });
+
+  g.setMetadataReceivingNode(geminiImage);
+
   return {
     g,
     positivePrompt,


### PR DESCRIPTION
## Summary

Metadata node was in the graph but not connected to the Gemini node, so it didn't get saved with the image.

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
