### PR TITLE
fix(app): path traversal via bulk downloads paths

### DIFF
--- a/invokeai/app/services/bulk_download/bulk_download_default.py
+++ b/invokeai/app/services/bulk_download/bulk_download_default.py
@@ -150,4 +150,15 @@ class BulkDownloadService(BulkDownloadBase):
     def _is_valid_path(self, path: Union[str, Path]) -> bool:
         """Validates the path given for a bulk download."""
         path = path if isinstance(path, Path) else Path(path)
-        return path.exists()
+
+        # Resolve the path to handle any path traversal attempts (e.g., ../)
+        resolved_path = path.resolve()
+
+        # The path may not traverse out of the bulk downloads folder or its subfolders
+        does_not_traverse = resolved_path.parent == self._bulk_downloads_folder.resolve()
+
+        # The path must exist and be a .zip file
+        does_exist = resolved_path.exists()
+        is_zip_file = resolved_path.suffix == ".zip"
+
+        return does_exist and is_zip_file and does_not_traverse


### PR DESCRIPTION
## Summary

Fix an issue where the bulk image download route could allow directory traversal on Windows.

When getting a bulk download item and validate the path, we do two new checks:
- New check: The file that will be retrieved by the route is in the bulk downloads temp dir (i.e. its parent dir is exactly the bulk downloads temp dir)
- New check: The file name ends in `.zip`
- Existing check: The file exists

## Related Issues / Discussions

n/a

## QA Instructions

- Create a file in some directory outside the Invoke install and write something to it, e.g. `C:\Temp\foo.txt` with content "bar"
- Go to the API docs http://localhost:9090/docs#/images/get_bulk_download_item
- Provide a relative path as the item name, e.g. `..\..\..\foo.txt` (the relative path will differ depending on your system)

On `main`, you'll get the file back. On this PR, you'll get a 404 not found.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
