### PR TITLE
fix(ui): extend lora weight schema to accept full range of weights

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -470,7 +470,7 @@ export const zLoRA = z.object({
   id: z.string(),
   isEnabled: z.boolean(),
   model: zModelIdentifierField,
-  weight: z.number().gte(-1).lte(2),
+  weight: z.number().gte(-10).lte(10),
 });
 export type LoRA = z.infer<typeof zLoRA>;
 


### PR DESCRIPTION
## Summary

This could cause a failure to rehydrate LoRA state, or failure to recall a LoRA.

## Related Issues / Discussions

Closes #8551

Bug was introduced when we moved to server-backed persistence.

## QA Instructions

- Add a LoRA
- Set the weight to something outside the default -1 to 2 range (e.g. 5)
- Generate
- Recall metadata from that image
  - Before the fix, it wouldn't recall the LoRA. After the fix, it will.
- Refresh the page
  - Before the fix, the LoRA setup will disappear (i.e. rehydration failure). After the fix, it will rehydrate successfully.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
