### PR TITLE
(fix): Fix controlnet import for latest diffusers version bump

### DIFF
--- a/invokeai/backend/util/hotfixes.py
+++ b/invokeai/backend/util/hotfixes.py
@@ -5,7 +5,11 @@ import torch
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders.single_file_model import FromOriginalModelMixin
 from diffusers.models.attention_processor import AttentionProcessor, AttnProcessor
-from diffusers.models.controlnet import ControlNetConditioningEmbedding, ControlNetOutput, zero_module
+from diffusers.models.controlnets.controlnet import (
+    ControlNetConditioningEmbedding,
+    ControlNetOutput,
+    zero_module,
+)
 from diffusers.models.embeddings import (
     TextImageProjection,
     TextImageTimeEmbedding,
@@ -775,7 +779,15 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalModelMixin):
 
 
 diffusers.ControlNetModel = ControlNetModel
-diffusers.models.controlnet.ControlNetModel = ControlNetModel
+# Patch both the new and legacy module paths for compatibility
+try:
+    diffusers.models.controlnets.controlnet.ControlNetModel = ControlNetModel
+except Exception:
+    # Fallback for environments still exposing the legacy path
+    try:
+        diffusers.models.controlnet.ControlNetModel = ControlNetModel
+    except Exception:
+        pass
 
 
 # patch LoRACompatibleConv to use original Conv2D forward function


### PR DESCRIPTION
## Summary

Updates a deprecated import on latest diffusers, once we upgrade to it.

## Related Issues / Discussions

Qwen image. 

## QA Instructions

Test that controlnets work.

## Merge Plan

Merge alongside diffusers update, or include this fix in that PR.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
