### PR TITLE
feat(ui): simple prompt history

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/store/types.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/types.ts
@@ -612,8 +612,13 @@ const zDimensionsState = z.object({
   aspectRatio: zAspectRatioConfig,
 });
 
+export const MAX_POSITIVE_PROMPT_HISTORY = 100;
+const zPositivePromptHistory = z
+  .array(zParameterPositivePrompt)
+  .transform((arr) => arr.slice(0, MAX_POSITIVE_PROMPT_HISTORY));
+
 export const zParamsState = z.object({
-  _version: z.literal(1),
+  _version: z.literal(2),
   maskBlur: z.number(),
   maskBlurMethod: zParameterMaskBlurMethod,
   canvasCoherenceMode: zParameterCanvasCoherenceMode,
@@ -644,6 +649,7 @@ export const zParamsState = z.object({
   clipSkip: z.number(),
   shouldUseCpuNoise: z.boolean(),
   positivePrompt: zParameterPositivePrompt,
+  positivePromptHistory: zPositivePromptHistory,
   negativePrompt: zParameterNegativePrompt,
   refinerModel: zParameterSDXLRefinerModel.nullable(),
   refinerSteps: z.number(),
@@ -661,7 +667,7 @@ export const zParamsState = z.object({
 });
 export type ParamsState = z.infer<typeof zParamsState>;
 export const getInitialParamsState = (): ParamsState => ({
-  _version: 1,
+  _version: 2,
   maskBlur: 16,
   maskBlurMethod: 'box',
   canvasCoherenceMode: 'Gaussian Blur',
@@ -692,6 +698,7 @@ export const getInitialParamsState = (): ParamsState => ({
   clipSkip: 0,
   shouldUseCpuNoise: true,
   positivePrompt: '',
+  positivePromptHistory: [],
   negativePrompt: null,
   refinerModel: null,
   refinerSteps: 20,

--- a/invokeai/frontend/web/src/features/parameters/components/Core/ParamPositivePrompt.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Core/ParamPositivePrompt.tsx
@@ -32,6 +32,8 @@ import type { HotkeyCallback } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 import { useListStylePresetsQuery } from 'services/api/endpoints/stylePresets';
 
+import { PositivePromptHistoryIconButton } from './PositivePromptHistory';
+
 const persistOptions: Parameters<typeof usePersistedTextAreaSize>[2] = {
   trackWidth: false,
   trackHeight: true,
@@ -118,6 +120,7 @@ export const ParamPositivePrompt = memo(() => {
             <Flex flexDir="column" gap={2} justifyContent="flex-start" alignItems="center">
               <AddPromptTriggerButton isOpen={isOpen} onOpen={onOpen} />
               <ShowDynamicPromptsPreviewButton />
+              <PositivePromptHistoryIconButton />
               {activeTab !== 'video' && modelSupportsNegativePrompt && <NegativePromptToggleButton />}
             </Flex>
             {isPromptExpansionEnabled && <PromptExpansionMenu />}

--- a/invokeai/frontend/web/src/features/parameters/components/Core/PositivePromptHistory.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Core/PositivePromptHistory.tsx
@@ -1,0 +1,160 @@
+import {
+  Button,
+  Divider,
+  Flex,
+  IconButton,
+  Input,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
+  Text,
+  useShiftModifier,
+} from '@invoke-ai/ui-library';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
+import {
+  positivePromptChanged,
+  promptHistoryCleared,
+  promptRemovedFromHistory,
+  selectPositivePromptHistory,
+} from 'features/controlLayers/store/paramsSlice';
+import type { ChangeEvent } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { PiArrowArcLeftBold, PiClockCounterClockwise, PiTrashBold, PiTrashSimpleBold } from 'react-icons/pi';
+
+export const PositivePromptHistoryIconButton = memo(() => {
+  return (
+    <Popover isLazy>
+      <PopoverTrigger>
+        <IconButton
+          size="sm"
+          variant="promptOverlay"
+          aria-label="Positive Prompt History"
+          icon={<PiClockCounterClockwise />}
+          tooltip="Prompt History"
+        />
+      </PopoverTrigger>
+      <Portal>
+        <PopoverContent>
+          <PopoverBody maxH={300} maxW={400} h={300} w={400}>
+            <PromptHistoryContent />
+          </PopoverBody>
+        </PopoverContent>
+      </Portal>
+    </Popover>
+  );
+});
+
+PositivePromptHistoryIconButton.displayName = 'PositivePromptHistoryIconButton';
+
+const PromptHistoryContent = memo(() => {
+  const dispatch = useAppDispatch();
+  const positivePromptHistory = useAppSelector(selectPositivePromptHistory);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const onClickClearHistory = useCallback(() => {
+    dispatch(promptHistoryCleared());
+  }, [dispatch]);
+
+  const filteredPrompts = useMemo(() => {
+    const trimmedSearchTerm = searchTerm.trim();
+    if (!trimmedSearchTerm) {
+      return positivePromptHistory;
+    }
+    return positivePromptHistory.filter((prompt) => prompt.toLowerCase().includes(trimmedSearchTerm.toLowerCase()));
+  }, [positivePromptHistory, searchTerm]);
+
+  const onChangeSearchTerm = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+  }, []);
+
+  return (
+    <Flex flexDir="column" gap={2} w="full" h="full">
+      <Flex alignItems="center" gap={2} justifyContent="space-between">
+        <Text fontWeight="semibold" color="base.300">
+          Prompt History
+        </Text>
+        <Input
+          size="sm"
+          variant="outline"
+          placeholder="Search..."
+          value={searchTerm}
+          onChange={onChangeSearchTerm}
+          width="max-content"
+          isDisabled={positivePromptHistory.length === 0}
+        />
+        <Button
+          size="sm"
+          variant="link"
+          leftIcon={<PiTrashSimpleBold />}
+          onClick={onClickClearHistory}
+          isDisabled={positivePromptHistory.length === 0}
+        >
+          Clear History
+        </Button>
+      </Flex>
+      <Divider />
+      {positivePromptHistory.length === 0 && (
+        <Flex w="full" h="full" alignItems="center" justifyContent="center">
+          <Text color="base.300">No prompt history recorded.</Text>
+        </Flex>
+      )}
+      {positivePromptHistory.length !== 0 && filteredPrompts.length === 0 && (
+        <Flex w="full" h="full" alignItems="center" justifyContent="center">
+          <Text color="base.300">No matching prompts in history.</Text>{' '}
+        </Flex>
+      )}
+      {filteredPrompts.length > 0 && (
+        <ScrollableContent>
+          <Flex flexDir="column">
+            {filteredPrompts.map((prompt, index) => (
+              <PromptItem key={`${prompt}-${index}`} prompt={prompt} />
+            ))}
+          </Flex>
+        </ScrollableContent>
+      )}
+    </Flex>
+  );
+});
+PromptHistoryContent.displayName = 'PromptHistoryContent';
+
+const PromptItem = memo(({ prompt }: { prompt: string }) => {
+  const dispatch = useAppDispatch();
+  const shiftKey = useShiftModifier();
+
+  const onClickUse = useCallback(() => {
+    dispatch(positivePromptChanged(prompt));
+  }, [dispatch, prompt]);
+
+  const onClickDelete = useCallback(() => {
+    dispatch(promptRemovedFromHistory(prompt));
+  }, [dispatch, prompt]);
+
+  return (
+    <Flex gap={2}>
+      {!shiftKey && (
+        <IconButton
+          size="sm"
+          variant="ghost"
+          aria-label="Use prompt"
+          icon={<PiArrowArcLeftBold />}
+          onClick={onClickUse}
+        />
+      )}
+      {shiftKey && (
+        <IconButton
+          size="sm"
+          variant="ghost"
+          aria-label="Delete"
+          icon={<PiTrashBold />}
+          onClick={onClickDelete}
+          colorScheme="error"
+        />
+      )}
+      <Text color="base.300">{prompt}</Text>
+    </Flex>
+  );
+});
+PromptItem.displayName = 'PromptItem';

--- a/invokeai/frontend/web/src/features/queue/hooks/useEnqueueCanvas.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useEnqueueCanvas.ts
@@ -7,6 +7,7 @@ import { extractMessageFromAssertionError } from 'common/util/extractMessageFrom
 import { withResult, withResultAsync } from 'common/util/result';
 import { useCanvasManagerSafe } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import type { CanvasManager } from 'features/controlLayers/konva/CanvasManager';
+import { positivePromptAddedToHistory, selectPositivePrompt } from 'features/controlLayers/store/paramsSlice';
 import { prepareLinearUIBatch } from 'features/nodes/util/graph/buildLinearBatchConfig';
 import { buildChatGPT4oGraph } from 'features/nodes/util/graph/generation/buildChatGPT4oGraph';
 import { buildCogView4Graph } from 'features/nodes/util/graph/generation/buildCogView4Graph';
@@ -129,6 +130,9 @@ const enqueueCanvas = async (store: AppStore, canvasManager: CanvasManager, prep
   );
 
   const enqueueResult = await req.unwrap();
+
+  // Push to prompt history on successful enqueue
+  dispatch(positivePromptAddedToHistory(selectPositivePrompt(state)));
 
   return { batchConfig, enqueueResult };
 };

--- a/invokeai/frontend/web/src/features/queue/hooks/useEnqueueGenerate.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useEnqueueGenerate.ts
@@ -5,6 +5,7 @@ import type { AppStore } from 'app/store/store';
 import { useAppStore } from 'app/store/storeHooks';
 import { extractMessageFromAssertionError } from 'common/util/extractMessageFromAssertionError';
 import { withResult, withResultAsync } from 'common/util/result';
+import { positivePromptAddedToHistory, selectPositivePrompt } from 'features/controlLayers/store/paramsSlice';
 import { prepareLinearUIBatch } from 'features/nodes/util/graph/buildLinearBatchConfig';
 import { buildChatGPT4oGraph } from 'features/nodes/util/graph/generation/buildChatGPT4oGraph';
 import { buildCogView4Graph } from 'features/nodes/util/graph/generation/buildCogView4Graph';
@@ -123,6 +124,9 @@ const enqueueGenerate = async (store: AppStore, prepend: boolean) => {
   );
 
   const enqueueResult = await req.unwrap();
+
+  // Push to prompt history on successful enqueue
+  dispatch(positivePromptAddedToHistory(selectPositivePrompt(state)));
 
   return { batchConfig, enqueueResult };
 };

--- a/invokeai/frontend/web/src/features/queue/hooks/useEnqueueUpscaling.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useEnqueueUpscaling.ts
@@ -2,6 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { logger } from 'app/logging/logger';
 import type { AppStore } from 'app/store/store';
 import { useAppStore } from 'app/store/storeHooks';
+import { positivePromptAddedToHistory, selectPositivePrompt } from 'features/controlLayers/store/paramsSlice';
 import { prepareLinearUIBatch } from 'features/nodes/util/graph/buildLinearBatchConfig';
 import { buildMultidiffusionUpscaleGraph } from 'features/nodes/util/graph/buildMultidiffusionUpscaleGraph';
 import { useCallback } from 'react';
@@ -42,6 +43,9 @@ const enqueueUpscaling = async (store: AppStore, prepend: boolean) => {
     queueApi.endpoints.enqueueBatch.initiate(batchConfig, { ...enqueueMutationFixedCacheKeyOptions, track: false })
   );
   const enqueueResult = await req.unwrap();
+
+  // Push to prompt history on successful enqueue
+  dispatch(positivePromptAddedToHistory(selectPositivePrompt(state)));
 
   return { batchConfig, enqueueResult };
 };

--- a/invokeai/frontend/web/src/features/queue/hooks/useEnqueueVideo.ts
+++ b/invokeai/frontend/web/src/features/queue/hooks/useEnqueueVideo.ts
@@ -5,6 +5,7 @@ import type { AppStore } from 'app/store/store';
 import { useAppStore } from 'app/store/storeHooks';
 import { extractMessageFromAssertionError } from 'common/util/extractMessageFromAssertionError';
 import { withResult, withResultAsync } from 'common/util/result';
+import { positivePromptAddedToHistory, selectPositivePrompt } from 'features/controlLayers/store/paramsSlice';
 import { prepareLinearUIBatch } from 'features/nodes/util/graph/buildLinearBatchConfig';
 import { buildRunwayVideoGraph } from 'features/nodes/util/graph/generation/buildRunwayVideoGraph';
 import { buildVeo3VideoGraph } from 'features/nodes/util/graph/generation/buildVeo3VideoGraph';
@@ -107,6 +108,9 @@ const enqueueVideo = async (store: AppStore, prepend: boolean) => {
   );
 
   const enqueueResult = await req.unwrap();
+
+  // Push to prompt history on successful enqueue
+  dispatch(positivePromptAddedToHistory(selectPositivePrompt(state)));
 
   return { batchConfig, enqueueResult };
 };


### PR DESCRIPTION
## Summary

Simple prompt history
- Shows on Generate, Canvas, Upscaling and Video tabs.
- Search, clear all, hold shift to delete individual prompts.
- Stores the last 100 prompts.
- Persisted in the params slice.
- Prompts are added to history on successful invoke. The prompt, as the user typed it into the prompt box, is stored.
  - We cannot store post-dynamic-prompts.
  - We could store the user prompt with style preset baked in?

<video src="https://github.com/user-attachments/assets/685fca50-3126-4a37-98ba-350b6c9dbb22"></video>

## Related Issues / Discussions

n/a

## QA Instructions

Take it for a spin.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
