### PR TITLE
fix(ui): dedupe prompt history

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/store/paramsSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/paramsSlice.ts
@@ -4,7 +4,7 @@ import type { RootState } from 'app/store/store';
 import type { SliceConfig } from 'app/store/types';
 import { deepClone } from 'common/util/deepClone';
 import { roundDownToMultiple, roundToMultiple } from 'common/util/roundDownToMultiple';
-import { isPlainObject, uniq } from 'es-toolkit';
+import { isPlainObject } from 'es-toolkit';
 import { clamp } from 'es-toolkit/compat';
 import type { AspectRatioID, ParamsState, RgbaColor } from 'features/controlLayers/store/types';
 import {
@@ -198,10 +198,11 @@ const slice = createSlice({
       if (prompt.length === 0) {
         return;
       }
-      // Remove if already exists
-      state.positivePromptHistory = uniq(state.positivePromptHistory);
 
-      // Add to front
+      if (state.positivePromptHistory.includes(prompt)) {
+        return;
+      }
+
       state.positivePromptHistory.unshift(prompt);
 
       if (state.positivePromptHistory.length > MAX_POSITIVE_PROMPT_HISTORY) {


### PR DESCRIPTION
## Summary

Fix an issue where prompt history wasn't deduped

## Related Issues / Discussions

n/a

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
