### PR TITLE
feat(ui): Color Picker V2

### DIFF
--- a/invokeai/frontend/web/src/common/components/ColorPicker/RgbaColorPicker.tsx
+++ b/invokeai/frontend/web/src/common/components/ColorPicker/RgbaColorPicker.tsx
@@ -45,8 +45,6 @@ const RgbaColorPicker = (props: Props) => {
   useEffect(() => {
     setHex(rgbaToHex(color, true));
   }, [color]);
-  const _setModeRgb = useCallback(() => setMode('rgb'), []);
-  const _setModeHex = useCallback(() => setMode('hex'), []);
   const onToggleMode = useCallback(() => setMode((m) => (m === 'rgb' ? 'hex' : 'rgb')), []);
   const onChangeHex = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {

--- a/invokeai/frontend/web/src/features/controlLayers/components/Tool/PinnedFillColorPickerOverlay.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Tool/PinnedFillColorPickerOverlay.tsx
@@ -1,0 +1,92 @@
+import { Flex, IconButton, Text } from '@invoke-ai/ui-library';
+import { createSelector } from '@reduxjs/toolkit';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import RgbaColorPicker from 'common/components/ColorPicker/RgbaColorPicker';
+import {
+  selectCanvasSettingsSlice,
+  settingsActiveColorToggled,
+  settingsBgColorChanged,
+  settingsFgColorChanged,
+  settingsFillColorPickerPinnedSet,
+} from 'features/controlLayers/store/canvasSettingsSlice';
+import type { RgbaColor } from 'features/controlLayers/store/types';
+import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiArrowsLeftRightBold,PiPushPinSlashBold } from 'react-icons/pi';
+
+const selectActiveColor = createSelector(selectCanvasSettingsSlice, (settings) => settings.activeColor);
+const selectBgColor = createSelector(selectCanvasSettingsSlice, (settings) => settings.bgColor);
+const selectFgColor = createSelector(selectCanvasSettingsSlice, (settings) => settings.fgColor);
+const selectPinned = createSelector(selectCanvasSettingsSlice, (settings) => settings.fillColorPickerPinned);
+
+export const PinnedFillColorPickerOverlay = memo(() => {
+  const { t } = useTranslation();
+  const isPinned = useAppSelector(selectPinned);
+  const activeColorType = useAppSelector(selectActiveColor);
+  const bgColor = useAppSelector(selectBgColor);
+  const fgColor = useAppSelector(selectFgColor);
+  const dispatch = useAppDispatch();
+
+  const activeColor = useMemo(() => (activeColorType === 'bgColor' ? bgColor : fgColor), [activeColorType, bgColor, fgColor]);
+
+  const onColorChange = useCallback(
+    (color: RgbaColor) => {
+      if (activeColorType === 'bgColor') {
+        dispatch(settingsBgColorChanged(color));
+      } else {
+        dispatch(settingsFgColorChanged(color));
+      }
+    },
+    [activeColorType, dispatch]
+  );
+
+  const onUnpin = useCallback(() => dispatch(settingsFillColorPickerPinnedSet(false)), [dispatch]);
+  const onToggleActive = useCallback(() => dispatch(settingsActiveColorToggled()), [dispatch]);
+
+  if (!isPinned) {
+    return null;
+  }
+
+  return (
+    <Flex pointerEvents="auto" direction="column" gap={2}>
+      <Flex
+        direction="column"
+        p={3}
+        bg="base.900"
+        borderColor="base.700"
+        borderWidth="1px"
+        borderStyle="solid"
+        shadow="dark-lg"
+        borderRadius="base"
+        minW={64}
+      >
+        <Flex justifyContent="space-between" alignItems="center" mb={2} gap={2}>
+          <Text fontWeight="semibold" color="base.300">
+            {t('controlLayers.fill.fillColor')}
+          </Text>
+          <Flex gap={1}>
+            <IconButton
+              aria-label={t('controlLayers.fill.switchColors', { defaultValue: 'Switch FG/BG (X)' })}
+              tooltip={t('controlLayers.fill.switchColors', { defaultValue: 'Switch FG/BG (X)' })}
+              size="sm"
+              variant="ghost"
+              onClick={onToggleActive}
+              icon={<PiArrowsLeftRightBold />}
+            />
+            <IconButton
+              aria-label={t('common.unpin', { defaultValue: 'Unpin' })}
+              tooltip={t('common.unpin', { defaultValue: 'Unpin' })}
+              size="sm"
+              variant="solid"
+              onClick={onUnpin}
+              icon={<PiPushPinSlashBold />}
+            />
+          </Flex>
+        </Flex>
+        <RgbaColorPicker color={activeColor} onChange={onColorChange} withNumberInput withSwatches />
+      </Flex>
+    </Flex>
+  );
+});
+
+PinnedFillColorPickerOverlay.displayName = 'PinnedFillColorPickerOverlay';

--- a/invokeai/frontend/web/src/features/controlLayers/components/Tool/PinnedFillColorPickerOverlay.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Tool/PinnedFillColorPickerOverlay.tsx
@@ -12,7 +12,7 @@ import {
 import type { RgbaColor } from 'features/controlLayers/store/types';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiArrowsLeftRightBold,PiPushPinSlashBold } from 'react-icons/pi';
+import { PiArrowsLeftRightBold, PiPushPinSlashBold } from 'react-icons/pi';
 
 const selectActiveColor = createSelector(selectCanvasSettingsSlice, (settings) => settings.activeColor);
 const selectBgColor = createSelector(selectCanvasSettingsSlice, (settings) => settings.bgColor);
@@ -27,7 +27,10 @@ export const PinnedFillColorPickerOverlay = memo(() => {
   const fgColor = useAppSelector(selectFgColor);
   const dispatch = useAppDispatch();
 
-  const activeColor = useMemo(() => (activeColorType === 'bgColor' ? bgColor : fgColor), [activeColorType, bgColor, fgColor]);
+  const activeColor = useMemo(
+    () => (activeColorType === 'bgColor' ? bgColor : fgColor),
+    [activeColorType, bgColor, fgColor]
+  );
 
   const onColorChange = useCallback(
     (color: RgbaColor) => {
@@ -58,7 +61,7 @@ export const PinnedFillColorPickerOverlay = memo(() => {
         borderStyle="solid"
         shadow="dark-lg"
         borderRadius="base"
-        minW={64}
+        minW={88}
       >
         <Flex justifyContent="space-between" alignItems="center" mb={2} gap={2}>
           <Text fontWeight="semibold" color="base.300">

--- a/invokeai/frontend/web/src/features/controlLayers/components/Tool/ToolFillColorPicker.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Tool/ToolFillColorPicker.tsx
@@ -60,6 +60,18 @@ export const ToolFillColorPicker = memo(() => {
     [activeColorType, dispatch]
   );
 
+  const handlePopoverClose = useCallback(() => {
+    disclosure.onClose();
+  }, [disclosure]);
+  const handlePinClick = useCallback(() => {
+    if (!isPinned) {
+      dispatch(settingsFillColorPickerPinnedSet(true));
+      disclosure.onClose();
+    } else {
+      dispatch(settingsFillColorPickerPinnedSet(false));
+    }
+  }, [dispatch, disclosure, isPinned]);
+
   // Note: when pinned, the persistent color picker renders in the canvas overlay instead.
 
   useRegisteredHotkeys({
@@ -83,9 +95,7 @@ export const ToolFillColorPicker = memo(() => {
       isLazy
       isOpen={!isPinned && disclosure.isOpen}
       onOpen={disclosure.onOpen}
-      onClose={() => {
-        disclosure.onClose();
-      }}
+      onClose={handlePopoverClose}
       closeOnBlur={true}
       closeOnEsc={true}
       returnFocusOnClose={true}
@@ -123,25 +133,17 @@ export const ToolFillColorPicker = memo(() => {
         </Flex>
       </PopoverTrigger>
       <Portal>
-        <PopoverContent>
+        <PopoverContent minW={96}>
           <PopoverArrow />
           <PopoverBody minH={64}>
             <Flex direction="column" gap={2}>
-              <Flex justifyContent="flex-end">
+              <Flex justifyContent="flex-end" alignItems="center">
                 <IconButton
                   aria-label={isPinned ? 'Unpin color picker' : 'Pin color picker'}
                   tooltip={isPinned ? 'Unpin' : 'Pin'}
                   size="sm"
                   variant={isPinned ? 'solid' : 'ghost'}
-                  onClick={() => {
-                    if (!isPinned) {
-                      // Pin and close the popover; the pinned picker renders in the canvas overlay
-                      dispatch(settingsFillColorPickerPinnedSet(true));
-                      disclosure.onClose();
-                    } else {
-                      dispatch(settingsFillColorPickerPinnedSet(false));
-                    }
-                  }}
+                  onClick={handlePinClick}
                   icon={<PiPushPinBold />}
                 />
               </Flex>

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSettingsSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSettingsSlice.ts
@@ -93,6 +93,10 @@ const zCanvasSettingsState = z.object({
    * The auto-switch mode for the canvas staging area.
    */
   stagingAreaAutoSwitch: zAutoSwitchMode,
+  /**
+   * Whether the fill color picker UI is pinned (persistently shown in the canvas overlay).
+   */
+  fillColorPickerPinned: z.boolean(),
 });
 
 type CanvasSettingsState = z.infer<typeof zCanvasSettingsState>;
@@ -118,6 +122,7 @@ const getInitialState = (): CanvasSettingsState => ({
   ruleOfThirds: false,
   saveAllImagesToGallery: false,
   stagingAreaAutoSwitch: 'switch_on_start',
+  fillColorPickerPinned: false,
 });
 
 const slice = createSlice({
@@ -197,6 +202,9 @@ const slice = createSlice({
     ) => {
       state.stagingAreaAutoSwitch = action.payload;
     },
+    settingsFillColorPickerPinnedSet: (state, action: PayloadAction<boolean>) => {
+      state.fillColorPickerPinned = action.payload;
+    },
   },
 });
 
@@ -223,6 +231,7 @@ export const {
   settingsRuleOfThirdsToggled,
   settingsSaveAllImagesToGalleryToggled,
   settingsStagingAreaAutoSwitchChanged,
+  settingsFillColorPickerPinnedSet,
 } = slice.actions;
 
 export const canvasSettingsSliceConfig: SliceConfig<typeof slice> = {
@@ -237,6 +246,8 @@ export const canvasSettingsSliceConfig: SliceConfig<typeof slice> = {
 export const selectCanvasSettingsSlice = (s: RootState) => s.canvasSettings;
 const createCanvasSettingsSelector = <T>(selector: Selector<CanvasSettingsState, T>) =>
   createSelector(selectCanvasSettingsSlice, selector);
+
+export const selectFillColorPickerPinned = createCanvasSettingsSelector((s) => s.fillColorPickerPinned);
 
 export const selectPreserveMask = createCanvasSettingsSelector((settings) => settings.preserveMask);
 export const selectOutputOnlyMaskedRegions = createCanvasSettingsSelector(

--- a/invokeai/frontend/web/src/features/ui/layouts/CanvasWorkspacePanel.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/CanvasWorkspacePanel.tsx
@@ -14,6 +14,7 @@ import { CanvasHUD } from 'features/controlLayers/components/HUD/CanvasHUD';
 import { InvokeCanvasComponent } from 'features/controlLayers/components/InvokeCanvasComponent';
 import { SelectObject } from 'features/controlLayers/components/SelectObject/SelectObject';
 import { StagingAreaContextProvider } from 'features/controlLayers/components/StagingArea/context';
+import { PinnedFillColorPickerOverlay } from 'features/controlLayers/components/Tool/PinnedFillColorPickerOverlay';
 import { CanvasToolbar } from 'features/controlLayers/components/Toolbar/CanvasToolbar';
 import { Transform } from 'features/controlLayers/components/Transform/Transform';
 import { CanvasManagerProviderGate } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
@@ -88,6 +89,7 @@ export const CanvasWorkspacePanel = memo(() => {
                   gap={2}
                   alignItems="flex-start"
                 >
+                  <PinnedFillColorPickerOverlay />
                   {showHUD && <CanvasHUD />}
                   <CanvasAlertsSaveAllImagesToGallery />
                   <CanvasAlertsSelectedEntityStatus />


### PR DESCRIPTION
## Summary

This adds new features to the color picker:
- Ability to pin the color picker into the top left corner of the canvas.
- Hex/RGB switch for the color picker
- Cleaner visibility of the FG/BG toggle.

## Related Issues / Discussions

Discord asks.

## QA Instructions

Pin it. Unpin it. Hex it. Bop it.

## Merge Plan

Merge away.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
