### PR TITLE
fix(ui): ref images for flux kontext not parsed correctly

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildChatGPT4oGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildChatGPT4oGraph.ts
@@ -5,7 +5,7 @@ import { selectRefImagesSlice } from 'features/controlLayers/store/refImagesSlic
 import { selectCanvasMetadata } from 'features/controlLayers/store/selectors';
 import { isChatGPT4oAspectRatioID, isChatGPT4oReferenceImageConfig } from 'features/controlLayers/store/types';
 import { getGlobalReferenceImageWarnings } from 'features/controlLayers/store/validators';
-import { type ImageField, zModelIdentifierField } from 'features/nodes/types/common';
+import { type ImageField, zImageField, zModelIdentifierField } from 'features/nodes/types/common';
 import { Graph } from 'features/nodes/util/graph/generation/Graph';
 import {
   getOriginalAndScaledSizesForOtherModes,
@@ -49,9 +49,7 @@ export const buildChatGPT4oGraph = async (arg: GraphBuilderArg): Promise<GraphBu
     reference_images = [];
     for (const entity of validRefImages) {
       assert(entity.config.image, 'Image is required for reference image');
-      reference_images.push({
-        image_name: entity.config.image.crop?.image.image_name ?? entity.config.image.original.image.image_name,
-      });
+      reference_images.push(zImageField.parse(entity.config.image.crop?.image ?? entity.config.image.original.image));
     }
   }
 

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
@@ -164,7 +164,7 @@ export const buildFLUXGraph = async (arg: GraphBuilderArg): Promise<GraphBuilder
         const kontextImagePrep = g.addNode({
           id: getPrefixedId('flux_kontext_image_prep'),
           type: 'flux_kontext_image_prep',
-          images: [zImageField.parse(config.image)],
+          images: [zImageField.parse(config.image?.crop?.image ?? config.image?.original.image)],
         });
         const kontextConditioning = g.addNode({
           type: 'flux_kontext',

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFluxKontextGraph.ts
@@ -60,9 +60,7 @@ export const buildFluxKontextGraph = (arg: GraphBuilderArg): GraphBuilderReturn 
         model: zModelIdentifierField.parse(model),
         aspect_ratio: aspectRatio.id,
         prompt_upsampling: true,
-        input_image: {
-          image_name: firstImage.crop?.image.image_name ?? firstImage.original.image.image_name,
-        },
+        input_image: zImageField.parse(firstImage.crop?.image ?? firstImage.original.image),
         ...selectCanvasOutputFields(state),
       });
     } else {
@@ -70,7 +68,9 @@ export const buildFluxKontextGraph = (arg: GraphBuilderArg): GraphBuilderReturn 
       const kontextConcatenator = g.addNode({
         id: getPrefixedId('flux_kontext_image_prep'),
         type: 'flux_kontext_image_prep',
-        images: validRefImages.map(({ config }) => zImageField.parse(config.image)),
+        images: validRefImages.map(({ config }) =>
+          zImageField.parse(config.image?.crop?.image ?? config.image?.original.image)
+        ),
       });
 
       fluxKontextImage = g.addNode({

--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildGemini2_5Graph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildGemini2_5Graph.ts
@@ -4,7 +4,7 @@ import { selectMainModelConfig } from 'features/controlLayers/store/paramsSlice'
 import { selectRefImagesSlice } from 'features/controlLayers/store/refImagesSlice';
 import { isGemini2_5ReferenceImageConfig } from 'features/controlLayers/store/types';
 import { getGlobalReferenceImageWarnings } from 'features/controlLayers/store/validators';
-import type { ImageField } from 'features/nodes/types/common';
+import { type ImageField, zImageField } from 'features/nodes/types/common';
 import { Graph } from 'features/nodes/util/graph/generation/Graph';
 import { selectCanvasOutputFields } from 'features/nodes/util/graph/graphBuilderUtils';
 import type { GraphBuilderArg, GraphBuilderReturn } from 'features/nodes/util/graph/types';
@@ -44,9 +44,7 @@ export const buildGemini2_5Graph = (arg: GraphBuilderArg): GraphBuilderReturn =>
     reference_images = [];
     for (const entity of validRefImages) {
       assert(entity.config.image, 'Image is required for reference image');
-      reference_images.push({
-        image_name: entity.config.image.crop?.image.image_name ?? entity.config.image.original.image.image_name,
-      });
+      reference_images.push(zImageField.parse(entity.config.image.crop?.image ?? entity.config.image.original.image));
     }
   }
 


### PR DESCRIPTION
## Summary

Fix an issue where croppable ref images were not parsed correctly when adding ref images to local flux kontext graphs. This would result in a `Failed to build graph` error.

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1149506274971631688/1418528861896835222

## QA Instructions

Use FLUX Kontext locally. Should work.

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
