### PR TITLE
fix(ui): do not bake opacity when rasterizing layer adjustments

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerAdjustmentsPanel.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/RasterLayer/RasterLayerAdjustmentsPanel.tsx
@@ -90,7 +90,7 @@ export const RasterLayerAdjustmentsPanel = memo(() => {
     }
     const rect = adapter.transformer.getRelativeRect();
     try {
-      await adapter.renderer.rasterize({ rect, replaceObjects: true });
+      await adapter.renderer.rasterize({ rect, replaceObjects: true, attrs: { opacity: 1 } });
       // Clear adjustments after baking
       dispatch(rasterLayerAdjustmentsSet({ entityIdentifier, adjustments: null }));
     } catch {


### PR DESCRIPTION
## Summary

fix(ui): do not bake opacity when rasterizing layer adjustments

## Related Issues / Discussions

Reported on discord: https://discord.com/channels/1020123559063990373/1418669273181720666/1418669273181720666

## QA Instructions

- Add some adjustments to a layer
- Reduce its opacity (e.g. to 50%)
- Apply the adjustments

Before the fix, the opacity setting would be baked in. As you click apply, you'll notice the layer becomes less opaque, because it's now a 50% opacity layer being rendered at 50% opacity -> 25% opacity.

After the fix, the opacity should not change. 

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
