### PR TITLE
fix(ui): correct the in-place install verbiage, add tooltip

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -922,7 +922,7 @@
         "nAlreadyInstalled": "{{count}} already installed",
         "installQueue": "Install Queue",
         "inplaceInstall": "In-place install",
-        "inplaceInstallDesc": "Install models without copying the files. When using the model, it will be loaded from its this location. If disabled, the model file(s) will be copied into the Invoke-managed models directory during installation.",
+        "inplaceInstallDesc": "Install models without moving the files. When using the model, it will be loaded from its original location. If disabled, the model file(s) will be moved into the Invoke-managed models directory during installation.",
         "install": "Install",
         "installAll": "Install All",
         "installRepo": "Install Repo",

--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ScanFolder/ScanFolderResults.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/AddModelPanel/ScanFolder/ScanFolderResults.tsx
@@ -10,6 +10,7 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  Tooltip,
 } from '@invoke-ai/ui-library';
 import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import ScrollableContent from 'common/components/OverlayScrollbars/ScrollableContent';
@@ -82,10 +83,12 @@ export const ScanModelsResults = memo(({ results }: ScanModelResultsProps) => {
         <Flex justifyContent="space-between" alignItems="center">
           <Heading size="sm">{t('modelManager.scanResults')}</Heading>
           <Flex alignItems="center" gap={3}>
-            <FormControl w="min-content">
-              <FormLabel m={0}>{t('modelManager.inplaceInstall')}</FormLabel>
-              <Checkbox isChecked={inplace} onChange={onChangeInplace} size="md" />
-            </FormControl>
+            <Tooltip label={t('modelManager.inplaceInstallDesc')} hasArrow>
+              <FormControl w="min-content">
+                <FormLabel m={0}>{t('modelManager.inplaceInstall')}</FormLabel>
+                <Checkbox isChecked={inplace} onChange={onChangeInplace} size="md" />
+              </FormControl>
+            </Tooltip>
             <Button size="sm" onClick={handleAddAll} isDisabled={filteredResults.length === 0}>
               {t('modelManager.installAll')}
             </Button>


### PR DESCRIPTION
## Summary

- Non-in-place install _moves_ the model files into the Invoke directory. The old verbiage said it copied. Fixed.
- Added tooltip to the in-place checkbox on the Scan Folder tab. There was no description of the checkbox on that tab.

## Related Issues / Discussions

Reported on discord https://discord.com/channels/1020123559063990373/1020123559831539744/1419505547035541616

## QA Instructions

n/a

## Merge Plan

n/a

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
