### PR TITLE
chore: switch requests_testadapter for requests_mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dependencies = [
   "pytest-cov",
   "pytest-timeout",
   "pytest-datadir",
-  "requests_testadapter",
+  "requests_mock",
   "httpx",
   "polyfactory==2.19.0",
   "humanize==4.12.1",

--- a/tests/app/services/download/test_download_queue.py
+++ b/tests/app/services/download/test_download_queue.py
@@ -9,7 +9,6 @@ from typing import Any, Generator, Optional
 import pytest
 from pydantic.networks import AnyHttpUrl
 from requests.sessions import Session
-from requests_testadapter import TestAdapter
 
 from invokeai.app.services.config import get_config
 from invokeai.app.services.config.config_default import URLRegexTokenPair
@@ -23,9 +22,6 @@ from invokeai.app.services.events.events_common import (
 )
 from invokeai.backend.model_manager.metadata import HuggingFaceMetadataFetch, ModelMetadataWithFiles, RemoteModelFile
 from tests.test_nodes import TestEventService
-
-# Prevent pytest deprecation warnings
-TestAdapter.__test__ = False
 
 
 @pytest.mark.timeout(timeout=10, method="thread")


### PR DESCRIPTION
## Summary

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

requests_testadapter is an archived repository

Carries on from https://github.com/invoke-ai/InvokeAI/pull/4252#discussion_r1353198552

Implementation using `requests_mock` is broadly similar and I wouldn't say it's much more complex than `requests_testadapter`

**TODO** still need to update uv lock, help updating this would be good. Also wanted to raise the PR to get feedback now.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

relates to #4252

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

Rerunning the tests is sufficient.
I've not ran the longer/more extensive suite but the default tests all run.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

Non user facing code so shouldn't require a merge plan.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _❗Changes to a redux slice have a corresponding migration_
- [X] _Documentation added / updated (if applicable)_
- [X] _Updated `What's New` copy (if doing a release after this PR)_
