### PR TITLE
fix: KeyError in DownloadQueueService

### DIFF
--- a/invokeai/app/services/model_install/model_install_default.py
+++ b/invokeai/app/services/model_install/model_install_default.py
@@ -15,7 +15,6 @@ import torch
 import yaml
 from huggingface_hub import HfFolder
 from pydantic.networks import AnyHttpUrl
-from pydantic_core import Url
 from requests import Session
 
 from invokeai.app.services.config import InvokeAIAppConfig
@@ -454,7 +453,7 @@ class ModelInstallService(ModelInstallServiceBase):
             )
         elif re.match(r"^https?://[^/]+", source):
             source_obj = URLModelSource(
-                url=Url(source),
+                url=AnyHttpUrl(source),
             )
         else:
             raise ValueError(f"Unsupported model source: '{source}'")


### PR DESCRIPTION
## Summary

This PR fixes a bug in the InvokeAI Download Service where type mismatches between `pydantic_core.Url` and `pydantic.networks.AnyHttpUrl` cause KeyError exceptions during download operations.

**Type of change:** Bug fix

**Why:** During model imports through the InvokeAI API, download cancellation and progress callbacks fail when looking up URLs in the `_download_part2parent` dictionary due to type mismatches between the dictionary keys and the lookup values.

**How:** The fix involves ensuring consistent use of the `AnyHttpUrl` type for URL handling in the download service callbacks.

## Related Issues / Discussions

This addresses exceptions found while importing model URLs through the InvokeAI API, specifically in the DownloadQueueService.

## QA Instructions

1. Import multiple model URLs (such as civitai) through the InvokeAI API
2. Verify that progress callbacks work correctly for all downloads
3. Cancel some downloads during the process
4. Verify that cancellation callbacks complete without KeyError exceptions
5. Check that no KeyError exceptions appear in the server logs during normal download operations

The following exception patterns should no longer occur:
- `KeyError: AnyHttpUrl('https://[provider]/api/download/models/[id]')` in `_mfd_cancelled`
- `KeyError: AnyHttpUrl('https://[provider]/api/download/models/[id]')` in `_mfd_progress`

## Merge Plan

This is a targeted bug fix that doesn't affect the core download functionality, only the error handling paths. Safe to merge after review.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [n/a] _Tests added / updated (if applicable)_ - Would have been caught by type checker
- [n/a] _❗Changes to a redux slice have a corresponding migration_
- [n/a] _Documentation added / updated (if applicable)_
- [n/a] _Updated `What's New` copy (if doing a release after this PR)_
