### PR TITLE
fix(mm): directory path leakage on scan folder error

### DIFF
--- a/invokeai/app/api/routers/model_manager.py
+++ b/invokeai/app/api/routers/model_manager.py
@@ -273,9 +273,10 @@ async def scan_for_models(
             found_model = FoundModel(path=path, is_installed=is_installed)
             scan_results.append(found_model)
     except Exception as e:
+        error_type = type(e).__name__
         raise HTTPException(
             status_code=500,
-            detail=f"An error occurred while searching the directory: {e}",
+            detail=f"An error occurred while searching the directory: {error_type}",
         )
     return scan_results
 


### PR DESCRIPTION
## Summary

This fixes a bug in which private directory paths on the host could be leaked to the user interface. The error occurs during the `scan_folders` operation when a subdirectory is not accessible. The UI shows a permission denied error message, followed by the path of the offending directory. This patch limits the error message to the error type only and does not give further details. 

## Related Issues / Discussions

This bug was reported in a private DM on the Discord server.

## QA Instructions

Before applying this PR, go to ***Model Manager -> Add Model -> Scan Folder*** and enter the path of a directory that has subdirectories that the backend should not have access to, for example `/etc`. Press the ***Scan Folder*** button. You will see a Permission Denied error message that gives away the path of the first inaccesislbe subdirectory.

After applying this PR, you will see just the Permission Denied error without details.

## Merge Plan

Merge when approved.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [X] _❗Changes to a redux slice have a corresponding migration_
- [X] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
