### PR TITLE
Fix to enable loading fp16 repo variant ControlNets

### DIFF
--- a/invokeai/backend/model_manager/configs/controlnet.py
+++ b/invokeai/backend/model_manager/configs/controlnet.py
@@ -88,7 +88,7 @@ class ControlNet_Diffusers_Config_Base(Diffusers_Config_Base):
 
         cls._validate_base(mod)
 
-        repo_variant = {'repo_variant': override_fields.get("repo_variant", cls._get_repo_variant_or_raise(mod))}
+        repo_variant = {"repo_variant": override_fields.get("repo_variant", cls._get_repo_variant_or_raise(mod))}
         args = override_fields | repo_variant
         return cls(**args)
 


### PR DESCRIPTION
## Summary
Ensured ControlNet diffusers configs detect and propagate the fp16 repo variant so fp16 weight files such as diffusion_pytorch_model.fp16.safetensors are accepted during loading.

Root cause
In the earlier implementation of ControlNet_Diffusers_Config_Base.from_model_on_disk(), the method simply returned cls(**override_fields) once it had validated the directory and base model. Because the repo_variant field was left at its default (ModelRepoVariant.Default), downstream loading logic always looked for the default diffusers weight filename (diffusion_pytorch_model.bin). That default does not match SDXL ControlNet repositories that ship only fp16 weights named diffusion_pytorch_model.fp16.safetensors, so InvokeAI failed to find the downloaded file even though it was present.

Resolution
The updated version now detects the repository variant before instantiating the config. It calls _get_repo_variant_or_raise(), which scans all .safetensors and .bin files beneath the model directory. When it encounters a filename that carries the .fp16 suffix—such as diffusion_pytorch_model.fp16.safetensors—it returns ModelRepoVariant.FP16. Passing that value into the config ensures the loader subsequently searches for the fp16-weight filename instead of the default .bin, allowing SDXL ControlNet models to load successfully without renaming their files

## Related Issues / Discussions
After deleting and reinstalling SDXL Depth Map CN Invoke no longer able to load it from assigned folder. Installation with model manager shows no error.
https://discord.com/channels/1020123559063990373/1149506274971631688/1432444353200128000
Fixes #8645
## QA Instructions

Did tests with my local dev build and CN loading works as intended.

## Merge Plan

Might need a look from someone more experienced.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
