### PR TITLE
chore(codeowners): remove commercial dev codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # continuous integration
-/.github/workflows/  @lstein @blessedcoolant @jazzhaiku 
+/.github/workflows/  @lstein @blessedcoolant  
 
 # documentation
 /docs/ @lstein @blessedcoolant  
 /mkdocs.yml @lstein @blessedcoolant  
 
 # nodes
-/invokeai/app/ @blessedcoolant @lstein @jazzhaiku
+/invokeai/app/ @blessedcoolant @lstein 
 
 # installation and configuration
 /pyproject.toml  @lstein @blessedcoolant  
@@ -21,7 +21,7 @@
 /invokeai/frontend @blessedcoolant  @lstein  
 
 # generation, model management, postprocessing
-/invokeai/backend  @lstein @blessedcoolant  @jazzhaiku   
+/invokeai/backend  @lstein @blessedcoolant     
 
 # front ends
 /invokeai/frontend/CLI @lstein  


### PR DESCRIPTION
## Summary

This PR removes the following CODEOWNERS from the repo. These were members of the commercial team who, I believe, will no longer be contributing to the code base or reviewing PRs:

- psychedelicious
- hipsterusername
- ebr
- maryhipp
- jazzhaiku

