### PR TITLE
[Draft] Discuss options for exposing original image metadata in upscaled images (Issue #6291)

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/buildMultidiffusionUpscaleGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/buildMultidiffusionUpscaleGraph.ts
@@ -178,6 +178,17 @@ export const buildMultidiffusionUpscaleGraph = async (state: RootState): Promise
 
   const modelConfig = await fetchModelConfigWithTypeGuard(model.key, isNonRefinerMainModelConfig);
   const upscaleModelConfig = await fetchModelConfigWithTypeGuard(upscaleModel.key, isSpandrelImageToImageModelConfig);
+  
+// DISCUSSION: Currently we store only a reference to the original image
+// via `upscale_initial_image`. The full metadata of the source image
+// (prompt, seed, scheduler, etc.) is not included here. 
+//
+// Two options could be considered:
+// 1) Expose a UI way to jump to the source image in the gallery (leveraging this reference).
+// 2) Store all original image metadata under a separate field (e.g., `source_image_metadata`) 
+//    for external or export use.
+//
+// This PR is meant to discuss which approach is preferred before implementing.
 
   g.upsertMetadata({
     cfg_scale,


### PR DESCRIPTION
## Summary

This draft PR is meant to **continue the discussion** from [[Issue #6291](https://github.com/invoke-ai/InvokeAI/issues/6291)] and the related Discord conversation regarding **original image metadata for upscaled images**.

Currently, upscaled images store a reference to the source image via `upscale_initial_image`, but the full metadata (prompt, seed, scheduler, etc.) is not stored.

Two alternatives are under discussion:

1. **Expose a UI way to jump to the source image in the gallery**, leveraging the existing reference.
2. **Store the full original metadata** under a separate field (e.g., `source_image_metadata`) for external/export use.

This PR does **not include any implementation**; it is intended to facilitate review and discussion among maintainers.

---

## Related Issues / Discussions

* GitHub Issue: [[Issue #6291](https://github.com/invoke-ai/InvokeAI/issues/6291)](https://github.com/invoke-ai/InvokeAI/issues/6291)
* Discord discussion: “I am sure someone will correct me if I am wrong… the biggest question here is what original metadata you keep…”

---

## QA Instructions

Not applicable — no code changes in this PR.

---

## Merge Plan

* Marked as **draft** to indicate discussion PR.
* No merging expected until a consensus on the approach is reached.

---

## Checklist

* [x] PR title is short but descriptive
* [ ] Implementation to be added after discussion
* [ ] Documentation updated once implementation is decided

