### PR TITLE
fix: CFG Scale min value reset to zero

### DIFF
--- a/invokeai/frontend/web/src/features/parameters/components/Core/ParamCFGScale.tsx
+++ b/invokeai/frontend/web/src/features/parameters/components/Core/ParamCFGScale.tsx
@@ -7,9 +7,9 @@ import { useTranslation } from 'react-i18next';
 
 export const CONSTRAINTS = {
   initial: 7,
-  sliderMin: 0,
+  sliderMin: 1,
   sliderMax: 20,
-  numberInputMin: 0,
+  numberInputMin: 1,
   numberInputMax: 200,
   fineStep: 0.1,
   coarseStep: 0.5,


### PR DESCRIPTION
## Summary

CFGScale min values on the frontend UI were changed to `0` during the implementation of Z Image initially. But this is no longer needed. Reverting back to the min being `1` which indicates no classifier free guidance.

## Merge Plan

Simple fix. Merge up.