### PR TITLE
fix(ui): misaligned Color Compensation Option

### DIFF
--- a/invokeai/frontend/web/src/features/settingsAccordions/components/AdvancedSettingsAccordion/AdvancedSettingsAccordion.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/AdvancedSettingsAccordion/AdvancedSettingsAccordion.tsx
@@ -1,5 +1,5 @@
 import type { FormLabelProps } from '@invoke-ai/ui-library';
-import { Flex, FormControlGroup, StandaloneAccordion } from '@invoke-ai/ui-library';
+import { Box, Flex, FormControlGroup, SimpleGrid, StandaloneAccordion } from '@invoke-ai/ui-library';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { createMemoizedSelector } from 'app/store/createMemoizedSelector';
 import { useAppSelector } from 'app/store/storeHooks';
@@ -104,13 +104,15 @@ export const AdvancedSettingsAccordion = memo(() => {
             </FormControlGroup>
             <Flex gap={4} w="full">
               <FormControlGroup formLabelProps={formLabelProps2}>
-                <ParamSeamlessXAxis />
-                <ParamSeamlessYAxis />
+                <SimpleGrid columns={2} spacing={4} w="full">
+                  <ParamSeamlessXAxis />
+                  <ParamSeamlessYAxis />
+                  <ParamColorCompensation />
+                  {/* Empty box for visual alignment. Replace with new option when needed. */}
+                  <Box />
+                </SimpleGrid>
               </FormControlGroup>
             </Flex>
-            <FormControlGroup formLabelProps={formLabelProps}>
-              <ParamColorCompensation />
-            </FormControlGroup>
           </>
         )}
         {isFLUX && (


### PR DESCRIPTION
## Summary

The Color Compensation setting was misaligned with the UI. That has now been fixed. An empty `Box` has been added as a spacer. When the next relevant option is added to this area, the `Box` can be replaced with that new option. Left a comment to let people know that.

**Before:**
<img width="401" height="112" alt="opera_7YQbpvOLct" src="https://github.com/user-attachments/assets/ac101dda-e5ba-43d6-a741-e6b6d9671abc" />

**After:**
<img width="404" height="112" alt="opera_mYwGwE7Uyc" src="https://github.com/user-attachments/assets/3e721136-6a19-488d-b9d7-aecdb1107086" />


# Merge Plan

Straight forward. Test for responsiveness at all sizes.
