### PR TITLE
chore(release): bump development version to 6.10.0.post1

### DIFF
--- a/invokeai/version/invokeai_version.py
+++ b/invokeai/version/invokeai_version.py
@@ -1,1 +1,1 @@
-__version__ = "6.10.0post1"
+__version__ = "6.10.0.post1"


### PR DESCRIPTION
## Summary

This bumps the InvokeAI version number to `6.10.0.post1` in order to distinguish the main branch from the recent release. There will not necessarily be a release labeled this way.

## Related Issues / Discussions

None

## QA Instructions

None needed.

## Merge Plan

Simple merge.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
