### PR TITLE
feat(z-image): add Seed Variance Enhancer node and Linear UI integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # continuous integration
 /.github/workflows/  @lstein @blessedcoolant  
 
-# documentation
-/docs/ @lstein @blessedcoolant  
-/mkdocs.yml @lstein @blessedcoolant  
+# documentation - anyone with write privileges can review
+/docs/
+/mkdocs.yml
 
 # nodes
 /invokeai/app/ @blessedcoolant @lstein @dunkeroni @JPPhoto

--- a/invokeai/app/services/invocation_stats/invocation_stats_common.py
+++ b/invokeai/app/services/invocation_stats/invocation_stats_common.py
@@ -14,7 +14,7 @@ class NodeExecutionStatsSummary:
     node_type: str
     num_calls: int
     time_used_seconds: float
-    peak_vram_gb: float
+    delta_vram_gb: float
 
 
 @dataclass
@@ -58,10 +58,10 @@ class InvocationStatsSummary:
     def __str__(self) -> str:
         _str = ""
         _str = f"Graph stats: {self.graph_stats.graph_execution_state_id}\n"
-        _str += f"{'Node':>30} {'Calls':>7} {'Seconds':>9} {'VRAM Used':>10}\n"
+        _str += f"{'Node':>30} {'Calls':>7} {'Seconds':>9} {'VRAM Change':+>10}\n"
 
         for summary in self.node_stats:
-            _str += f"{summary.node_type:>30} {summary.num_calls:>7} {summary.time_used_seconds:>8.3f}s {summary.peak_vram_gb:>9.3f}G\n"
+            _str += f"{summary.node_type:>30} {summary.num_calls:>7} {summary.time_used_seconds:>8.3f}s {summary.delta_vram_gb:+10.3f}G\n"
 
         _str += f"TOTAL GRAPH EXECUTION TIME: {self.graph_stats.execution_time_seconds:7.3f}s\n"
 
@@ -100,7 +100,7 @@ class NodeExecutionStats:
     start_ram_gb: float  # GB
     end_ram_gb: float  # GB
 
-    peak_vram_gb: float  # GB
+    delta_vram_gb: float  # GB
 
     def total_time(self) -> float:
         return self.end_time - self.start_time
@@ -174,9 +174,9 @@ class GraphExecutionStats:
         for node_type, node_type_stats_list in node_stats_by_type.items():
             num_calls = len(node_type_stats_list)
             time_used = sum([n.total_time() for n in node_type_stats_list])
-            peak_vram = max([n.peak_vram_gb for n in node_type_stats_list])
+            delta_vram = max([n.delta_vram_gb for n in node_type_stats_list])
             summary = NodeExecutionStatsSummary(
-                node_type=node_type, num_calls=num_calls, time_used_seconds=time_used, peak_vram_gb=peak_vram
+                node_type=node_type, num_calls=num_calls, time_used_seconds=time_used, delta_vram_gb=delta_vram
             )
             summaries.append(summary)
 

--- a/invokeai/backend/model_manager/load/model_cache/model_cache.py
+++ b/invokeai/backend/model_manager/load/model_cache/model_cache.py
@@ -240,6 +240,9 @@ class ModelCache:
     def stats(self, stats: CacheStats) -> None:
         """Set the CacheStats object for collecting cache statistics."""
         self._stats = stats
+        # Populate the cache size in the stats object when it's set
+        if self._stats is not None:
+            self._stats.cache_size = self._ram_cache_size_bytes
 
     def _record_activity(self) -> None:
         """Record model activity and reset the timeout timer if configured.

--- a/invokeai/backend/util/vae_working_memory.py
+++ b/invokeai/backend/util/vae_working_memory.py
@@ -47,8 +47,6 @@ def estimate_vae_working_memory_sd15_sdxl(
         # If we are running in FP32, then we should account for the likely increase in model size (~250MB).
         working_memory += 250 * 2**20
 
-    print(f"estimate_vae_working_memory_sd15_sdxl: {int(working_memory)}")
-
     return int(working_memory)
 
 

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1621,7 +1621,7 @@
             "heading": "Variance Strength",
             "paragraphs": [
                 "Controls the intensity of the noise added to embeddings. The strength is automatically calibrated relative to the embedding's standard deviation.",
-                "0 = off, 0.1 = subtle variation, 0.5 = strong variation. Values above 1.0 may produce unexpected results."
+                "Values less than 0.1 will produce subtle variations, increasing to stronger ones at 0.5. Values above 0.5 may lead to unexpected results."
             ]
         },
         "seedVarianceRandomizePercent": {
@@ -2212,6 +2212,9 @@
         "showHUD": "Show HUD",
         "rectangle": "Rectangle",
         "maskFill": "Mask Fill",
+        "maskLayerEmpty": "Mask layer is empty",
+        "extractMaskedAreaFailed": "Unable to extract masked area.",
+        "extractMaskedAreaMissingData": "Cannot extract: image or mask data is missing.",
         "addPositivePrompt": "Add $t(controlLayers.prompt)",
         "addNegativePrompt": "Add $t(controlLayers.negativePrompt)",
         "addReferenceImage": "Add $t(controlLayers.referenceImage)",
@@ -2541,6 +2544,13 @@
             "fitModeContain": "Contain",
             "fitModeCover": "Cover",
             "fitModeFill": "Fill",
+            "smoothing": "Smoothing",
+            "smoothingDesc": "Apply a high-quality backend resample when committing transforms.",
+            "smoothingMode": "Resample Mode",
+            "smoothingModeBilinear": "Bilinear",
+            "smoothingModeBicubic": "Bicubic",
+            "smoothingModeHamming": "Hamming",
+            "smoothingModeLanczos": "Lanczos",
             "reset": "Reset",
             "apply": "Apply",
             "cancel": "Cancel"

--- a/invokeai/frontend/web/src/features/controlLayers/components/InpaintMask/InpaintMaskMenuItemsExtractMaskedArea.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/InpaintMask/InpaintMaskMenuItemsExtractMaskedArea.tsx
@@ -27,7 +27,7 @@ export const InpaintMaskMenuItemsExtractMaskedArea = memo(() => {
       const maskAdapter = canvasManager.getAdapter(entityIdentifier);
       if (!maskAdapter) {
         log.error({ entityIdentifier }, 'Inpaint mask adapter not found when extracting masked area');
-        toast({ status: 'error', title: 'Unable to extract masked area.' });
+        toast({ status: 'error', title: t('controlLayers.extractMaskedAreaFailed') });
         return;
       }
 
@@ -44,7 +44,7 @@ export const InpaintMaskMenuItemsExtractMaskedArea = memo(() => {
 
         // Abort when the canvas is effectively empty—no pixels to extract.
         if (rect.width <= 0 || rect.height <= 0) {
-          toast({ status: 'warning', title: 'Canvas is empty.' });
+          toast({ status: 'warning', title: t('controlLayers.maskLayerEmpty') });
           return;
         }
 
@@ -74,7 +74,7 @@ export const InpaintMaskMenuItemsExtractMaskedArea = memo(() => {
             },
             'Mask and composite dimensions did not match when extracting masked area'
           );
-          toast({ status: 'error', title: 'Unable to extract masked area.' });
+          toast({ status: 'error', title: t('controlLayers.extractMaskedAreaFailed') });
           return;
         }
 
@@ -82,7 +82,7 @@ export const InpaintMaskMenuItemsExtractMaskedArea = memo(() => {
         const maskArray = maskImageData.data;
 
         if (!compositeArray || !maskArray) {
-          toast({ status: 'error', title: 'Cannot extract: image or mask data is missing.' });
+          toast({ status: 'error', title: t('controlLayers.extractMaskedAreaMissingData') });
           return;
         }
 
@@ -137,10 +137,10 @@ export const InpaintMaskMenuItemsExtractMaskedArea = memo(() => {
         });
       } catch (error) {
         log.error({ error: serializeError(error as Error) }, 'Failed to extract masked area to raster layer');
-        toast({ status: 'error', title: 'Unable to extract masked area.' });
+        toast({ status: 'error', title: t('controlLayers.extractMaskedAreaFailed') });
       }
     })();
-  }, [canvasManager, entityIdentifier]);
+  }, [canvasManager, entityIdentifier, t]);
 
   return (
     <MenuItem onClick={onExtract} icon={<PiSelectionBackgroundBold />} isDisabled={isBusy}>

--- a/invokeai/frontend/web/src/features/controlLayers/components/Transform/Transform.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Transform/Transform.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react';
 import { useFocusRegion, useIsRegionFocused } from 'common/hooks/focus';
 import { CanvasOperationIsolatedLayerPreviewSwitch } from 'features/controlLayers/components/CanvasOperationIsolatedLayerPreviewSwitch';
 import { TransformFitToBboxButtons } from 'features/controlLayers/components/Transform/TransformFitToBboxButtons';
+import { TransformSmoothingControls } from 'features/controlLayers/components/Transform/TransformSmoothingControls';
 import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
 import type { CanvasEntityAdapter } from 'features/controlLayers/konva/CanvasEntity/types';
 import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/useHotkeyData';
@@ -58,6 +59,8 @@ const TransformContent = memo(({ adapter }: { adapter: CanvasEntityAdapter }) =>
         <Spacer />
         <CanvasOperationIsolatedLayerPreviewSwitch />
       </Flex>
+
+      <TransformSmoothingControls />
 
       <TransformFitToBboxButtons adapter={adapter} />
 

--- a/invokeai/frontend/web/src/features/controlLayers/components/Transform/TransformSmoothingControls.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Transform/TransformSmoothingControls.tsx
@@ -1,0 +1,52 @@
+import { Flex, FormControl, FormLabel, Select, Switch, Tooltip } from '@invoke-ai/ui-library';
+import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
+import {
+  selectTransformSmoothingEnabled,
+  selectTransformSmoothingMode,
+  settingsTransformSmoothingEnabledToggled,
+  settingsTransformSmoothingModeChanged,
+  type TransformSmoothingMode,
+} from 'features/controlLayers/store/canvasSettingsSlice';
+import type { ChangeEvent } from 'react';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const TransformSmoothingControls = memo(() => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const smoothingEnabled = useAppSelector(selectTransformSmoothingEnabled);
+  const smoothingMode = useAppSelector(selectTransformSmoothingMode);
+
+  const onToggle = useCallback(() => {
+    dispatch(settingsTransformSmoothingEnabledToggled());
+  }, [dispatch]);
+
+  const onModeChange = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      dispatch(settingsTransformSmoothingModeChanged(e.target.value as TransformSmoothingMode));
+    },
+    [dispatch]
+  );
+
+  return (
+    <Flex w="full" gap={4} alignItems="center" flexWrap="wrap">
+      <Tooltip label={t('controlLayers.transform.smoothingDesc')}>
+        <FormControl w="min-content">
+          <FormLabel m={0}>{t('controlLayers.transform.smoothing')}</FormLabel>
+          <Switch size="sm" isChecked={smoothingEnabled} onChange={onToggle} />
+        </FormControl>
+      </Tooltip>
+      <FormControl flex={1} minW={200} maxW={280}>
+        <FormLabel m={0}>{t('controlLayers.transform.smoothingMode')}</FormLabel>
+        <Select size="sm" value={smoothingMode} onChange={onModeChange} isDisabled={!smoothingEnabled}>
+          <option value="bilinear">{t('controlLayers.transform.smoothingModeBilinear')}</option>
+          <option value="bicubic">{t('controlLayers.transform.smoothingModeBicubic')}</option>
+          <option value="hamming">{t('controlLayers.transform.smoothingModeHamming')}</option>
+          <option value="lanczos">{t('controlLayers.transform.smoothingModeLanczos')}</option>
+        </Select>
+      </FormControl>
+    </Flex>
+  );
+});
+
+TransformSmoothingControls.displayName = 'TransformSmoothingControls';

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityObjectRenderer.ts
@@ -556,37 +556,67 @@ export class CanvasEntityObjectRenderer extends CanvasModuleBase {
     this.rasterCacheKeys.clear();
   };
 
-  cloneObjectGroup = (arg: { attrs?: GroupConfig } = {}): Konva.Group => {
-    const { attrs } = arg;
+  cloneObjectGroup = (
+    arg: { attrs?: GroupConfig; cache?: { pixelRatio?: number; imageSmoothingEnabled?: boolean } } = {}
+  ): Konva.Group => {
+    const { attrs, cache } = arg;
     const clone = this.konva.objectGroup.clone();
     if (attrs) {
       clone.setAttrs(attrs);
     }
     if (clone.hasChildren()) {
-      clone.cache({ pixelRatio: 1, imageSmoothingEnabled: false });
+      const { pixelRatio = 1, imageSmoothingEnabled = false } = cache ?? {};
+      clone.cache({ pixelRatio, imageSmoothingEnabled });
     }
     return clone;
   };
 
-  getCanvas = (arg: { rect?: Rect; attrs?: GroupConfig; bg?: string } = {}): HTMLCanvasElement => {
-    const { rect, attrs, bg } = arg;
-    const clone = this.cloneObjectGroup({ attrs });
-    const canvas = konvaNodeToCanvas({ node: clone, rect, bg });
+  getCanvas = (
+    arg: {
+      rect?: Rect;
+      attrs?: GroupConfig;
+      bg?: string;
+      imageSmoothingEnabled?: boolean;
+      pixelRatio?: number;
+      cache?: { pixelRatio?: number; imageSmoothingEnabled?: boolean };
+    } = {}
+  ): HTMLCanvasElement => {
+    const { rect, attrs, bg, imageSmoothingEnabled, pixelRatio, cache } = arg;
+    const clone = this.cloneObjectGroup({ attrs, cache });
+    const canvas = konvaNodeToCanvas({ node: clone, rect, bg, imageSmoothingEnabled, pixelRatio });
     clone.destroy();
     return canvas;
   };
 
-  getBlob = async (arg: { rect?: Rect; attrs?: GroupConfig; bg?: string } = {}): Promise<Blob> => {
-    const { rect, attrs, bg } = arg;
-    const clone = this.cloneObjectGroup({ attrs });
-    const blob = await konvaNodeToBlob({ node: clone, rect, bg });
+  getBlob = async (
+    arg: {
+      rect?: Rect;
+      attrs?: GroupConfig;
+      bg?: string;
+      imageSmoothingEnabled?: boolean;
+      pixelRatio?: number;
+      cache?: { pixelRatio?: number; imageSmoothingEnabled?: boolean };
+    } = {}
+  ): Promise<Blob> => {
+    const { rect, attrs, bg, imageSmoothingEnabled, pixelRatio, cache } = arg;
+    const clone = this.cloneObjectGroup({ attrs, cache });
+    const blob = await konvaNodeToBlob({ node: clone, rect, bg, imageSmoothingEnabled, pixelRatio });
     return blob;
   };
 
-  getImageData = (arg: { rect?: Rect; attrs?: GroupConfig; bg?: string } = {}): ImageData => {
-    const { rect, attrs, bg } = arg;
-    const clone = this.cloneObjectGroup({ attrs });
-    const imageData = konvaNodeToImageData({ node: clone, rect, bg });
+  getImageData = (
+    arg: {
+      rect?: Rect;
+      attrs?: GroupConfig;
+      bg?: string;
+      imageSmoothingEnabled?: boolean;
+      pixelRatio?: number;
+      cache?: { pixelRatio?: number; imageSmoothingEnabled?: boolean };
+    } = {}
+  ): ImageData => {
+    const { rect, attrs, bg, imageSmoothingEnabled, pixelRatio, cache } = arg;
+    const clone = this.cloneObjectGroup({ attrs, cache });
+    const imageData = konvaNodeToImageData({ node: clone, rect, bg, imageSmoothingEnabled, pixelRatio });
     clone.destroy();
     return imageData;
   };

--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasEntity/CanvasEntityTransformer.ts
@@ -14,14 +14,19 @@ import {
   offsetCoord,
   roundRect,
 } from 'features/controlLayers/konva/util';
+import type { TransformSmoothingMode } from 'features/controlLayers/store/canvasSettingsSlice';
 import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
 import type { Coordinate, LifecycleCallback, Rect, RectWithRotation } from 'features/controlLayers/store/types';
+import { imageDTOToImageObject } from 'features/controlLayers/store/util';
+import { Graph } from 'features/nodes/util/graph/generation/Graph';
 import { toast } from 'features/toast/toast';
 import Konva from 'konva';
 import type { GroupConfig } from 'konva/lib/Group';
 import { atom } from 'nanostores';
 import type { Logger } from 'roarr';
 import { serializeError } from 'serialize-error';
+import { uploadImage } from 'services/api/endpoints/images';
+import type { ImageDTO } from 'services/api/types';
 import { assert } from 'tsafe';
 
 type CanvasEntityTransformerConfig = {
@@ -89,6 +94,8 @@ const DEFAULT_CONFIG: CanvasEntityTransformerConfig = {
   ROTATE_ANCHOR_STROKE_COLOR: 'hsl(200 76% 40% / 1)', // invokeBlue.700
   ROTATE_ANCHOR_SIZE: 12,
 };
+
+const TRANSFORM_SMOOTHING_PIXEL_RATIO = 2;
 
 export class CanvasEntityTransformer extends CanvasModuleBase {
   readonly type = 'entity_transformer';
@@ -807,21 +814,103 @@ export class CanvasEntityTransformer extends CanvasModuleBase {
     this.log.debug('Applying transform');
     this.$isProcessing.set(true);
     this._setInteractionMode('off');
-    const rect = this.getRelativeRect();
-    const rasterizeResult = await withResultAsync(() =>
-      this.parent.renderer.rasterize({
-        rect: roundRect(rect),
-        replaceObjects: true,
-        ignoreCache: true,
+    const rect = roundRect(this.getRelativeRect());
+    const { transformSmoothingEnabled, transformSmoothingMode } = this.manager.stateApi.getSettings();
+    if (!transformSmoothingEnabled) {
+      const rasterizeResult = await withResultAsync(() =>
+        this.parent.renderer.rasterize({
+          rect,
+          replaceObjects: true,
+          ignoreCache: true,
+          attrs: { opacity: 1, filters: [] },
+        })
+      );
+      if (rasterizeResult.isErr()) {
+        toast({ status: 'error', title: 'Failed to apply transform' });
+        this.log.error({ error: serializeError(rasterizeResult.error) }, 'Failed to rasterize entity');
+      }
+      this.requestRectCalculation();
+      this.stopTransform();
+      return;
+    }
+
+    const rasterizeResult = await withResultAsync(async () => {
+      const blob = await this.parent.renderer.getBlob({
+        rect,
         attrs: { opacity: 1, filters: [] },
-      })
-    );
+        imageSmoothingEnabled: true,
+        pixelRatio: TRANSFORM_SMOOTHING_PIXEL_RATIO,
+        cache: {
+          imageSmoothingEnabled: true,
+          pixelRatio: TRANSFORM_SMOOTHING_PIXEL_RATIO,
+        },
+      });
+
+      return await uploadImage({
+        file: new File([blob], `${this.parent.id}_transform.png`, { type: 'image/png' }),
+        image_category: 'other',
+        is_intermediate: true,
+        silent: true,
+      });
+    });
+
     if (rasterizeResult.isErr()) {
       toast({ status: 'error', title: 'Failed to apply transform' });
       this.log.error({ error: serializeError(rasterizeResult.error) }, 'Failed to rasterize entity');
+      this.requestRectCalculation();
+      this.stopTransform();
+      return;
     }
+
+    const resizeResult = await withResultAsync(() =>
+      this.manager.stateApi.runGraphAndReturnImageOutput({
+        ...CanvasEntityTransformer.buildTransformSmoothingGraph(rasterizeResult.value, rect, transformSmoothingMode),
+        options: {
+          prepend: true,
+        },
+      })
+    );
+
+    if (resizeResult.isErr()) {
+      toast({ status: 'error', title: 'Failed to apply transform' });
+      this.log.error({ error: serializeError(resizeResult.error) }, 'Failed to smooth transformed entity');
+      this.requestRectCalculation();
+      this.stopTransform();
+      return;
+    }
+
+    const imageObject = imageDTOToImageObject(resizeResult.value);
+    await this.parent.bufferRenderer.setBuffer(imageObject);
+    this.parent.bufferRenderer.commitBuffer({ pushToState: false });
+    this.manager.stateApi.rasterizeEntity({
+      entityIdentifier: this.parent.entityIdentifier,
+      imageObject,
+      position: {
+        x: rect.x,
+        y: rect.y,
+      },
+      replaceObjects: true,
+    });
     this.requestRectCalculation();
     this.stopTransform();
+  };
+
+  private static buildTransformSmoothingGraph = (
+    imageDTO: ImageDTO,
+    rect: Rect,
+    resampleMode: TransformSmoothingMode
+  ): { graph: Graph; outputNodeId: string } => {
+    const graph = new Graph(getPrefixedId('transform_smoothing'));
+    const outputNodeId = getPrefixedId('transform_smoothing_resize');
+    graph.addNode({
+      id: outputNodeId,
+      type: 'img_resize',
+      image: { image_name: imageDTO.image_name },
+      width: rect.width,
+      height: rect.height,
+      resample_mode: resampleMode,
+    });
+    return { graph, outputNodeId };
   };
 
   resetTransform = () => {

--- a/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/util.ts
@@ -368,9 +368,15 @@ export const dataURLToImageData = (dataURL: string, width: number, height: numbe
   });
 };
 
-export const konvaNodeToCanvas = (arg: { node: Konva.Node; rect?: Rect; bg?: string }): HTMLCanvasElement => {
-  const { node, rect, bg } = arg;
-  const canvas = node.toCanvas({ ...(rect ?? {}), imageSmoothingEnabled: false, pixelRatio: 1 });
+export const konvaNodeToCanvas = (arg: {
+  node: Konva.Node;
+  rect?: Rect;
+  bg?: string;
+  imageSmoothingEnabled?: boolean;
+  pixelRatio?: number;
+}): HTMLCanvasElement => {
+  const { node, rect, bg, imageSmoothingEnabled = false, pixelRatio = 1 } = arg;
+  const canvas = node.toCanvas({ ...(rect ?? {}), imageSmoothingEnabled, pixelRatio });
 
   if (!bg) {
     return canvas;
@@ -382,7 +388,7 @@ export const konvaNodeToCanvas = (arg: { node: Konva.Node; rect?: Rect; bg?: str
   bgCanvas.height = canvas.height;
   const bgCtx = bgCanvas.getContext('2d');
   assert(bgCtx !== null, 'bgCtx is null');
-  bgCtx.imageSmoothingEnabled = false;
+  bgCtx.imageSmoothingEnabled = imageSmoothingEnabled;
   bgCtx.fillStyle = bg;
   bgCtx.fillRect(0, 0, bgCanvas.width, bgCanvas.height);
   bgCtx.drawImage(canvas, 0, 0);
@@ -419,9 +425,15 @@ export const canvasToImageData = (canvas: HTMLCanvasElement): ImageData => {
  * @param rect - The bounding box to crop to
  * @returns A Promise that resolves with ImageData object of the node cropped to the bounding box
  */
-export const konvaNodeToImageData = (arg: { node: Konva.Node; rect?: Rect; bg?: string }): ImageData => {
-  const { node, rect, bg } = arg;
-  const canvas = konvaNodeToCanvas({ node, rect, bg });
+export const konvaNodeToImageData = (arg: {
+  node: Konva.Node;
+  rect?: Rect;
+  bg?: string;
+  imageSmoothingEnabled?: boolean;
+  pixelRatio?: number;
+}): ImageData => {
+  const { node, rect, bg, imageSmoothingEnabled, pixelRatio } = arg;
+  const canvas = konvaNodeToCanvas({ node, rect, bg, imageSmoothingEnabled, pixelRatio });
   return canvasToImageData(canvas);
 };
 
@@ -431,9 +443,15 @@ export const konvaNodeToImageData = (arg: { node: Konva.Node; rect?: Rect; bg?: 
  * @param rect - The bounding box to crop to
  * @returns A Promise that resolves to the Blob or null,
  */
-export const konvaNodeToBlob = (arg: { node: Konva.Node; rect?: Rect; bg?: string }): Promise<Blob> => {
-  const { node, rect, bg } = arg;
-  const canvas = konvaNodeToCanvas({ node, rect, bg });
+export const konvaNodeToBlob = (arg: {
+  node: Konva.Node;
+  rect?: Rect;
+  bg?: string;
+  imageSmoothingEnabled?: boolean;
+  pixelRatio?: number;
+}): Promise<Blob> => {
+  const { node, rect, bg, imageSmoothingEnabled, pixelRatio } = arg;
+  const canvas = konvaNodeToCanvas({ node, rect, bg, imageSmoothingEnabled, pixelRatio });
   return canvasToBlob(canvas);
 };
 

--- a/invokeai/frontend/web/src/features/controlLayers/store/canvasSettingsSlice.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/store/canvasSettingsSlice.ts
@@ -9,6 +9,9 @@ import { z } from 'zod';
 const zAutoSwitchMode = z.enum(['off', 'switch_on_start', 'switch_on_finish']);
 export type AutoSwitchMode = z.infer<typeof zAutoSwitchMode>;
 
+const zTransformSmoothingMode = z.enum(['bilinear', 'bicubic', 'hamming', 'lanczos']);
+export type TransformSmoothingMode = z.infer<typeof zTransformSmoothingMode>;
+
 const zCanvasSettingsState = z.object({
   /**
    * Whether to show HUD (Heads-Up Display) on the canvas.
@@ -86,6 +89,14 @@ const zCanvasSettingsState = z.object({
    */
   ruleOfThirds: z.boolean(),
   /**
+   * Whether to apply smoothing when rasterizing transformed layers.
+   */
+  transformSmoothingEnabled: z.boolean().default(false),
+  /**
+   * The resampling mode to use when smoothing transformed layers.
+   */
+  transformSmoothingMode: zTransformSmoothingMode.default('bicubic'),
+  /**
    * Whether to save all staging images to the gallery instead of keeping them as intermediate images.
    */
   saveAllImagesToGallery: z.boolean(),
@@ -123,6 +134,8 @@ const getInitialState = (): CanvasSettingsState => ({
   saveAllImagesToGallery: false,
   stagingAreaAutoSwitch: 'switch_on_start',
   fillColorPickerPinned: false,
+  transformSmoothingEnabled: false,
+  transformSmoothingMode: 'bicubic',
 });
 
 const slice = createSlice({
@@ -196,6 +209,15 @@ const slice = createSlice({
     settingsSaveAllImagesToGalleryToggled: (state) => {
       state.saveAllImagesToGallery = !state.saveAllImagesToGallery;
     },
+    settingsTransformSmoothingEnabledToggled: (state) => {
+      state.transformSmoothingEnabled = !state.transformSmoothingEnabled;
+    },
+    settingsTransformSmoothingModeChanged: (
+      state,
+      action: PayloadAction<CanvasSettingsState['transformSmoothingMode']>
+    ) => {
+      state.transformSmoothingMode = action.payload;
+    },
     settingsStagingAreaAutoSwitchChanged: (
       state,
       action: PayloadAction<CanvasSettingsState['stagingAreaAutoSwitch']>
@@ -230,6 +252,8 @@ export const {
   settingsPressureSensitivityToggled,
   settingsRuleOfThirdsToggled,
   settingsSaveAllImagesToGalleryToggled,
+  settingsTransformSmoothingEnabledToggled,
+  settingsTransformSmoothingModeChanged,
   settingsStagingAreaAutoSwitchChanged,
   settingsFillColorPickerPinnedSet,
 } = slice.actions;
@@ -267,3 +291,7 @@ export const selectPressureSensitivity = createCanvasSettingsSelector((settings)
 export const selectRuleOfThirds = createCanvasSettingsSelector((settings) => settings.ruleOfThirds);
 export const selectSaveAllImagesToGallery = createCanvasSettingsSelector((settings) => settings.saveAllImagesToGallery);
 export const selectStagingAreaAutoSwitch = createCanvasSettingsSelector((settings) => settings.stagingAreaAutoSwitch);
+export const selectTransformSmoothingEnabled = createCanvasSettingsSelector(
+  (settings) => settings.transformSmoothingEnabled
+);
+export const selectTransformSmoothingMode = createCanvasSettingsSelector((settings) => settings.transformSmoothingMode);


### PR DESCRIPTION
## Summary

Add a new conditioning node for Z-Image models that injects seed-based noise into text embeddings to increase visual variation between seeds.

Z-Image-Turbo can produce relatively similar images with different seeds, making it harder to explore variations of a prompt. This feature implements reproducible, seed-based noise injection into text embeddings to increase visual variation while maintaining reproducibility.

**Backend:**
- New invocation: `z_image_seed_variance_enhancer.py`
- Parameters: `strength` (0-2), `randomize_percent` (1-100%), `seed`
- Auto-calibrates noise intensity relative to embedding standard deviation

**Frontend:**
- State management in `paramsSlice` with selectors and reducers
- UI components in `SeedVariance/` folder with toggle and sliders
- Integration in GenerationSettingsAccordion (Advanced Options)
- Graph builder integration in `buildZImageGraph.ts`
- Metadata recall handlers for remix functionality
- Translations and tooltip descriptions

Based on: https://github.com/Pfannkuchensack/invokeai-z-image-seed-variance-enhancer

## Related Issues / Discussions

Integrates community node as core feature for Z-Image models.

## QA Instructions

1. Select a Z-Image model (e.g., Z-Image-Turbo)
2. Open "Advanced Options" in the Generation Settings
3. Enable "Seed Variance Enhancer"
4. Adjust Strength (0.1 = subtle, 0.5 = strong) and Randomize Percent
5. Generate images with different seeds - they should show more variation
6. Verify metadata recall works: generate an image, then use "Recall Parameters" on it

**Workflow Editor:**
- The node is available under Conditioning → "Seed Variance Enhancer - Z-Image"
- Connect between Z-Image Text Encoder and Z-Image Denoise

## Merge Plan

No special merge requirements. Schema will be auto-generated on backend start.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [x] _Changes to a redux slice have a corresponding migration_ (uses existing migration pattern)
- [x] _Documentation added / updated (if applicable)_ (tooltips added)
- [ ] _Updated `What's New` copy (if doing a release after this PR)_