### PR TITLE
fix(model_manager): prevent Z-Image LoRAs from being misclassified as main models

### DIFF
--- a/invokeai/backend/model_manager/configs/main.py
+++ b/invokeai/backend/model_manager/configs/main.py
@@ -135,7 +135,6 @@ def _has_z_image_keys(state_dict: dict[str | int, Any]) -> bool:
         ".dora_scale",
     )
 
-    has_z_image_keys = False
     for key in state_dict.keys():
         if isinstance(key, int):
             continue
@@ -150,10 +149,9 @@ def _has_z_image_keys(state_dict: dict[str | int, Any]) -> bool:
         key_parts = key.split(".")
         for part in key_parts:
             if part in z_image_specific_keys:
-                has_z_image_keys = True
-                break
+                return True
 
-    return has_z_image_keys
+    return False
 
 
 class Main_SD_Checkpoint_Config_Base(Checkpoint_Config_Base, Main_Config_Base):


### PR DESCRIPTION
## Summary

Z-Image LoRAs containing keys like `diffusion_model.context_refiner.*` were being incorrectly classified as main checkpoint models instead of LoRAs. This happened because the `_has_z_image_keys()` function checked for Z-Image specific keys (like `context_refiner`) without verifying if the file was actually a LoRA.

Since main models have higher priority than LoRAs in the classification sort order, the incorrect main model classification would win.

The fix adds detection of LoRA-specific weight suffixes (`.lora_down.weight`, `.lora_up.weight`, `.lora_A.weight`, `.lora_B.weight`, `.dora_scale`) and returns False if any are found, ensuring LoRAs are correctly classified.

## Related Issues / Discussions

#8707

## QA Instructions

1. Import a Z-Image LoRA file (e.g., one with `diffusion_model.context_refiner.*` or `diffusion_model.layers.*` keys)
2. Verify it is classified as `LoRA` type with `z-image` base and `lycoris` format
3. Import a Z-Image main model checkpoint
4. Verify it is still correctly classified as `Main` type with `z-image` base

## Merge Plan

Standard merge, no special considerations.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_