### PR TITLE
feat(flux2): add non-commercial license indicator for FLUX.2 Klein 9B

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -1989,7 +1989,7 @@
         "fluxDevLicense": {
             "heading": "Non-Commercial License",
             "paragraphs": [
-                "FLUX.1 [dev] models are licensed under the FLUX [dev] non-commercial license. To use this model type for commercial purposes in Invoke, visit our website to learn more."
+                "This model is licensed for non-commercial use only. FLUX.1 [dev] models use the FLUX.1 [dev] Non-Commercial License, and FLUX.2 Klein 9B uses the FLUX.2 Non-Commercial License."
             ]
         },
         "optimizedDenoising": {

--- a/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/MainModelPicker.tsx
+++ b/invokeai/frontend/web/src/features/settingsAccordions/components/GenerationSettingsAccordion/MainModelPicker.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { MdMoneyOff } from 'react-icons/md';
 import { useMainModels } from 'services/api/hooks/modelsByType';
 import { useSelectedModelConfig } from 'services/api/hooks/useSelectedModelConfig';
-import { type AnyModelConfig, isFluxDevMainModelConfig } from 'services/api/types';
+import { type AnyModelConfig, isNonCommercialMainModelConfig } from 'services/api/types';
 
 export const MainModelPicker = memo(() => {
   const { t } = useTranslation();
@@ -23,8 +23,8 @@ export const MainModelPicker = memo(() => {
     [dispatch]
   );
 
-  const isFluxDevSelected = useMemo(
-    () => selectedModelConfig && isFluxDevMainModelConfig(selectedModelConfig),
+  const isNonCommercialSelected = useMemo(
+    () => selectedModelConfig && isNonCommercialMainModelConfig(selectedModelConfig),
     [selectedModelConfig]
   );
 
@@ -33,7 +33,7 @@ export const MainModelPicker = memo(() => {
       <InformationalPopover feature="paramModel">
         <FormLabel>{t('modelManager.model')}</FormLabel>
       </InformationalPopover>
-      {isFluxDevSelected && (
+      {isNonCommercialSelected && (
         <InformationalPopover feature="fluxDevLicense" hideDisable={true}>
           <Flex justifyContent="flex-start">
             <Icon as={MdMoneyOff} />

--- a/invokeai/frontend/web/src/features/ui/layouts/InitialStateMainModelPicker.tsx
+++ b/invokeai/frontend/web/src/features/ui/layouts/InitialStateMainModelPicker.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { MdMoneyOff } from 'react-icons/md';
 import { useMainModels } from 'services/api/hooks/modelsByType';
 import { useSelectedModelConfig } from 'services/api/hooks/useSelectedModelConfig';
-import { type AnyModelConfig, isFluxDevMainModelConfig } from 'services/api/types';
+import { type AnyModelConfig, isNonCommercialMainModelConfig } from 'services/api/types';
 
 export const InitialStateMainModelPicker = memo(() => {
   const { t } = useTranslation();
@@ -22,8 +22,8 @@ export const InitialStateMainModelPicker = memo(() => {
     [dispatch]
   );
 
-  const isFluxDevSelected = useMemo(
-    () => selectedModelConfig && isFluxDevMainModelConfig(selectedModelConfig),
+  const isNonCommercialSelected = useMemo(
+    () => selectedModelConfig && isNonCommercialMainModelConfig(selectedModelConfig),
     [selectedModelConfig]
   );
 
@@ -31,7 +31,7 @@ export const InitialStateMainModelPicker = memo(() => {
     <FormControl orientation="vertical" alignItems="unset">
       <FormLabel display="flex" fontSize="md" gap={2}>
         {t('common.selectYourModel')}{' '}
-        {isFluxDevSelected && (
+        {isNonCommercialSelected && (
           <InformationalPopover feature="fluxDevLicense" hideDisable={true}>
             <Flex justifyContent="flex-start">
               <Icon as={MdMoneyOff} />

--- a/invokeai/frontend/web/src/services/api/types.ts
+++ b/invokeai/frontend/web/src/services/api/types.ts
@@ -293,6 +293,14 @@ export const isFluxDevMainModelConfig = (config: AnyModelConfig): config is Main
   return config.type === 'main' && config.base === 'flux' && config.variant === 'dev';
 };
 
+export const isFlux2Klein9BMainModelConfig = (config: AnyModelConfig): config is MainModelConfig => {
+  return config.type === 'main' && config.base === 'flux2' && config.name.toLowerCase().includes('9b');
+};
+
+export const isNonCommercialMainModelConfig = (config: AnyModelConfig): config is MainModelConfig => {
+  return isFluxDevMainModelConfig(config) || isFlux2Klein9BMainModelConfig(config);
+};
+
 export const isFluxFillMainModelModelConfig = (config: AnyModelConfig): config is MainModelConfig => {
   return config.type === 'main' && config.base === 'flux' && config.variant === 'dev_fill';
 };


### PR DESCRIPTION
## Summary

- Add `isFlux2Klein9BMainModelConfig` and `isNonCommercialMainModelConfig` functions to detect non-commercial licensed models
- Update `MainModelPicker` and `InitialStateMainModelPicker` to show the non-commercial license icon for FLUX.2 Klein 9B models
- Update license tooltip text to include both FLUX.1 [dev] and FLUX.2 Klein 9B

## Related Issues / Discussions

Extends the non-commercial license indicator (already present for FLUX.1 [dev]) to also cover FLUX.2 Klein 9B models.

## QA Instructions

1. Install or have a FLUX.2 Klein 9B model available
2. Select the FLUX.2 Klein 9B model in the model picker
3. Verify that the non-commercial license icon (💰 with strikethrough) appears next to the model selector
4. Hover over the icon and verify the tooltip mentions both FLUX.1 [dev] and FLUX.2 Klein 9B licenses
5. Select FLUX.2 Klein 4B and verify the icon does NOT appear (4B has a different license)

## Merge Plan

after #8768 is merged

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_