### PR TITLE
Fix ref_images metadata format for FLUX Kontext recall

### DIFF
--- a/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/graph/generation/buildFLUXGraph.ts
@@ -277,7 +277,7 @@ export const buildFLUXGraph = async (arg: GraphBuilderArg): Promise<GraphBuilder
       }
       g.addEdge(flux2KontextCollect, 'collection', flux2Denoise, 'kontext_conditioning');
 
-      g.upsertMetadata({ ref_images: [validFlux2RefImageConfigs] }, 'merge');
+      g.upsertMetadata({ ref_images: validFlux2RefImageConfigs }, 'merge');
     }
 
     if (generationMode === 'txt2img') {
@@ -379,7 +379,7 @@ export const buildFLUXGraph = async (arg: GraphBuilderArg): Promise<GraphBuilder
         }
         g.addEdge(fluxKontextCollect, 'collection', fluxDenoise, 'kontext_conditioning');
 
-        g.upsertMetadata({ ref_images: [validFLUXKontextConfigs] }, 'merge');
+        g.upsertMetadata({ ref_images: validFLUXKontextConfigs }, 'merge');
       }
     }
 


### PR DESCRIPTION
## Summary

Remove extra array wrapper when saving ref_images metadata for FLUX.2 Klein

and FLUX.1 Kontext reference images. The double-nested array [[...]] was

preventing recall from parsing the metadata correctly.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
