### PR TITLE
Chore(CI/CD): bump version to 6.11.0.post1

### DIFF
--- a/invokeai/version/invokeai_version.py
+++ b/invokeai/version/invokeai_version.py
@@ -1,1 +1,1 @@
-__version__ = "6.11.0.rc1"
+__version__ = "6.11.0.post1"


### PR DESCRIPTION
## Summary

This PR bumps InvokeAI to version 6.11.0.post1 in preparation for development of the 6.12.x release candidate.

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
