### PR TITLE
fix(ui): reset seed variance toggle when recalling images without that metadata

### DIFF
--- a/invokeai/frontend/web/src/features/metadata/parsing.tsx
+++ b/invokeai/frontend/web/src/features/metadata/parsing.tsx
@@ -623,9 +623,14 @@ const ZImageSeedVarianceEnabled: SingleMetadataHandler<boolean> = {
   [SingleMetadataKey]: true,
   type: 'ZImageSeedVarianceEnabled',
   parse: (metadata, _store) => {
-    const raw = getProperty(metadata, 'z_image_seed_variance_enabled');
-    const parsed = z.boolean().parse(raw);
-    return Promise.resolve(parsed);
+    try {
+      const raw = getProperty(metadata, 'z_image_seed_variance_enabled');
+      const parsed = z.boolean().parse(raw);
+      return Promise.resolve(parsed);
+    } catch {
+      // Default to false when metadata doesn't contain this field (e.g. older images)
+      return Promise.resolve(false);
+    }
   },
   recall: (value, store) => {
     store.dispatch(setZImageSeedVarianceEnabled(value));


### PR DESCRIPTION
 ## Summary

  When recalling an image that lacks `z_image_seed_variance_enabled` metadata
  (e.g. older images), the toggle now defaults to off instead of retaining the
  previous state.

  ## Related Issues / Discussions

  https://discord.com/channels/1020123559063990373/1149513625321603162/1466581142533570793

  ## QA Instructions

  1. Generate an image with seed variance **enabled**
  2. Recall that image — verify the seed variance toggle is **on**
  3. Recall an older image that was generated **before** seed variance existed
  4. Verify the seed variance toggle is now **off**

  ## Merge Plan

  No special merge considerations.

  ## Checklist

  - [x] _The PR has a short but descriptive title, suitable for a changelog_
  - [ ] _Tests added / updated (if applicable)_
  - [ ] _❗Changes to a redux slice have a corresponding migration_
  - [ ] _Documentation added / updated (if applicable)_
  - [ ] _Updated `What's New` copy (if doing a release after this PR)_