### PR TITLE
Fix: Improve non square bbox coverage for linear gradient tool.

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasGradientToolModule.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/konva/CanvasTool/CanvasGradientToolModule.ts
@@ -134,19 +134,14 @@ export class CanvasGradientToolModule extends CanvasModuleBase {
     };
 
     if (settings.gradientType === 'linear') {
-      const bboxCenter = {
-        x: bboxInLayer.x + bboxInLayer.width / 2,
-        y: bboxInLayer.y + bboxInLayer.height / 2,
-      };
-      const cos = Math.cos(angle);
-      const sin = Math.sin(angle);
-      const halfWidth = (Math.abs(bboxInLayer.width * cos) + Math.abs(bboxInLayer.height * sin)) / 2;
-      const halfHeight = (Math.abs(bboxInLayer.width * sin) + Math.abs(bboxInLayer.height * cos)) / 2;
+      // Always render linear gradients on a rect that fully covers the bbox.
+      // Angle-dependent rect sizing can undershoot on non-square bboxes (e.g. 90deg on tall bboxes),
+      // leaving uncovered bands when the result is clipped back to bbox.
       rect = {
-        x: bboxCenter.x - halfWidth,
-        y: bboxCenter.y - halfHeight,
-        width: Math.max(halfWidth * 2, 1),
-        height: Math.max(halfHeight * 2, 1),
+        x: bboxInLayer.x,
+        y: bboxInLayer.y,
+        width: Math.max(bboxInLayer.width, 1),
+        height: Math.max(bboxInLayer.height, 1),
       };
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the issue with linear gradient not entirely covering BBox if dimensions set to non square.

The previous math could produce a render rect smaller than a non-square bbox at some angles (e.g. near vertical), which left uncovered strips.

Using the bbox directly guarantees full coverage for all drag vectors and aspect ratios.

## QA Instructions

1. Set non square BBox i.e. 1024x1536.
2. Draw linear gradient in different directions.
3. Verify that gradient fully covers the BBox area.

## Merge Plan

Simple merge

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
