### PR TITLE
Fix(Text-tool): Remove redundant Font tooltip on fonts selection

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/components/Text/TextToolOptions.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Text/TextToolOptions.tsx
@@ -96,16 +96,14 @@ const FontSelect = () => {
       <Text fontSize="sm" lineHeight="1" whiteSpace="nowrap">
         {t('controlLayers.text.font', { defaultValue: 'Font' })}
       </Text>
-      <Tooltip label={t('controlLayers.text.font', { defaultValue: 'Font' })}>
-        <Combobox
-          size="sm"
-          variant="outline"
-          isSearchable={false}
-          options={options}
-          value={selectedOption}
-          onChange={handleFontChange}
-        />
-      </Tooltip>
+      <Combobox
+        size="sm"
+        variant="outline"
+        isSearchable={false}
+        options={options}
+        value={selectedOption}
+        onChange={handleFontChange}
+      />
     </Flex>
   );
 };


### PR DESCRIPTION
## Summary

- Removed the redundant `Font` tooltip that appeared when opening the Text Tool font dropdown.

## QA Instructions

1. Activate the Text Tool.
2. Click the font selection dropdown.
3. Confirm the dropdown opens normally and no extra `Font` popup appears in the top-right UI.

## Merge Plan

Simple merge
## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
