### PR TITLE
fix(ui): stabilize workflow node execution state updates

### DIFF
--- a/invokeai/frontend/web/src/services/events/invocationTracking.test.ts
+++ b/invokeai/frontend/web/src/services/events/invocationTracking.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clearCompletedInvocationKeysForQueueItem,
+  hasCompletedInvocationKey,
+  markInvocationAsCompleted,
+  shouldIgnoreFinishedQueueItemInvocationEvent,
+} from './invocationTracking';
+
+describe(markInvocationAsCompleted.name, () => {
+  it('tracks completed invocations per queue item', () => {
+    const completedInvocationKeysByItemId = new Map<number, Set<string>>();
+
+    markInvocationAsCompleted(completedInvocationKeysByItemId, 1, 'prepared-node-1');
+    markInvocationAsCompleted(completedInvocationKeysByItemId, 2, 'prepared-node-1');
+
+    expect(hasCompletedInvocationKey(completedInvocationKeysByItemId, 1, 'prepared-node-1')).toBe(true);
+    expect(hasCompletedInvocationKey(completedInvocationKeysByItemId, 2, 'prepared-node-1')).toBe(true);
+  });
+
+  it('clears only the completed invocations for a finished queue item', () => {
+    const completedInvocationKeysByItemId = new Map<number, Set<string>>();
+
+    markInvocationAsCompleted(completedInvocationKeysByItemId, 1, 'prepared-node-1');
+    markInvocationAsCompleted(completedInvocationKeysByItemId, 2, 'prepared-node-1');
+
+    clearCompletedInvocationKeysForQueueItem(completedInvocationKeysByItemId, 1);
+
+    expect(hasCompletedInvocationKey(completedInvocationKeysByItemId, 1, 'prepared-node-1')).toBe(false);
+    expect(hasCompletedInvocationKey(completedInvocationKeysByItemId, 2, 'prepared-node-1')).toBe(true);
+  });
+});
+
+describe(shouldIgnoreFinishedQueueItemInvocationEvent.name, () => {
+  it('ignores late started and progress events for finished queue items', () => {
+    const finishedQueueItemIds = new Set<number>([1]);
+
+    expect(shouldIgnoreFinishedQueueItemInvocationEvent('invocation_started', finishedQueueItemIds, 1)).toBe(true);
+    expect(shouldIgnoreFinishedQueueItemInvocationEvent('invocation_progress', finishedQueueItemIds, 1)).toBe(true);
+  });
+
+  it('does not ignore late error events for finished queue items', () => {
+    const finishedQueueItemIds = new Set<number>([1]);
+
+    expect(shouldIgnoreFinishedQueueItemInvocationEvent('invocation_error', finishedQueueItemIds, 1)).toBe(false);
+  });
+});

--- a/invokeai/frontend/web/src/services/events/invocationTracking.ts
+++ b/invokeai/frontend/web/src/services/events/invocationTracking.ts
@@ -1,0 +1,45 @@
+type CompletedInvocationKeysByItemId = Map<number, Set<string>>;
+
+type FinishedQueueItemIds = {
+  has: (itemId: number) => boolean;
+};
+
+type FinishedQueueItemInvocationEventName = 'invocation_error' | 'invocation_progress' | 'invocation_started';
+
+export const hasCompletedInvocationKey = (
+  completedInvocationKeysByItemId: CompletedInvocationKeysByItemId,
+  itemId: number,
+  invocationId: string
+) => completedInvocationKeysByItemId.get(itemId)?.has(invocationId) ?? false;
+
+export const markInvocationAsCompleted = (
+  completedInvocationKeysByItemId: CompletedInvocationKeysByItemId,
+  itemId: number,
+  invocationId: string
+) => {
+  let completedInvocationKeys = completedInvocationKeysByItemId.get(itemId);
+  if (!completedInvocationKeys) {
+    completedInvocationKeys = new Set<string>();
+    completedInvocationKeysByItemId.set(itemId, completedInvocationKeys);
+  }
+  completedInvocationKeys.add(invocationId);
+};
+
+export const clearCompletedInvocationKeysForQueueItem = (
+  completedInvocationKeysByItemId: CompletedInvocationKeysByItemId,
+  itemId: number
+) => {
+  completedInvocationKeysByItemId.delete(itemId);
+};
+
+export const shouldIgnoreFinishedQueueItemInvocationEvent = (
+  eventName: FinishedQueueItemInvocationEventName,
+  finishedQueueItemIds: FinishedQueueItemIds,
+  itemId: number
+) => {
+  if (eventName === 'invocation_error') {
+    return false;
+  }
+
+  return finishedQueueItemIds.has(itemId);
+};

--- a/invokeai/frontend/web/src/services/events/nodeExecutionState.test.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionState.test.ts
@@ -111,7 +111,7 @@ const buildInvocationErrorEvent = (overrides: Partial<S['InvocationErrorEvent']>
 describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
   it('creates an execution state when started arrives before initialization', () => {
     const event = buildInvocationStartedEvent();
-    const updated = getUpdatedNodeExecutionStateOnInvocationStarted(undefined, event, new Set<string>());
+    const updated = getUpdatedNodeExecutionStateOnInvocationStarted(undefined, event, new Map<number, Set<string>>());
 
     expect(updated?.nodeId).toBe(event.invocation_source_id);
     expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
@@ -122,7 +122,7 @@ describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
     const updated = getUpdatedNodeExecutionStateOnInvocationStarted(
       buildNodeExecutionState(),
       buildInvocationStartedEvent(),
-      new Set<string>()
+      new Map<number, Set<string>>()
     );
 
     expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
@@ -133,7 +133,7 @@ describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
     const updated = getUpdatedNodeExecutionStateOnInvocationStarted(
       buildNodeExecutionState({ status: zNodeStatus.enum.COMPLETED, progress: 1 }),
       event,
-      new Set([`${event.item_id}:${event.invocation.id}`])
+      new Map([[event.item_id, new Set([event.invocation.id])]])
     );
 
     expect(updated).toBeUndefined();
@@ -143,7 +143,7 @@ describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
 describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
   it('creates an execution state when progress arrives before initialization', () => {
     const event = buildInvocationProgressEvent();
-    const updated = getUpdatedNodeExecutionStateOnInvocationProgress(undefined, event, new Set<string>());
+    const updated = getUpdatedNodeExecutionStateOnInvocationProgress(undefined, event, new Map<number, Set<string>>());
 
     expect(updated?.nodeId).toBe(event.invocation_source_id);
     expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
@@ -156,7 +156,7 @@ describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
     const updated = getUpdatedNodeExecutionStateOnInvocationProgress(
       buildNodeExecutionState(),
       event,
-      new Set<string>()
+      new Map<number, Set<string>>()
     );
 
     expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
@@ -169,7 +169,7 @@ describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
     const updated = getUpdatedNodeExecutionStateOnInvocationProgress(
       buildNodeExecutionState({ status: zNodeStatus.enum.COMPLETED, progress: 1 }),
       event,
-      new Set([`${event.item_id}:${event.invocation.id}`])
+      new Map([[event.item_id, new Set([event.invocation.id])]])
     );
 
     expect(updated).toBeUndefined();
@@ -179,29 +179,29 @@ describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
 describe(getUpdatedNodeExecutionStateOnInvocationComplete.name, () => {
   it('creates an execution state when completion arrives before initialization', () => {
     const event = buildInvocationCompleteEvent();
-    const completedInvocationKeys = new Set<string>();
-    const updated = getUpdatedNodeExecutionStateOnInvocationComplete(undefined, event, completedInvocationKeys);
+    const completedInvocationKeysByItemId = new Map<number, Set<string>>();
+    const updated = getUpdatedNodeExecutionStateOnInvocationComplete(undefined, event, completedInvocationKeysByItemId);
 
     expect(updated?.nodeId).toBe(event.invocation_source_id);
     expect(updated?.status).toBe(zNodeStatus.enum.COMPLETED);
     expect(updated?.outputs).toEqual([event.result]);
-    expect(completedInvocationKeys).toEqual(new Set([`${event.item_id}:${event.invocation.id}`]));
+    expect(completedInvocationKeysByItemId).toEqual(new Map([[event.item_id, new Set([event.invocation.id])]]));
   });
 
   it('records a completed invocation result once', () => {
     const event = buildInvocationCompleteEvent();
-    const completedInvocationKeys = new Set<string>();
+    const completedInvocationKeysByItemId = new Map<number, Set<string>>();
 
     const updated = getUpdatedNodeExecutionStateOnInvocationComplete(
       buildNodeExecutionState({ status: zNodeStatus.enum.IN_PROGRESS, progress: 0.5 }),
       event,
-      completedInvocationKeys
+      completedInvocationKeysByItemId
     );
 
     expect(updated?.status).toBe(zNodeStatus.enum.COMPLETED);
     expect(updated?.progress).toBe(1);
     expect(updated?.outputs).toEqual([event.result]);
-    expect(completedInvocationKeys).toEqual(new Set([`${event.item_id}:${event.invocation.id}`]));
+    expect(completedInvocationKeysByItemId).toEqual(new Map([[event.item_id, new Set([event.invocation.id])]]));
   });
 
   it('ignores duplicate completion events for the same invocation', () => {
@@ -209,7 +209,7 @@ describe(getUpdatedNodeExecutionStateOnInvocationComplete.name, () => {
     const updated = getUpdatedNodeExecutionStateOnInvocationComplete(
       buildNodeExecutionState({ status: zNodeStatus.enum.COMPLETED, progress: 1, outputs: [event.result] }),
       event,
-      new Set([`${event.item_id}:${event.invocation.id}`])
+      new Map([[event.item_id, new Set([event.invocation.id])]])
     );
 
     expect(updated).toBeUndefined();
@@ -224,17 +224,17 @@ describe(getUpdatedNodeExecutionStateOnInvocationComplete.name, () => {
       item_id: 2,
       result: { type: 'integer_output', value: 2 } as unknown as S['InvocationCompleteEvent']['result'],
     });
-    const completedInvocationKeys = new Set<string>();
+    const completedInvocationKeysByItemId = new Map<number, Set<string>>();
 
     const firstUpdate = getUpdatedNodeExecutionStateOnInvocationComplete(
       buildNodeExecutionState(),
       firstEvent,
-      completedInvocationKeys
+      completedInvocationKeysByItemId
     );
     const secondUpdate = getUpdatedNodeExecutionStateOnInvocationComplete(
       firstUpdate,
       secondEvent,
-      completedInvocationKeys
+      completedInvocationKeysByItemId
     );
 
     expect(secondUpdate?.outputs).toEqual([firstEvent.result, secondEvent.result]);

--- a/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
@@ -1,0 +1,73 @@
+import { deepClone } from 'common/util/deepClone';
+import type { NodeExecutionState } from 'features/nodes/types/invocation';
+import { zNodeStatus } from 'features/nodes/types/invocation';
+import type { S } from 'services/api/types';
+
+const getInvocationKey = (data: { item_id: number; invocation: { id: string } }) =>
+  `${data.item_id}:${data.invocation.id}`;
+
+export const getUpdatedNodeExecutionStateOnInvocationStarted = (
+  nodeExecutionState: NodeExecutionState | undefined,
+  data: S['InvocationStartedEvent'],
+  completedInvocationKeys: Set<string>
+) => {
+  if (!nodeExecutionState) {
+    return;
+  }
+
+  if (completedInvocationKeys.has(getInvocationKey(data))) {
+    return;
+  }
+
+  const _nodeExecutionState = deepClone(nodeExecutionState);
+  _nodeExecutionState.status = zNodeStatus.enum.IN_PROGRESS;
+
+  return _nodeExecutionState;
+};
+
+export const getUpdatedNodeExecutionStateOnInvocationProgress = (
+  nodeExecutionState: NodeExecutionState | undefined,
+  data: S['InvocationProgressEvent'],
+  completedInvocationKeys: Set<string>
+) => {
+  if (!nodeExecutionState) {
+    return;
+  }
+
+  if (completedInvocationKeys.has(getInvocationKey(data))) {
+    return;
+  }
+
+  const _nodeExecutionState = deepClone(nodeExecutionState);
+  _nodeExecutionState.status = zNodeStatus.enum.IN_PROGRESS;
+  _nodeExecutionState.progress = data.percentage ?? null;
+  _nodeExecutionState.progressImage = data.image ?? null;
+
+  return _nodeExecutionState;
+};
+
+export const getUpdatedNodeExecutionStateOnInvocationComplete = (
+  nodeExecutionState: NodeExecutionState | undefined,
+  data: S['InvocationCompleteEvent'],
+  completedInvocationKeys: Set<string>
+) => {
+  if (!nodeExecutionState) {
+    return;
+  }
+
+  const completedInvocationKey = getInvocationKey(data);
+
+  if (completedInvocationKeys.has(completedInvocationKey)) {
+    return;
+  }
+
+  const _nodeExecutionState = deepClone(nodeExecutionState);
+  _nodeExecutionState.status = zNodeStatus.enum.COMPLETED;
+  if (_nodeExecutionState.progress !== null) {
+    _nodeExecutionState.progress = 1;
+  }
+  _nodeExecutionState.outputs.push(data.result);
+  completedInvocationKeys.add(completedInvocationKey);
+
+  return _nodeExecutionState;
+};

--- a/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
@@ -2,9 +2,9 @@ import { deepClone } from 'common/util/deepClone';
 import type { NodeExecutionState } from 'features/nodes/types/invocation';
 import { zNodeStatus } from 'features/nodes/types/invocation';
 import type { S } from 'services/api/types';
+import { hasCompletedInvocationKey, markInvocationAsCompleted } from 'services/events/invocationTracking';
 
-const getInvocationKey = (data: { item_id: number; invocation: { id: string } }) =>
-  `${data.item_id}:${data.invocation.id}`;
+type CompletedInvocationKeysByItemId = Map<number, Set<string>>;
 
 const getInitialNodeExecutionState = (nodeId: string): NodeExecutionState => ({
   nodeId,
@@ -18,9 +18,9 @@ const getInitialNodeExecutionState = (nodeId: string): NodeExecutionState => ({
 export const getUpdatedNodeExecutionStateOnInvocationStarted = (
   nodeExecutionState: NodeExecutionState | undefined,
   data: S['InvocationStartedEvent'],
-  completedInvocationKeys: Set<string>
+  completedInvocationKeysByItemId: CompletedInvocationKeysByItemId
 ) => {
-  if (completedInvocationKeys.has(getInvocationKey(data))) {
+  if (hasCompletedInvocationKey(completedInvocationKeysByItemId, data.item_id, data.invocation.id)) {
     return;
   }
 
@@ -33,9 +33,9 @@ export const getUpdatedNodeExecutionStateOnInvocationStarted = (
 export const getUpdatedNodeExecutionStateOnInvocationProgress = (
   nodeExecutionState: NodeExecutionState | undefined,
   data: S['InvocationProgressEvent'],
-  completedInvocationKeys: Set<string>
+  completedInvocationKeysByItemId: CompletedInvocationKeysByItemId
 ) => {
-  if (completedInvocationKeys.has(getInvocationKey(data))) {
+  if (hasCompletedInvocationKey(completedInvocationKeysByItemId, data.item_id, data.invocation.id)) {
     return;
   }
 
@@ -50,11 +50,9 @@ export const getUpdatedNodeExecutionStateOnInvocationProgress = (
 export const getUpdatedNodeExecutionStateOnInvocationComplete = (
   nodeExecutionState: NodeExecutionState | undefined,
   data: S['InvocationCompleteEvent'],
-  completedInvocationKeys: Set<string>
+  completedInvocationKeysByItemId: CompletedInvocationKeysByItemId
 ) => {
-  const completedInvocationKey = getInvocationKey(data);
-
-  if (completedInvocationKeys.has(completedInvocationKey)) {
+  if (hasCompletedInvocationKey(completedInvocationKeysByItemId, data.item_id, data.invocation.id)) {
     return;
   }
 
@@ -64,7 +62,7 @@ export const getUpdatedNodeExecutionStateOnInvocationComplete = (
     _nodeExecutionState.progress = 1;
   }
   _nodeExecutionState.outputs.push(data.result);
-  completedInvocationKeys.add(completedInvocationKey);
+  markInvocationAsCompleted(completedInvocationKeysByItemId, data.item_id, data.invocation.id);
 
   return _nodeExecutionState;
 };

--- a/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
@@ -68,3 +68,20 @@ export const getUpdatedNodeExecutionStateOnInvocationComplete = (
 
   return _nodeExecutionState;
 };
+
+export const getUpdatedNodeExecutionStateOnInvocationError = (
+  nodeExecutionState: NodeExecutionState | undefined,
+  data: S['InvocationErrorEvent']
+) => {
+  const _nodeExecutionState = deepClone(nodeExecutionState ?? getInitialNodeExecutionState(data.invocation_source_id));
+  _nodeExecutionState.status = zNodeStatus.enum.FAILED;
+  _nodeExecutionState.progress = null;
+  _nodeExecutionState.progressImage = null;
+  _nodeExecutionState.error = {
+    error_type: data.error_type,
+    error_message: data.error_message,
+    error_traceback: data.error_traceback,
+  };
+
+  return _nodeExecutionState;
+};

--- a/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionState.ts
@@ -6,20 +6,25 @@ import type { S } from 'services/api/types';
 const getInvocationKey = (data: { item_id: number; invocation: { id: string } }) =>
   `${data.item_id}:${data.invocation.id}`;
 
+const getInitialNodeExecutionState = (nodeId: string): NodeExecutionState => ({
+  nodeId,
+  status: zNodeStatus.enum.PENDING,
+  progress: null,
+  progressImage: null,
+  outputs: [],
+  error: null,
+});
+
 export const getUpdatedNodeExecutionStateOnInvocationStarted = (
   nodeExecutionState: NodeExecutionState | undefined,
   data: S['InvocationStartedEvent'],
   completedInvocationKeys: Set<string>
 ) => {
-  if (!nodeExecutionState) {
-    return;
-  }
-
   if (completedInvocationKeys.has(getInvocationKey(data))) {
     return;
   }
 
-  const _nodeExecutionState = deepClone(nodeExecutionState);
+  const _nodeExecutionState = deepClone(nodeExecutionState ?? getInitialNodeExecutionState(data.invocation_source_id));
   _nodeExecutionState.status = zNodeStatus.enum.IN_PROGRESS;
 
   return _nodeExecutionState;
@@ -30,15 +35,11 @@ export const getUpdatedNodeExecutionStateOnInvocationProgress = (
   data: S['InvocationProgressEvent'],
   completedInvocationKeys: Set<string>
 ) => {
-  if (!nodeExecutionState) {
-    return;
-  }
-
   if (completedInvocationKeys.has(getInvocationKey(data))) {
     return;
   }
 
-  const _nodeExecutionState = deepClone(nodeExecutionState);
+  const _nodeExecutionState = deepClone(nodeExecutionState ?? getInitialNodeExecutionState(data.invocation_source_id));
   _nodeExecutionState.status = zNodeStatus.enum.IN_PROGRESS;
   _nodeExecutionState.progress = data.percentage ?? null;
   _nodeExecutionState.progressImage = data.image ?? null;
@@ -51,17 +52,13 @@ export const getUpdatedNodeExecutionStateOnInvocationComplete = (
   data: S['InvocationCompleteEvent'],
   completedInvocationKeys: Set<string>
 ) => {
-  if (!nodeExecutionState) {
-    return;
-  }
-
   const completedInvocationKey = getInvocationKey(data);
 
   if (completedInvocationKeys.has(completedInvocationKey)) {
     return;
   }
 
-  const _nodeExecutionState = deepClone(nodeExecutionState);
+  const _nodeExecutionState = deepClone(nodeExecutionState ?? getInitialNodeExecutionState(data.invocation_source_id));
   _nodeExecutionState.status = zNodeStatus.enum.COMPLETED;
   if (_nodeExecutionState.progress !== null) {
     _nodeExecutionState.progress = 1;

--- a/invokeai/frontend/web/src/services/events/nodeExecutionStateHelpers.test.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionStateHelpers.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getUpdatedNodeExecutionStateOnInvocationComplete,
+  getUpdatedNodeExecutionStateOnInvocationError,
   getUpdatedNodeExecutionStateOnInvocationProgress,
   getUpdatedNodeExecutionStateOnInvocationStarted,
 } from './nodeExecutionState';
@@ -86,6 +87,26 @@ const buildInvocationCompleteEvent = (
     },
     ...overrides,
   }) as S['InvocationCompleteEvent'];
+
+const buildInvocationErrorEvent = (overrides: Partial<S['InvocationErrorEvent']> = {}): S['InvocationErrorEvent'] =>
+  ({
+    queue_id: 'default',
+    item_id: 1,
+    batch_id: 'batch-1',
+    origin: 'workflows',
+    destination: 'gallery',
+    user_id: 'user-1',
+    session_id: 'session-1',
+    invocation_source_id: 'node-1',
+    invocation: {
+      id: 'prepared-node-1',
+      type: 'add',
+    },
+    error_type: 'TestError',
+    error_message: 'boom',
+    error_traceback: 'traceback',
+    ...overrides,
+  }) as S['InvocationErrorEvent'];
 
 describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
   it('creates an execution state when started arrives before initialization', () => {
@@ -217,5 +238,43 @@ describe(getUpdatedNodeExecutionStateOnInvocationComplete.name, () => {
     );
 
     expect(secondUpdate?.outputs).toEqual([firstEvent.result, secondEvent.result]);
+  });
+});
+
+describe(getUpdatedNodeExecutionStateOnInvocationError.name, () => {
+  it('creates an execution state when error arrives before initialization', () => {
+    const event = buildInvocationErrorEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationError(undefined, event);
+
+    expect(updated?.nodeId).toBe(event.invocation_source_id);
+    expect(updated?.status).toBe(zNodeStatus.enum.FAILED);
+    expect(updated?.progress).toBeNull();
+    expect(updated?.progressImage).toBeNull();
+    expect(updated?.error).toEqual({
+      error_type: event.error_type,
+      error_message: event.error_message,
+      error_traceback: event.error_traceback,
+    });
+  });
+
+  it('marks the node failed and records the error', () => {
+    const event = buildInvocationErrorEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationError(
+      buildNodeExecutionState({
+        status: zNodeStatus.enum.IN_PROGRESS,
+        progress: 0.5,
+        progressImage: { dataURL: 'data:image/png;base64,abc', width: 64, height: 64 },
+      }),
+      event
+    );
+
+    expect(updated?.status).toBe(zNodeStatus.enum.FAILED);
+    expect(updated?.progress).toBeNull();
+    expect(updated?.progressImage).toBeNull();
+    expect(updated?.error).toEqual({
+      error_type: event.error_type,
+      error_message: event.error_message,
+      error_traceback: event.error_traceback,
+    });
   });
 });

--- a/invokeai/frontend/web/src/services/events/nodeExecutionStateHelpers.test.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionStateHelpers.test.ts
@@ -88,6 +88,15 @@ const buildInvocationCompleteEvent = (
   }) as S['InvocationCompleteEvent'];
 
 describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
+  it('creates an execution state when started arrives before initialization', () => {
+    const event = buildInvocationStartedEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationStarted(undefined, event, new Set<string>());
+
+    expect(updated?.nodeId).toBe(event.invocation_source_id);
+    expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
+    expect(updated?.outputs).toEqual([]);
+  });
+
   it('marks the node in progress on invocation start', () => {
     const updated = getUpdatedNodeExecutionStateOnInvocationStarted(
       buildNodeExecutionState(),
@@ -111,6 +120,16 @@ describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
 });
 
 describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
+  it('creates an execution state when progress arrives before initialization', () => {
+    const event = buildInvocationProgressEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationProgress(undefined, event, new Set<string>());
+
+    expect(updated?.nodeId).toBe(event.invocation_source_id);
+    expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
+    expect(updated?.progress).toBe(event.percentage);
+    expect(updated?.progressImage).toEqual(event.image);
+  });
+
   it('marks the node in progress and preserves progress updates', () => {
     const event = buildInvocationProgressEvent();
     const updated = getUpdatedNodeExecutionStateOnInvocationProgress(
@@ -137,6 +156,17 @@ describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
 });
 
 describe(getUpdatedNodeExecutionStateOnInvocationComplete.name, () => {
+  it('creates an execution state when completion arrives before initialization', () => {
+    const event = buildInvocationCompleteEvent();
+    const completedInvocationKeys = new Set<string>();
+    const updated = getUpdatedNodeExecutionStateOnInvocationComplete(undefined, event, completedInvocationKeys);
+
+    expect(updated?.nodeId).toBe(event.invocation_source_id);
+    expect(updated?.status).toBe(zNodeStatus.enum.COMPLETED);
+    expect(updated?.outputs).toEqual([event.result]);
+    expect(completedInvocationKeys).toEqual(new Set([`${event.item_id}:${event.invocation.id}`]));
+  });
+
   it('records a completed invocation result once', () => {
     const event = buildInvocationCompleteEvent();
     const completedInvocationKeys = new Set<string>();

--- a/invokeai/frontend/web/src/services/events/nodeExecutionStateHelpers.test.ts
+++ b/invokeai/frontend/web/src/services/events/nodeExecutionStateHelpers.test.ts
@@ -1,0 +1,191 @@
+import type { NodeExecutionState } from 'features/nodes/types/invocation';
+import { zNodeStatus } from 'features/nodes/types/invocation';
+import type { S } from 'services/api/types';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getUpdatedNodeExecutionStateOnInvocationComplete,
+  getUpdatedNodeExecutionStateOnInvocationProgress,
+  getUpdatedNodeExecutionStateOnInvocationStarted,
+} from './nodeExecutionState';
+
+const buildNodeExecutionState = (overrides: Partial<NodeExecutionState> = {}): NodeExecutionState => ({
+  nodeId: 'node-1',
+  status: zNodeStatus.enum.PENDING,
+  progress: null,
+  progressImage: null,
+  outputs: [],
+  error: null,
+  ...overrides,
+});
+
+const buildInvocationStartedEvent = (
+  overrides: Partial<S['InvocationStartedEvent']> = {}
+): S['InvocationStartedEvent'] =>
+  ({
+    queue_id: 'default',
+    item_id: 1,
+    batch_id: 'batch-1',
+    origin: 'workflows',
+    destination: 'gallery',
+    user_id: 'user-1',
+    session_id: 'session-1',
+    invocation_source_id: 'node-1',
+    invocation: {
+      id: 'prepared-node-1',
+      type: 'add',
+    },
+    ...overrides,
+  }) as S['InvocationStartedEvent'];
+
+const buildInvocationProgressEvent = (
+  overrides: Partial<S['InvocationProgressEvent']> = {}
+): S['InvocationProgressEvent'] =>
+  ({
+    queue_id: 'default',
+    item_id: 1,
+    batch_id: 'batch-1',
+    origin: 'workflows',
+    destination: 'gallery',
+    user_id: 'user-1',
+    session_id: 'session-1',
+    invocation_source_id: 'node-1',
+    invocation: {
+      id: 'prepared-node-1',
+      type: 'add',
+    },
+    percentage: 0.42,
+    image: {
+      dataURL: 'data:image/png;base64,abc',
+      width: 64,
+      height: 64,
+    },
+    message: 'working',
+    ...overrides,
+  }) as S['InvocationProgressEvent'];
+
+const buildInvocationCompleteEvent = (
+  overrides: Partial<S['InvocationCompleteEvent']> = {}
+): S['InvocationCompleteEvent'] =>
+  ({
+    queue_id: 'default',
+    item_id: 1,
+    batch_id: 'batch-1',
+    origin: 'workflows',
+    destination: 'gallery',
+    user_id: 'user-1',
+    session_id: 'session-1',
+    invocation_source_id: 'node-1',
+    invocation: {
+      id: 'prepared-node-1',
+      type: 'add',
+    },
+    result: {
+      type: 'integer_output',
+      value: 42,
+    },
+    ...overrides,
+  }) as S['InvocationCompleteEvent'];
+
+describe(getUpdatedNodeExecutionStateOnInvocationStarted.name, () => {
+  it('marks the node in progress on invocation start', () => {
+    const updated = getUpdatedNodeExecutionStateOnInvocationStarted(
+      buildNodeExecutionState(),
+      buildInvocationStartedEvent(),
+      new Set<string>()
+    );
+
+    expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
+  });
+
+  it('ignores a late started event after that invocation already completed', () => {
+    const event = buildInvocationStartedEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationStarted(
+      buildNodeExecutionState({ status: zNodeStatus.enum.COMPLETED, progress: 1 }),
+      event,
+      new Set([`${event.item_id}:${event.invocation.id}`])
+    );
+
+    expect(updated).toBeUndefined();
+  });
+});
+
+describe(getUpdatedNodeExecutionStateOnInvocationProgress.name, () => {
+  it('marks the node in progress and preserves progress updates', () => {
+    const event = buildInvocationProgressEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationProgress(
+      buildNodeExecutionState(),
+      event,
+      new Set<string>()
+    );
+
+    expect(updated?.status).toBe(zNodeStatus.enum.IN_PROGRESS);
+    expect(updated?.progress).toBe(event.percentage);
+    expect(updated?.progressImage).toEqual(event.image);
+  });
+
+  it('ignores a late progress event after that invocation already completed', () => {
+    const event = buildInvocationProgressEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationProgress(
+      buildNodeExecutionState({ status: zNodeStatus.enum.COMPLETED, progress: 1 }),
+      event,
+      new Set([`${event.item_id}:${event.invocation.id}`])
+    );
+
+    expect(updated).toBeUndefined();
+  });
+});
+
+describe(getUpdatedNodeExecutionStateOnInvocationComplete.name, () => {
+  it('records a completed invocation result once', () => {
+    const event = buildInvocationCompleteEvent();
+    const completedInvocationKeys = new Set<string>();
+
+    const updated = getUpdatedNodeExecutionStateOnInvocationComplete(
+      buildNodeExecutionState({ status: zNodeStatus.enum.IN_PROGRESS, progress: 0.5 }),
+      event,
+      completedInvocationKeys
+    );
+
+    expect(updated?.status).toBe(zNodeStatus.enum.COMPLETED);
+    expect(updated?.progress).toBe(1);
+    expect(updated?.outputs).toEqual([event.result]);
+    expect(completedInvocationKeys).toEqual(new Set([`${event.item_id}:${event.invocation.id}`]));
+  });
+
+  it('ignores duplicate completion events for the same invocation', () => {
+    const event = buildInvocationCompleteEvent();
+    const updated = getUpdatedNodeExecutionStateOnInvocationComplete(
+      buildNodeExecutionState({ status: zNodeStatus.enum.COMPLETED, progress: 1, outputs: [event.result] }),
+      event,
+      new Set([`${event.item_id}:${event.invocation.id}`])
+    );
+
+    expect(updated).toBeUndefined();
+  });
+
+  it('allows the same prepared invocation id on a different queue item', () => {
+    const firstEvent = buildInvocationCompleteEvent({
+      item_id: 1,
+      result: { type: 'integer_output', value: 1 } as unknown as S['InvocationCompleteEvent']['result'],
+    });
+    const secondEvent = buildInvocationCompleteEvent({
+      item_id: 2,
+      result: { type: 'integer_output', value: 2 } as unknown as S['InvocationCompleteEvent']['result'],
+    });
+    const completedInvocationKeys = new Set<string>();
+
+    const firstUpdate = getUpdatedNodeExecutionStateOnInvocationComplete(
+      buildNodeExecutionState(),
+      firstEvent,
+      completedInvocationKeys
+    );
+    const secondUpdate = getUpdatedNodeExecutionStateOnInvocationComplete(
+      firstUpdate,
+      secondEvent,
+      completedInvocationKeys
+    );
+
+    expect(secondUpdate?.outputs).toEqual([firstEvent.result, secondEvent.result]);
+  });
+});

--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -1,6 +1,5 @@
 import { logger } from 'app/logging/logger';
 import type { AppDispatch, AppGetState } from 'app/store/store';
-import { deepClone } from 'common/util/deepClone';
 import { canvasWorkflowIntegrationProcessingCompleted } from 'features/controlLayers/store/canvasWorkflowIntegrationSlice';
 import {
   selectAutoSwitch,
@@ -12,8 +11,6 @@ import {
 import { boardIdSelected, galleryViewChanged, imageSelected } from 'features/gallery/store/gallerySlice';
 import { $nodeExecutionStates, upsertExecutionState } from 'features/nodes/hooks/useNodeExecutionState';
 import { isImageField, isImageFieldCollection } from 'features/nodes/types/common';
-import { zNodeStatus } from 'features/nodes/types/invocation';
-import type { LRUCache } from 'lru-cache';
 import { LIST_ALL_TAG } from 'services/api';
 import { boardsApi } from 'services/api/endpoints/boards';
 import { getImageDTOSafe, imagesApi } from 'services/api/endpoints/images';
@@ -21,6 +18,7 @@ import { queueApi } from 'services/api/endpoints/queue';
 import type { ImageDTO, S } from 'services/api/types';
 import { getCategories } from 'services/api/util';
 import { insertImageIntoNamesResult } from 'services/api/util/optimisticUpdates';
+import { getUpdatedNodeExecutionStateOnInvocationComplete } from 'services/events/nodeExecutionState';
 import { $lastProgressEvent } from 'services/events/stores';
 import stableHash from 'stable-hash';
 import type { Param0 } from 'tsafe';
@@ -38,13 +36,13 @@ const nodeTypeDenylist = ['load_image', 'image'];
  *
  * @param getState The Redux getState function.
  * @param dispatch The Redux dispatch function.
- * @param finishedQueueItemIds A cache of finished queue item IDs to prevent duplicate handling and avoid race
- * conditions that can happen when a graph finishes very quickly.
+ * @param completedInvocationKeys A listener-local set used to dedupe repeated invocation completion events and to
+ * share completion knowledge with the other invocation event handlers.
  */
 export const buildOnInvocationComplete = (
   getState: AppGetState,
   dispatch: AppDispatch,
-  finishedQueueItemIds: LRUCache<number, boolean>
+  completedInvocationKeys: Set<string>
 ) => {
   const addImagesToGallery = async (data: S['InvocationCompleteEvent']) => {
     if (nodeTypeDenylist.includes(data.invocation.type)) {
@@ -242,22 +240,24 @@ export const buildOnInvocationComplete = (
   };
 
   return async (data: S['InvocationCompleteEvent']) => {
-    if (finishedQueueItemIds.has(data.item_id)) {
-      log.trace({ data } as JsonObject, `Received event for already-finished queue item ${data.item_id}`);
-      return;
-    }
     log.debug({ data } as JsonObject, `Invocation complete (${data.invocation.type}, ${data.invocation_source_id})`);
 
     const nodeExecutionState = $nodeExecutionStates.get()[data.invocation_source_id];
+    const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationComplete(
+      nodeExecutionState,
+      data,
+      completedInvocationKeys
+    );
 
-    if (nodeExecutionState) {
-      const _nodeExecutionState = deepClone(nodeExecutionState);
-      _nodeExecutionState.status = zNodeStatus.enum.COMPLETED;
-      if (_nodeExecutionState.progress !== null) {
-        _nodeExecutionState.progress = 1;
-      }
-      _nodeExecutionState.outputs.push(data.result);
-      upsertExecutionState(_nodeExecutionState.nodeId, _nodeExecutionState);
+    if (nodeExecutionState && !updatedNodeExecutionState) {
+      log.trace(
+        { data } as JsonObject,
+        `Ignoring duplicate invocation complete (${data.invocation.type}, ${data.invocation_source_id})`
+      );
+    }
+
+    if (updatedNodeExecutionState) {
+      upsertExecutionState(updatedNodeExecutionState.nodeId, updatedNodeExecutionState);
     }
 
     // Clear canvas workflow integration processing state if needed

--- a/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
+++ b/invokeai/frontend/web/src/services/events/onInvocationComplete.tsx
@@ -36,13 +36,13 @@ const nodeTypeDenylist = ['load_image', 'image'];
  *
  * @param getState The Redux getState function.
  * @param dispatch The Redux dispatch function.
- * @param completedInvocationKeys A listener-local set used to dedupe repeated invocation completion events and to
- * share completion knowledge with the other invocation event handlers.
+ * @param completedInvocationKeysByItemId A listener-local map used to dedupe repeated invocation completion events
+ * and to share completion knowledge with the other invocation event handlers.
  */
 export const buildOnInvocationComplete = (
   getState: AppGetState,
   dispatch: AppDispatch,
-  completedInvocationKeys: Set<string>
+  completedInvocationKeysByItemId: Map<number, Set<string>>
 ) => {
   const addImagesToGallery = async (data: S['InvocationCompleteEvent']) => {
     if (nodeTypeDenylist.includes(data.invocation.type)) {
@@ -246,7 +246,7 @@ export const buildOnInvocationComplete = (
     const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationComplete(
       nodeExecutionState,
       data,
-      completedInvocationKeys
+      completedInvocationKeysByItemId
     );
 
     if (nodeExecutionState && !updatedNodeExecutionState) {

--- a/invokeai/frontend/web/src/services/events/setEventListeners.tsx
+++ b/invokeai/frontend/web/src/services/events/setEventListeners.tsx
@@ -38,6 +38,10 @@ import { imagesApi } from 'services/api/endpoints/images';
 import { modelsApi } from 'services/api/endpoints/models';
 import { queueApi } from 'services/api/endpoints/queue';
 import {
+  clearCompletedInvocationKeysForQueueItem,
+  shouldIgnoreFinishedQueueItemInvocationEvent,
+} from 'services/events/invocationTracking';
+import {
   getUpdatedNodeExecutionStateOnInvocationError,
   getUpdatedNodeExecutionStateOnInvocationProgress,
   getUpdatedNodeExecutionStateOnInvocationStarted,
@@ -70,7 +74,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
   // We can have race conditions where we receive a progress event for a queue item that has already finished. Easiest
   // way to handle this is to keep track of finished queue items in a cache and ignore progress events for those.
   const finishedQueueItemIds = new LRUCache<number, boolean>({ max: 100 });
-  const completedInvocationKeys = new Set<string>();
+  const completedInvocationKeysByItemId = new Map<number, Set<string>>();
 
   socket.on('connect', () => {
     log.debug('Connected');
@@ -108,7 +112,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
   });
 
   socket.on('invocation_started', (data) => {
-    if (finishedQueueItemIds.has(data.item_id)) {
+    if (shouldIgnoreFinishedQueueItemInvocationEvent('invocation_started', finishedQueueItemIds, data.item_id)) {
       return;
     }
     const { invocation_source_id, invocation } = data;
@@ -117,7 +121,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationStarted(
       nes,
       data,
-      completedInvocationKeys
+      completedInvocationKeysByItemId
     );
     if (updatedNodeExecutionState) {
       upsertExecutionState(updatedNodeExecutionState.nodeId, updatedNodeExecutionState);
@@ -125,7 +129,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
   });
 
   socket.on('invocation_progress', (data) => {
-    if (finishedQueueItemIds.has(data.item_id)) {
+    if (shouldIgnoreFinishedQueueItemInvocationEvent('invocation_progress', finishedQueueItemIds, data.item_id)) {
       log.trace({ data } as JsonObject, `Received event for already-finished queue item ${data.item_id}`);
       return;
     }
@@ -149,7 +153,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
       const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationProgress(
         nes,
         data,
-        completedInvocationKeys
+        completedInvocationKeysByItemId
       );
       if (updatedNodeExecutionState) {
         upsertExecutionState(updatedNodeExecutionState.nodeId, updatedNodeExecutionState);
@@ -158,10 +162,6 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
   });
 
   socket.on('invocation_error', (data) => {
-    if (finishedQueueItemIds.has(data.item_id)) {
-      log.trace({ data } as JsonObject, `Received event for already-finished queue item ${data.item_id}`);
-      return;
-    }
     const { invocation_source_id, invocation } = data;
     log.error({ data } as JsonObject, `Invocation error (${invocation.type}, ${invocation_source_id})`);
     const nes = $nodeExecutionStates.get()[invocation_source_id];
@@ -175,7 +175,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     }
   });
 
-  const onInvocationComplete = buildOnInvocationComplete(getState, dispatch, completedInvocationKeys);
+  const onInvocationComplete = buildOnInvocationComplete(getState, dispatch, completedInvocationKeysByItemId);
   socket.on('invocation_complete', onInvocationComplete);
 
   socket.on('model_load_started', (data) => {
@@ -477,6 +477,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
       });
     } else if (status === 'completed' || status === 'failed' || status === 'canceled') {
       finishedQueueItemIds.set(item_id, true);
+      clearCompletedInvocationKeysForQueueItem(completedInvocationKeysByItemId, item_id);
       if (status === 'failed' && error_type) {
         toast({
           id: `INVOCATION_ERROR_${error_type}`,

--- a/invokeai/frontend/web/src/services/events/setEventListeners.tsx
+++ b/invokeai/frontend/web/src/services/events/setEventListeners.tsx
@@ -38,6 +38,7 @@ import { imagesApi } from 'services/api/endpoints/images';
 import { modelsApi } from 'services/api/endpoints/models';
 import { queueApi } from 'services/api/endpoints/queue';
 import {
+  getUpdatedNodeExecutionStateOnInvocationError,
   getUpdatedNodeExecutionStateOnInvocationProgress,
   getUpdatedNodeExecutionStateOnInvocationStarted,
 } from 'services/events/nodeExecutionState';
@@ -161,19 +162,12 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
       log.trace({ data } as JsonObject, `Received event for already-finished queue item ${data.item_id}`);
       return;
     }
-    const { invocation_source_id, invocation, error_type, error_message, error_traceback } = data;
+    const { invocation_source_id, invocation } = data;
     log.error({ data } as JsonObject, `Invocation error (${invocation.type}, ${invocation_source_id})`);
-    const nes = deepClone($nodeExecutionStates.get()[invocation_source_id]);
-    if (nes) {
-      nes.status = zNodeStatus.enum.FAILED;
-      nes.progress = null;
-      nes.progressImage = null;
-      nes.error = {
-        error_type,
-        error_message,
-        error_traceback,
-      };
-      upsertExecutionState(nes.nodeId, nes);
+    const nes = $nodeExecutionStates.get()[invocation_source_id];
+    const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationError(nes, data);
+    if (updatedNodeExecutionState) {
+      upsertExecutionState(updatedNodeExecutionState.nodeId, updatedNodeExecutionState);
     }
     // Clear canvas workflow integration processing state on error
     if (data.origin === 'canvas_workflow_integration') {

--- a/invokeai/frontend/web/src/services/events/setEventListeners.tsx
+++ b/invokeai/frontend/web/src/services/events/setEventListeners.tsx
@@ -37,6 +37,10 @@ import { api, LIST_ALL_TAG, LIST_TAG } from 'services/api';
 import { imagesApi } from 'services/api/endpoints/images';
 import { modelsApi } from 'services/api/endpoints/models';
 import { queueApi } from 'services/api/endpoints/queue';
+import {
+  getUpdatedNodeExecutionStateOnInvocationProgress,
+  getUpdatedNodeExecutionStateOnInvocationStarted,
+} from 'services/events/nodeExecutionState';
 import { buildOnInvocationComplete } from 'services/events/onInvocationComplete';
 import { buildOnModelInstallError, DiscordLink, GitHubIssuesLink } from 'services/events/onModelInstallError';
 import type { ClientToServerEvents, ServerToClientEvents } from 'services/events/types';
@@ -65,6 +69,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
   // We can have race conditions where we receive a progress event for a queue item that has already finished. Easiest
   // way to handle this is to keep track of finished queue items in a cache and ignore progress events for those.
   const finishedQueueItemIds = new LRUCache<number, boolean>({ max: 100 });
+  const completedInvocationKeys = new Set<string>();
 
   socket.on('connect', () => {
     log.debug('Connected');
@@ -107,10 +112,14 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     }
     const { invocation_source_id, invocation } = data;
     log.debug({ data } as JsonObject, `Invocation started (${invocation.type}, ${invocation_source_id})`);
-    const nes = deepClone($nodeExecutionStates.get()[invocation_source_id]);
-    if (nes) {
-      nes.status = zNodeStatus.enum.IN_PROGRESS;
-      upsertExecutionState(nes.nodeId, nes);
+    const nes = $nodeExecutionStates.get()[invocation_source_id];
+    const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationStarted(
+      nes,
+      data,
+      completedInvocationKeys
+    );
+    if (updatedNodeExecutionState) {
+      upsertExecutionState(updatedNodeExecutionState.nodeId, updatedNodeExecutionState);
     }
   });
 
@@ -119,7 +128,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
       log.trace({ data } as JsonObject, `Received event for already-finished queue item ${data.item_id}`);
       return;
     }
-    const { invocation_source_id, invocation, image, origin, percentage, message } = data;
+    const { invocation_source_id, invocation, origin, percentage, message } = data;
 
     let _message = 'Invocation progress';
     if (message) {
@@ -135,12 +144,14 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     $lastProgressEvent.set(data);
 
     if (origin === 'workflows') {
-      const nes = deepClone($nodeExecutionStates.get()[invocation_source_id]);
-      if (nes) {
-        nes.status = zNodeStatus.enum.IN_PROGRESS;
-        nes.progress = percentage;
-        nes.progressImage = image ?? null;
-        upsertExecutionState(nes.nodeId, nes);
+      const nes = $nodeExecutionStates.get()[invocation_source_id];
+      const updatedNodeExecutionState = getUpdatedNodeExecutionStateOnInvocationProgress(
+        nes,
+        data,
+        completedInvocationKeys
+      );
+      if (updatedNodeExecutionState) {
+        upsertExecutionState(updatedNodeExecutionState.nodeId, updatedNodeExecutionState);
       }
     }
   });
@@ -170,7 +181,7 @@ export const setEventListeners = ({ socket, store, setIsConnected }: SetEventLis
     }
   });
 
-  const onInvocationComplete = buildOnInvocationComplete(getState, dispatch, finishedQueueItemIds);
+  const onInvocationComplete = buildOnInvocationComplete(getState, dispatch, completedInvocationKeys);
   socket.on('invocation_complete', onInvocationComplete);
 
   socket.on('model_load_started', (data) => {


### PR DESCRIPTION
## Summary

Fixes workflow node execution state updates in the frontend event layer.

This change fixes nodes getting stuck in `IN_PROGRESS` or showing duplicate outputs when socket events arrive out of order or are repeated. The fix moves the event-ordering logic into shared helpers and uses a listener-local completed-invocation key set so late `invocation_started` / `invocation_progress` events cannot overwrite a completed node state.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

1. On `main`, run a workflow in the Workflow Editor and examine the Outputs pane for a node that executes. You should see two outputs even when the node is executed once.
2. After pulling and building (or running in dev mode), open the Workflow Editor and run a workflow with visible node progress.
    - Confirm nodes transition from pending to in progress to completed.
    - Confirm completed nodes do not revert back to in progress during or after the run.
    - Confirm the Outputs pane does not show duplicate outputs for a single node execution.
3. Execute `pnpm vitest run` to run regression tests.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
