### PR TITLE
Feat(canvas): Add hotkey for Merge Down and Merge Visible layers

### DIFF
--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -771,7 +771,7 @@
                 "desc": "Reset the selected layer. Only applies to Inpaint Mask and Regional Guidance."
             },
             "mergeDown": {
-                "title": "Merge Down",
+                "title": "Merge Layer Down",
                 "desc": "Merge the selected layer into the layer directly below it."
             },
             "mergeVisible": {

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -770,6 +770,14 @@
                 "title": "Reset Layer",
                 "desc": "Reset the selected layer. Only applies to Inpaint Mask and Regional Guidance."
             },
+            "mergeDown": {
+                "title": "Merge Down",
+                "desc": "Merge the selected layer into the layer directly below it."
+            },
+            "mergeVisible": {
+                "title": "Merge All Visible Layers",
+                "desc": "Merge all visible layers of the selected layer type."
+            },
             "undo": {
                 "title": "Undo",
                 "desc": "Undo the last canvas action."

--- a/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbar.tsx
+++ b/invokeai/frontend/web/src/features/controlLayers/components/Toolbar/CanvasToolbar.tsx
@@ -22,6 +22,8 @@ import { useCanvasDeleteLayerHotkey } from 'features/controlLayers/hooks/useCanv
 import { useCanvasEntityQuickSwitchHotkey } from 'features/controlLayers/hooks/useCanvasEntityQuickSwitchHotkey';
 import { useCanvasFilterHotkey } from 'features/controlLayers/hooks/useCanvasFilterHotkey';
 import { useCanvasInvertMaskHotkey } from 'features/controlLayers/hooks/useCanvasInvertMaskHotkey';
+import { useCanvasMergeDownHotkey } from 'features/controlLayers/hooks/useCanvasMergeDownHotkey';
+import { useCanvasMergeVisibleHotkey } from 'features/controlLayers/hooks/useCanvasMergeVisibleHotkey';
 import { useCanvasResetLayerHotkey } from 'features/controlLayers/hooks/useCanvasResetLayerHotkey';
 import { useCanvasToggleBboxHotkey } from 'features/controlLayers/hooks/useCanvasToggleBboxHotkey';
 import { useCanvasToggleNonRasterLayersHotkey } from 'features/controlLayers/hooks/useCanvasToggleNonRasterLayersHotkey';
@@ -42,6 +44,8 @@ export const CanvasToolbar = memo(() => {
 
   useCanvasResetLayerHotkey();
   useCanvasDeleteLayerHotkey();
+  useCanvasMergeDownHotkey();
+  useCanvasMergeVisibleHotkey();
   useCanvasUndoRedoHotkeys();
   useCanvasEntityQuickSwitchHotkey();
   useNextPrevEntityHotkeys();

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/canvasMergeHotkeyUtils.test.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/canvasMergeHotkeyUtils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { getIsCanvasMergeDownHotkeyEnabled, getIsCanvasMergeVisibleHotkeyEnabled } from './canvasMergeHotkeyUtils';
+
+describe('canvas merge hotkey gating', () => {
+  const selectedEntityIdentifier = { id: 'selected', type: 'raster_layer' } as const;
+  const entityIdentifierBelowThisOne = { id: 'below', type: 'raster_layer' } as const;
+
+  describe('getIsCanvasMergeDownHotkeyEnabled', () => {
+    it('returns false when nothing is selected', () => {
+      expect(getIsCanvasMergeDownHotkeyEnabled(null, entityIdentifierBelowThisOne, false)).toBe(false);
+    });
+
+    it('returns false when there is no entity below the selection', () => {
+      expect(getIsCanvasMergeDownHotkeyEnabled(selectedEntityIdentifier, null, false)).toBe(false);
+    });
+
+    it('returns false when the canvas is busy', () => {
+      expect(getIsCanvasMergeDownHotkeyEnabled(selectedEntityIdentifier, entityIdentifierBelowThisOne, true)).toBe(
+        false
+      );
+    });
+
+    it('returns true when the selection can be merged down', () => {
+      expect(getIsCanvasMergeDownHotkeyEnabled(selectedEntityIdentifier, entityIdentifierBelowThisOne, false)).toBe(
+        true
+      );
+    });
+  });
+
+  describe('getIsCanvasMergeVisibleHotkeyEnabled', () => {
+    it('returns false when nothing is selected', () => {
+      expect(getIsCanvasMergeVisibleHotkeyEnabled(null, 2, false)).toBe(false);
+    });
+
+    it('returns false when there are not enough visible entities', () => {
+      expect(getIsCanvasMergeVisibleHotkeyEnabled(selectedEntityIdentifier, 1, false)).toBe(false);
+    });
+
+    it('returns false when the canvas is busy', () => {
+      expect(getIsCanvasMergeVisibleHotkeyEnabled(selectedEntityIdentifier, 2, true)).toBe(false);
+    });
+
+    it('returns true when visible entities can be merged', () => {
+      expect(getIsCanvasMergeVisibleHotkeyEnabled(selectedEntityIdentifier, 2, false)).toBe(true);
+    });
+  });
+});

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/canvasMergeHotkeyUtils.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/canvasMergeHotkeyUtils.ts
@@ -1,0 +1,32 @@
+import type { CanvasEntityIdentifier } from 'features/controlLayers/store/types';
+
+export const getIsCanvasMergeDownHotkeyEnabled = (
+  selectedEntityIdentifier: CanvasEntityIdentifier | null,
+  entityIdentifierBelowThisOne: CanvasEntityIdentifier | null,
+  isBusy: boolean
+): boolean => {
+  if (!selectedEntityIdentifier || !entityIdentifierBelowThisOne) {
+    return false;
+  }
+  if (isBusy) {
+    return false;
+  }
+  return true;
+};
+
+export const getIsCanvasMergeVisibleHotkeyEnabled = (
+  selectedEntityIdentifier: CanvasEntityIdentifier | null,
+  visibleEntityCount: number,
+  isBusy: boolean
+): boolean => {
+  if (!selectedEntityIdentifier) {
+    return false;
+  }
+  if (visibleEntityCount <= 1) {
+    return false;
+  }
+  if (isBusy) {
+    return false;
+  }
+  return true;
+};

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeDownHotkey.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeDownHotkey.ts
@@ -1,0 +1,41 @@
+import { useAppSelector } from 'app/store/storeHooks';
+import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
+import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
+import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
+import { useEntityIdentifierBelowThisOne } from 'features/controlLayers/hooks/useNextRenderableEntityIdentifier';
+import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
+import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/useHotkeyData';
+import { useCallback, useMemo } from 'react';
+
+export const useCanvasMergeDownHotkey = () => {
+  useAssertSingleton(useCanvasMergeDownHotkey.name);
+  const canvasManager = useCanvasManager();
+  const selectedEntityIdentifier = useAppSelector(selectSelectedEntityIdentifier);
+  const entityIdentifierBelowThisOne = useEntityIdentifierBelowThisOne(selectedEntityIdentifier);
+  const isBusy = useCanvasIsBusy();
+
+  const mergeDown = useCallback(() => {
+    if (!selectedEntityIdentifier || !entityIdentifierBelowThisOne) {
+      return;
+    }
+    canvasManager.compositor.mergeByEntityIdentifiers([entityIdentifierBelowThisOne, selectedEntityIdentifier], true);
+  }, [canvasManager.compositor, entityIdentifierBelowThisOne, selectedEntityIdentifier]);
+
+  const isEnabled = useMemo(() => {
+    if (!selectedEntityIdentifier || !entityIdentifierBelowThisOne) {
+      return false;
+    }
+    if (isBusy) {
+      return false;
+    }
+    return true;
+  }, [entityIdentifierBelowThisOne, isBusy, selectedEntityIdentifier]);
+
+  useRegisteredHotkeys({
+    id: 'mergeDown',
+    category: 'canvas',
+    callback: mergeDown,
+    options: { enabled: isEnabled, preventDefault: true },
+    dependencies: [isEnabled, mergeDown],
+  });
+};

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeDownHotkey.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeDownHotkey.ts
@@ -1,11 +1,12 @@
 import { useAppSelector } from 'app/store/storeHooks';
 import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
 import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
+import { getIsCanvasMergeDownHotkeyEnabled } from 'features/controlLayers/hooks/canvasMergeHotkeyUtils';
 import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useEntityIdentifierBelowThisOne } from 'features/controlLayers/hooks/useNextRenderableEntityIdentifier';
 import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
 import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/useHotkeyData';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 export const useCanvasMergeDownHotkey = () => {
   useAssertSingleton(useCanvasMergeDownHotkey.name);
@@ -13,23 +14,24 @@ export const useCanvasMergeDownHotkey = () => {
   const selectedEntityIdentifier = useAppSelector(selectSelectedEntityIdentifier);
   const entityIdentifierBelowThisOne = useEntityIdentifierBelowThisOne(selectedEntityIdentifier);
   const isBusy = useCanvasIsBusy();
+  const isMergeInFlightRef = useRef(false);
 
   const mergeDown = useCallback(() => {
-    if (!selectedEntityIdentifier || !entityIdentifierBelowThisOne) {
+    if (!selectedEntityIdentifier || !entityIdentifierBelowThisOne || isMergeInFlightRef.current) {
       return;
     }
-    canvasManager.compositor.mergeByEntityIdentifiers([entityIdentifierBelowThisOne, selectedEntityIdentifier], true);
+    isMergeInFlightRef.current = true;
+    void canvasManager.compositor
+      .mergeByEntityIdentifiers([entityIdentifierBelowThisOne, selectedEntityIdentifier], true)
+      .finally(() => {
+        isMergeInFlightRef.current = false;
+      });
   }, [canvasManager.compositor, entityIdentifierBelowThisOne, selectedEntityIdentifier]);
 
-  const isEnabled = useMemo(() => {
-    if (!selectedEntityIdentifier || !entityIdentifierBelowThisOne) {
-      return false;
-    }
-    if (isBusy) {
-      return false;
-    }
-    return true;
-  }, [entityIdentifierBelowThisOne, isBusy, selectedEntityIdentifier]);
+  const isEnabled = useMemo(
+    () => getIsCanvasMergeDownHotkeyEnabled(selectedEntityIdentifier, entityIdentifierBelowThisOne, isBusy),
+    [entityIdentifierBelowThisOne, isBusy, selectedEntityIdentifier]
+  );
 
   useRegisteredHotkeys({
     id: 'mergeDown',

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeVisibleHotkey.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeVisibleHotkey.ts
@@ -1,11 +1,12 @@
 import { useAppSelector } from 'app/store/storeHooks';
 import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
 import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
+import { getIsCanvasMergeVisibleHotkeyEnabled } from 'features/controlLayers/hooks/canvasMergeHotkeyUtils';
 import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
 import { useVisibleEntityCountByType } from 'features/controlLayers/hooks/useVisibleEntityCountByType';
 import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
 import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/useHotkeyData';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 export const useCanvasMergeVisibleHotkey = () => {
   useAssertSingleton(useCanvasMergeVisibleHotkey.name);
@@ -13,26 +14,22 @@ export const useCanvasMergeVisibleHotkey = () => {
   const selectedEntityIdentifier = useAppSelector(selectSelectedEntityIdentifier);
   const isBusy = useCanvasIsBusy();
   const visibleEntityCount = useVisibleEntityCountByType(selectedEntityIdentifier?.type ?? 'raster_layer');
+  const isMergeInFlightRef = useRef(false);
 
   const mergeVisible = useCallback(() => {
-    if (!selectedEntityIdentifier) {
+    if (!selectedEntityIdentifier || isMergeInFlightRef.current) {
       return;
     }
-    canvasManager.compositor.mergeVisibleOfType(selectedEntityIdentifier.type);
+    isMergeInFlightRef.current = true;
+    void canvasManager.compositor.mergeVisibleOfType(selectedEntityIdentifier.type).finally(() => {
+      isMergeInFlightRef.current = false;
+    });
   }, [canvasManager.compositor, selectedEntityIdentifier]);
 
-  const isEnabled = useMemo(() => {
-    if (!selectedEntityIdentifier) {
-      return false;
-    }
-    if (visibleEntityCount <= 1) {
-      return false;
-    }
-    if (isBusy) {
-      return false;
-    }
-    return true;
-  }, [isBusy, selectedEntityIdentifier, visibleEntityCount]);
+  const isEnabled = useMemo(
+    () => getIsCanvasMergeVisibleHotkeyEnabled(selectedEntityIdentifier, visibleEntityCount, isBusy),
+    [isBusy, selectedEntityIdentifier, visibleEntityCount]
+  );
 
   useRegisteredHotkeys({
     id: 'mergeVisible',

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeVisibleHotkey.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useCanvasMergeVisibleHotkey.ts
@@ -1,0 +1,44 @@
+import { useAppSelector } from 'app/store/storeHooks';
+import { useAssertSingleton } from 'common/hooks/useAssertSingleton';
+import { useCanvasManager } from 'features/controlLayers/contexts/CanvasManagerProviderGate';
+import { useCanvasIsBusy } from 'features/controlLayers/hooks/useCanvasIsBusy';
+import { useVisibleEntityCountByType } from 'features/controlLayers/hooks/useVisibleEntityCountByType';
+import { selectSelectedEntityIdentifier } from 'features/controlLayers/store/selectors';
+import { useRegisteredHotkeys } from 'features/system/components/HotkeysModal/useHotkeyData';
+import { useCallback, useMemo } from 'react';
+
+export const useCanvasMergeVisibleHotkey = () => {
+  useAssertSingleton(useCanvasMergeVisibleHotkey.name);
+  const canvasManager = useCanvasManager();
+  const selectedEntityIdentifier = useAppSelector(selectSelectedEntityIdentifier);
+  const isBusy = useCanvasIsBusy();
+  const visibleEntityCount = useVisibleEntityCountByType(selectedEntityIdentifier?.type ?? 'raster_layer');
+
+  const mergeVisible = useCallback(() => {
+    if (!selectedEntityIdentifier) {
+      return;
+    }
+    canvasManager.compositor.mergeVisibleOfType(selectedEntityIdentifier.type);
+  }, [canvasManager.compositor, selectedEntityIdentifier]);
+
+  const isEnabled = useMemo(() => {
+    if (!selectedEntityIdentifier) {
+      return false;
+    }
+    if (visibleEntityCount <= 1) {
+      return false;
+    }
+    if (isBusy) {
+      return false;
+    }
+    return true;
+  }, [isBusy, selectedEntityIdentifier, visibleEntityCount]);
+
+  useRegisteredHotkeys({
+    id: 'mergeVisible',
+    category: 'canvas',
+    callback: mergeVisible,
+    options: { enabled: isEnabled, preventDefault: true },
+    dependencies: [isEnabled, mergeVisible],
+  });
+};

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useNextRenderableEntityIdentifier.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useNextRenderableEntityIdentifier.ts
@@ -5,7 +5,9 @@ import type { CanvasEntityIdentifier } from 'features/controlLayers/store/types'
 import { getEntityIdentifier } from 'features/controlLayers/store/types';
 import { useMemo } from 'react';
 
-export const useEntityIdentifierBelowThisOne = <T extends CanvasEntityIdentifier>(entityIdentifier: T | null): T | null => {
+export const useEntityIdentifierBelowThisOne = <T extends CanvasEntityIdentifier>(
+  entityIdentifier: T | null
+): T | null => {
   const selector = useMemo(
     () =>
       createMemoizedSelector(selectCanvasSlice, (canvas) => {

--- a/invokeai/frontend/web/src/features/controlLayers/hooks/useNextRenderableEntityIdentifier.ts
+++ b/invokeai/frontend/web/src/features/controlLayers/hooks/useNextRenderableEntityIdentifier.ts
@@ -5,10 +5,13 @@ import type { CanvasEntityIdentifier } from 'features/controlLayers/store/types'
 import { getEntityIdentifier } from 'features/controlLayers/store/types';
 import { useMemo } from 'react';
 
-export const useEntityIdentifierBelowThisOne = <T extends CanvasEntityIdentifier>(entityIdentifier: T): T | null => {
+export const useEntityIdentifierBelowThisOne = <T extends CanvasEntityIdentifier>(entityIdentifier: T | null): T | null => {
   const selector = useMemo(
     () =>
       createMemoizedSelector(selectCanvasSlice, (canvas) => {
+        if (entityIdentifier === null) {
+          return null;
+        }
         const nextEntity = selectEntityIdentifierBelowThisOne(canvas, entityIdentifier);
         if (!nextEntity) {
           return null;

--- a/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.test.ts
+++ b/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHotkeysData } from './useHotkeyData';
+
+describe('buildHotkeysData', () => {
+  const t = (key: string) => key;
+
+  it('registers default merge hotkeys for canvas layers', () => {
+    const hotkeysData = buildHotkeysData(t, {});
+    const mergeDown = hotkeysData.canvas.hotkeys.mergeDown;
+    const mergeVisible = hotkeysData.canvas.hotkeys.mergeVisible;
+
+    expect(mergeDown).toBeDefined();
+    expect(mergeVisible).toBeDefined();
+    if (!mergeDown || !mergeVisible) {
+      throw new Error('Expected merge hotkeys to be registered');
+    }
+
+    expect(mergeDown.defaultHotkeys).toEqual(['mod+e']);
+    expect(mergeDown.hotkeys).toEqual(['mod+e']);
+    expect(mergeVisible.defaultHotkeys).toEqual(['mod+shift+e']);
+    expect(mergeVisible.hotkeys).toEqual(['mod+shift+e']);
+  });
+
+  it('applies custom hotkey overrides to merge actions', () => {
+    const hotkeysData = buildHotkeysData(t, {
+      'canvas.mergeDown': ['alt+m'],
+      'canvas.mergeVisible': ['alt+shift+m'],
+    });
+    const mergeDown = hotkeysData.canvas.hotkeys.mergeDown;
+    const mergeVisible = hotkeysData.canvas.hotkeys.mergeVisible;
+
+    expect(mergeDown).toBeDefined();
+    expect(mergeVisible).toBeDefined();
+    if (!mergeDown || !mergeVisible) {
+      throw new Error('Expected merge hotkeys to be registered');
+    }
+
+    expect(mergeDown.defaultHotkeys).toEqual(['mod+e']);
+    expect(mergeDown.hotkeys).toEqual(['alt+m']);
+    expect(mergeVisible.defaultHotkeys).toEqual(['mod+shift+e']);
+    expect(mergeVisible.hotkeys).toEqual(['alt+shift+m']);
+  });
+});

--- a/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
+++ b/invokeai/frontend/web/src/features/system/components/HotkeysModal/useHotkeyData.ts
@@ -33,6 +33,8 @@ export type Hotkey = {
 type HotkeyCategoryData = { title: string; hotkeys: Record<string, Hotkey> };
 
 type HotkeysData = Record<HotkeyCategory, HotkeyCategoryData>;
+type HotkeyTranslator = (key: string) => string;
+type CustomHotkeys = Record<string, string[]>;
 
 const formatKeysForPlatform = (keys: string[]): string[][] => {
   return keys.map((k) => {
@@ -44,150 +46,154 @@ const formatKeysForPlatform = (keys: string[]): string[][] => {
   });
 };
 
+export const buildHotkeysData = (t: HotkeyTranslator, customHotkeys: CustomHotkeys): HotkeysData => {
+  const data: HotkeysData = {
+    app: {
+      title: t('hotkeys.app.title'),
+      hotkeys: {},
+    },
+    canvas: {
+      title: t('hotkeys.canvas.title'),
+      hotkeys: {},
+    },
+    viewer: {
+      title: t('hotkeys.viewer.title'),
+      hotkeys: {},
+    },
+    gallery: {
+      title: t('hotkeys.gallery.title'),
+      hotkeys: {},
+    },
+    workflows: {
+      title: t('hotkeys.workflows.title'),
+      hotkeys: {},
+    },
+  };
+
+  const addHotkey = (category: HotkeyCategory, id: string, keys: string[], isEnabled: boolean = true) => {
+    const hotkeyId = `${category}.${id}`;
+    const effectiveKeys = customHotkeys[hotkeyId] ?? keys;
+    data[category].hotkeys[id] = {
+      id,
+      category,
+      title: t(`hotkeys.${category}.${id}.title`),
+      desc: t(`hotkeys.${category}.${id}.desc`),
+      hotkeys: effectiveKeys,
+      defaultHotkeys: keys,
+      platformKeys: formatKeysForPlatform(effectiveKeys),
+      isEnabled,
+    };
+  };
+
+  addHotkey('app', 'invoke', ['mod+enter']);
+  addHotkey('app', 'invokeFront', ['mod+shift+enter']);
+  addHotkey('app', 'cancelQueueItem', ['shift+x']);
+  addHotkey('app', 'clearQueue', ['mod+shift+x']);
+  addHotkey('app', 'selectGenerateTab', ['1']);
+  addHotkey('app', 'selectCanvasTab', ['2']);
+  addHotkey('app', 'selectUpscalingTab', ['3']);
+  addHotkey('app', 'selectWorkflowsTab', ['4']);
+  addHotkey('app', 'selectModelsTab', ['5']);
+  addHotkey('app', 'selectQueueTab', ['6']);
+
+  // Prompt/history navigation (when prompt textarea is focused)
+  addHotkey('app', 'promptHistoryPrev', ['alt+arrowup']);
+  addHotkey('app', 'promptHistoryNext', ['alt+arrowdown']);
+  addHotkey('app', 'promptWeightUp', ['ctrl+arrowup']);
+  addHotkey('app', 'promptWeightDown', ['ctrl+arrowdown']);
+
+  addHotkey('app', 'focusPrompt', ['alt+a']);
+  addHotkey('app', 'toggleLeftPanel', ['t', 'o']);
+  addHotkey('app', 'toggleRightPanel', ['g']);
+  addHotkey('app', 'resetPanelLayout', ['shift+r']);
+  addHotkey('app', 'togglePanels', ['f']);
+
+  // Canvas
+  addHotkey('canvas', 'selectBrushTool', ['b']);
+  addHotkey('canvas', 'selectBboxTool', ['c']);
+  addHotkey('canvas', 'decrementToolWidth', ['[']);
+  addHotkey('canvas', 'incrementToolWidth', [']']);
+  addHotkey('canvas', 'selectEraserTool', ['e']);
+  addHotkey('canvas', 'selectMoveTool', ['v']);
+  addHotkey('canvas', 'selectRectTool', ['u']);
+  addHotkey('canvas', 'selectLassoTool', ['l']);
+  addHotkey('canvas', 'selectViewTool', ['h']);
+  addHotkey('canvas', 'selectColorPickerTool', ['i']);
+  addHotkey('canvas', 'setFillColorsToDefault', ['d']);
+  addHotkey('canvas', 'toggleFillColor', ['x']);
+  addHotkey('canvas', 'fitLayersToCanvas', ['mod+0']);
+  addHotkey('canvas', 'fitBboxToCanvas', ['mod+shift+0']);
+  addHotkey('canvas', 'fitBboxToLayers', ['shift+n']);
+  addHotkey('canvas', 'setZoomTo100Percent', ['mod+1']);
+  addHotkey('canvas', 'setZoomTo200Percent', ['mod+2']);
+  addHotkey('canvas', 'setZoomTo400Percent', ['mod+3']);
+  addHotkey('canvas', 'setZoomTo800Percent', ['mod+4']);
+  addHotkey('canvas', 'quickSwitch', ['q']);
+  addHotkey('canvas', 'deleteSelected', ['delete', 'backspace']);
+  addHotkey('canvas', 'resetSelected', ['shift+c']);
+  addHotkey('canvas', 'mergeDown', ['mod+e']);
+  addHotkey('canvas', 'mergeVisible', ['mod+shift+e']);
+  addHotkey('canvas', 'transformSelected', ['shift+t']);
+  addHotkey('canvas', 'filterSelected', ['shift+f']);
+  addHotkey('canvas', 'invertMask', ['shift+v']);
+  addHotkey('canvas', 'undo', ['mod+z']);
+  addHotkey('canvas', 'redo', ['mod+shift+z', 'mod+y']);
+  addHotkey('canvas', 'nextEntity', ['alt+]']);
+  addHotkey('canvas', 'prevEntity', ['alt+[']);
+  addHotkey('canvas', 'applyFilter', ['enter']);
+  addHotkey('canvas', 'cancelFilter', ['esc']);
+  addHotkey('canvas', 'applyTransform', ['enter']);
+  addHotkey('canvas', 'cancelTransform', ['esc']);
+  addHotkey('canvas', 'applySegmentAnything', ['enter']);
+  addHotkey('canvas', 'cancelSegmentAnything', ['esc']);
+  addHotkey('canvas', 'toggleNonRasterLayers', ['shift+h']);
+  addHotkey('canvas', 'fitBboxToMasks', ['shift+b']);
+  addHotkey('canvas', 'toggleBbox', ['shift+o']);
+
+  // Workflows
+  addHotkey('workflows', 'addNode', ['shift+a', 'space']);
+  addHotkey('workflows', 'copySelection', ['mod+c']);
+  addHotkey('workflows', 'pasteSelection', ['mod+v']);
+  addHotkey('workflows', 'pasteSelectionWithEdges', ['mod+shift+v']);
+  addHotkey('workflows', 'selectAll', ['mod+a']);
+  addHotkey('workflows', 'deleteSelection', ['delete', 'backspace']);
+  addHotkey('workflows', 'undo', ['mod+z']);
+  addHotkey('workflows', 'redo', ['mod+shift+z', 'mod+y']);
+
+  // Viewer
+  addHotkey('viewer', 'toggleViewer', ['z']);
+  addHotkey('viewer', 'swapImages', ['c']);
+  addHotkey('viewer', 'nextComparisonMode', ['m']);
+  addHotkey('viewer', 'loadWorkflow', ['w']);
+  addHotkey('viewer', 'recallAll', ['a']);
+  addHotkey('viewer', 'recallSeed', ['s']);
+  addHotkey('viewer', 'recallPrompts', ['p']);
+  addHotkey('viewer', 'remix', ['r']);
+  addHotkey('viewer', 'useSize', ['d']);
+  addHotkey('viewer', 'toggleMetadata', ['i']);
+
+  // Gallery
+  addHotkey('gallery', 'selectAllOnPage', ['mod+a']);
+  addHotkey('gallery', 'clearSelection', ['esc']);
+  addHotkey('gallery', 'galleryNavUp', ['up']);
+  addHotkey('gallery', 'galleryNavRight', ['right']);
+  addHotkey('gallery', 'galleryNavDown', ['down']);
+  addHotkey('gallery', 'galleryNavLeft', ['left']);
+  addHotkey('gallery', 'galleryNavUpAlt', ['alt+up']);
+  addHotkey('gallery', 'galleryNavRightAlt', ['alt+right']);
+  addHotkey('gallery', 'galleryNavDownAlt', ['alt+down']);
+  addHotkey('gallery', 'galleryNavLeftAlt', ['alt+left']);
+  addHotkey('gallery', 'deleteSelection', ['delete', 'backspace']);
+  addHotkey('gallery', 'starImage', ['.']);
+
+  return data;
+};
+
 export const useHotkeyData = (): HotkeysData => {
   const { t } = useTranslation();
   const customHotkeys = useAppSelector(selectCustomHotkeys);
 
-  const hotkeysData = useMemo<HotkeysData>(() => {
-    const data: HotkeysData = {
-      app: {
-        title: t('hotkeys.app.title'),
-        hotkeys: {},
-      },
-      canvas: {
-        title: t('hotkeys.canvas.title'),
-        hotkeys: {},
-      },
-      viewer: {
-        title: t('hotkeys.viewer.title'),
-        hotkeys: {},
-      },
-      gallery: {
-        title: t('hotkeys.gallery.title'),
-        hotkeys: {},
-      },
-      workflows: {
-        title: t('hotkeys.workflows.title'),
-        hotkeys: {},
-      },
-    };
-
-    const addHotkey = (category: HotkeyCategory, id: string, keys: string[], isEnabled: boolean = true) => {
-      const hotkeyId = `${category}.${id}`;
-      const effectiveKeys = customHotkeys[hotkeyId] ?? keys;
-      data[category].hotkeys[id] = {
-        id,
-        category,
-        title: t(`hotkeys.${category}.${id}.title`),
-        desc: t(`hotkeys.${category}.${id}.desc`),
-        hotkeys: effectiveKeys,
-        defaultHotkeys: keys,
-        platformKeys: formatKeysForPlatform(effectiveKeys),
-        isEnabled,
-      };
-    };
-
-    addHotkey('app', 'invoke', ['mod+enter']);
-    addHotkey('app', 'invokeFront', ['mod+shift+enter']);
-    addHotkey('app', 'cancelQueueItem', ['shift+x']);
-    addHotkey('app', 'clearQueue', ['mod+shift+x']);
-    addHotkey('app', 'selectGenerateTab', ['1']);
-    addHotkey('app', 'selectCanvasTab', ['2']);
-    addHotkey('app', 'selectUpscalingTab', ['3']);
-    addHotkey('app', 'selectWorkflowsTab', ['4']);
-    addHotkey('app', 'selectModelsTab', ['5']);
-    addHotkey('app', 'selectQueueTab', ['6']);
-
-    // Prompt/history navigation (when prompt textarea is focused)
-    addHotkey('app', 'promptHistoryPrev', ['alt+arrowup']);
-    addHotkey('app', 'promptHistoryNext', ['alt+arrowdown']);
-    addHotkey('app', 'promptWeightUp', ['ctrl+arrowup']);
-    addHotkey('app', 'promptWeightDown', ['ctrl+arrowdown']);
-
-    addHotkey('app', 'focusPrompt', ['alt+a']);
-    addHotkey('app', 'toggleLeftPanel', ['t', 'o']);
-    addHotkey('app', 'toggleRightPanel', ['g']);
-    addHotkey('app', 'resetPanelLayout', ['shift+r']);
-    addHotkey('app', 'togglePanels', ['f']);
-
-    // Canvas
-    addHotkey('canvas', 'selectBrushTool', ['b']);
-    addHotkey('canvas', 'selectBboxTool', ['c']);
-    addHotkey('canvas', 'decrementToolWidth', ['[']);
-    addHotkey('canvas', 'incrementToolWidth', [']']);
-    addHotkey('canvas', 'selectEraserTool', ['e']);
-    addHotkey('canvas', 'selectMoveTool', ['v']);
-    addHotkey('canvas', 'selectRectTool', ['u']);
-    addHotkey('canvas', 'selectLassoTool', ['l']);
-    addHotkey('canvas', 'selectViewTool', ['h']);
-    addHotkey('canvas', 'selectColorPickerTool', ['i']);
-    addHotkey('canvas', 'setFillColorsToDefault', ['d']);
-    addHotkey('canvas', 'toggleFillColor', ['x']);
-    addHotkey('canvas', 'fitLayersToCanvas', ['mod+0']);
-    addHotkey('canvas', 'fitBboxToCanvas', ['mod+shift+0']);
-    addHotkey('canvas', 'fitBboxToLayers', ['shift+n']);
-    addHotkey('canvas', 'setZoomTo100Percent', ['mod+1']);
-    addHotkey('canvas', 'setZoomTo200Percent', ['mod+2']);
-    addHotkey('canvas', 'setZoomTo400Percent', ['mod+3']);
-    addHotkey('canvas', 'setZoomTo800Percent', ['mod+4']);
-    addHotkey('canvas', 'quickSwitch', ['q']);
-    addHotkey('canvas', 'deleteSelected', ['delete', 'backspace']);
-    addHotkey('canvas', 'resetSelected', ['shift+c']);
-    addHotkey('canvas', 'transformSelected', ['shift+t']);
-    addHotkey('canvas', 'filterSelected', ['shift+f']);
-    addHotkey('canvas', 'invertMask', ['shift+v']);
-    addHotkey('canvas', 'undo', ['mod+z']);
-    addHotkey('canvas', 'redo', ['mod+shift+z', 'mod+y']);
-    addHotkey('canvas', 'nextEntity', ['alt+]']);
-    addHotkey('canvas', 'prevEntity', ['alt+[']);
-    addHotkey('canvas', 'applyFilter', ['enter']);
-    addHotkey('canvas', 'cancelFilter', ['esc']);
-    addHotkey('canvas', 'applyTransform', ['enter']);
-    addHotkey('canvas', 'cancelTransform', ['esc']);
-    addHotkey('canvas', 'applySegmentAnything', ['enter']);
-    addHotkey('canvas', 'cancelSegmentAnything', ['esc']);
-    addHotkey('canvas', 'toggleNonRasterLayers', ['shift+h']);
-    addHotkey('canvas', 'fitBboxToMasks', ['shift+b']);
-    addHotkey('canvas', 'toggleBbox', ['shift+o']);
-
-    // Workflows
-    addHotkey('workflows', 'addNode', ['shift+a', 'space']);
-    addHotkey('workflows', 'copySelection', ['mod+c']);
-    addHotkey('workflows', 'pasteSelection', ['mod+v']);
-    addHotkey('workflows', 'pasteSelectionWithEdges', ['mod+shift+v']);
-    addHotkey('workflows', 'selectAll', ['mod+a']);
-    addHotkey('workflows', 'deleteSelection', ['delete', 'backspace']);
-    addHotkey('workflows', 'undo', ['mod+z']);
-    addHotkey('workflows', 'redo', ['mod+shift+z', 'mod+y']);
-
-    // Viewer
-    addHotkey('viewer', 'toggleViewer', ['z']);
-    addHotkey('viewer', 'swapImages', ['c']);
-    addHotkey('viewer', 'nextComparisonMode', ['m']);
-    addHotkey('viewer', 'loadWorkflow', ['w']);
-    addHotkey('viewer', 'recallAll', ['a']);
-    addHotkey('viewer', 'recallSeed', ['s']);
-    addHotkey('viewer', 'recallPrompts', ['p']);
-    addHotkey('viewer', 'remix', ['r']);
-    addHotkey('viewer', 'useSize', ['d']);
-    addHotkey('viewer', 'toggleMetadata', ['i']);
-
-    // Gallery
-    addHotkey('gallery', 'selectAllOnPage', ['mod+a']);
-    addHotkey('gallery', 'clearSelection', ['esc']);
-    addHotkey('gallery', 'galleryNavUp', ['up']);
-    addHotkey('gallery', 'galleryNavRight', ['right']);
-    addHotkey('gallery', 'galleryNavDown', ['down']);
-    addHotkey('gallery', 'galleryNavLeft', ['left']);
-    addHotkey('gallery', 'galleryNavUpAlt', ['alt+up']);
-    addHotkey('gallery', 'galleryNavRightAlt', ['alt+right']);
-    addHotkey('gallery', 'galleryNavDownAlt', ['alt+down']);
-    addHotkey('gallery', 'galleryNavLeftAlt', ['alt+left']);
-    addHotkey('gallery', 'deleteSelection', ['delete', 'backspace']);
-    addHotkey('gallery', 'starImage', ['.']);
-
-    return data;
-  }, [customHotkeys, t]);
+  const hotkeysData = useMemo<HotkeysData>(() => buildHotkeysData((key) => t(key), customHotkeys), [customHotkeys, t]);
 
   return hotkeysData;
 };


### PR DESCRIPTION
## Summary

Add configurable Canvas hotkeys for layer merging:
- `Ctrl/Cmd+E` merges the selected layer down into the layer below
- `Ctrl/Cmd+Shift+E` merges all visible layers of the selected layer type

Both actions are now registered in the Hotkeys modal so users can remap them as needed. This PR also adds the localized Hotkeys modal labels, including the clearer `Merge Layer Down` title, wires the new hooks into the canvas toolbar lifecycle, and adds focused coverage for hotkey registration and overrides.

## Related Issues / Discussions

None.

## QA Instructions

- Open Canvas, select a layer with another layer below it, and press `Ctrl+E` to confirm it merges down.
- Select a layer type with multiple visible layers, and press `Ctrl+Shift+E` to confirm all visible layers of that type are merged.
- Open the Hotkeys modal and confirm both actions appear under Canvas and can be remapped.
- Rebind one or both hotkeys in the Hotkeys modal and confirm the updated shortcuts trigger the correct merge action.

## Merge Plan

Simple merge.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
