### PR TITLE
Fix tooltip display on desktop

### DIFF
--- a/invokeai/frontend/web/src/app/components/GlobalHookIsolator.tsx
+++ b/invokeai/frontend/web/src/app/components/GlobalHookIsolator.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/storeHooks';
 import { useFocusRegionWatcher } from 'common/hooks/focus';
 import { useCloseChakraTooltipsOnDragFix } from 'common/hooks/useCloseChakraTooltipsOnDragFix';
 import { useGlobalHotkeys } from 'common/hooks/useGlobalHotkeys';
+import { useTouchDeviceClass } from 'common/hooks/useTouchDeviceClass';
 import { useDndMonitor } from 'features/dnd/useDndMonitor';
 import { useDynamicPromptsWatcher } from 'features/dynamicPrompts/hooks/useDynamicPromptsWatcher';
 import { useStarterModelsToast } from 'features/modelManagerV2/hooks/useStarterModelsToast';
@@ -42,6 +43,7 @@ export const GlobalHookIsolator = memo(() => {
   useGetOpenAPISchemaQuery();
   useSyncLoggingConfig();
   useCloseChakraTooltipsOnDragFix();
+  useTouchDeviceClass();
   useDndMonitor();
   useSyncNodeErrors();
   useSyncLangDirection();

--- a/invokeai/frontend/web/src/app/components/touchDevice.css
+++ b/invokeai/frontend/web/src/app/components/touchDevice.css
@@ -1,7 +1,5 @@
-/* Hide tooltips on touch devices where hover gets "stuck" */
-@media (hover: none) {
-  [role='tooltip'] {
-    visibility: hidden !important;
-    opacity: 0 !important;
-  }
+/* Hide tooltips after touch input, where hover can get stuck. */
+.invokeai-touch-device [role='tooltip'] {
+  visibility: hidden !important;
+  opacity: 0 !important;
 }

--- a/invokeai/frontend/web/src/app/components/touchDevice.test.ts
+++ b/invokeai/frontend/web/src/app/components/touchDevice.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('./touchDevice.css', import.meta.url), 'utf8');
+
+describe('touchDevice.css', () => {
+  it('hides tooltips only after touch input has been detected', () => {
+    expect(css).toMatch(/\.invokeai-touch-device\s+\[role='tooltip'\]\s*{/);
+  });
+
+  it('does not force all tooltips invisible', () => {
+    expect(css).not.toMatch(/@media\s*\([^)]*hover[^)]*\)/);
+  });
+});

--- a/invokeai/frontend/web/src/common/hooks/useTouchDeviceClass.ts
+++ b/invokeai/frontend/web/src/common/hooks/useTouchDeviceClass.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+const TOUCH_DEVICE_CLASS = 'invokeai-touch-device';
+
+export const useTouchDeviceClass = () => {
+  useEffect(() => {
+    const onPointerInput = (e: PointerEvent) => {
+      if (e.pointerType === 'touch') {
+        document.documentElement.classList.add(TOUCH_DEVICE_CLASS);
+      } else if (e.pointerType === 'mouse') {
+        document.documentElement.classList.remove(TOUCH_DEVICE_CLASS);
+      }
+    };
+
+    window.addEventListener('pointerdown', onPointerInput, { passive: true });
+    window.addEventListener('pointermove', onPointerInput, { passive: true });
+
+    return () => {
+      window.removeEventListener('pointerdown', onPointerInput);
+      window.removeEventListener('pointermove', onPointerInput);
+    };
+  }, []);
+};


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #9001 where tooltips were being hidden on desktop Chrome when the browser reported no hover capability. Replaces the broad `(hover: none)` CSS suppression with a runtime touch-input class, so tooltips are hidden only after actual touch input and restored when mouse input is detected. Adds a focused regression test for the tooltip CSS behavior.

## Related Issues / Discussions

#9001

## QA Instructions

Verify that tooltips are present on Chrome desktop and still hidden on mobile devices.

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
