### PR TITLE
Improve image collection chaining

### DIFF
--- a/invokeai/app/invocations/primitives.py
+++ b/invokeai/app/invocations/primitives.py
@@ -279,15 +279,28 @@ class ImageInvocation(BaseInvocation):
     title="Image Collection Primitive",
     tags=["primitives", "image", "collection"],
     category="primitives",
-    version="1.0.1",
+    version="1.0.2",
 )
 class ImageCollectionInvocation(BaseInvocation):
     """A collection of image primitive values"""
 
-    collection: list[ImageField] = InputField(description="The collection of image values")
+    collection: Optional[list[ImageField]] = InputField(
+        default=None,
+        description="An optional image collection to append to",
+        input=Input.Connection,
+        title="Collection",
+        ui_order=0,
+    )
+    images: Optional[list[ImageField]] = InputField(
+        default=None,
+        description="The images to append to the collection",
+        input=Input.Direct,
+        title="Images",
+        ui_order=1,
+    )
 
     def invoke(self, context: InvocationContext) -> ImageCollectionOutput:
-        return ImageCollectionOutput(collection=self.collection)
+        return ImageCollectionOutput(collection=[*(self.collection or []), *(self.images or [])])
 
 
 # endregion

--- a/invokeai/frontend/web/openapi.json
+++ b/invokeai/frontend/web/openapi.json
@@ -32518,11 +32518,34 @@
               }
             ],
             "default": null,
-            "description": "The collection of image values",
+            "description": "An optional image collection to append to",
             "field_kind": "input",
-            "input": "any",
-            "orig_required": true,
-            "title": "Collection"
+            "input": "connection",
+            "orig_default": null,
+            "orig_required": false,
+            "title": "Collection",
+            "ui_order": 0
+          },
+          "images": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ImageField"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The images to append to the collection",
+            "field_kind": "input",
+            "input": "direct",
+            "orig_default": null,
+            "orig_required": false,
+            "title": "Images",
+            "ui_order": 1
           },
           "type": {
             "const": "image_collection",
@@ -32536,7 +32559,7 @@
         "tags": ["primitives", "image", "collection"],
         "title": "Image Collection Primitive",
         "type": "object",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "output": {
           "$ref": "#/components/schemas/ImageCollectionOutput"
         }

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/UpdateNodesButton.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/UpdateNodesButton.tsx
@@ -3,7 +3,7 @@ import { logger } from 'app/logging/logger';
 import { useAppStore } from 'app/store/storeHooks';
 import { useGetNodesNeedUpdate } from 'features/nodes/hooks/useGetNodesNeedUpdate';
 import { $templates, nodesChanged } from 'features/nodes/store/nodesSlice';
-import { selectNodes } from 'features/nodes/store/selectors';
+import { selectEdges, selectNodes } from 'features/nodes/store/selectors';
 import { NodeUpdateError } from 'features/nodes/types/error';
 import { isInvocationNode } from 'features/nodes/types/invocation';
 import { getNeedsUpdate, updateNode } from 'features/nodes/util/node/nodeUpdate';
@@ -20,6 +20,7 @@ const useUpdateNodes = () => {
 
   const updateNodes = useCallback(() => {
     const nodes = selectNodes(store.getState());
+    const edges = selectEdges(store.getState());
     const templates = $templates.get();
 
     let unableToUpdateCount = 0;
@@ -35,7 +36,12 @@ const useUpdateNodes = () => {
         return;
       }
       try {
-        const updatedNode = updateNode(node, template);
+        const connectedInputNames = new Set(
+          edges.flatMap((edge) =>
+            edge.type === 'default' && edge.target === node.id && edge.targetHandle ? [edge.targetHandle] : []
+          )
+        );
+        const updatedNode = updateNode(node, template, { connectedInputNames });
         store.dispatch(
           nodesChanged([
             { type: 'remove', id: updatedNode.id },

--- a/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/UpdateNodesButton.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/panels/TopPanel/UpdateNodesButton.tsx
@@ -4,9 +4,8 @@ import { useAppStore } from 'app/store/storeHooks';
 import { useGetNodesNeedUpdate } from 'features/nodes/hooks/useGetNodesNeedUpdate';
 import { $templates, nodesChanged } from 'features/nodes/store/nodesSlice';
 import { selectEdges, selectNodes } from 'features/nodes/store/selectors';
-import { NodeUpdateError } from 'features/nodes/types/error';
 import { isInvocationNode } from 'features/nodes/types/invocation';
-import { getNeedsUpdate, updateNode } from 'features/nodes/util/node/nodeUpdate';
+import { getConnectedInputNames, getNeedsUpdate, updateNode } from 'features/nodes/util/node/nodeUpdate';
 import { toast } from 'features/toast/toast';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,11 +35,7 @@ const useUpdateNodes = () => {
         return;
       }
       try {
-        const connectedInputNames = new Set(
-          edges.flatMap((edge) =>
-            edge.type === 'default' && edge.target === node.id && edge.targetHandle ? [edge.targetHandle] : []
-          )
-        );
+        const connectedInputNames = getConnectedInputNames(node.id, edges);
         const updatedNode = updateNode(node, template, { connectedInputNames });
         store.dispatch(
           nodesChanged([
@@ -48,10 +43,8 @@ const useUpdateNodes = () => {
             { type: 'add', item: updatedNode },
           ])
         );
-      } catch (e) {
-        if (e instanceof NodeUpdateError) {
-          unableToUpdateCount++;
-        }
+      } catch {
+        unableToUpdateCount++;
       }
     });
 

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.test.ts
@@ -66,7 +66,7 @@ const currentImageCollectionTemplate = {
         cardinality: 'COLLECTION',
         batch: false,
       },
-      default: [],
+      default: undefined,
     },
     images: {
       name: 'images',
@@ -96,14 +96,14 @@ describe('updateNode', () => {
     }
     collectionInput.value = images;
 
-    const updated = updateNode(node, currentImageCollectionTemplate);
+    const updated = updateNode(node, currentImageCollectionTemplate, { connectedInputNames: new Set() });
 
     expect(updated.data.version).toBe('1.0.2');
     expect(updated.data.inputs.images?.value).toEqual(images);
     expect(updated.data.inputs.collection?.value).toEqual([]);
   });
 
-  it('does not move old image_collection direct collection values when collection is connected', () => {
+  it('preserves old image_collection direct collection values when collection is connected', () => {
     const node = buildInvocationNode({ x: 0, y: 0 }, oldImageCollectionTemplate);
     const images = [{ image_name: 'stale' }];
     const collectionInput = node.data.inputs.collection;
@@ -117,6 +117,6 @@ describe('updateNode', () => {
     });
 
     expect(updated.data.inputs.images?.value).toBeUndefined();
-    expect(updated.data.inputs.collection?.value).toEqual([]);
+    expect(updated.data.inputs.collection?.value).toEqual(images);
   });
 });

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.test.ts
@@ -1,0 +1,122 @@
+import type { InvocationTemplate } from 'features/nodes/types/invocation';
+import { buildInvocationNode } from 'features/nodes/util/node/buildInvocationNode';
+import { updateNode } from 'features/nodes/util/node/nodeUpdate';
+import { describe, expect, it } from 'vitest';
+
+const imageCollectionOutput = {
+  collection: {
+    fieldKind: 'output',
+    name: 'collection',
+    title: 'Collection',
+    description: 'The output images',
+    type: {
+      name: 'ImageField',
+      cardinality: 'COLLECTION',
+      batch: false,
+    },
+    ui_hidden: false,
+  },
+} satisfies InvocationTemplate['outputs'];
+
+const oldImageCollectionTemplate = {
+  title: 'Image Collection Primitive',
+  type: 'image_collection',
+  version: '1.0.1',
+  tags: ['primitives', 'image', 'collection'],
+  description: 'A collection of image primitive values',
+  outputType: 'image_collection_output',
+  inputs: {
+    collection: {
+      name: 'collection',
+      title: 'Collection',
+      required: false,
+      description: 'The collection of image values',
+      fieldKind: 'input',
+      input: 'any',
+      ui_hidden: false,
+      type: {
+        name: 'ImageField',
+        cardinality: 'COLLECTION',
+        batch: false,
+      },
+      default: undefined,
+    },
+  },
+  outputs: imageCollectionOutput,
+  useCache: true,
+  nodePack: 'invokeai',
+  classification: 'stable',
+  category: 'primitives',
+} satisfies InvocationTemplate;
+
+const currentImageCollectionTemplate = {
+  ...oldImageCollectionTemplate,
+  version: '1.0.2',
+  inputs: {
+    collection: {
+      name: 'collection',
+      title: 'Collection',
+      required: false,
+      description: 'An optional image collection to append to',
+      fieldKind: 'input',
+      input: 'connection',
+      ui_hidden: false,
+      type: {
+        name: 'ImageField',
+        cardinality: 'COLLECTION',
+        batch: false,
+      },
+      default: [],
+    },
+    images: {
+      name: 'images',
+      title: 'Images',
+      required: false,
+      description: 'The images to append to the collection',
+      fieldKind: 'input',
+      input: 'direct',
+      ui_hidden: false,
+      type: {
+        name: 'ImageField',
+        cardinality: 'COLLECTION',
+        batch: false,
+      },
+      default: undefined,
+    },
+  },
+} satisfies InvocationTemplate;
+
+describe('updateNode', () => {
+  it('moves old image_collection direct collection values to the new images field', () => {
+    const node = buildInvocationNode({ x: 0, y: 0 }, oldImageCollectionTemplate);
+    const images = [{ image_name: 'first' }, { image_name: 'second' }];
+    const collectionInput = node.data.inputs.collection;
+    if (!collectionInput) {
+      throw new Error('Expected collection input');
+    }
+    collectionInput.value = images;
+
+    const updated = updateNode(node, currentImageCollectionTemplate);
+
+    expect(updated.data.version).toBe('1.0.2');
+    expect(updated.data.inputs.images?.value).toEqual(images);
+    expect(updated.data.inputs.collection?.value).toEqual([]);
+  });
+
+  it('does not move old image_collection direct collection values when collection is connected', () => {
+    const node = buildInvocationNode({ x: 0, y: 0 }, oldImageCollectionTemplate);
+    const images = [{ image_name: 'stale' }];
+    const collectionInput = node.data.inputs.collection;
+    if (!collectionInput) {
+      throw new Error('Expected collection input');
+    }
+    collectionInput.value = images;
+
+    const updated = updateNode(node, currentImageCollectionTemplate, {
+      connectedInputNames: new Set(['collection']),
+    });
+
+    expect(updated.data.inputs.images?.value).toBeUndefined();
+    expect(updated.data.inputs.collection?.value).toEqual([]);
+  });
+});

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.test.ts
@@ -49,6 +49,11 @@ const oldImageCollectionTemplate = {
   category: 'primitives',
 } satisfies InvocationTemplate;
 
+const oldestImageCollectionTemplate = {
+  ...oldImageCollectionTemplate,
+  version: '1.0.0',
+} satisfies InvocationTemplate;
+
 const currentImageCollectionTemplate = {
   ...oldImageCollectionTemplate,
   version: '1.0.2',
@@ -90,6 +95,22 @@ describe('updateNode', () => {
   it('moves old image_collection direct collection values to the new images field', () => {
     const node = buildInvocationNode({ x: 0, y: 0 }, oldImageCollectionTemplate);
     const images = [{ image_name: 'first' }, { image_name: 'second' }];
+    const collectionInput = node.data.inputs.collection;
+    if (!collectionInput) {
+      throw new Error('Expected collection input');
+    }
+    collectionInput.value = images;
+
+    const updated = updateNode(node, currentImageCollectionTemplate, { connectedInputNames: new Set() });
+
+    expect(updated.data.version).toBe('1.0.2');
+    expect(updated.data.inputs.images?.value).toEqual(images);
+    expect(updated.data.inputs.collection?.value).toEqual([]);
+  });
+
+  it('moves 1.0.0 image_collection direct collection values to the new images field', () => {
+    const node = buildInvocationNode({ x: 0, y: 0 }, oldestImageCollectionTemplate);
+    const images = [{ image_name: 'first' }];
     const collectionInput = node.data.inputs.collection;
     if (!collectionInput) {
       throw new Error('Expected collection input');

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
@@ -7,8 +7,24 @@ import { zParsedSemver } from 'features/nodes/types/semver';
 
 import { buildInvocationNode } from './buildInvocationNode';
 
-type UpdateNodeOptions = {
-  connectedInputNames?: Set<string>;
+export type ConnectedInputEdge = { type?: string; target: string; targetHandle?: string | null };
+
+export type UpdateNodeOptions = {
+  connectedInputNames: Set<string>;
+};
+
+export const getConnectedInputNames = (nodeId: string, edges: ConnectedInputEdge[]): Set<string> =>
+  new Set(
+    edges.flatMap((edge) =>
+      edge.type === 'default' && edge.target === nodeId && edge.targetHandle ? [edge.targetHandle] : []
+    )
+  );
+
+export const getUpdatedFieldName = (node: InvocationNode, fieldName: string): string => {
+  if (node.data.type === 'image_collection' && fieldName === 'collection' && node.data.inputs.images) {
+    return 'images';
+  }
+  return fieldName;
 };
 
 export const getNeedsUpdate = (data: InvocationNodeData, template: InvocationTemplate): boolean => {
@@ -33,8 +49,14 @@ const getMayUpdateNode = (node: InvocationNode, template: InvocationTemplate): b
   return satisfies(node.data.version, `^${templateMajor}`);
 };
 
-const migrateImageCollectionInputValues = (node: InvocationNode, options?: UpdateNodeOptions) => {
+export const migrateImageCollectionInputValues = (
+  node: InvocationNode,
+  options: UpdateNodeOptions & { sourceVersion?: string }
+) => {
   if (node.data.type !== 'image_collection') {
+    return;
+  }
+  if (options.sourceVersion && options.sourceVersion !== '1.0.1') {
     return;
   }
 
@@ -47,9 +69,11 @@ const migrateImageCollectionInputValues = (node: InvocationNode, options?: Updat
     return;
   }
 
-  if (!options?.connectedInputNames?.has('collection')) {
-    images.value = collection.value;
+  if (options.connectedInputNames.has('collection')) {
+    return;
   }
+
+  images.value = collection.value;
   collection.value = [];
 };
 
@@ -67,7 +91,7 @@ const migrateImageCollectionInputValues = (node: InvocationNode, options?: Updat
 export const updateNode = (
   node: InvocationNode,
   template: InvocationTemplate,
-  options?: UpdateNodeOptions
+  options: UpdateNodeOptions
 ): InvocationNode => {
   const mayUpdate = getMayUpdateNode(node, template);
 
@@ -82,9 +106,10 @@ export const updateNode = (
   // being valid. We rely on the template's major version to be majorly incremented if this kind of
   // merge would result in an invalid node.
   const clone = deepClone(node);
+  const sourceVersion = clone.data.version;
   clone.data.version = template.version;
   defaultsDeep(clone, defaults); // mutates!
-  migrateImageCollectionInputValues(clone, options);
+  migrateImageCollectionInputValues(clone, { ...options, sourceVersion });
 
   // Remove any fields that are not in the template
   clone.data.inputs = pick(clone.data.inputs, keys(defaults.data.inputs));

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
@@ -7,9 +7,9 @@ import { zParsedSemver } from 'features/nodes/types/semver';
 
 import { buildInvocationNode } from './buildInvocationNode';
 
-export type ConnectedInputEdge = { type?: string; target: string; targetHandle?: string | null };
+type ConnectedInputEdge = { type?: string; target: string; targetHandle?: string | null };
 
-export type UpdateNodeOptions = {
+type UpdateNodeOptions = {
   connectedInputNames: Set<string>;
 };
 

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
@@ -7,6 +7,10 @@ import { zParsedSemver } from 'features/nodes/types/semver';
 
 import { buildInvocationNode } from './buildInvocationNode';
 
+type UpdateNodeOptions = {
+  connectedInputNames?: Set<string>;
+};
+
 export const getNeedsUpdate = (data: InvocationNodeData, template: InvocationTemplate): boolean => {
   if (data.type !== template.type) {
     return true;
@@ -29,6 +33,26 @@ const getMayUpdateNode = (node: InvocationNode, template: InvocationTemplate): b
   return satisfies(node.data.version, `^${templateMajor}`);
 };
 
+const migrateImageCollectionInputValues = (node: InvocationNode, options?: UpdateNodeOptions) => {
+  if (node.data.type !== 'image_collection') {
+    return;
+  }
+
+  const collection = node.data.inputs.collection;
+  const images = node.data.inputs.images;
+  if (!collection || !images || !Array.isArray(collection.value)) {
+    return;
+  }
+  if (Array.isArray(images.value) && images.value.length > 0) {
+    return;
+  }
+
+  if (!options?.connectedInputNames?.has('collection')) {
+    images.value = collection.value;
+  }
+  collection.value = [];
+};
+
 /**
  * Updates a node to the latest version of its template:
  * - Create a new node data object with the latest version of the template.
@@ -40,7 +64,11 @@ const getMayUpdateNode = (node: InvocationNode, template: InvocationTemplate): b
  * @param template The invocation template to update to.
  * @throws {NodeUpdateError} If the node is not an invocation node.
  */
-export const updateNode = (node: InvocationNode, template: InvocationTemplate): InvocationNode => {
+export const updateNode = (
+  node: InvocationNode,
+  template: InvocationTemplate,
+  options?: UpdateNodeOptions
+): InvocationNode => {
   const mayUpdate = getMayUpdateNode(node, template);
 
   if (!mayUpdate || node.data.type !== template.type) {
@@ -56,6 +84,7 @@ export const updateNode = (node: InvocationNode, template: InvocationTemplate): 
   const clone = deepClone(node);
   clone.data.version = template.version;
   defaultsDeep(clone, defaults); // mutates!
+  migrateImageCollectionInputValues(clone, options);
 
   // Remove any fields that are not in the template
   clone.data.inputs = pick(clone.data.inputs, keys(defaults.data.inputs));

--- a/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/node/nodeUpdate.ts
@@ -1,5 +1,5 @@
 import { deepClone } from 'common/util/deepClone';
-import { satisfies } from 'compare-versions';
+import { compare, satisfies } from 'compare-versions';
 import { defaultsDeep, keys, pick } from 'es-toolkit/compat';
 import { NodeUpdateError } from 'features/nodes/types/error';
 import type { InvocationNode, InvocationNodeData, InvocationTemplate } from 'features/nodes/types/invocation';
@@ -56,7 +56,7 @@ export const migrateImageCollectionInputValues = (
   if (node.data.type !== 'image_collection') {
     return;
   }
-  if (options.sourceVersion && options.sourceVersion !== '1.0.1') {
+  if (options.sourceVersion && compare(options.sourceVersion, '1.0.2', '>=')) {
     return;
   }
 

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.test.ts
@@ -1,0 +1,122 @@
+import { $templates } from 'features/nodes/store/nodesSlice';
+import type { InvocationTemplate } from 'features/nodes/types/invocation';
+import { isWorkflowInvocationNode } from 'features/nodes/types/workflow';
+import { graphToWorkflow } from 'features/nodes/util/workflow/graphToWorkflow';
+import type { NonNullableGraph } from 'services/api/types';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const imageCollectionTemplate = {
+  title: 'Image Collection Primitive',
+  type: 'image_collection',
+  version: '1.0.2',
+  tags: ['primitives', 'image', 'collection'],
+  description: 'A collection of image primitive values',
+  outputType: 'image_collection_output',
+  inputs: {
+    collection: {
+      name: 'collection',
+      title: 'Collection',
+      required: false,
+      description: 'An optional image collection to append to',
+      fieldKind: 'input',
+      input: 'connection',
+      ui_hidden: false,
+      type: { name: 'ImageField', cardinality: 'COLLECTION', batch: false },
+      default: undefined,
+    },
+    images: {
+      name: 'images',
+      title: 'Images',
+      required: false,
+      description: 'The images to append to the collection',
+      fieldKind: 'input',
+      input: 'direct',
+      ui_hidden: false,
+      type: { name: 'ImageField', cardinality: 'COLLECTION', batch: false },
+      default: undefined,
+    },
+  },
+  outputs: {
+    collection: {
+      fieldKind: 'output',
+      name: 'collection',
+      title: 'Collection',
+      description: 'The output images',
+      type: { name: 'ImageField', cardinality: 'COLLECTION', batch: false },
+      ui_hidden: false,
+    },
+  },
+  useCache: true,
+  nodePack: 'invokeai',
+  classification: 'stable',
+  category: 'primitives',
+} satisfies InvocationTemplate;
+
+describe('graphToWorkflow', () => {
+  const originalTemplates = $templates.get();
+
+  beforeEach(() => {
+    $templates.set({ image_collection: imageCollectionTemplate });
+  });
+
+  afterEach(() => {
+    $templates.set(originalTemplates);
+  });
+
+  it('moves legacy image_collection graph collection values to the visible images field', () => {
+    const images = [{ image_name: 'legacy.png' }];
+    const graph: NonNullableGraph = {
+      id: 'graph',
+      nodes: {
+        image_collection: {
+          id: 'image_collection',
+          type: 'image_collection',
+          collection: images,
+        },
+      },
+      edges: [],
+    };
+
+    const workflow = graphToWorkflow(graph, false);
+    const node = workflow.nodes[0];
+
+    if (!node || !isWorkflowInvocationNode(node)) {
+      throw new Error('Expected an image_collection workflow node');
+    }
+    expect(node.data.inputs.images?.value).toEqual(images);
+    expect(node.data.inputs.collection?.value).toEqual([]);
+  });
+
+  it('preserves legacy image_collection graph collection values when collection is connected', () => {
+    const images = [{ image_name: 'shadowed.png' }];
+    const graph: NonNullableGraph = {
+      id: 'graph',
+      nodes: {
+        source: {
+          id: 'source',
+          type: 'image_collection',
+        },
+        target: {
+          id: 'target',
+          type: 'image_collection',
+          collection: images,
+        },
+      },
+      edges: [
+        {
+          source: { node_id: 'source', field: 'collection' },
+          destination: { node_id: 'target', field: 'collection' },
+        },
+      ],
+    };
+
+    const workflow = graphToWorkflow(graph, false);
+    const node = workflow.nodes[1];
+
+    if (!node || !isWorkflowInvocationNode(node)) {
+      throw new Error('Expected an image_collection workflow node');
+    }
+    expect(node.data.inputs.images?.value).toBeUndefined();
+    expect(node.data.inputs.collection?.value).toEqual(images);
+  });
+});

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/graphToWorkflow.ts
@@ -5,7 +5,8 @@ import { $templates } from 'features/nodes/store/nodesSlice';
 import { NODE_WIDTH } from 'features/nodes/types/constants';
 import type { FieldInputInstance } from 'features/nodes/types/field';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
-import { getDefaultForm } from 'features/nodes/types/workflow';
+import { getDefaultForm, isWorkflowInvocationNode } from 'features/nodes/types/workflow';
+import { getConnectedInputNames, migrateImageCollectionInputValues } from 'features/nodes/util/node/nodeUpdate';
 import { buildFieldInputInstance } from 'features/nodes/util/schema/buildFieldInputInstance';
 import type { NonNullableGraph } from 'services/api/types';
 import { v4 as uuidv4 } from 'uuid';
@@ -101,6 +102,21 @@ export const graphToWorkflow = (graph: NonNullableGraph, autoLayout = true): Wor
       sourceHandle: edge.source.field,
       target: edge.destination.node_id,
       targetHandle: edge.destination.field,
+    });
+  });
+
+  workflow.nodes.filter(isWorkflowInvocationNode).forEach((node) => {
+    if (
+      node.data.type === 'image_collection' &&
+      node.data.inputs.collection &&
+      !node.data.inputs.images &&
+      templates.image_collection?.inputs.images
+    ) {
+      node.data.inputs.images = buildFieldInputInstance(node.id, templates.image_collection.inputs.images);
+    }
+
+    migrateImageCollectionInputValues(node, {
+      connectedInputNames: getConnectedInputNames(node.id, workflow.edges),
     });
   });
 

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
@@ -1,10 +1,59 @@
 import { get } from 'es-toolkit/compat';
+import { addElement } from 'features/nodes/components/sidePanel/builder/form-manipulation';
 import { CONNECTOR_INPUT_HANDLE, CONNECTOR_OUTPUT_HANDLE } from 'features/nodes/store/util/connectorTopology';
 import { img_resize, main_model_loader } from 'features/nodes/store/util/testUtils';
+import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
-import { getDefaultForm } from 'features/nodes/types/workflow';
+import { buildNodeFieldElement, getDefaultForm, isNodeFieldElement } from 'features/nodes/types/workflow';
 import { validateWorkflow } from 'features/nodes/util/workflow/validateWorkflow';
 import { describe, expect, it } from 'vitest';
+
+const imageCollectionTemplate = {
+  title: 'Image Collection Primitive',
+  type: 'image_collection',
+  version: '1.0.2',
+  tags: ['primitives', 'image', 'collection'],
+  description: 'A collection of image primitive values',
+  outputType: 'image_collection_output',
+  inputs: {
+    collection: {
+      name: 'collection',
+      title: 'Collection',
+      required: false,
+      description: 'An optional image collection to append to',
+      fieldKind: 'input',
+      input: 'connection',
+      ui_hidden: false,
+      type: { name: 'ImageField', cardinality: 'COLLECTION', batch: false },
+      default: undefined,
+    },
+    images: {
+      name: 'images',
+      title: 'Images',
+      required: false,
+      description: 'The images to append to the collection',
+      fieldKind: 'input',
+      input: 'direct',
+      ui_hidden: false,
+      type: { name: 'ImageField', cardinality: 'COLLECTION', batch: false },
+      default: undefined,
+    },
+  },
+  outputs: {
+    collection: {
+      fieldKind: 'output',
+      name: 'collection',
+      title: 'Collection',
+      description: 'The output images',
+      type: { name: 'ImageField', cardinality: 'COLLECTION', batch: false },
+      ui_hidden: false,
+    },
+  },
+  useCache: true,
+  nodePack: 'invokeai',
+  classification: 'stable',
+  category: 'primitives',
+} satisfies InvocationTemplate;
 
 //TODO(psyche): Test workflow validation for form builder fields
 describe('validateWorkflow', () => {
@@ -106,6 +155,32 @@ describe('validateWorkflow', () => {
     new Promise((resolve) => {
       resolve(false);
     });
+  const addLegacyImageCollectionNode = (workflow: WorkflowV3, id: string, images = [{ image_name: `${id}.png` }]) => {
+    workflow.nodes.push({
+      id,
+      type: 'invocation',
+      data: {
+        id,
+        type: 'image_collection',
+        version: '1.0.1',
+        label: '',
+        notes: '',
+        isOpen: true,
+        isIntermediate: true,
+        useCache: true,
+        nodePack: 'invokeai',
+        inputs: {
+          collection: {
+            name: 'collection',
+            label: '',
+            description: '',
+            value: images,
+          },
+        },
+      },
+      position: { x: 0, y: 0 },
+    });
+  };
   it('should reset images that are inaccessible', async () => {
     const validationResult = await validateWorkflow({
       workflow: getWorkflow(),
@@ -273,5 +348,86 @@ describe('validateWorkflow', () => {
 
     expect(validationResult.workflow.edges).toEqual([unresolvedEdge]);
     expect(validationResult.warnings).toEqual([]);
+  });
+
+  it('should migrate image_collection direct values when its old collection edge is invalid', async () => {
+    const workflow = getWorkflow();
+    const images = [{ image_name: 'legacy.png' }];
+    addLegacyImageCollectionNode(workflow, 'image-collection', images);
+    workflow.edges.push({
+      id: 'missing-source-edge',
+      type: 'default',
+      source: 'missing-node',
+      sourceHandle: 'collection',
+      target: 'image-collection',
+      targetHandle: 'collection',
+    });
+
+    const validationResult = await validateWorkflow({
+      workflow,
+      templates: { img_resize, main_model_loader, image_collection: imageCollectionTemplate },
+      checkImageAccess: resolveTrue,
+      checkBoardAccess: resolveTrue,
+      checkModelAccess: resolveTrue,
+    });
+
+    expect(validationResult.workflow.edges).toEqual([]);
+    expect(get(validationResult.workflow, 'nodes[2].data.inputs.images.value')).toEqual(images);
+    expect(get(validationResult.workflow, 'nodes[2].data.inputs.collection.value')).toEqual([]);
+  });
+
+  it('should preserve image_collection collection values when its old collection edge is valid', async () => {
+    const workflow = getWorkflow();
+    const images = [{ image_name: 'shadowed.png' }];
+    addLegacyImageCollectionNode(workflow, 'source-collection', []);
+    addLegacyImageCollectionNode(workflow, 'target-collection', images);
+    workflow.edges.push({
+      id: 'valid-edge',
+      type: 'default',
+      source: 'source-collection',
+      sourceHandle: 'collection',
+      target: 'target-collection',
+      targetHandle: 'collection',
+    });
+
+    const validationResult = await validateWorkflow({
+      workflow,
+      templates: { img_resize, main_model_loader, image_collection: imageCollectionTemplate },
+      checkImageAccess: resolveTrue,
+      checkBoardAccess: resolveTrue,
+      checkModelAccess: resolveTrue,
+    });
+
+    expect(validationResult.workflow.edges).toHaveLength(1);
+    expect(get(validationResult.workflow, 'nodes[3].data.inputs.images.value')).toBeUndefined();
+    expect(get(validationResult.workflow, 'nodes[3].data.inputs.collection.value')).toEqual(images);
+  });
+
+  it('should remap image_collection form and exposed collection fields to images', async () => {
+    const workflow = getWorkflow();
+    const images = [{ image_name: 'legacy.png' }];
+    addLegacyImageCollectionNode(workflow, 'image-collection', images);
+    workflow.exposedFields = [{ nodeId: 'image-collection', fieldName: 'collection' }];
+    const element = buildNodeFieldElement('image-collection', 'collection', {
+      name: 'ImageField',
+      cardinality: 'COLLECTION',
+      batch: false,
+    });
+    addElement({ form: workflow.form, element, parentId: workflow.form.rootElementId });
+
+    const validationResult = await validateWorkflow({
+      workflow,
+      templates: { img_resize, main_model_loader, image_collection: imageCollectionTemplate },
+      checkImageAccess: resolveTrue,
+      checkBoardAccess: resolveTrue,
+      checkModelAccess: resolveTrue,
+    });
+
+    expect(validationResult.workflow.exposedFields).toEqual([{ nodeId: 'image-collection', fieldName: 'images' }]);
+    const updatedElement = validationResult.workflow.form.elements[element.id];
+    if (!updatedElement || !isNodeFieldElement(updatedElement)) {
+      throw new Error('Expected a node field form element');
+    }
+    expect(updatedElement.data.fieldIdentifier.fieldName).toBe('images');
   });
 });

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -81,7 +81,12 @@ export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<Vali
     // This node needs to be updated, based on comparison of its version to the template version
     if (getNeedsUpdate(node.data, template)) {
       try {
-        const updatedNode = updateNode(node, template);
+        const connectedInputNames = new Set(
+          edges.flatMap((edge) =>
+            edge.type === 'default' && edge.target === node.id && edge.targetHandle ? [edge.targetHandle] : []
+          )
+        );
+        const updatedNode = updateNode(node, template, { connectedInputNames });
         node.data = updatedNode.data;
       } catch {
         const message = t('nodes.unableToUpdateNode', {

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -16,7 +16,12 @@ import {
   isNodeFieldElement,
   isWorkflowInvocationNode,
 } from 'features/nodes/types/workflow';
-import { getNeedsUpdate, updateNode } from 'features/nodes/util/node/nodeUpdate';
+import {
+  getConnectedInputNames,
+  getNeedsUpdate,
+  getUpdatedFieldName,
+  updateNode,
+} from 'features/nodes/util/node/nodeUpdate';
 import { t } from 'i18next';
 import type { JsonObject } from 'type-fest';
 
@@ -58,104 +63,7 @@ export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<Vali
   // Now we can validate the graph
   const { nodes, edges } = _workflow;
   const warnings: WorkflowWarning[] = [];
-
-  for (const node of nodes) {
-    if (!isWorkflowInvocationNode(node)) {
-      // We don't need to validate Note nodes or CurrentImage nodes - only Invocation nodes
-      continue;
-    }
-    const template = templates[node.data.type];
-    if (!template) {
-      // This node's type template does not exist
-      const message = t('nodes.missingTemplate', {
-        node: node.id,
-        type: node.data.type,
-      });
-      warnings.push({
-        message,
-        data: parseify(node),
-      });
-      continue;
-    }
-
-    // This node needs to be updated, based on comparison of its version to the template version
-    if (getNeedsUpdate(node.data, template)) {
-      try {
-        const connectedInputNames = new Set(
-          edges.flatMap((edge) =>
-            edge.type === 'default' && edge.target === node.id && edge.targetHandle ? [edge.targetHandle] : []
-          )
-        );
-        const updatedNode = updateNode(node, template, { connectedInputNames });
-        node.data = updatedNode.data;
-      } catch {
-        const message = t('nodes.unableToUpdateNode', {
-          node: node.id,
-          type: node.data.type,
-        });
-        warnings.push({
-          message,
-          data: parseify({ node, nodeTemplate: template }),
-        });
-        continue;
-      }
-    }
-
-    for (const input of Object.values(node.data.inputs)) {
-      const fieldTemplate = template.inputs[input.name];
-
-      if (!fieldTemplate) {
-        const message = t('nodes.missingFieldTemplate');
-        warnings.push({
-          message,
-          data: parseify({ node, nodeTemplate: template, input }),
-        });
-        continue;
-      }
-
-      // We need to confirm that all images, boards and models are accessible before loading,
-      // else the workflow could end up with stale data an an error state.
-      if (fieldTemplate.type.name === 'ImageField' && input.value && isImageFieldInputInstance(input)) {
-        const hasAccess = await checkImageAccess(input.value.image_name);
-        if (!hasAccess) {
-          const message = t('nodes.imageAccessError', { image_name: input.value.image_name });
-          warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
-          input.value = undefined;
-        }
-      }
-      if (fieldTemplate.type.name === 'ImageField' && input.value && isImageFieldCollectionInputInstance(input)) {
-        for (const { image_name } of [...input.value]) {
-          const hasAccess = await checkImageAccess(image_name);
-          if (!hasAccess) {
-            const message = t('nodes.imageAccessError', { image_name });
-            warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
-            input.value = input.value.filter((image) => image.image_name !== image_name);
-          }
-        }
-      }
-      if (fieldTemplate.type.name === 'BoardField' && input.value && isBoardFieldInputInstance(input)) {
-        if (input.value === 'none' || input.value === 'auto') {
-          continue;
-        }
-        const hasAccess = await checkBoardAccess(input.value.board_id);
-        if (!hasAccess) {
-          const message = t('nodes.boardAccessError', { board_id: input.value.board_id });
-          warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
-          input.value = undefined;
-        }
-      }
-      if (isModelFieldType(fieldTemplate.type) && input.value && isModelIdentifierFieldInputInstance(input)) {
-        const hasAccess = await checkModelAccess(input.value.key);
-        if (!hasAccess) {
-          const message = t('nodes.modelAccessError', { key: input.value.key });
-          warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
-          input.value = undefined;
-        }
-      }
-    }
-  }
-
-  const validEdges = [];
+  const validEdges: WorkflowV3['edges'] = [];
 
   for (const edge of edges) {
     // Validate each edge. If the edge is invalid, we must remove it to prevent runtime errors with reactflow.
@@ -232,7 +140,7 @@ export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<Vali
 
     if (issues.length) {
       const source = edge.type === 'default' ? `${edge.source}.${edge.sourceHandle}` : edge.source;
-      const target = edge.type === 'default' ? `${edge.source}.${edge.targetHandle}` : edge.target;
+      const target = edge.type === 'default' ? `${edge.target}.${edge.targetHandle}` : edge.target;
       warnings.push({
         message: t('nodes.deletedInvalidEdge', { source, target }),
         issues,
@@ -243,8 +151,119 @@ export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<Vali
     }
   }
 
-  // Remove invalid edges
+  // Remove invalid edges before node updates so migrations only trust surviving connections.
   _workflow.edges = validEdges;
+
+  for (const node of nodes) {
+    if (!isWorkflowInvocationNode(node)) {
+      // We don't need to validate Note nodes or CurrentImage nodes - only Invocation nodes
+      continue;
+    }
+    const template = templates[node.data.type];
+    if (!template) {
+      // This node's type template does not exist
+      const message = t('nodes.missingTemplate', {
+        node: node.id,
+        type: node.data.type,
+      });
+      warnings.push({
+        message,
+        data: parseify(node),
+      });
+      continue;
+    }
+
+    // This node needs to be updated, based on comparison of its version to the template version
+    if (getNeedsUpdate(node.data, template)) {
+      try {
+        const connectedInputNames = getConnectedInputNames(node.id, validEdges);
+        const updatedNode = updateNode(node, template, { connectedInputNames });
+        node.data = updatedNode.data;
+      } catch {
+        const message = t('nodes.unableToUpdateNode', {
+          node: node.id,
+          type: node.data.type,
+        });
+        warnings.push({
+          message,
+          data: parseify({ node, nodeTemplate: template }),
+        });
+        continue;
+      }
+    }
+
+    for (const input of Object.values(node.data.inputs)) {
+      const fieldTemplate = template.inputs[input.name];
+
+      if (!fieldTemplate) {
+        const message = t('nodes.missingFieldTemplate');
+        warnings.push({
+          message,
+          data: parseify({ node, nodeTemplate: template, input }),
+        });
+        continue;
+      }
+
+      // We need to confirm that all images, boards and models are accessible before loading,
+      // else the workflow could end up with stale data an an error state.
+      if (fieldTemplate.type.name === 'ImageField' && input.value && isImageFieldInputInstance(input)) {
+        const hasAccess = await checkImageAccess(input.value.image_name);
+        if (!hasAccess) {
+          const message = t('nodes.imageAccessError', { image_name: input.value.image_name });
+          warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
+          input.value = undefined;
+        }
+      }
+      if (fieldTemplate.type.name === 'ImageField' && input.value && isImageFieldCollectionInputInstance(input)) {
+        for (const { image_name } of [...input.value]) {
+          const hasAccess = await checkImageAccess(image_name);
+          if (!hasAccess) {
+            const message = t('nodes.imageAccessError', { image_name });
+            warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
+            input.value = input.value.filter((image) => image.image_name !== image_name);
+          }
+        }
+      }
+      if (fieldTemplate.type.name === 'BoardField' && input.value && isBoardFieldInputInstance(input)) {
+        if (input.value === 'none' || input.value === 'auto') {
+          continue;
+        }
+        const hasAccess = await checkBoardAccess(input.value.board_id);
+        if (!hasAccess) {
+          const message = t('nodes.boardAccessError', { board_id: input.value.board_id });
+          warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
+          input.value = undefined;
+        }
+      }
+      if (isModelFieldType(fieldTemplate.type) && input.value && isModelIdentifierFieldInputInstance(input)) {
+        const hasAccess = await checkModelAccess(input.value.key);
+        if (!hasAccess) {
+          const message = t('nodes.modelAccessError', { key: input.value.key });
+          warnings.push({ message, data: parseify({ node, nodeTemplate: template, input }) });
+          input.value = undefined;
+        }
+      }
+    }
+  }
+
+  _workflow.exposedFields = _workflow.exposedFields.map((fieldIdentifier) => {
+    const node = nodes.filter(isWorkflowInvocationNode).find(({ id }) => id === fieldIdentifier.nodeId);
+    if (!node) {
+      return fieldIdentifier;
+    }
+    return { ...fieldIdentifier, fieldName: getUpdatedFieldName(node, fieldIdentifier.fieldName) };
+  });
+
+  for (const element of Object.values(_workflow.form.elements)) {
+    if (!isNodeFieldElement(element)) {
+      continue;
+    }
+    const node = nodes.filter(isWorkflowInvocationNode).find(({ id }) => id === element.data.fieldIdentifier.nodeId);
+    if (!node) {
+      continue;
+    }
+    element.data.fieldIdentifier.fieldName = getUpdatedFieldName(node, element.data.fieldIdentifier.fieldName);
+  }
 
   // Migrated exposed fields to form elements if they exist and the form does not
   // Note: If the form is invalid per its zod schema, it will be reset to a default, empty form!

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -13818,10 +13818,16 @@ export type components = {
             use_cache?: boolean;
             /**
              * Collection
-             * @description The collection of image values
+             * @description An optional image collection to append to
              * @default null
              */
             collection?: components["schemas"]["ImageField"][] | null;
+            /**
+             * Images
+             * @description The images to append to the collection
+             * @default null
+             */
+            images?: components["schemas"]["ImageField"][] | null;
             /**
              * type
              * @default image_collection

--- a/tests/app/invocations/test_image.py
+++ b/tests/app/invocations/test_image.py
@@ -8,6 +8,7 @@ import torch
 from PIL import Image, ImageFilter
 
 from invokeai.app.invocations.image import ImageField, OklabUnsharpMaskInvocation, OklchImageHueAdjustmentInvocation
+from invokeai.app.invocations.primitives import ImageCollectionInvocation
 from invokeai.backend.image_util.color_conversion import (
     linear_srgb_from_oklab,
     linear_srgb_from_oklch,
@@ -45,6 +46,37 @@ def _max_abs_diff_uint8(left: Image.Image, right: Image.Image) -> int:
     left_arr = numpy.asarray(left, dtype=numpy.int16)
     right_arr = numpy.asarray(right, dtype=numpy.int16)
     return int(numpy.abs(left_arr - right_arr).max())
+
+
+def test_image_collection_invocation_preserves_existing_collection_values() -> None:
+    images = [ImageField(image_name="first"), ImageField(image_name="second")]
+
+    output = ImageCollectionInvocation(collection=images).invoke(MagicMock())
+
+    assert output.collection == images
+
+
+def test_image_collection_invocation_appends_direct_images_after_chained_collection() -> None:
+    chained_images = [ImageField(image_name="chained")]
+    direct_images = [ImageField(image_name="direct_1"), ImageField(image_name="direct_2")]
+
+    output = ImageCollectionInvocation(collection=chained_images, images=direct_images).invoke(MagicMock())
+
+    assert output.collection == [*chained_images, *direct_images]
+
+
+def test_image_collection_invocation_supports_empty_direct_images() -> None:
+    chained_images = [ImageField(image_name="chained")]
+
+    output = ImageCollectionInvocation(collection=chained_images, images=None).invoke(MagicMock())
+
+    assert output.collection == chained_images
+
+
+def test_image_collection_invocation_outputs_empty_collection_when_inputs_are_empty() -> None:
+    output = ImageCollectionInvocation(collection=None, images=None).invoke(MagicMock())
+
+    assert output.collection == []
 
 
 def test_oklab_unsharp_mask_invocation_preserves_alpha_and_sharpens_lightness_only() -> None:


### PR DESCRIPTION
## Summary

Give the `Image Collection Primitive` node the ability to chain that a normal `Collection` node has.

## Related Issues / Discussions

## QA Instructions

Try upgrading an old workflow that uses this node.

Also try dropping it into a new workflow and make sure you can chain as well as add new images to the collection. It should work with no inputs, one, and both.

## Merge Plan

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
