### PR TITLE
feat(mm): swap Anima Preview 3 starter for Anima Base 1.0

### DIFF
--- a/invokeai/backend/model_manager/starter_models.py
+++ b/invokeai/backend/model_manager/starter_models.py
@@ -1545,11 +1545,11 @@ anima_vae = StarterModel(
     format=ModelFormat.Checkpoint,
 )
 
-anima_preview3 = StarterModel(
-    name="Anima Preview 3",
+anima_base = StarterModel(
+    name="Anima Base 1.0",
     base=BaseModelType.Anima,
-    source="https://huggingface.co/circlestone-labs/Anima/resolve/main/split_files/diffusion_models/anima-preview3-base.safetensors",
-    description="Anima Preview 3 - 2B parameter anime-focused text-to-image model built on Cosmos Predict2 DiT. ~4.5GB",
+    source="https://huggingface.co/circlestone-labs/Anima/resolve/main/split_files/diffusion_models/anima-base-v1.0.safetensors",
+    description="Anima Base 1.0 - 2B parameter anime-focused text-to-image model built on Cosmos Predict2 DiT. ~4.5GB",
     type=ModelType.Main,
     format=ModelFormat.Checkpoint,
     dependencies=[anima_qwen3_encoder, anima_vae, t5_base_encoder],
@@ -1688,7 +1688,7 @@ STARTER_MODELS: list[StarterModel] = [
     alibabacloud_qwen_image_max,
     alibabacloud_wan26_t2i,
     alibabacloud_qwen_image_edit_max,
-    anima_preview3,
+    anima_base,
     anima_qwen3_encoder,
     anima_vae,
 ]
@@ -1775,7 +1775,7 @@ qwen_image_bundle: list[StarterModel] = [
 ]
 
 anima_bundle: list[StarterModel] = [
-    anima_preview3,
+    anima_base,
     anima_qwen3_encoder,
     anima_vae,
     t5_base_encoder,


### PR DESCRIPTION

## Summary

Anima Preview 3 has been replaced by Anima Base v1.0, this updates the entry in the starter models to download Base v1.0 instead of the preview model.

Model works with no changes to underlying code. 

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

Open the model manager, download the Anima starter pack. 

Generate an image successfully with Anima Base 1.0

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
