### PR TITLE
fix(docs): clarify Shapes tool description

### DIFF
--- a/docs/src/content/docs/features/shapes-tool.mdx
+++ b/docs/src/content/docs/features/shapes-tool.mdx
@@ -32,7 +32,7 @@ specialized masking tool and can create a new mask layer automatically when one 
 
 - Shapes preview live while you draw.
 - The fill color uses the current active color.
-- The active color's alpha is respected when adding pixels.
+- On a raster layer, the active color's alpha is respected when adding pixels.
 - Hold <kbd>Ctrl</kbd> on Windows/Linux or <kbd>Cmd</kbd> on macOS to switch to **subtractive** mode and cut pixels
   out of the active layer.
 - In subtractive mode, alpha is ignored and the shape fully clears pixels.
@@ -85,10 +85,10 @@ The <kbd>Alt</kbd> key behaves differently depending on the active Shapes mode:
 
 ## Practical Examples
 
-- Use **Rect** or **Oval** to block in clean mask regions quickly.
+- Use **Rect** or **Oval** to quickly add clean filled regions.
 - Use **Polygon** when you need straight edges and deliberate corner placement.
 - Use **Freehand** for irregular organic regions.
-- Use **subtractive mode** to cut holes back out of an existing raster or mask layer.
+- Use **subtractive mode** to cut holes back out of an existing filled region.
 
 ## Summary
 


### PR DESCRIPTION
## Summary

This PR clarifies the Shapes tool docs to better match actual behavior.
It removes layer type specific wording from the practical examples and explicitly notes that color alpha handling applies to raster layers.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
