### PR TITLE
feat(anima): Make Anima respect the `precision` property in Invoke.yaml

### DIFF
--- a/invokeai/app/invocations/anima_denoise.py
+++ b/invokeai/app/invocations/anima_denoise.py
@@ -396,7 +396,7 @@ class AnimaDenoiseInvocation(BaseInvocation):
 
     def _run_diffusion(self, context: InvocationContext) -> torch.Tensor:
         device = TorchDevice.choose_torch_device()
-        inference_dtype = TorchDevice.choose_bfloat16_safe_dtype(device)
+        inference_dtype = TorchDevice.choose_anima_inference_dtype(device)
 
         if self.denoising_start >= self.denoising_end:
             raise ValueError(

--- a/invokeai/app/invocations/anima_text_encoder.py
+++ b/invokeai/app/invocations/anima_text_encoder.py
@@ -132,7 +132,7 @@ class AnimaTextEncoderInvocation(BaseInvocation):
             device = text_encoder.device
 
             # Apply LoRA models to the text encoder
-            lora_dtype = TorchDevice.choose_bfloat16_safe_dtype(device)
+            lora_dtype = TorchDevice.choose_anima_inference_dtype(device)
             exit_stack.enter_context(
                 LayerPatcher.apply_smart_model_patches(
                     model=text_encoder,

--- a/invokeai/backend/model_manager/load/model_loaders/anima.py
+++ b/invokeai/backend/model_manager/load/model_loaders/anima.py
@@ -110,7 +110,7 @@ class AnimaCheckpointModel(ModelLoader):
 
         # Determine safe dtype
         target_device = TorchDevice.choose_torch_device()
-        model_dtype = TorchDevice.choose_bfloat16_safe_dtype(target_device)
+        model_dtype = TorchDevice.choose_anima_inference_dtype(target_device)
 
         # Handle memory management
         new_sd_size = sum(ten.nelement() * model_dtype.itemsize for ten in sd.values())

--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -137,3 +137,17 @@ class TorchDevice:
             if device.type == "cuda":
                 return torch.float16
             return torch.float32
+
+    @classmethod
+    def choose_anima_inference_dtype(cls, device: Optional[torch.device] = None) -> torch.dtype:
+        """Choose the inference dtype for Anima models, honoring config.precision.
+
+        When precision is 'auto', delegates to choose_bfloat16_safe_dtype (current
+        behavior). When precision is set to a specific value (float16, bfloat16,
+        float32), returns that dtype directly without hardware probing.
+        """
+        device = device or cls.choose_torch_device()
+        config = get_config()
+        if config.precision == "auto":
+            return cls.choose_bfloat16_safe_dtype(device)
+        return NAME_TO_PRECISION[config.precision]

--- a/tests/backend/util/test_devices.py
+++ b/tests/backend/util/test_devices.py
@@ -130,3 +130,42 @@ def test_legacy_precision_name():
         assert "float16" == choose_precision(torch.device("cuda"))
         assert "float16" == choose_precision(torch.device("mps"))
         assert "float32" == choose_precision(torch.device("cpu"))
+
+
+# ===== choose_anima_inference_dtype (config.precision honoring) ============
+
+
+def test_choose_anima_inference_dtype_float16():
+    """precision='float16' returns torch.float16 without touching hardware."""
+    config = get_config()
+    config.precision = "float16"
+    result = TorchDevice.choose_anima_inference_dtype(torch.device("cpu"))
+    assert result is torch.float16
+
+
+def test_choose_anima_inference_dtype_bfloat16():
+    """precision='bfloat16' returns torch.bfloat16 without touching hardware."""
+    config = get_config()
+    config.precision = "bfloat16"
+    result = TorchDevice.choose_anima_inference_dtype(torch.device("cpu"))
+    assert result is torch.bfloat16
+
+
+def test_choose_anima_inference_dtype_float32():
+    """precision='float32' returns torch.float32 without touching hardware."""
+    config = get_config()
+    config.precision = "float32"
+    result = TorchDevice.choose_anima_inference_dtype(torch.device("cpu"))
+    assert result is torch.float32
+
+
+def test_choose_anima_inference_dtype_auto_delegates_to_safe_dtype():
+    """precision='auto' delegates to choose_bfloat16_safe_dtype (current behavior)."""
+    config = get_config()
+    config.precision = "auto"
+    device = torch.device("cpu")
+    sentinel = torch.bfloat16
+    with patch.object(TorchDevice, "choose_bfloat16_safe_dtype", return_value=sentinel) as mock_safe:
+        result = TorchDevice.choose_anima_inference_dtype(device)
+    assert result is sentinel
+    mock_safe.assert_called_once_with(device)


### PR DESCRIPTION
## Summary

Makes it so that Anima respects the `precision` property in invoke.yaml

**Why?**

Anima runs in bf16 precision. This is slow on 2000 series and earlier Nvidia GPUs, and on mac. Allowing the user to configure this, enables that hardware to run the model at adequate performance on those systems. 

**Why only Anima?**

Today - Qwen and Z-Image do not respect the `precision` property. Which is fine, because neither Z-Image nor Qwen support fp16 at all (it produces broken output.) If we make Z-Image and Qwen respect `precision`, they will break if set to `float16` and if set to `float32` they will double their VRAM cost and realistically not be usable on consumer hardware. (Qwen will take >40gb of VRAM)

Anima, SD, and Flux 1 are the only models which safely and feasibly support all precisions. So it is natural to add Anima to the list. 

I have documented an issue here for a more robust fix for all models by implementing a similar fix to how Forge and Comfy both handle this automatically. However, testing this is difficult. It requires testing on many different devices (2000 series nvidia gpu, mac): https://github.com/invoke-ai/InvokeAI/issues/9153 

## QA Instructions

1. Generate an image with anima, you will use this as a reference for the other steps
2. In `invoke.yaml` add `precision: float32` 
3. Generate the same image with anima (same seed / settings). You will notice 2 things: it should take up 2x the VRAM and likely run a bit slower. You will also notice very slight changes to the output image. 
4. In `invoke.yaml` add `precision: float16`
5. Generate the same image with anima (same seed / settings). You will again notice very slight changes to the image. You likely won't notice much of a VRAM difference this time. 

## Merge Plan

Standard merge. Backend-only change isolated to Anima paths.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added (4 new unit tests in tests/backend/util/test_devices.py)_
- [x] _No redux slice migrations needed_
- [x] _No docs needed (internal helper)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)