### PR TITLE
Add the `frontend-openapi` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo "frontend-build           Build the frontend for localhost:9090"
 	@echo "frontend-test            Run the frontend test suite once"
 	@echo "frontend-dev             Run the frontend in developer mode on localhost:5173"
+	@echo "frontend-openapi         Generate the OpenAPI schema"
 	@echo "frontend-typegen         Generate types for the frontend from the OpenAPI schema"
 	@echo "frontend-lint            Run frontend checks and fixable lint/format steps"
 	@echo "wheel                    Build the wheel for the current version"
@@ -65,6 +66,11 @@ frontend-test:
 # Run the frontend in dev mode
 frontend-dev:
 	cd invokeai/frontend/web && pnpm dev
+
+frontend-openapi:
+	cd invokeai/frontend/web && \
+	python ../../../scripts/generate_openapi_schema.py > openapi.json && \
+	pnpm prettier --write openapi.json
 
 frontend-typegen:
 	cd invokeai/frontend/web && python ../../../scripts/generate_openapi_schema.py | pnpm typegen


### PR DESCRIPTION
## Summary

Since we're going to see more openapi check conflicts, this adds a `Makefile` target that can be run prior to the `make typegen` target.

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

`make frontend-openapi`

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
