### PR TITLE
fix(anima): correct RoPE configuration to restore Anima image quality

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/anima.py
+++ b/invokeai/backend/model_manager/load/model_loaders/anima.py
@@ -102,6 +102,14 @@ class AnimaCheckpointModel(ModelLoader):
                 mlp_ratio=4.0,
                 crossattn_emb_channels=1024,
                 pos_emb_cls="rope3d",
+                # Anima reuses the Cosmos-Predict2 2B Text2Image DiT, which trains with
+                # rope_scale=(t=1.0, h=4.0, w=4.0). The NTK-scaled spatial RoPE base is
+                # mandatory; omitting it (theta=10000 on all axes) shifts every step's
+                # velocity ~7% off and compounds into degraded images. Matches diffusers
+                # CosmosTransformer3DModel rope_scale via *_extrapolation_ratio.
+                rope_h_extrapolation_ratio=4.0,
+                rope_w_extrapolation_ratio=4.0,
+                rope_t_extrapolation_ratio=1.0,
                 use_adaln_lora=True,
                 adaln_lora_dim=256,
                 extra_per_block_abs_pos_emb=False,


### PR DESCRIPTION
## Summary

Anima now has a diffusers implementation in progress. I did a thorough analysis to compare the invoke implementation against the diffusers implementation (which also has direct review from the actual author of the model confirming its correctness.) 

I found one noteworth mismatch. Anima's transformer was being set up with incorrect positional-embedding (RoPE) configuration values. 

This does not affect the visual output quality, but instead degrades the spatial awareness of the model, resulting in scenes that are slightly more nonsensical than they should otherwise be. 

## Where the correct values came from

The official Anima integration in 🤗 diffusers: **huggingface/diffusers#13732** (authored with confirmation from the Anima creator).

The exact block of code in the reference which sets these values is here: [`Cosmos-2.0-Diffusion-2B-Text2Image` in `scripts/convert_cosmos_to_diffusers.py` (L336–L350)](https://github.com/huggingface/diffusers/blob/v0.37.0/scripts/convert_cosmos_to_diffusers.py#L336-L350)  `rope_scale=(1.0, 4.0, 4.0)`.

## Before / After

The before and after is noticeably different. "Before" is on the left. Notice: the dog had 5 legs, and it also placed the dog in the tree. These are artifacts. The "after" is on the right side. I tested many before and after prompts, and the "After" version (with this fix) consistently produced higher quality with fewer artifacts. 

<img width="1852" height="928" alt="image" src="https://github.com/user-attachments/assets/ae996d05-988e-4d12-9b1f-9c5a165928ab" />

## QA Steps

The actual QA of this will be somewhat subjective. This fix does not improve the overall visual quality of the image, it reduces artifacts and improves spatial awareness of the model. Elements in the scene will appear in more logical places. 

- Generate an image with Anima. Confirm successful generation. 

