### PR TITLE
Remove OpenAPI target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ help:
 	@echo "frontend-lint            Run frontend checks and fixable lint/format steps"
 	@echo "wheel                    Build the wheel for the current version"
 	@echo "tag-release              Tag the GitHub repository with the current version (use at release time only!)"
-	@echo "openapi                  Generate the OpenAPI schema for the app, outputting to stdout"
 	@echo "docs                     Serve the mkdocs site with live reload"
 
 # Runs ruff, fixing any safely-fixable errors and formatting
@@ -67,6 +66,7 @@ frontend-test:
 frontend-dev:
 	cd invokeai/frontend/web && pnpm dev
 
+# Generate the OpenAPI Schema for the app
 frontend-openapi:
 	cd invokeai/frontend/web && \
 	python ../../../scripts/generate_openapi_schema.py > openapi.json && \
@@ -89,10 +89,6 @@ wheel:
 # Tag the release
 tag-release:
 	cd scripts && ./tag_release.sh
-
-# Generate the OpenAPI Schema for the app
-openapi:
-	python scripts/generate_openapi_schema.py
 
 # Serve the mkdocs site w/ live reload
 .PHONY: docs


### PR DESCRIPTION
## Summary

Remove the `make openapi` Makefile target.

## Related Issues / Discussions

## QA Instructions

## Merge Plan

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
