### PR TITLE
fix(scripts): resolve invokeai from repo root in generate_openapi_schema.py

### DIFF
--- a/scripts/generate_openapi_schema.py
+++ b/scripts/generate_openapi_schema.py
@@ -5,7 +5,16 @@ import sys
 
 def main():
     # Change working directory to the repo root
-    os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    os.chdir(repo_root)
+
+    # When invoked as a script, sys.path[0] is this script's directory rather than the repo
+    # root, so ``import invokeai`` would resolve via the venv install — which on systems with
+    # multi-worktree editable installs can pick up an `invokeai` namespace package missing
+    # some of this worktree's invocation modules. Prepending the repo root ensures we always
+    # import the local sources and so register every invocation declared here.
+    if sys.path[0] != repo_root:
+        sys.path.insert(0, repo_root)
 
     from invokeai.app.api_app import app
     from invokeai.app.util.custom_openapi import get_openapi_func


### PR DESCRIPTION
## Summary

- When ``scripts/generate_openapi_schema.py`` is launched as ``python scripts/generate_openapi_schema.py``, Python sets ``sys.path[0]`` to the script's directory rather than the repo root. ``import invokeai`` then resolves via the venv's ``site-packages``. On systems with multiple editable installs of this repo (e.g. ``git worktree`` checkouts), the venv exposes ``invokeai`` as a PEP 420 namespace package that aggregates every worktree's ``invokeai/`` directory, and submodule-discovery imports silently miss whichever worktree isn't first on the namespace path.
- Concretely: in a multi-worktree setup, the registry came up short by 15 invocations (every node declared only in the worktree I was running against), and those nodes silently disappeared from the generated ``openapi.json``. Running the same imports via ``python -c`` worked, because ``sys.path[0]`` defaulted to the cwd and ``invokeai/__init__.py`` resolved cleanly to the worktree.
- Fix: prepend the resolved repo root to ``sys.path`` before importing ``invokeai.*`` so the script always picks up the local sources regardless of how it's launched. ``os.chdir`` to the repo root is retained; only ``sys.path`` is augmented.
- Single-worktree users are unaffected — for them ``invokeai`` already resolves to a regular package and the new ``sys.path`` insert is a no-op (the import would have found the same files anyway).

## Test plan

- [ ] In a multi-worktree editable install, run ``python scripts/generate_openapi_schema.py`` and confirm the resulting ``InvocationOutputMap`` contains every invocation listed by ``InvocationRegistry.get_invocation_classes()``.
- [ ] In a single-worktree install, confirm the script's output is byte-identical before and after this change (the new ``sys.path`` entry should be a no-op when the entry would have been found anyway).
- [ ] Run ``make frontend-openapi && make frontend-typegen`` and confirm no spurious diff appears in ``invokeai/frontend/web/openapi.json`` or ``invokeai/frontend/web/src/services/api/schema.ts``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)