### PR TITLE
Fix python tests on CUDA

### DIFF
--- a/invokeai/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/custom_invoke_linear_nf4.py
+++ b/invokeai/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/custom_invoke_linear_nf4.py
@@ -75,6 +75,12 @@ class CustomInvokeLinearNF4(InvokeLinearNF4, CustomModuleMixin):
         weight.quant_state.code = cast_to_device(weight.quant_state.code, x.device)
 
         bias = cast_to_device(self.bias, x.device)
+        if x.numel() == x.shape[-1]:
+            # bitsandbytes routes single-vector inputs through gemv_4bit, which can fail with CPU-stored,
+            # device-autocasted Params4bit weights on some CUDA/bnb combinations. Use the same dequantized
+            # matmul path that bnb.matmul_4bit uses for batched inputs.
+            dequantized_weight = bnb.functional.dequantize_4bit(weight, weight.quant_state).to(x.dtype)
+            return torch.nn.functional.linear(x, dequantized_weight, bias).to(inp_dtype)
         return bnb.matmul_4bit(x, weight.t(), bias=bias, quant_state=weight.quant_state).to(inp_dtype)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/invokeai/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/custom_invoke_linear_nf4.py
+++ b/invokeai/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/custom_invoke_linear_nf4.py
@@ -66,6 +66,7 @@ class CustomInvokeLinearNF4(InvokeLinearNF4, CustomModuleMixin):
 
         # Make a shallow copy of the quant_state so that we can undo the in-place modification that occurs when casting
         # to a new device.
+        weight_was_offloaded = self.weight.device.type != x.device.type
         old_quant_state = copy.copy(self.weight.quant_state)
         weight = cast_to_device(self.weight, x.device)
         self.weight.quant_state = old_quant_state
@@ -75,7 +76,7 @@ class CustomInvokeLinearNF4(InvokeLinearNF4, CustomModuleMixin):
         weight.quant_state.code = cast_to_device(weight.quant_state.code, x.device)
 
         bias = cast_to_device(self.bias, x.device)
-        if x.numel() == x.shape[-1]:
+        if weight_was_offloaded and x.numel() == x.shape[-1]:
             # bitsandbytes routes single-vector inputs through gemv_4bit, which can fail with CPU-stored,
             # device-autocasted Params4bit weights on some CUDA/bnb combinations. Use the same dequantized
             # matmul path that bnb.matmul_4bit uses for batched inputs.

--- a/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py
+++ b/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py
@@ -579,8 +579,7 @@ def test_quantized_linear_sidecar_patches(
     patches, input = patch_under_test
 
     linear_layer, quantized_linear_layer = quantized_linear_layer_under_test
-    if _is_bnb_quantized_linear(quantized_linear_layer) and _has_dora_patch(patches):
-        pytest.skip("DoRA patches require readable base weights and are not compatible with bnb quantized layers.")
+    expect_dora_incompatible = _is_bnb_quantized_linear(quantized_linear_layer) and _has_dora_patch(patches)
 
     # Move everything to the device.
     layer_to_device_via_state_dict(linear_layer, device)
@@ -599,6 +598,11 @@ def test_quantized_linear_sidecar_patches(
 
     # Run inference with the original layer and the patched layer and assert they are equal.
     output_linear_patched = linear_layer_custom(input)
+    if expect_dora_incompatible:
+        with pytest.raises(RuntimeError, match="not compatible with DoRA patches"):
+            quantized_linear_layer_custom(input)
+        return
+
     output_quantized_patched = quantized_linear_layer_custom(input)
     assert torch.allclose(output_linear_patched, output_quantized_patched, rtol=0.2, atol=0.2)
 
@@ -615,8 +619,7 @@ def test_quantized_linear_sidecar_patches_with_autocast_from_cpu_to_device(
     patches, input = patch_under_test
 
     _, quantized_linear_layer = quantized_linear_layer_under_test
-    if _is_bnb_quantized_linear(quantized_linear_layer) and _has_dora_patch(patches):
-        pytest.skip("DoRA patches require readable base weights and are not compatible with bnb quantized layers.")
+    expect_dora_incompatible = _is_bnb_quantized_linear(quantized_linear_layer) and _has_dora_patch(patches)
 
     # Move everything to the device.
     layer_to_device_via_state_dict(quantized_linear_layer, device)
@@ -629,6 +632,11 @@ def test_quantized_linear_sidecar_patches_with_autocast_from_cpu_to_device(
         quantized_linear_layer_custom.add_patch(patch, weight)
 
     # Run inference with the custom layer on the device.
+    if expect_dora_incompatible:
+        with pytest.raises(RuntimeError, match="not compatible with DoRA patches"):
+            quantized_linear_layer_custom(input)
+        return
+
     expected_output = quantized_linear_layer_custom(input)
 
     # Move the custom layer to the CPU.

--- a/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py
+++ b/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py
@@ -316,28 +316,43 @@ def test_inference_autocast_from_cpu_to_device(device: str, layer_under_test: La
     # Move the original layer to the CPU.
     layer_to_device_via_state_dict(orig_layer, "cpu")
 
-    # Inference should fail with an input on the device.
-    with pytest.raises(RuntimeError):
-        _ = orig_layer(x)
+    is_nf4_layer = type(orig_layer).__name__ == "InvokeLinearNF4"
+    # Inference should fail with an input on the device. Do not probe raw NF4 here: with CPU-stored weights and a
+    # single-row CUDA input, some bitsandbytes versions hit an unsafe gemv_4bit path instead of raising safely.
+    if not is_nf4_layer:
+        with pytest.raises((RuntimeError, ValueError)):
+            _ = orig_layer(x)
 
     # Wrap the original layer.
     custom_layer = copy.deepcopy(orig_layer)
     custom_layer = wrap_single_custom_layer(custom_layer)
 
-    # Inference should still fail with autocasting disabled.
+    # Inference should still fail with autocasting disabled. See the raw NF4 note above.
     custom_layer.set_device_autocasting_enabled(False)
-    with pytest.raises(RuntimeError):
-        _ = custom_layer(x)
+    if not is_nf4_layer:
+        with pytest.raises((RuntimeError, ValueError)):
+            _ = custom_layer(x)
 
     # Run inference with the wrapped layer on the device.
     custom_layer.set_device_autocasting_enabled(True)
     custom_output = custom_layer(x)
     assert custom_output.device.type == device
 
-    assert torch.allclose(orig_output, custom_output)
+    if is_nf4_layer:
+        assert torch.allclose(orig_output, custom_output, atol=1e-5)
+    else:
+        assert torch.allclose(orig_output, custom_output)
 
 
 PatchUnderTest = tuple[list[tuple[BaseLayerPatch, float]], torch.Tensor]
+
+
+def _has_dora_patch(patches: list[tuple[BaseLayerPatch, float]]) -> bool:
+    return any(isinstance(patch, DoRALayer) for patch, _ in patches)
+
+
+def _is_bnb_quantized_linear(layer: torch.nn.Module) -> bool:
+    return type(layer).__name__ in {"InvokeLinear8bitLt", "InvokeLinearNF4"}
 
 
 @pytest.fixture(
@@ -564,6 +579,8 @@ def test_quantized_linear_sidecar_patches(
     patches, input = patch_under_test
 
     linear_layer, quantized_linear_layer = quantized_linear_layer_under_test
+    if _is_bnb_quantized_linear(quantized_linear_layer) and _has_dora_patch(patches):
+        pytest.skip("DoRA patches require readable base weights and are not compatible with bnb quantized layers.")
 
     # Move everything to the device.
     layer_to_device_via_state_dict(linear_layer, device)
@@ -598,6 +615,8 @@ def test_quantized_linear_sidecar_patches_with_autocast_from_cpu_to_device(
     patches, input = patch_under_test
 
     _, quantized_linear_layer = quantized_linear_layer_under_test
+    if _is_bnb_quantized_linear(quantized_linear_layer) and _has_dora_patch(patches):
+        pytest.skip("DoRA patches require readable base weights and are not compatible with bnb quantized layers.")
 
     # Move everything to the device.
     layer_to_device_via_state_dict(quantized_linear_layer, device)

--- a/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_8_bit_lt.py
+++ b/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_8_bit_lt.py
@@ -70,7 +70,7 @@ def test_custom_invoke_linear_8bit_lt_all_weights_on_cpu(linear_8bit_lt_layer: I
     linear_8bit_lt_layer.load_state_dict(state_dict)
 
     # Inference of the original layer should fail.
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, ValueError)):
         linear_8bit_lt_layer(x)
 
     # Wrap the InvokeLinear8bitLt layer in a CustomInvokeLinear8bitLt layer, and run inference on it.

--- a/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_nf4.py
+++ b/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_nf4.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 import torch
 
@@ -54,6 +56,20 @@ def test_custom_invoke_linear_nf4_all_weights_on_cuda(linear_nf4_layer: InvokeLi
 
     # Assert that the quantized and custom layers produce the same output.
     assert torch.allclose(y_quantized, y_custom, atol=1e-5)
+
+
+def test_custom_invoke_linear_nf4_all_weights_on_cuda_uses_bnb_single_vector_path(
+    linear_nf4_layer: InvokeLinearNF4,
+):
+    """GPU-resident single-vector inference should keep using bnb's gemv_4bit path."""
+    x = torch.randn(1, 64).to("cuda")
+    custom_linear_nf4_layer = wrap_custom_layer(linear_nf4_layer, CustomInvokeLinearNF4)
+    custom_linear_nf4_layer.set_device_autocasting_enabled(True)
+
+    with patch("bitsandbytes.functional.dequantize_4bit") as mock_dequantize:
+        _ = custom_linear_nf4_layer(x)
+
+    mock_dequantize.assert_not_called()
 
 
 # We run with two different input dimensions, because the NF4 layer follows a different code path depending on the

--- a/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_nf4.py
+++ b/tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_nf4.py
@@ -70,9 +70,9 @@ def test_custom_invoke_linear_nf4_all_weights_on_cpu(linear_nf4_layer: InvokeLin
     state_dict = {k: v.to("cpu") for k, v in state_dict.items()}
     linear_nf4_layer.load_state_dict(state_dict)
 
-    # Inference of the original layer should fail.
-    with pytest.raises(RuntimeError):
-        linear_nf4_layer(x)
+    # Do not call the raw bitsandbytes NF4 layer here. With CPU-stored weights and a single-row CUDA input, some
+    # bitsandbytes versions hit an unsafe gemv_4bit path instead of raising a Python exception. The custom layer below
+    # is the behavior under test.
 
     # Wrap the InvokeLinearNF4 layer in a CustomInvokeLinearNF4 layer, and run inference on it.
     custom_linear_nf4_layer = wrap_custom_layer(linear_nf4_layer, CustomInvokeLinearNF4)


### PR DESCRIPTION
## Summary

Fix CUDA test and runtime compatibility issues in bnb custom linear autocast paths.

- Avoid the bitsandbytes NF4 single-vector `gemv_4bit` path for CPU-stored, device-autocasted weights by using the dequantized linear path for that shape.
- Update CUDA tests to account for current bitsandbytes/PyTorch failure modes, including `ValueError` from raw 8-bit CPU-weight inference.
- Avoid unsafe raw NF4 CPU-weight probes in tests and skip unsupported DoRA + bnb quantized layer combinations.

## Related Issues / Discussions

@keturn reported issues on Discord: https://discord.com/channels/1020123559063990373/1049495067846524939/1506160085108396092

## QA Instructions

1. Validate in a CUDA environment:
```bash
python -m pytest \
  tests/app/util/test_torch_cuda_allocator.py \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_8_bit_lt.py \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_nf4.py \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/test_torch_module_autocast.py::test_torch_module_autocast_bnb_llm_int8_linear_layer \
  tests/backend/patches/test_layer_patcher.py::test_apply_smart_lora_patches_to_partially_loaded_model \
  tests/backend/patches/test_layer_patcher.py::test_apply_smart_model_patches_change_device \
  tests/backend/quantization/test_bnb_llm_int8.py \
  tests/backend/quantization/gguf/test_ggml_tensor.py::test_ggml_tensor_to_device \
  tests/backend/model_manager/load/model_cache/cached_model/ \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py \
  tests/backend/patches/test_layer_patcher.py \
  tests/backend/patches/layers/test_lora_layer.py \
  tests/backend/patches/layers/test_set_parameter_layer.py \
  tests/backend/quantization/gguf/test_ggml_tensor.py
```
2. Validate in any environment:
```bash
CUDA_VISIBLE_DEVICES="" python -m pytest \
  tests/app/util/test_torch_cuda_allocator.py \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_8_bit_lt.py \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_custom_invoke_linear_nf4.py \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/test_torch_module_autocast.py::test_torch_module_autocast_bnb_llm_int8_linear_layer \
  tests/backend/patches/test_layer_patcher.py::test_apply_smart_lora_patches_to_partially_loaded_model \
  tests/backend/patches/test_layer_patcher.py::test_apply_smart_model_patches_change_device \
  tests/backend/quantization/test_bnb_llm_int8.py \
  tests/backend/quantization/gguf/test_ggml_tensor.py::test_ggml_tensor_to_device \
  tests/backend/model_manager/load/model_cache/cached_model/ \
  tests/backend/model_manager/load/model_cache/torch_module_autocast/custom_modules/test_all_custom_modules.py \
  tests/backend/patches/test_layer_patcher.py \
  tests/backend/patches/layers/test_lora_layer.py \
  tests/backend/patches/layers/test_set_parameter_layer.py \
  tests/backend/quantization/gguf/test_ggml_tensor.py
```
3. Try various models to make sure that generation isn't impacted.

## Merge Plan

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
