### PR TITLE
fix(z-image): split pos_ids by own length in regional forward

### DIFF
--- a/invokeai/backend/z_image/z_image_transformer_patch.py
+++ b/invokeai/backend/z_image/z_image_transformer_patch.py
@@ -73,10 +73,13 @@ def create_regional_forward(
         adaln_input = t_emb.type_as(x_cat)
         x_cat[torch.cat(x_inner_pad_mask)] = self.x_pad_token
         x_list = list(x_cat.split(x_item_seqlens, dim=0))
-        x_freqs_cis = list(self.rope_embedder(torch.cat(x_pos_ids, dim=0)).split(x_item_seqlens, dim=0))
+        # Split pos_ids by their own lengths — diffusers' _pad_with_ids can emit pos_ids
+        # longer than the padded feature when ori_len is not a multiple of SEQ_MULTI_OF.
+        x_freqs_cis = list(self.rope_embedder(torch.cat(x_pos_ids, dim=0)).split([len(p) for p in x_pos_ids], dim=0))
 
         x_padded = pad_sequence(x_list, batch_first=True, padding_value=0.0)
         x_freqs_cis_padded = pad_sequence(x_freqs_cis, batch_first=True, padding_value=0.0)
+        x_freqs_cis_padded = x_freqs_cis_padded[:, : x_padded.shape[1]]
         x_attn_mask = torch.zeros((bsz, x_max_item_seqlen), dtype=torch.bool, device=device)
         for i, seq_len in enumerate(x_item_seqlens):
             x_attn_mask[i, :seq_len] = 1
@@ -100,10 +103,13 @@ def create_regional_forward(
         cap_cat = self.cap_embedder(cap_cat)
         cap_cat[torch.cat(cap_inner_pad_mask)] = self.cap_pad_token
         cap_list = list(cap_cat.split(cap_item_seqlens, dim=0))
-        cap_freqs_cis = list(self.rope_embedder(torch.cat(cap_pos_ids, dim=0)).split(cap_item_seqlens, dim=0))
+        cap_freqs_cis = list(
+            self.rope_embedder(torch.cat(cap_pos_ids, dim=0)).split([len(p) for p in cap_pos_ids], dim=0)
+        )
 
         cap_padded = pad_sequence(cap_list, batch_first=True, padding_value=0.0)
         cap_freqs_cis_padded = pad_sequence(cap_freqs_cis, batch_first=True, padding_value=0.0)
+        cap_freqs_cis_padded = cap_freqs_cis_padded[:, : cap_padded.shape[1]]
         cap_attn_mask = torch.zeros((bsz, cap_max_item_seqlen), dtype=torch.bool, device=device)
         for i, seq_len in enumerate(cap_item_seqlens):
             cap_attn_mask[i, :seq_len] = 1


### PR DESCRIPTION
## Summary

The regional transformer forward split rope position IDs by feature sequence lengths, but diffusers' `_pad_with_ids` emits `pos_ids` longer than the padded feature when the original length is not a multiple of `SEQ_MULTI_OF` (32), causing `split_with_sizes` to fail mid-denoise (e.g. "sum exactly to 46, got [32]"). Mirror the diffusers `_prepare_sequence` pattern (also used in the ControlNet extension): split by `pos_ids` lengths and trim the padded `freqs_cis` to the feature width.

## Related Issues / Discussions

#9251

## QA Instructions

Reproduce the original crash, then confirm it is gone:

1. Load a Z-Image (Turbo) model and enable **Regional Guidance** on the canvas.
2. Use a generation size whose latent token count is **not a multiple of 32** per region — e.g. a 1024×1024 image with a regional mask that yields ~46 tokens (any non-square or non-multiple-of-32 region works). The issue in #9251 reproduces reliably with arbitrary region shapes from the bbox/mask tool.
3. Run denoise.
   - **Before the fix:** crash with `split_with_sizes expects split_sizes to sum exactly to N, got [32]` (or similar mismatch).
   - **After the fix:** denoise completes; the regional prompt is respected inside the region and the global prompt outside.
4. Sanity-check non-regional Z-Image generations still work (no regional guidance), to confirm the patched forward path is unchanged for the common case.
5. If possible, also test with multiple regions and with both Z-Image and Z-Image Turbo to cover both `rope_embedder` paths (x and cap).

## Merge Plan

Single-file change.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
