### PR TITLE
fix(ci/cd): fix typegen test failure introduced by PR 9209

### DIFF
--- a/.github/workflows/openapi-checks.yml
+++ b/.github/workflows/openapi-checks.yml
@@ -33,6 +33,9 @@ on:
 
 jobs:
   openapi-checks:
+    env:
+      # uv requires a venv by default - but for this, we can simply use the system python
+      UV_SYSTEM_PYTHON: 1
     runs-on: ubuntu-22.04
     timeout-minutes: 15 # expected run time: <5 min
     steps:

--- a/.github/workflows/typegen-checks.yml
+++ b/.github/workflows/typegen-checks.yml
@@ -33,6 +33,9 @@ on:
 
 jobs:
   typegen-checks:
+    env:
+      # uv requires a venv by default - but for this, we can simply use the system python
+      UV_SYSTEM_PYTHON: 1
     runs-on: ubuntu-22.04
     timeout-minutes: 15 # expected run time: <5 min
     steps:


### PR DESCRIPTION
## Summary

PR #9209 introduced a regression in the typegen check CI script manifested by the following error during the install dependencies step:

```
 error: No virtual environment found for Python 3.11; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment                                           
```

The core issue is that after the change to  `setup-uv@v8 + python-version`, uv 0.6.10 now refuses `uv pip install`
without a venv being created. This PR fixes the issue by setting the environment variable `UV_SYSTEM_PYTHON` which restores the earlier behavior of using the system Python. 

`openapi-checks` has the same issue, so I fixed it here as well.

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

The PR checks should now succeed.

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

Simple merge

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
