### PR TITLE
chore(ci): update cached-lfs-checkout from deprecated node 20 version

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: checkout
         # https://github.com/nschloe/action-cached-lfs-checkout
-        uses: nschloe/action-cached-lfs-checkout@f46300cd8952454b9f0a21a3d133d4bd5684cfc2
+        uses: nschloe/action-cached-lfs-checkout@385a8ecc719e50b8c71af6ab01a624b486b7c3bc
 
       - name: check for changed python files
         if: ${{ inputs.always_run != true }}


### PR DESCRIPTION
Follow-up to #9149. Missed this one because it wasn't directly named in the deprecation notice; it's a transitive use of other old actions.


## Merge Plan

Do it soon! No more than two days left before workers stop running Node 20.


## Checklist

- [y] _The PR has a short but descriptive title, suitable for a changelog_
- [y] _Tests added / updated (if applicable)_
- [N/A] _❗Changes to a redux slice have a corresponding migration_
- [N/A] _Documentation added / updated (if applicable)_
- [N/A] _Updated `What's New` copy (if doing a release after this PR)_
