### PR TITLE
ci: run pytest via uv run to fix venv PATH breakage from #9214

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -61,7 +61,6 @@ jobs:
     timeout-minutes: 15 # expected run time: 2-6 min, depending on platform
     env:
       PIP_USE_PEP517: '1'
-      UV_SYSTEM_PYTHON: 1
 
     steps:
       - name: checkout
@@ -93,12 +92,6 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: setup python
-        if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: install dependencies
         if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
         env:
@@ -107,4 +100,4 @@ jobs:
 
       - name: run pytest
         if: ${{ steps.changed-files.outputs.python_any_changed == 'true' || inputs.always_run == true }}
-        run: pytest
+        run: uv run --no-sync pytest


### PR DESCRIPTION
## Summary

PR #9214 switched the python-tests workflow's install step from `uv pip install --editable ".[test]"` to `uv sync --no-progress --locked --extra test`. This broke every pytest matrix job with:

```
pytest: command not found
##[error]Process completed with exit code 127.
```

(Visible on PR #9246's CI; only one job shows the error — the rest report "canceled" because the matrix's default fail-fast kills them once the first fails.)

### Root cause

The old `uv pip install` honored `UV_SYSTEM_PYTHON: 1` and installed into the runner's system Python, putting `pytest` on the `PATH`. `uv sync` is a project command — it always installs into a project-local `.venv` and ignores `UV_SYSTEM_PYTHON` — so the bare `pytest` invocation in the next step never sees the synced environment.

### Fix

- Run pytest via `uv run --no-sync pytest`. The `--no-sync` flag matters: a plain `uv run pytest` would first re-sync the environment *without* `--extra test`, uninstalling pytest right before trying to run it.
- Drop `UV_SYSTEM_PYTHON: 1` — dead config now that nothing in the job uses the `uv pip` interface.
- Drop the `actions/setup-python` step — `setup-uv` is already given the matrix `python-version`, and `uv sync` provisions its own interpreter.

## Related Issues / Discussions

- Follow-up to #9214 (ci: use uv.lock when running tests)
- Failure visible on #9246's CI runs

## QA Instructions

Note that this PR's own pull_request CI run skips the pytest steps (no python files changed, and the `changed-files` filter only matches `pyproject.toml`/`invokeai/**`/`tests/**`), so a green check there is vacuous. To exercise the fix for real, a `workflow_dispatch` run with `always_run=true` was triggered on this branch: https://github.com/invoke-ai/InvokeAI/actions/runs/27374428547 — all six matrix jobs should reach pytest and pass.

## Merge Plan

Straight merge. Unblocks CI for all open PRs touching python files.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ — n/a, CI config only
- [ ] _❗Changes to a redux slice have a corresponding migration_ — n/a
- [ ] _Documentation added / updated (if applicable)_ — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)