### PR TITLE
docs: fix git-lfs link formatting in dev environment guide

### DIFF
--- a/docs/src/content/docs/development/Setup/dev-environment.mdx
+++ b/docs/src/content/docs/development/Setup/dev-environment.mdx
@@ -1,6 +1,6 @@
 ---
 title: Development Environment
-lastUpdated: 2026-02-19
+lastUpdated: 2026-07-01
 ---
 
 import { LinkCard, Steps, Tabs, TabItem, FileTree, LinkButton } from '@astrojs/starlight/components'
@@ -34,7 +34,7 @@ import SystemRequirementsLink from '@components/SystemRequirmentsLink.astro'
       Next, clone your fork to your local machine. You can use either HTTPS or SSH, depending on your git configuration.
 
   3. This repository uses Git LFS to manage large files. To ensure all assets are downloaded:
-        - Install git-lfs → [Download here](https://git-lfs.com/)
+        - Install git-lfs -> [Download here](https://git-lfs.com/)
         - Enable automatic LFS fetching for this repository:
           ```shell
           git config lfs.fetchinclude "*"


### PR DESCRIPTION
## Summary
- replace the malformed arrow character in the Git LFS setup bullet with a plain ASCII arrow
- refresh the page's `lastUpdated` value to reflect the documentation change

## Why
The current Git LFS installation bullet contains a formatting artifact that makes the setup step look broken in some environments. This keeps the onboarding instructions readable for new contributors following the dev setup guide.