### PR TITLE
fix(qwen): restore legacy key remapping for single-file VL encoders under transformers 5.x

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/qwen_image.py
+++ b/invokeai/backend/model_manager/load/model_loaders/qwen_image.py
@@ -443,8 +443,14 @@ class QwenVLEncoderCheckpointLoader(ModelLoader):
         # (`visual.X`, `model.X`); transformers ≥4.50 expects `model.visual.X` and
         # `model.language_model.X`. Apply the same conversion mapping that
         # `Qwen2_5_VLForConditionalGeneration.from_pretrained` would, since
-        # `load_state_dict` does not.
-        key_mapping = Qwen2_5_VLForConditionalGeneration._checkpoint_conversion_mapping
+        # `load_state_dict` does not. transformers 4.x published that mapping as
+        # `_checkpoint_conversion_mapping`; transformers 5.x ships it empty (conversion moved
+        # into from_pretrained's weight-converter machinery, which load_state_dict bypasses),
+        # so fall back to the equivalent mapping when the attribute is empty or gone.
+        key_mapping = getattr(Qwen2_5_VLForConditionalGeneration, "_checkpoint_conversion_mapping", None) or {
+            r"^visual": "model.visual",
+            r"^model(?!\.(?:language_model|visual))": "model.language_model",
+        }
         if key_mapping:
             remapped_sd: dict[str, torch.Tensor] = {}
             for old_key, tensor in sd.items():


### PR DESCRIPTION
## Summary

Loading a single-file (ComfyUI-style) Qwen2.5-VL text encoder — e.g. `qwen_2.5_vl_7b_fp8_scaled.safetensors` — fails under transformers 5.x with:

```
RuntimeError: Failed to load all parameters from checkpoint. Meta tensors remain: ['model.visual.patch_embed.proj.weight', ...]
```

**Why:** the loader translates the checkpoint's legacy key layout (`visual.*`, `model.layers.*`) to the modern layout (`model.visual.*`, `model.language_model.*`) using `Qwen2_5_VLForConditionalGeneration._checkpoint_conversion_mapping`. transformers 4.x published that mapping on the class, but transformers 5.x ships it **empty** — the conversion moved into `from_pretrained`'s weight-converter machinery, which our manual `load_state_dict` path bypasses. The remap silently no-ops, all ~714 vision-tower keys land as "unexpected", and the model's `model.visual.*` parameters are left on the meta device.

Since `pyproject.toml` pins `transformers>=5.5,<5.6`, every current install is affected; any workflow using a single-file Qwen VL encoder (typical for GGUF-quantized Qwen Image installs) fails at the text-encoder node. Encoders installed in diffusers folder layout are unaffected (they load via `from_pretrained`).

**How:** fall back to the equivalent hardcoded mapping (`^visual → model.visual`, `^model → model.language_model` with a lookahead guard excluding already-modern keys) when the class attribute is empty or absent. transformers 4.x installs keep using the class-provided mapping.

## Related Issues / Discussions

None filed; discovered while testing Qwen Image 2512 (Q8_0) + Qwen Image Lightning LoRA.

## QA Instructions

1. Install a single-file Qwen2.5-VL encoder (e.g. ComfyUI's `qwen_2.5_vl_7b_fp8_scaled.safetensors`) and a Qwen Image main model that uses it.
2. On current main, any generation fails at the `qwen_image_text_encoder` node with the "Meta tensors remain" error above.
3. With this PR, the same generation succeeds. Verified locally: the encoder loads all 8.29B parameters in bf16 with zero meta tensors remaining, and end-to-end Qwen Image renders complete.

## Merge Plan

Trivial single-file change; no DB or schema impact.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ — not practical: exercising the path requires a multi-GB checkpoint file
- [ ] _❗Changes to a redux slice have a corresponding migration_ — n/a
- [ ] _Documentation added / updated (if applicable)_ — n/a
- [ ] _Updated `What's New` copy (if doing a release after this PR)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)