### PR TITLE
Fix workflow library unsupported badge

### DIFF
--- a/invokeai/app/api/routers/workflows.py
+++ b/invokeai/app/api/routers/workflows.py
@@ -1,4 +1,5 @@
 import io
+import math
 import traceback
 from typing import Optional
 
@@ -177,6 +178,11 @@ async def list_workflows(
     query: Optional[str] = Query(default=None, description="The text to query by (matches name and description)"),
     has_been_opened: Optional[bool] = Query(default=None, description="Whether to include/exclude recent workflows"),
     is_public: Optional[bool] = Query(default=None, description="Filter by public/shared status"),
+    is_callable: Optional[bool] = Query(
+        default=None,
+        alias="callable",
+        description="Filter by whether workflows are callable by call_saved_workflow",
+    ),
 ) -> PaginatedResults[WorkflowRecordListItemWithThumbnailDTO]:
     """Gets a page of workflows"""
     config = ApiDependencies.invoker.services.configuration
@@ -194,7 +200,7 @@ async def list_workflows(
         order_by=order_by,
         direction=direction,
         page=page,
-        per_page=per_page,
+        per_page=None if is_callable is not None else per_page,
         query=query,
         categories=categories,
         tags=tags,
@@ -217,6 +223,8 @@ async def list_workflows(
             maximum_children=ApiDependencies.invoker.services.configuration.max_queue_size,
             resolve_generator_items=False,
         )
+        if is_callable is not None and compatibility.is_callable != is_callable:
+            continue
         workflows_with_thumbnails.append(
             WorkflowRecordListItemWithThumbnailDTO(
                 thumbnail_url=ApiDependencies.invoker.services.workflow_thumbnails.get_url(workflow.workflow_id),
@@ -224,6 +232,25 @@ async def list_workflows(
                 **workflow.model_dump(),
             )
         )
+
+    if is_callable is not None:
+        total = len(workflows_with_thumbnails)
+        if per_page:
+            start = page * per_page
+            end = start + per_page
+            page_items = workflows_with_thumbnails[start:end]
+            pages = math.ceil(total / per_page)
+        else:
+            page_items = workflows_with_thumbnails
+            pages = 1
+        return PaginatedResults[WorkflowRecordListItemWithThumbnailDTO](
+            items=page_items,
+            total=total,
+            page=page,
+            pages=pages,
+            per_page=per_page if per_page else total,
+        )
+
     return PaginatedResults[WorkflowRecordListItemWithThumbnailDTO](
         items=workflows_with_thumbnails,
         total=max(len(workflows_with_thumbnails), workflows.total - skipped_missing_workflows),

--- a/invokeai/app/services/shared/workflow_graph_builder.py
+++ b/invokeai/app/services/shared/workflow_graph_builder.py
@@ -304,6 +304,10 @@ def build_graph_from_workflow(workflow: Mapping[str, Any]) -> Graph:
                 # Saved workflows may include input metadata for unfilled optional fields without a "value".
                 # Omit those fields so invocation defaults are applied instead of forcing None.
                 if "value" in field_value:
+                    # The frontend board picker may persist the "auto" sentinel; graph nodes model automatic
+                    # board selection as the board field default, None.
+                    if field_name == "board" and field_value["value"] == "auto":
+                        continue
                     graph_node[field_name] = field_value["value"]
 
         parsed_nodes[node_id] = graph_node

--- a/invokeai/app/services/shared/workflow_graph_builder.py
+++ b/invokeai/app/services/shared/workflow_graph_builder.py
@@ -304,9 +304,9 @@ def build_graph_from_workflow(workflow: Mapping[str, Any]) -> Graph:
                 # Saved workflows may include input metadata for unfilled optional fields without a "value".
                 # Omit those fields so invocation defaults are applied instead of forcing None.
                 if "value" in field_value:
-                    # The frontend board picker may persist the "auto" sentinel; graph nodes model automatic
-                    # board selection as the board field default, None.
-                    if field_name == "board" and field_value["value"] == "auto":
+                    # The frontend board picker may persist sentinel strings; graph nodes model both
+                    # automatic and no-board selection as the board field default, None.
+                    if field_name == "board" and field_value["value"] in ("auto", "none"):
                         continue
                     graph_node[field_name] = field_value["value"]
 

--- a/invokeai/app/services/shared/workflow_graph_builder.py
+++ b/invokeai/app/services/shared/workflow_graph_builder.py
@@ -301,7 +301,10 @@ def build_graph_from_workflow(workflow: Mapping[str, Any]) -> Graph:
             for field_name, field_value in inputs.items():
                 if not isinstance(field_name, str) or not _is_mapping(field_value):
                     continue
-                graph_node[field_name] = field_value.get("value")
+                # Saved workflows may include input metadata for unfilled optional fields without a "value".
+                # Omit those fields so invocation defaults are applied instead of forcing None.
+                if "value" in field_value:
+                    graph_node[field_name] = field_value["value"]
 
         parsed_nodes[node_id] = graph_node
 

--- a/invokeai/frontend/web/openapi.json
+++ b/invokeai/frontend/web/openapi.json
@@ -8451,6 +8451,24 @@
               "title": "Is Public"
             },
             "description": "Filter by public/shared status"
+          },
+          {
+            "name": "callable",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by whether workflows are callable by call_saved_workflow",
+              "title": "Callable"
+            },
+            "description": "Filter by whether workflows are callable by call_saved_workflow"
           }
         ],
         "responses": {

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -2491,7 +2491,6 @@
         "private": "Private",
         "shared": "Shared",
         "callable": "Callable",
-        "savedWorkflowUnsupportedDescription": "This workflow cannot currently be used by Call Saved Workflow.",
         "savedWorkflowCompatibility": {
             "missingWorkflowReturn": "The workflow must contain a Workflow Return node.",
             "multipleWorkflowReturn": "The workflow may contain only one Workflow Return node.",

--- a/invokeai/frontend/web/public/locales/en.json
+++ b/invokeai/frontend/web/public/locales/en.json
@@ -2490,6 +2490,7 @@
         "noRecentWorkflows": "No Recent Workflows",
         "private": "Private",
         "shared": "Shared",
+        "callable": "Callable",
         "savedWorkflowUnsupportedDescription": "This workflow cannot currently be used by Call Saved Workflow.",
         "savedWorkflowCompatibility": {
             "missingWorkflowReturn": "The workflow must contain a Workflow Return node.",

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/CallSavedWorkflowNode.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/CallSavedWorkflowNode.tsx
@@ -21,6 +21,7 @@ import { useGetWorkflowQuery } from 'services/api/endpoints/workflows';
 import {
   getSavedWorkflowDynamicEdgeIdsToRemove,
   getSavedWorkflowDynamicFields,
+  getSelectedSavedWorkflow,
   shouldSyncSavedWorkflowDynamicFields,
 } from './callSavedWorkflowFormUtils';
 
@@ -60,8 +61,15 @@ const CallSavedWorkflowNode = ({ nodeId, isOpen }: Props) => {
     skip: !workflowIdField.value,
   });
 
-  const shouldSyncDynamicFields = shouldSyncSavedWorkflowDynamicFields({ workflowId: workflowIdField.value, workflow });
-  const dynamicFields = useMemo(() => getSavedWorkflowDynamicFields(workflow, templates), [templates, workflow]);
+  const selectedWorkflow = getSelectedSavedWorkflow(workflowIdField.value, workflow);
+  const shouldSyncDynamicFields = shouldSyncSavedWorkflowDynamicFields({
+    workflowId: workflowIdField.value,
+    workflow: selectedWorkflow,
+  });
+  const dynamicFields = useMemo(
+    () => getSavedWorkflowDynamicFields(selectedWorkflow, templates),
+    [templates, selectedWorkflow]
+  );
   const edgeIdsToRemove = useMemo(
     () =>
       getSavedWorkflowDynamicEdgeIdsToRemove({

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.test.ts
@@ -124,6 +124,27 @@ describe('callSavedWorkflowFormUtils', () => {
     expect(getRenderableWorkflowForm(workflow, templates)).toBe(form);
   });
 
+  it('adds exposed fields missing from a non-empty stored form', () => {
+    const form = getDefaultForm();
+    const element = buildNodeFieldElement('node-1', 'a', addInputA.type);
+    form.elements[element.id] = { ...element, parentId: form.rootElementId };
+    getRootChildren(form).push(element.id);
+    const workflow = buildWorkflowResponse({
+      exposedFields: [
+        { nodeId: 'node-1', fieldName: 'a' },
+        { nodeId: 'node-1', fieldName: 'b' },
+      ],
+      form,
+    });
+
+    const dynamicFields = getSavedWorkflowDynamicFields(workflow, templates);
+
+    expect(dynamicFields.map((field) => field.fieldName)).toEqual([
+      'saved_workflow_input::node-1::a',
+      'saved_workflow_input::node-1::b',
+    ]);
+  });
+
   it('builds a fallback form from exposed fields when the stored form is empty', () => {
     const workflow = buildWorkflowResponse({
       exposedFields: [{ nodeId: 'node-1', fieldName: 'a' }],

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.test.ts
@@ -15,6 +15,7 @@ import {
   getSavedWorkflowDynamicEdgeIdsToRemove,
   getSavedWorkflowDynamicFields,
   getSavedWorkflowFormFieldData,
+  getSelectedSavedWorkflow,
   shouldSyncSavedWorkflowDynamicFields,
 } from './callSavedWorkflowFormUtils';
 
@@ -111,6 +112,14 @@ describe('callSavedWorkflowFormUtils', () => {
         workflow: buildWorkflowResponse(),
       })
     ).toBe(true);
+  });
+
+  it('ignores stale saved workflow query data after the selection is cleared or changed', () => {
+    const workflow = buildWorkflowResponse();
+
+    expect(getSelectedSavedWorkflow('', workflow)).toBeUndefined();
+    expect(getSelectedSavedWorkflow('workflow-2', workflow)).toBeUndefined();
+    expect(getSelectedSavedWorkflow('workflow-1', workflow)).toBe(workflow);
   });
 
   it('returns the stored form when it is non-empty and valid', () => {

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.ts
@@ -105,6 +105,74 @@ const buildFormFromExposedFields = (
   return form;
 };
 
+const getFormFieldKey = (nodeId: string, fieldName: string) => `${nodeId}.${fieldName}`;
+
+const getFormFieldKeys = (form: BuilderForm): Set<string> => {
+  const fieldKeys = new Set<string>();
+
+  for (const element of Object.values(form.elements)) {
+    if (!element || element.type !== 'node-field') {
+      continue;
+    }
+    const { nodeId, fieldName } = element.data.fieldIdentifier;
+    fieldKeys.add(getFormFieldKey(nodeId, fieldName));
+  }
+
+  return fieldKeys;
+};
+
+const addMissingExposedFieldsToForm = (
+  form: BuilderForm,
+  workflow: WorkflowResponse | undefined,
+  templates: Templates
+): BuilderForm => {
+  const exposedFields = (workflow?.workflow.exposedFields ?? []) as ExposedFieldLike[];
+  if (exposedFields.length === 0) {
+    return form;
+  }
+
+  const nodes = getWorkflowNodes(workflow);
+  const fieldKeys = getFormFieldKeys(form);
+  const nextForm = structuredClone(form);
+
+  for (const { nodeId, fieldName } of exposedFields) {
+    if (!nodeId || !fieldName || fieldKeys.has(getFormFieldKey(nodeId, fieldName))) {
+      continue;
+    }
+
+    const node = nodes.find((candidate) => candidate.data?.id === nodeId);
+    const nodeType = node?.data?.type;
+    if (!nodeType) {
+      continue;
+    }
+
+    const fieldTemplate = templates[nodeType]?.inputs[fieldName];
+    if (!fieldTemplate) {
+      continue;
+    }
+
+    const element = buildNodeFieldElement(nodeId, fieldName, fieldTemplate.type);
+    element.data.showDescription = false;
+    addElement({
+      form: nextForm,
+      element,
+      parentId: nextForm.rootElementId,
+      index: getRootChildCount(nextForm),
+    });
+    fieldKeys.add(getFormFieldKey(nodeId, fieldName));
+  }
+
+  return nextForm;
+};
+
+const getRootChildCount = (form: BuilderForm): number => {
+  const rootElement = form.elements[form.rootElementId];
+  if (!rootElement || !isContainerElement(rootElement)) {
+    return 0;
+  }
+  return rootElement.data.children.length;
+};
+
 export const getRenderableWorkflowForm = (
   workflow: WorkflowResponse | undefined,
   templates: Templates
@@ -112,7 +180,7 @@ export const getRenderableWorkflowForm = (
   const storedForm = getStoredForm(workflow);
 
   if (storedForm && validateFormStructure(storedForm) && !getIsFormEmpty(storedForm)) {
-    return storedForm;
+    return addMissingExposedFieldsToForm(storedForm, workflow, templates);
   }
 
   const fallbackForm = buildFormFromExposedFields(workflow, templates);

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils.ts
@@ -316,6 +316,16 @@ export const getSavedWorkflowDynamicFields = (
   return dynamicFields;
 };
 
+export const getSelectedSavedWorkflow = (
+  workflowId: string | null | undefined,
+  workflow: WorkflowResponse | undefined
+): WorkflowResponse | undefined => {
+  if (!workflowId || workflow?.workflow_id !== workflowId) {
+    return undefined;
+  }
+  return workflow;
+};
+
 export const shouldSyncSavedWorkflowDynamicFields = ({
   workflowId,
   workflow,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.test.ts
@@ -165,6 +165,7 @@ describe('savedWorkflowFieldUtils', () => {
       query: 'landscape',
       categories: ['user', 'default'],
       is_public: undefined,
+      callable: true,
     });
     expect(getSavedWorkflowPickerSharedQueryArg('landscape')).toMatchObject({
       page: 0,
@@ -172,6 +173,7 @@ describe('savedWorkflowFieldUtils', () => {
       query: 'landscape',
       categories: ['user'],
       is_public: true,
+      callable: true,
     });
   });
 

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.test.ts
@@ -161,14 +161,14 @@ describe('savedWorkflowFieldUtils', () => {
   it('queries owned/default workflows and shared public workflows separately', () => {
     expect(getSavedWorkflowPickerOwnedQueryArg('landscape')).toMatchObject({
       page: 0,
-      per_page: 50,
+      per_page: undefined,
       query: 'landscape',
       categories: ['user', 'default'],
       is_public: undefined,
     });
     expect(getSavedWorkflowPickerSharedQueryArg('landscape')).toMatchObject({
       page: 0,
-      per_page: 50,
+      per_page: undefined,
       query: 'landscape',
       categories: ['user'],
       is_public: true,

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.ts
@@ -6,7 +6,6 @@ import {
 import type { S, WorkflowRecordListItemWithThumbnailDTO } from 'services/api/types';
 
 export const MISSING_WORKFLOW_OPTION_VALUE = '__missing_workflow__';
-const SAVED_WORKFLOW_PICKER_PAGE_SIZE = 50;
 type SavedWorkflowBadge = 'unsupported' | 'default' | 'shared';
 
 type SavedWorkflowSelectionState =
@@ -24,7 +23,7 @@ export const buildSavedWorkflowOptions = (workflows: WorkflowRecordListItemWithT
 
 const baseSavedWorkflowPickerQueryArg = {
   page: 0,
-  per_page: SAVED_WORKFLOW_PICKER_PAGE_SIZE,
+  per_page: undefined,
   order_by: 'name',
   direction: 'ASC',
   tags: [] as string[],

--- a/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.ts
+++ b/invokeai/frontend/web/src/features/nodes/components/flow/nodes/Invocation/fields/inputs/savedWorkflowFieldUtils.ts
@@ -28,6 +28,7 @@ const baseSavedWorkflowPickerQueryArg = {
   direction: 'ASC',
   tags: [] as string[],
   has_been_opened: undefined,
+  callable: true,
 } as const;
 
 export const getSavedWorkflowPickerOwnedQueryArg = (query = '') => ({

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/WorkflowLibrary/WorkflowListItem.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/WorkflowLibrary/WorkflowListItem.tsx
@@ -145,26 +145,6 @@ export const WorkflowListItem = memo(({ workflow }: { workflow: WorkflowRecordLi
                   {t('workflows.callable')}
                 </Badge>
               )}
-              {listItemState.showUnsupportedBadge && (
-                <Tooltip
-                  label={
-                    listItemState.unsupportedMessageKey
-                      ? t(listItemState.unsupportedMessageKey)
-                      : t('workflows.savedWorkflowUnsupportedDescription')
-                  }
-                >
-                  <Badge
-                    color="warning.300"
-                    borderColor="warning.600"
-                    borderWidth={1}
-                    bg="transparent"
-                    flexShrink={0}
-                    variant="subtle"
-                  >
-                    {t('nodes.savedWorkflowUnsupported')}
-                  </Badge>
-                </Tooltip>
-              )}
               {listItemState.showDefaultIcon && (
                 <Image
                   src={InvokeLogo}
@@ -182,13 +162,6 @@ export const WorkflowListItem = memo(({ workflow }: { workflow: WorkflowRecordLi
           <Text variant="subtext" fontSize="xs" noOfLines={3}>
             {workflow.description}
           </Text>
-          {listItemState.showUnsupportedBadge && (
-            <Text variant="subtext" fontSize="xs" noOfLines={2} color="warning.300">
-              {listItemState.unsupportedMessageKey
-                ? t(listItemState.unsupportedMessageKey)
-                : t('workflows.savedWorkflowUnsupportedDescription')}
-            </Text>
-          )}
           {tags.length > 0 && (
             <Text fontSize="xs" noOfLines={1}>
               <Text as="span" color="base.400">

--- a/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/WorkflowLibrary/WorkflowListItem.tsx
+++ b/invokeai/frontend/web/src/features/nodes/components/sidePanel/workflow/WorkflowLibrary/WorkflowListItem.tsx
@@ -133,6 +133,18 @@ export const WorkflowListItem = memo(({ workflow }: { workflow: WorkflowRecordLi
                   {t('workflows.shared')}
                 </Badge>
               )}
+              {listItemState.showCallableBadge && (
+                <Badge
+                  color="invokeBlue.400"
+                  borderColor="invokeBlue.700"
+                  borderWidth={1}
+                  bg="transparent"
+                  flexShrink={0}
+                  variant="subtle"
+                >
+                  {t('workflows.callable')}
+                </Badge>
+              )}
               {listItemState.showUnsupportedBadge && (
                 <Tooltip
                   label={

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.test.ts
@@ -1,5 +1,6 @@
 import { deepClone } from 'common/util/deepClone';
 import type { IntegerFieldInputTemplate, StringFieldInputTemplate } from 'features/nodes/types/field';
+import { buildNodeFieldElement } from 'features/nodes/types/workflow';
 import { buildConnectorNode } from 'features/nodes/util/node/buildConnectorNode';
 import { describe, expect, it } from 'vitest';
 
@@ -8,6 +9,7 @@ import {
   connectorInserted,
   fieldIntegerValueChanged,
   fieldStringValueChanged,
+  fieldValueReset,
   nodesChanged,
   nodesSliceConfig,
 } from './nodesSlice';
@@ -332,6 +334,125 @@ describe('callSavedWorkflowDynamicFieldsChanged', () => {
     expect(clearedNode.data.inputs[fieldName]).toBeUndefined();
     expect(clearedNode.data.dynamicInputTemplates[fieldName]).toBeUndefined();
     expect(nextState.edges).toHaveLength(0);
+  });
+
+  it('clears dynamic fields from the form when the selected workflow is cleared', () => {
+    const state = nodesSliceConfig.getInitialState();
+    const targetNode = buildNode(callSavedWorkflowTemplate);
+    const workflowIdInput = targetNode.data.inputs.workflow_id;
+    if (!workflowIdInput) {
+      throw new Error('Expected workflow_id input');
+    }
+    workflowIdInput.value = 'workflow-1';
+    state.nodes.push(targetNode);
+
+    const fieldName = 'saved_workflow_input::node-1::a';
+    const formElement = buildNodeFieldElement(targetNode.id, fieldName, addIntegerInputTemplate.type);
+    state.form.elements[formElement.id] = {
+      ...formElement,
+      parentId: state.form.rootElementId,
+    };
+    const rootElement = state.form.elements[state.form.rootElementId];
+    if (!rootElement || rootElement.type !== 'container') {
+      throw new Error('Expected root container');
+    }
+    rootElement.data.children.push(formElement.id);
+    state.formFieldInitialValues[formElement.id] = 23;
+
+    let nextState = nodesSliceConfig.slice.reducer(
+      state,
+      callSavedWorkflowDynamicFieldsChanged({
+        nodeId: targetNode.id,
+        fields: [
+          {
+            fieldName,
+            fieldTemplate: buildDynamicIntegerTemplate(fieldName),
+            label: 'Left Addend',
+            description: 'The first number',
+            initialValue: 23,
+          },
+        ],
+        edgeIdsToRemove: [],
+      })
+    );
+
+    nextState = nodesSliceConfig.slice.reducer(
+      nextState,
+      fieldStringValueChanged({
+        nodeId: targetNode.id,
+        fieldName: 'workflow_id',
+        value: '',
+      })
+    );
+
+    expect(nextState.form.elements[formElement.id]).toBeUndefined();
+    expect(nextState.formFieldInitialValues[formElement.id]).toBeUndefined();
+    const nextRootElement = nextState.form.elements[nextState.form.rootElementId];
+    if (!nextRootElement || nextRootElement.type !== 'container') {
+      throw new Error('Expected root container');
+    }
+    expect(nextRootElement.data.children).not.toContain(formElement.id);
+  });
+
+  it('clears dynamic fields when the selected workflow field is reset to empty', () => {
+    const state = nodesSliceConfig.getInitialState();
+    const sourceNode = buildNode(addTemplate);
+    const targetNode = buildNode(callSavedWorkflowTemplate);
+    const workflowIdInput = targetNode.data.inputs.workflow_id;
+    if (!workflowIdInput) {
+      throw new Error('Expected workflow_id input');
+    }
+    workflowIdInput.value = 'workflow-1';
+    state.nodes.push(sourceNode, targetNode);
+
+    const fieldName = 'saved_workflow_input::node-1::a';
+    const formElement = buildNodeFieldElement(targetNode.id, fieldName, addIntegerInputTemplate.type);
+    state.form.elements[formElement.id] = {
+      ...formElement,
+      parentId: state.form.rootElementId,
+    };
+    const rootElement = state.form.elements[state.form.rootElementId];
+    if (!rootElement || rootElement.type !== 'container') {
+      throw new Error('Expected root container');
+    }
+    rootElement.data.children.push(formElement.id);
+    state.formFieldInitialValues[formElement.id] = 23;
+    state.edges.push(buildEdge(sourceNode.id, 'value', targetNode.id, fieldName));
+
+    let nextState = nodesSliceConfig.slice.reducer(
+      state,
+      callSavedWorkflowDynamicFieldsChanged({
+        nodeId: targetNode.id,
+        fields: [
+          {
+            fieldName,
+            fieldTemplate: buildDynamicIntegerTemplate(fieldName),
+            label: 'Left Addend',
+            description: 'The first number',
+            initialValue: 23,
+          },
+        ],
+        edgeIdsToRemove: [],
+      })
+    );
+
+    nextState = nodesSliceConfig.slice.reducer(
+      nextState,
+      fieldValueReset({
+        nodeId: targetNode.id,
+        fieldName: 'workflow_id',
+        value: '',
+      })
+    );
+
+    const clearedNode = nextState.nodes.find((node) => node.id === targetNode.id);
+    if (!clearedNode || clearedNode.type !== 'invocation') {
+      throw new Error('Expected invocation node');
+    }
+    expect(clearedNode.data.inputs[fieldName]).toBeUndefined();
+    expect(nextState.edges).toHaveLength(0);
+    expect(nextState.form.elements[formElement.id]).toBeUndefined();
+    expect(nextState.formFieldInitialValues[formElement.id]).toBeUndefined();
   });
 });
 

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.test.ts
@@ -7,6 +7,7 @@ import {
   callSavedWorkflowDynamicFieldsChanged,
   connectorInserted,
   fieldIntegerValueChanged,
+  fieldStringValueChanged,
   nodesChanged,
   nodesSliceConfig,
 } from './nodesSlice';
@@ -272,6 +273,64 @@ describe('callSavedWorkflowDynamicFieldsChanged', () => {
       })
     );
 
+    expect(nextState.edges).toHaveLength(0);
+  });
+
+  it('clears dynamic fields and inbound dynamic field edges when the selected workflow is cleared', () => {
+    const state = nodesSliceConfig.getInitialState();
+    const sourceNode = buildNode(addTemplate);
+    const targetNode = buildNode(callSavedWorkflowTemplate);
+    const workflowIdInput = targetNode.data.inputs.workflow_id;
+    if (!workflowIdInput) {
+      throw new Error('Expected workflow_id input');
+    }
+    workflowIdInput.value = 'workflow-1';
+    state.nodes.push(sourceNode, targetNode);
+
+    const fieldName = 'saved_workflow_input::node-1::a';
+    state.edges.push({
+      id: 'edge-1',
+      type: 'default',
+      source: sourceNode.id,
+      sourceHandle: 'value',
+      target: targetNode.id,
+      targetHandle: fieldName,
+    });
+
+    let nextState = nodesSliceConfig.slice.reducer(
+      state,
+      callSavedWorkflowDynamicFieldsChanged({
+        nodeId: targetNode.id,
+        fields: [
+          {
+            fieldName,
+            fieldTemplate: buildDynamicIntegerTemplate(fieldName),
+            label: 'Left Addend',
+            description: 'The first number',
+            initialValue: 23,
+          },
+        ],
+        edgeIdsToRemove: [],
+      })
+    );
+
+    nextState = nodesSliceConfig.slice.reducer(
+      nextState,
+      fieldStringValueChanged({
+        nodeId: targetNode.id,
+        fieldName: 'workflow_id',
+        value: '',
+      })
+    );
+
+    const clearedNode = nextState.nodes.find((node) => node.id === targetNode.id);
+    if (!clearedNode || clearedNode.type !== 'invocation') {
+      throw new Error('Expected invocation node');
+    }
+
+    expect(clearedNode.data.inputs.workflow_id?.value).toBe('');
+    expect(clearedNode.data.inputs[fieldName]).toBeUndefined();
+    expect(clearedNode.data.dynamicInputTemplates[fieldName]).toBeUndefined();
     expect(nextState.edges).toHaveLength(0);
   });
 });

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -188,8 +188,10 @@ const clearCallSavedWorkflowDynamicFields = (state: NodesState, nodeId: string) 
     return;
   }
 
+  const removedFieldNames = new Set<string>();
   for (const fieldName of Object.keys(node.data.inputs)) {
     if (fieldName.startsWith(CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX)) {
+      removedFieldNames.add(fieldName);
       delete node.data.inputs[fieldName];
       delete node.data.dynamicInputTemplates[fieldName];
     }
@@ -202,6 +204,43 @@ const clearCallSavedWorkflowDynamicFields = (state: NodesState, nodeId: string) 
       !edge.targetHandle?.startsWith(CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX)
     );
   });
+
+  removeCallSavedWorkflowDynamicFieldsFromForm(state, nodeId, removedFieldNames);
+};
+
+const clearCallSavedWorkflowDynamicFieldsIfWorkflowIdIsEmpty = (
+  state: NodesState,
+  { nodeId, fieldName, value }: FieldValueAction<StatefulFieldValue>['payload']
+) => {
+  if (fieldName === 'workflow_id' && value === '') {
+    clearCallSavedWorkflowDynamicFields(state, nodeId);
+  }
+};
+
+const removeCallSavedWorkflowDynamicFieldsFromForm = (
+  state: NodesState,
+  nodeId: string,
+  fieldNames: ReadonlySet<string>
+) => {
+  if (fieldNames.size === 0) {
+    return;
+  }
+
+  const formElementIdsToRemove = Object.values(state.form.elements).flatMap((element) => {
+    if (!isNodeFieldElement(element)) {
+      return [];
+    }
+    const { fieldIdentifier } = element.data;
+    if (fieldIdentifier.nodeId === nodeId && fieldNames.has(fieldIdentifier.fieldName)) {
+      return [element.id];
+    }
+    return [];
+  });
+
+  for (const id of formElementIdsToRemove) {
+    removeElement({ form: state.form, id });
+    delete state.formFieldInitialValues[id];
+  }
 };
 
 const slice = createSlice({
@@ -511,12 +550,11 @@ const slice = createSlice({
     },
     fieldValueReset: (state, action: FieldValueAction<StatefulFieldValue>) => {
       fieldValueReducer(state, action, zStatefulFieldValue);
+      clearCallSavedWorkflowDynamicFieldsIfWorkflowIdIsEmpty(state, action.payload);
     },
     fieldStringValueChanged: (state, action: FieldValueAction<StringFieldValue>) => {
       fieldValueReducer(state, action, zStringFieldValue);
-      if (action.payload.fieldName === 'workflow_id' && action.payload.value === '') {
-        clearCallSavedWorkflowDynamicFields(state, action.payload.nodeId);
-      }
+      clearCallSavedWorkflowDynamicFieldsIfWorkflowIdIsEmpty(state, action.payload);
     },
     fieldStringCollectionValueChanged: (state, action: FieldValueAction<StringFieldCollectionValue>) => {
       fieldValueReducer(state, action, zStringFieldCollectionValue);
@@ -604,13 +642,16 @@ const slice = createSlice({
       }
 
       const nextFieldNames = new Set(fields.map((field) => field.fieldName));
+      const removedFieldNames = new Set<string>();
 
       for (const fieldName of Object.keys(node.data.inputs)) {
         if (fieldName.startsWith(CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX) && !nextFieldNames.has(fieldName)) {
+          removedFieldNames.add(fieldName);
           delete node.data.inputs[fieldName];
           delete node.data.dynamicInputTemplates[fieldName];
         }
       }
+      removeCallSavedWorkflowDynamicFieldsFromForm(state, nodeId, removedFieldNames);
 
       for (const { fieldName, fieldTemplate, label, description, initialValue } of fields) {
         const existingTemplate = node.data.dynamicInputTemplates[fieldName];

--- a/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
+++ b/invokeai/frontend/web/src/features/nodes/store/nodesSlice.ts
@@ -182,6 +182,28 @@ const fieldValueReducer = <T extends FieldValue>(
   field.value = result.data;
 };
 
+const clearCallSavedWorkflowDynamicFields = (state: NodesState, nodeId: string) => {
+  const node = state.nodes.find((n) => n.id === nodeId);
+  if (!isInvocationNode(node) || node.data.type !== 'call_saved_workflow') {
+    return;
+  }
+
+  for (const fieldName of Object.keys(node.data.inputs)) {
+    if (fieldName.startsWith(CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX)) {
+      delete node.data.inputs[fieldName];
+      delete node.data.dynamicInputTemplates[fieldName];
+    }
+  }
+
+  state.edges = state.edges.filter((edge) => {
+    return (
+      edge.type !== 'default' ||
+      edge.target !== nodeId ||
+      !edge.targetHandle?.startsWith(CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX)
+    );
+  });
+};
+
 const slice = createSlice({
   name: 'nodes',
   initialState: getInitialState(),
@@ -492,6 +514,9 @@ const slice = createSlice({
     },
     fieldStringValueChanged: (state, action: FieldValueAction<StringFieldValue>) => {
       fieldValueReducer(state, action, zStringFieldValue);
+      if (action.payload.fieldName === 'workflow_id' && action.payload.value === '') {
+        clearCallSavedWorkflowDynamicFields(state, action.payload.nodeId);
+      }
     },
     fieldStringCollectionValueChanged: (state, action: FieldValueAction<StringFieldCollectionValue>) => {
       fieldValueReducer(state, action, zStringFieldCollectionValue);

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.test.ts
@@ -1,11 +1,18 @@
 import { get } from 'es-toolkit/compat';
 import { addElement } from 'features/nodes/components/sidePanel/builder/form-manipulation';
 import { CONNECTOR_INPUT_HANDLE, CONNECTOR_OUTPUT_HANDLE } from 'features/nodes/store/util/connectorTopology';
-import { img_resize, main_model_loader, workflow_return } from 'features/nodes/store/util/testUtils';
+import {
+  add,
+  call_saved_workflow,
+  img_resize,
+  main_model_loader,
+  workflow_return,
+} from 'features/nodes/store/util/testUtils';
 import type { InvocationTemplate } from 'features/nodes/types/invocation';
 import type { WorkflowV3 } from 'features/nodes/types/workflow';
 import { buildNodeFieldElement, getDefaultForm, isNodeFieldElement } from 'features/nodes/types/workflow';
 import { buildInvocationNode } from 'features/nodes/util/node/buildInvocationNode';
+import { buildFieldInputInstance } from 'features/nodes/util/schema/buildFieldInputInstance';
 import { validateWorkflow } from 'features/nodes/util/workflow/validateWorkflow';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -483,5 +490,98 @@ describe('validateWorkflow', () => {
       throw new Error('Expected a node field form element');
     }
     expect(updatedElement.data.fieldIdentifier.fieldName).toBe('images');
+  });
+
+  it('should refresh call_saved_workflow dynamic inputs while loading a stale serialized workflow', async () => {
+    const workflow = getWorkflow();
+    const callNode = buildInvocationNode({ x: 0, y: 0 }, call_saved_workflow);
+    const workflowIdInput = callNode.data.inputs.workflow_id;
+    if (!workflowIdInput) {
+      throw new Error('Expected workflow_id input');
+    }
+    workflowIdInput.value = 'saved-workflow-1';
+    const addInputA = add.inputs.a;
+    if (!addInputA) {
+      throw new Error('Expected add.a input template');
+    }
+    const oldFieldName = 'saved_workflow_input::child-add::a';
+    const oldFieldTemplate = structuredClone(addInputA);
+    oldFieldTemplate.name = oldFieldName;
+    oldFieldTemplate.title = 'A';
+    oldFieldTemplate.input = 'any';
+    oldFieldTemplate.ui_hidden = false;
+    callNode.data.dynamicInputTemplates[oldFieldName] = oldFieldTemplate;
+    callNode.data.inputs[oldFieldName] = buildFieldInputInstance(oldFieldName, oldFieldTemplate);
+    callNode.data.inputs[oldFieldName]!.value = 99;
+    workflow.nodes = [callNode];
+
+    const validationResult = await validateWorkflow({
+      workflow,
+      templates: { add, call_saved_workflow },
+      checkImageAccess: resolveTrue,
+      checkBoardAccess: resolveTrue,
+      checkModelAccess: resolveTrue,
+      getWorkflow: (workflowId) => {
+        expect(workflowId).toBe('saved-workflow-1');
+        return Promise.resolve({
+          workflow_id: 'saved-workflow-1',
+          name: 'Saved workflow',
+          created_at: '2026-04-08T00:00:00Z',
+          updated_at: '2026-04-08T00:00:00Z',
+          opened_at: null,
+          user_id: 'user-1',
+          is_public: false,
+          thumbnail_url: null,
+          workflow: {
+            id: 'saved-workflow-1',
+            name: 'Saved workflow',
+            author: '',
+            description: '',
+            version: '',
+            contact: '',
+            tags: '',
+            notes: '',
+            exposedFields: [
+              { nodeId: 'child-add', fieldName: 'a' },
+              { nodeId: 'child-add', fieldName: 'b' },
+            ],
+            meta: { version: '4.0.0', category: 'user' },
+            form: getDefaultForm(),
+            nodes: [
+              {
+                id: 'child-add',
+                type: 'invocation',
+                data: {
+                  id: 'child-add',
+                  type: 'add',
+                  version: '1.0.1',
+                  label: '',
+                  notes: '',
+                  dynamicInputTemplates: {},
+                  isOpen: true,
+                  isIntermediate: true,
+                  useCache: true,
+                  nodePack: 'invokeai',
+                  inputs: {
+                    a: { name: 'a', label: 'A', description: '', value: 1 },
+                    b: { name: 'b', label: 'B', description: '', value: 2 },
+                  },
+                },
+                position: { x: 0, y: 0 },
+              },
+            ],
+            edges: [],
+          },
+        });
+      },
+    });
+
+    const refreshedCallNode = validationResult.workflow.nodes[0];
+    if (!refreshedCallNode || refreshedCallNode.type !== 'invocation') {
+      throw new Error('Expected invocation node');
+    }
+    expect(refreshedCallNode.data.inputs['saved_workflow_input::child-add::a']?.value).toBe(99);
+    expect(refreshedCallNode.data.inputs['saved_workflow_input::child-add::b']?.value).toBe(2);
+    expect(refreshedCallNode.data.dynamicInputTemplates['saved_workflow_input::child-add::b']).toBeDefined();
   });
 });

--- a/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
+++ b/invokeai/frontend/web/src/features/nodes/util/workflow/validateWorkflow.ts
@@ -1,5 +1,7 @@
 import { parseify } from 'common/util/serialize';
+import { getSavedWorkflowDynamicFields } from 'features/nodes/components/flow/nodes/Invocation/callSavedWorkflowFormUtils';
 import { addElement, getIsFormEmpty } from 'features/nodes/components/sidePanel/builder/form-manipulation';
+import { CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX } from 'features/nodes/store/nodesSlice';
 import type { Templates } from 'features/nodes/store/types';
 import { validateConnection } from 'features/nodes/store/util/validateConnection';
 import {
@@ -23,6 +25,7 @@ import {
   getUpdatedFieldName,
   updateNode,
 } from 'features/nodes/util/node/nodeUpdate';
+import { buildFieldInputInstance } from 'features/nodes/util/schema/buildFieldInputInstance';
 import { t } from 'i18next';
 import type { JsonObject } from 'type-fest';
 
@@ -40,11 +43,86 @@ type ValidateWorkflowArgs = {
   checkImageAccess: (name: string) => Promise<boolean>;
   checkBoardAccess: (id: string) => Promise<boolean>;
   checkModelAccess: (key: string) => Promise<boolean>;
+  getWorkflow?: (workflowId: string) => Promise<NonNullable<Parameters<typeof getSavedWorkflowDynamicFields>[0]>>;
 };
 
 type ValidateWorkflowResult = {
   workflow: WorkflowV3;
   warnings: WorkflowWarning[];
+};
+
+const refreshCallSavedWorkflowDynamicInputs = async ({
+  workflow,
+  templates,
+  getWorkflow,
+  warnings,
+}: {
+  workflow: WorkflowV3;
+  templates: Templates;
+  getWorkflow: ValidateWorkflowArgs['getWorkflow'];
+  warnings: WorkflowWarning[];
+}) => {
+  if (!getWorkflow) {
+    return;
+  }
+
+  for (const node of workflow.nodes) {
+    if (!isWorkflowInvocationNode(node) || node.data.type !== 'call_saved_workflow') {
+      continue;
+    }
+
+    const workflowId = node.data.inputs.workflow_id?.value;
+    if (typeof workflowId !== 'string' || !workflowId) {
+      continue;
+    }
+
+    try {
+      const savedWorkflow = await getWorkflow(workflowId);
+      const fields = getSavedWorkflowDynamicFields(savedWorkflow, templates);
+      const nextFieldNames = new Set(fields.map((field) => field.fieldName));
+
+      for (const fieldName of Object.keys(node.data.inputs)) {
+        if (fieldName.startsWith(CALL_SAVED_WORKFLOW_DYNAMIC_FIELD_PREFIX) && !nextFieldNames.has(fieldName)) {
+          delete node.data.inputs[fieldName];
+          delete node.data.dynamicInputTemplates[fieldName];
+        }
+      }
+
+      for (const { fieldName, fieldTemplate, label, description, initialValue } of fields) {
+        const existingTemplate = node.data.dynamicInputTemplates[fieldName];
+        node.data.dynamicInputTemplates[fieldName] = fieldTemplate;
+        const existing = node.data.inputs[fieldName];
+        if (existing) {
+          if (
+            existingTemplate?.type.name !== fieldTemplate.type.name ||
+            existingTemplate?.type.cardinality !== fieldTemplate.type.cardinality ||
+            existingTemplate?.type.batch !== fieldTemplate.type.batch
+          ) {
+            const instance = buildFieldInputInstance(fieldName, fieldTemplate);
+            instance.label = label;
+            instance.description = description;
+            instance.value = initialValue;
+            node.data.inputs[fieldName] = instance;
+            continue;
+          }
+          existing.label = label;
+          existing.description = description;
+          continue;
+        }
+
+        const instance = buildFieldInputInstance(fieldName, fieldTemplate);
+        instance.label = label;
+        instance.description = description;
+        instance.value = initialValue;
+        node.data.inputs[fieldName] = instance;
+      }
+    } catch {
+      warnings.push({
+        message: t('toast.problemRetrievingWorkflow'),
+        data: { workflowId },
+      });
+    }
+  }
 };
 
 /**
@@ -57,7 +135,7 @@ type ValidateWorkflowResult = {
  * @throws {z.ZodError} If there is a validation error.
  */
 export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<ValidateWorkflowResult> => {
-  const { workflow, templates, checkImageAccess, checkBoardAccess, checkModelAccess } = args;
+  const { workflow, templates, checkImageAccess, checkBoardAccess, checkModelAccess, getWorkflow } = args;
   // Parse the raw workflow data & migrate it to the latest version
   const _workflow = parseAndMigrateWorkflow(workflow);
 
@@ -65,6 +143,8 @@ export const validateWorkflow = async (args: ValidateWorkflowArgs): Promise<Vali
   const { nodes, edges } = _workflow;
   const warnings: WorkflowWarning[] = [];
   const validEdges: WorkflowV3['edges'] = [];
+
+  await refreshCallSavedWorkflowDynamicInputs({ workflow: _workflow, templates, getWorkflow, warnings });
 
   for (const edge of edges) {
     // Validate each edge. If the edge is invalid, we must remove it to prevent runtime errors with reactflow.

--- a/invokeai/frontend/web/src/features/workflowLibrary/hooks/useValidateAndLoadWorkflow.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/hooks/useValidateAndLoadWorkflow.ts
@@ -14,6 +14,7 @@ import { VIEWER_PANEL_ID, WORKSPACE_PANEL_ID } from 'features/ui/layouts/shared'
 import { t } from 'i18next';
 import { useCallback } from 'react';
 import { serializeError } from 'serialize-error';
+import { workflowsApi } from 'services/api/endpoints/workflows';
 import { checkBoardAccess, checkImageAccess, checkModelAccess } from 'services/api/hooks/accessChecks';
 import { z } from 'zod';
 import { fromZodError } from 'zod-validation-error';
@@ -57,6 +58,10 @@ export const useValidateAndLoadWorkflow = () => {
           checkImageAccess,
           checkBoardAccess,
           checkModelAccess,
+          getWorkflow: (workflowId) =>
+            dispatch(
+              workflowsApi.endpoints.getWorkflow.initiate(workflowId, { forceRefetch: true, subscribe: false })
+            ).unwrap(),
         });
 
         if (origin !== 'library') {

--- a/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.test.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.test.ts
@@ -17,6 +17,27 @@ describe('workflowLibraryListItemState', () => {
     ).toEqual({
       showUnsupportedBadge: false,
       unsupportedMessageKey: null,
+      showCallableBadge: false,
+      showSharedBadge: false,
+      showDefaultIcon: false,
+    });
+  });
+
+  it('marks callable workflows with a positive callable badge', () => {
+    expect(
+      getWorkflowLibraryListItemState({
+        category: 'user',
+        is_public: false,
+        call_saved_workflow_compatibility: {
+          is_callable: true,
+          reason: 'ok',
+          message: null,
+        },
+      })
+    ).toEqual({
+      showUnsupportedBadge: false,
+      unsupportedMessageKey: null,
+      showCallableBadge: true,
       showSharedBadge: false,
       showDefaultIcon: false,
     });
@@ -36,6 +57,7 @@ describe('workflowLibraryListItemState', () => {
     ).toEqual({
       showUnsupportedBadge: false,
       unsupportedMessageKey: null,
+      showCallableBadge: true,
       showSharedBadge: true,
       showDefaultIcon: false,
     });
@@ -55,6 +77,7 @@ describe('workflowLibraryListItemState', () => {
     ).toEqual({
       showUnsupportedBadge: false,
       unsupportedMessageKey: null,
+      showCallableBadge: true,
       showSharedBadge: false,
       showDefaultIcon: true,
     });

--- a/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.test.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { getWorkflowLibraryListItemState } from './workflowLibraryListItemState';
 
 describe('workflowLibraryListItemState', () => {
-  it('marks unsupported workflows with their localized reason key', () => {
+  it('does not mark ordinary workflows unsupported when they are not callable as sub-workflows', () => {
     expect(
       getWorkflowLibraryListItemState({
         category: 'user',
@@ -15,8 +15,8 @@ describe('workflowLibraryListItemState', () => {
         },
       })
     ).toEqual({
-      showUnsupportedBadge: true,
-      unsupportedMessageKey: 'workflows.savedWorkflowCompatibility.missingWorkflowReturn',
+      showUnsupportedBadge: false,
+      unsupportedMessageKey: null,
       showSharedBadge: false,
       showDefaultIcon: false,
     });

--- a/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.test.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.test.ts
@@ -15,8 +15,6 @@ describe('workflowLibraryListItemState', () => {
         },
       })
     ).toEqual({
-      showUnsupportedBadge: false,
-      unsupportedMessageKey: null,
       showCallableBadge: false,
       showSharedBadge: false,
       showDefaultIcon: false,
@@ -35,8 +33,6 @@ describe('workflowLibraryListItemState', () => {
         },
       })
     ).toEqual({
-      showUnsupportedBadge: false,
-      unsupportedMessageKey: null,
       showCallableBadge: true,
       showSharedBadge: false,
       showDefaultIcon: false,
@@ -55,8 +51,6 @@ describe('workflowLibraryListItemState', () => {
         },
       })
     ).toEqual({
-      showUnsupportedBadge: false,
-      unsupportedMessageKey: null,
       showCallableBadge: true,
       showSharedBadge: true,
       showDefaultIcon: false,
@@ -75,8 +69,6 @@ describe('workflowLibraryListItemState', () => {
         },
       })
     ).toEqual({
-      showUnsupportedBadge: false,
-      unsupportedMessageKey: null,
       showCallableBadge: true,
       showSharedBadge: false,
       showDefaultIcon: true,

--- a/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.ts
@@ -1,12 +1,8 @@
-import {
-  getWorkflowCallCompatibilityState,
-  type WorkflowCallCompatibilityMessageKey,
-} from 'features/workflowLibrary/util/workflowCallCompatibility';
 import type { WorkflowRecordListItemWithThumbnailDTO } from 'services/api/types';
 
 type WorkflowLibraryListItemState = {
   showUnsupportedBadge: boolean;
-  unsupportedMessageKey: WorkflowCallCompatibilityMessageKey | null;
+  unsupportedMessageKey: null;
   showSharedBadge: boolean;
   showDefaultIcon: boolean;
 };
@@ -14,11 +10,9 @@ type WorkflowLibraryListItemState = {
 export const getWorkflowLibraryListItemState = (
   workflow: Pick<WorkflowRecordListItemWithThumbnailDTO, 'category' | 'is_public' | 'call_saved_workflow_compatibility'>
 ): WorkflowLibraryListItemState => {
-  const compatibilityState = getWorkflowCallCompatibilityState(workflow);
-
   return {
-    showUnsupportedBadge: compatibilityState.isUnsupported,
-    unsupportedMessageKey: compatibilityState.messageKey,
+    showUnsupportedBadge: false,
+    unsupportedMessageKey: null,
     showSharedBadge: workflow.is_public && workflow.category !== 'default',
     showDefaultIcon: workflow.category === 'default',
   };

--- a/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.ts
@@ -1,8 +1,6 @@
 import type { WorkflowRecordListItemWithThumbnailDTO } from 'services/api/types';
 
 type WorkflowLibraryListItemState = {
-  showUnsupportedBadge: boolean;
-  unsupportedMessageKey: null;
   showCallableBadge: boolean;
   showSharedBadge: boolean;
   showDefaultIcon: boolean;
@@ -12,8 +10,6 @@ export const getWorkflowLibraryListItemState = (
   workflow: Pick<WorkflowRecordListItemWithThumbnailDTO, 'category' | 'is_public' | 'call_saved_workflow_compatibility'>
 ): WorkflowLibraryListItemState => {
   return {
-    showUnsupportedBadge: false,
-    unsupportedMessageKey: null,
     showCallableBadge: workflow.call_saved_workflow_compatibility?.is_callable === true,
     showSharedBadge: workflow.is_public && workflow.category !== 'default',
     showDefaultIcon: workflow.category === 'default',

--- a/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.ts
+++ b/invokeai/frontend/web/src/features/workflowLibrary/util/workflowLibraryListItemState.ts
@@ -3,6 +3,7 @@ import type { WorkflowRecordListItemWithThumbnailDTO } from 'services/api/types'
 type WorkflowLibraryListItemState = {
   showUnsupportedBadge: boolean;
   unsupportedMessageKey: null;
+  showCallableBadge: boolean;
   showSharedBadge: boolean;
   showDefaultIcon: boolean;
 };
@@ -13,6 +14,7 @@ export const getWorkflowLibraryListItemState = (
   return {
     showUnsupportedBadge: false,
     unsupportedMessageKey: null,
+    showCallableBadge: workflow.call_saved_workflow_compatibility?.is_callable === true,
     showSharedBadge: workflow.is_public && workflow.category !== 'default',
     showDefaultIcon: workflow.category === 'default',
   };

--- a/invokeai/frontend/web/src/services/api/schema.ts
+++ b/invokeai/frontend/web/src/services/api/schema.ts
@@ -38401,6 +38401,8 @@ export interface operations {
                 has_been_opened?: boolean | null;
                 /** @description Filter by public/shared status */
                 is_public?: boolean | null;
+                /** @description Filter by whether workflows are callable by call_saved_workflow */
+                callable?: boolean | null;
             };
             header?: never;
             path?: never;

--- a/tests/app/routers/test_workflows_multiuser.py
+++ b/tests/app/routers/test_workflows_multiuser.py
@@ -419,6 +419,82 @@ def test_list_workflows_includes_call_saved_workflow_compatibility(client: TestC
     }
 
 
+def _create_callable_workflow(client: TestClient, token: str, name: str) -> str:
+    return create_workflow(
+        client,
+        token,
+        {
+            **WORKFLOW_BODY,
+            "name": name,
+            "nodes": [
+                {
+                    "id": "return",
+                    "type": "invocation",
+                    "position": {"x": 0, "y": 0},
+                    "data": {
+                        "id": "return",
+                        "type": "workflow_return",
+                        "version": "1.0.0",
+                        "nodePack": "invokeai",
+                        "label": "",
+                        "notes": "",
+                        "isOpen": True,
+                        "isIntermediate": False,
+                        "useCache": True,
+                        "dynamicInputTemplates": {},
+                        "inputs": {"values": {"value": []}},
+                    },
+                }
+            ],
+        },
+    )
+
+
+def test_list_workflows_callable_filter_counts_only_callable_workflows(client: TestClient, user1_token: str):
+    callable_a = _create_callable_workflow(client, user1_token, "Callable A")
+    create_workflow(client, user1_token, {**WORKFLOW_BODY, "name": "Not Callable A"})
+    callable_b = _create_callable_workflow(client, user1_token, "Callable B")
+    create_workflow(client, user1_token, {**WORKFLOW_BODY, "name": "Not Callable B"})
+    callable_c = _create_callable_workflow(client, user1_token, "Callable C")
+
+    response = client.get(
+        "/api/v1/workflows/?categories=user&callable=true&per_page=2&page=0&order_by=name&direction=ASC",
+        headers={"Authorization": f"Bearer {user1_token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["total"] == 3
+    assert payload["pages"] == 2
+    assert payload["per_page"] == 2
+    assert [item["workflow_id"] for item in payload["items"]] == [callable_a, callable_b]
+    assert {item["workflow_id"] for item in payload["items"]}.isdisjoint({callable_c})
+    assert all(item["call_saved_workflow_compatibility"]["is_callable"] for item in payload["items"])
+
+
+def test_list_workflows_callable_filter_paginates_callable_workflows_after_filtering(
+    client: TestClient, user1_token: str
+):
+    _create_callable_workflow(client, user1_token, "Callable A")
+    create_workflow(client, user1_token, {**WORKFLOW_BODY, "name": "Not Callable A"})
+    _create_callable_workflow(client, user1_token, "Callable B")
+    create_workflow(client, user1_token, {**WORKFLOW_BODY, "name": "Not Callable B"})
+    callable_c = _create_callable_workflow(client, user1_token, "Callable C")
+
+    response = client.get(
+        "/api/v1/workflows/?categories=user&callable=true&per_page=2&page=1&order_by=name&direction=ASC",
+        headers={"Authorization": f"Bearer {user1_token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["total"] == 3
+    assert payload["pages"] == 2
+    assert payload["per_page"] == 2
+    assert [item["workflow_id"] for item in payload["items"]] == [callable_c]
+    assert all(item["call_saved_workflow_compatibility"]["is_callable"] for item in payload["items"])
+
+
 def test_get_workflow_includes_call_saved_workflow_compatibility(client: TestClient, user1_token: str):
     workflow_id = create_workflow(client, user1_token)
 

--- a/tests/app/services/test_workflow_call_compatibility.py
+++ b/tests/app/services/test_workflow_call_compatibility.py
@@ -140,6 +140,32 @@ def test_get_workflow_call_compatibility_returns_ok_for_simple_callable_workflow
     assert compatibility.message is None
 
 
+def test_get_workflow_call_compatibility_allows_legacy_none_board_values() -> None:
+    workflow = _workflow_dump(
+        nodes=[
+            _invocation_node(
+                "image",
+                "blank_image",
+                {"board": {"value": "none"}, "width": {"value": 64}, "height": {"value": 64}},
+            ),
+            *_return_nodes(),
+        ],
+        edges=_return_edges("image", "image"),
+    )
+
+    compatibility = get_workflow_call_compatibility(
+        workflow=workflow,
+        workflow_id="workflow-a",
+        services=_services(),
+        user_id="user-1",
+        maximum_children=1000,
+    )
+
+    assert compatibility.is_callable is True
+    assert compatibility.reason is WorkflowCallCompatibilityReason.Ok
+    assert compatibility.message is None
+
+
 def test_get_workflow_call_compatibility_allows_single_return_value_connected_directly() -> None:
     workflow = _workflow_dump(
         nodes=[

--- a/tests/app/services/test_workflow_graph_builder.py
+++ b/tests/app/services/test_workflow_graph_builder.py
@@ -209,6 +209,20 @@ def test_build_graph_from_workflow_uses_defaults_for_inputs_without_saved_values
     assert graph.nodes["return-collect-1"].collection == []
 
 
+def test_build_graph_from_workflow_uses_default_for_legacy_auto_board_values():
+    workflow = _build_workflow(
+        nodes=[
+            _build_workflow_node("image-1", "blank_image", {"board": "auto", "width": 64, "height": 64}),
+            *_build_named_return_nodes(),
+        ],
+        edges=_build_named_return_edges("image-1", "image"),
+    )
+
+    graph = build_graph_from_workflow(workflow)
+
+    assert graph.nodes["image-1"].board is None
+
+
 def test_build_graph_from_workflow_rejects_batch_special_nodes_with_clear_error():
     workflow = _build_workflow(
         nodes=[_build_workflow_node("image-batch-1", "image_batch", {"images": []})],

--- a/tests/app/services/test_workflow_graph_builder.py
+++ b/tests/app/services/test_workflow_graph_builder.py
@@ -223,6 +223,20 @@ def test_build_graph_from_workflow_uses_default_for_legacy_auto_board_values():
     assert graph.nodes["image-1"].board is None
 
 
+def test_build_graph_from_workflow_uses_default_for_legacy_none_board_values():
+    workflow = _build_workflow(
+        nodes=[
+            _build_workflow_node("image-1", "blank_image", {"board": "none", "width": 64, "height": 64}),
+            *_build_named_return_nodes(),
+        ],
+        edges=_build_named_return_edges("image-1", "image"),
+    )
+
+    graph = build_graph_from_workflow(workflow)
+
+    assert graph.nodes["image-1"].board is None
+
+
 def test_build_graph_from_workflow_rejects_batch_special_nodes_with_clear_error():
     workflow = _build_workflow(
         nodes=[_build_workflow_node("image-batch-1", "image_batch", {"images": []})],

--- a/tests/app/services/test_workflow_graph_builder.py
+++ b/tests/app/services/test_workflow_graph_builder.py
@@ -172,6 +172,43 @@ def test_build_graph_from_workflow_flattens_connector_edges():
     assert graph.nodes["return-1"].values == []
 
 
+def test_build_graph_from_workflow_uses_defaults_for_inputs_without_saved_values():
+    collect_node = _build_workflow_node("return-collect-1", "collect", {})
+    collect_node["data"]["inputs"] = {
+        "item": {"name": "item", "label": "", "description": ""},
+        "collection": {"name": "collection", "label": "", "description": ""},
+    }
+    workflow = _build_workflow(
+        nodes=[
+            _build_workflow_node("return-value-1", "workflow_return_value", {"key": "result", "value": None}),
+            collect_node,
+            _build_workflow_node("return-1", "workflow_return", {"values": []}),
+        ],
+        edges=[
+            {
+                "id": "edge-return-collect",
+                "type": "default",
+                "source": "return-value-1",
+                "sourceHandle": "value",
+                "target": "return-collect-1",
+                "targetHandle": "item",
+            },
+            {
+                "id": "edge-return-values",
+                "type": "default",
+                "source": "return-collect-1",
+                "sourceHandle": "collection",
+                "target": "return-1",
+                "targetHandle": "values",
+            },
+        ],
+    )
+
+    graph = build_graph_from_workflow(workflow)
+
+    assert graph.nodes["return-collect-1"].collection == []
+
+
 def test_build_graph_from_workflow_rejects_batch_special_nodes_with_clear_error():
     workflow = _build_workflow(
         nodes=[_build_workflow_node("image-batch-1", "image_batch", {"images": []})],


### PR DESCRIPTION
## Summary

Fixes Workflow Library callability messaging after Call Saved Workflow support landed. The prior work created too much output noise in the Workflow Library by surfacing negative sub-workflow compatibility state on ordinary workflows. This PR removes that negative badge from the general library view and adds a positive `Callable` badge only when a workflow can be called by another workflow (i.e. it has a Workflow Return node).

Fixed callable workflow graph validation so saved optional inputs without explicit values use invocation defaults instead of being coerced to `None`.

Also fixed call-saved-workflow dynamic inputs to automatically resync when a selected child workflow's exposed fields change, preventing stale caller workflows from showing missing-field errors.

## Related Issues / Discussions

## QA Instructions

- Open the Workflow Library.
- Confirm ordinary workflows without a Workflow Return node do not show `Unsupported`.
- Confirm workflows that can be used by Call Saved Workflow show a `Callable` badge.
- Confirm the Call Saved Workflow node picker still disables non-callable workflows and displays the detailed reason there.

## Merge Plan

## Checklist

- [X] _The PR has a short but descriptive title, suitable for a changelog_
- [X] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
