### PR TITLE
Handle missing queue items in session failure

### DIFF
--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -528,16 +528,18 @@ class DefaultSessionProcessor(SessionProcessorBase):
         self._invoker.services.logger.error(error_traceback)
 
         if queue_item is not None:
-            # Update the queue item with the completed session & fail it
-            queue_item = self._invoker.services.session_queue.set_queue_item_session(
-                queue_item.item_id, queue_item.session
-            )
-            queue_item = self._invoker.services.session_queue.fail_queue_item(
-                item_id=queue_item.item_id,
-                error_type=error_type,
-                error_message=error_message,
-                error_traceback=error_traceback,
-            )
+            try:
+                queue_item = self._invoker.services.session_queue.set_queue_item_session(
+                    queue_item.item_id, queue_item.session
+                )
+                queue_item = self._invoker.services.session_queue.fail_queue_item(
+                    item_id=queue_item.item_id,
+                    error_type=error_type,
+                    error_message=error_message,
+                    error_traceback=error_traceback,
+                )
+            except SessionQueueItemNotFoundError:
+                self._invoker.services.logger.warning(f"Could not mark queue item {queue_item.item_id} as failed because it no longer exists in the database.")
 
         for callback in self._on_non_fatal_processor_error_callbacks:
             callback(

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -539,7 +539,9 @@ class DefaultSessionProcessor(SessionProcessorBase):
                     error_traceback=error_traceback,
                 )
             except SessionQueueItemNotFoundError:
-                self._invoker.services.logger.warning(f"Could not mark queue item {queue_item.item_id} as failed because it no longer exists in the database.")
+                self._invoker.services.logger.warning(
+                    f"Could not mark queue item {queue_item.item_id} as failed because it no longer exists in the database."
+                )
 
         for callback in self._on_non_fatal_processor_error_callbacks:
             callback(


### PR DESCRIPTION
Added error handling for missing queue items when failing a session.

## Summary

Quick fix to avoid a non fatal error, becoming a fatal error
(doesn’t fix the underlying issue of the missing id, but avoids the fatal error)

## Related Issues / Discussions

https://discord.com/channels/1020123559063990373/1049495067846524939/1525012683211145306

## QA Instructions

start more then one queue item and click "cancel and clear all'

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
