### PR TITLE
fix(tests): deflake custom-nodes uninstall test (global shutil.rmtree patch)

### DIFF
--- a/tests/app/routers/test_custom_nodes.py
+++ b/tests/app/routers/test_custom_nodes.py
@@ -129,7 +129,10 @@ class TestUninstallPackNameValidation:
         for pack_name in ("..", ".", "foo/bar", "..\\outside"):
             with (
                 patch("invokeai.app.api.routers.custom_nodes._get_custom_nodes_path") as mock_get_path,
-                patch("invokeai.app.api.routers.custom_nodes.shutil.rmtree") as mock_rmtree,
+                # Patch the router's `shutil` attribute, NOT `shutil.rmtree`: patching the latter
+                # mutates the global shutil module, so a gc pass that finalizes a TemporaryDirectory
+                # leaked anywhere else in the suite calls the mock and fails assert_not_called().
+                patch("invokeai.app.api.routers.custom_nodes.shutil") as mock_shutil,
                 patch("invokeai.app.api.routers.custom_nodes._remove_workflows_by_ids") as mock_remove_workflows,
             ):
                 response = asyncio.run(uninstall_custom_node_pack(MagicMock(), pack_name))
@@ -138,7 +141,7 @@ class TestUninstallPackNameValidation:
             assert response.success is False
             assert response.message == "Invalid node pack name."
             mock_get_path.assert_not_called()
-            mock_rmtree.assert_not_called()
+            mock_shutil.rmtree.assert_not_called()
             mock_remove_workflows.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

`TestUninstallPackNameValidation::test_rejects_invalid_pack_names_before_filesystem_side_effects` (added in #9256) fails intermittently in CI:

```
FAILED tests/app/routers/test_custom_nodes.py::TestUninstallPackNameValidation::test_rejects_invalid_pack_names_before_filesystem_side_effects
  AssertionError: Expected 'rmtree' to not have been called. Called 1 times.
  Calls: [call('/var/folders/g3/.../T/tmp7n0m81lc', onerror=<function TemporaryDirectory._rmtree.<locals>.onerror at 0x164d5e480>)]
```

Seen on `py3.11 macos-default` in [this run](https://github.com/invoke-ai/InvokeAI/actions/runs/29830753380/job/88634646335) on PR #9367 (which doesn't touch this code); the same run passed on re-run.

## Root cause

The test patches `invokeai.app.api.routers.custom_nodes.shutil.rmtree`. Since `custom_nodes.py` does a plain `import shutil`, that target resolves to the **global** `shutil` module — the patch affects every caller in the process, not just the router.

Several tests in the suite leak `TemporaryDirectory` objects inside reference cycles (the CI log shows many `ResourceWarning: Implicitly cleaning up <TemporaryDirectory ...>`). Whenever the cyclic GC happens to run while the patch is active, `tempfile`'s finalizer calls `shutil.rmtree` — i.e. the mock — and `assert_not_called()` fails. The recorded call's `onerror=<TemporaryDirectory._rmtree...>` argument shows it is tempdir cleanup, not the router. Whether it fires is pure GC-timing luck, hence one platform failing while five pass.

Reproducible deterministically:

```python
import gc, tempfile
from unittest.mock import patch
gc.disable()

td = tempfile.TemporaryDirectory()
class H: pass
h = H(); h.td = td; h.self = h   # cycle: only the cyclic GC can free it
del td, h

with patch("invokeai.app.api.routers.custom_nodes.shutil.rmtree") as m:
    gc.collect()                  # stands in for CI's unlucky GC pass
    m.assert_not_called()         # AssertionError: Called 1 times
```

## Fix

Patch the router module's `shutil` **attribute** (`patch("...custom_nodes.shutil")`) instead of the global `shutil.rmtree`, and assert on `mock_shutil.rmtree`. Only lookups through `custom_nodes.shutil` hit the mock; tempdir finalizers keep the real `shutil`.

Verified both properties:
- the repro above no longer trips the narrowed mock;
- a valid pack name still drives the router's real `shutil.rmtree(target_dir)` call into the mock, so the test still catches a broken validator.

## QA Instructions

`uv run pytest tests/app/routers/test_custom_nodes.py` — 39 passed.

## Merge Plan

Squash-merge whenever; test-only change.

## Checklist

- [x] The PR has a short but descriptive title, suitable for a changelog
- [x] Tests added / updated (if applicable)
- [ ] Documentation added / updated (if applicable)
- [ ] Updated `What's New` copy (if doing a release after this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)