### PR TITLE
ci: raise python-tests job timeout to 30 minutes

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -58,7 +58,7 @@ jobs:
             github-env: $env:GITHUB_ENV
     name: 'py${{ matrix.python-version }}: ${{ matrix.platform }}'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15 # expected run time: 2-6 min, depending on platform
+    timeout-minutes: 30 # expected run time: 10-16 min, depending on platform
     env:
       PIP_USE_PEP517: '1'
 


### PR DESCRIPTION
## Summary

Raises the pytest matrix job `timeout-minutes` from 15 to 30 in `python-tests.yml`.

The stated expectation in the old comment ("2-6 min") is long out of date: the matrix jobs already take 9–11 minutes per platform on `main`, and windows-cpu runs on heavier PRs (e.g. #9163, where windows jobs currently take ~15m43s) exceed the 15-minute cap and get cancelled mid-pytest. This is now blocking several open PRs.

Split out of #9163 (where this change has been running green since 2026-07-20) so other PRs can benefit immediately.

## Related Issues / Discussions

- #9163 — the change originated there; once this merges, the identical commit in that branch dedupes on the next merge from `main`.

## QA Instructions

CI-only change. Verify the pytest matrix jobs on this PR still pass and report their usual duration.

## Merge Plan

No special instructions — squash as usual.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_ — n/a, CI config only
- [ ] _Documentation added / updated (if applicable)_ — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)