### PR TITLE
Fix model rename validation off-by-one and Save button gating (#9364)

### DIFF
--- a/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
+++ b/invokeai/frontend/web/src/features/modelManagerV2/subpanels/ModelPanel/ModelEdit.tsx
@@ -47,7 +47,7 @@ type ModelEditFormValues = UpdateModelBody & {
 };
 
 const stringFieldOptions = {
-  validate: (value?: string | null) => (value && value.trim().length > 3) || 'Must be at least 3 characters',
+  validate: (value?: string | null) => (value && value.trim().length >= 3) || 'Must be at least 3 characters',
 };
 
 export const ModelEdit = memo(({ modelConfig }: Props) => {
@@ -142,7 +142,7 @@ export const ModelEdit = memo(({ modelConfig }: Props) => {
           leftIcon={<PiCheckBold />}
           onClick={form.handleSubmit(onSubmit)}
           isLoading={isSubmitting}
-          isDisabled={Boolean(Object.keys(form.formState.errors).length)}
+          isDisabled={!form.formState.isValid}
         >
           {t('common.save')}
         </Button>


### PR DESCRIPTION
## Summary

Closes #9364

Two changes in `ModelEdit.tsx`:

1. The name validator required `length > 3` while its message says "Must be at least 3 characters" — 3-character names are now accepted (`>= 3`), matching the message (screenshots in the issue show 3 rejected / 4 accepted).
2. The Save button was disabled by counting keys of `formState.errors`; it is now gated on `!form.formState.isValid`, the same pattern used by `SystemPromptForm`. This is the canonical react-hook-form validity subscription and addresses the reported "Save stays greyed out after deleting and retyping the name until you cancel".

## Related Issues / Discussions

#9364

## QA Instructions

Model Manager → select a model → Edit → delete the whole name → retype 3+ characters → Save should enable; a 3-character name should be accepted.

Verification done here: reproduced the off-by-one and validated both fixes in an isolated harness using the repo's locked react-hook-form 7.69.0 + React 19.2.6 (clear → retype recovers; exactly 3 chars accepted); `pnpm lint` (tsc/eslint/prettier) clean; `pnpm test:no-watch` 1707/1707 passing. Note: I could not reproduce the stuck-button state in isolation with a plain input — it may depend on the ui-library composition — but the validity-based gate cannot wedge that way and matches the existing pattern in the codebase.

## Merge Plan

Simple frontend-only change, no special merge considerations.

## Checklist

- [x] The PR has a short but descriptive title, suitable for a changelog
- [ ] Tests added / updated (n/a — no existing tests for this component; verified via lint, full unit suite, and an isolated harness)
- [ ] Documentation added / updated (n/a)
