### PR TITLE
tests: relax 5s pytest-timeout marks that flake on slow CI runners

### DIFF
--- a/tests/app/services/model_install/test_model_install.py
+++ b/tests/app/services/model_install/test_model_install.py
@@ -686,7 +686,7 @@ def test_prune_jobs_rebind_preserves_existing_iterators(
     assert all(job not in mm2_installer.list_jobs() for job in jobs)
 
 
-@pytest.mark.timeout(timeout=5, method="thread")
+@pytest.mark.timeout(timeout=30, method="thread")
 def test_prune_jobs_waits_for_the_installer_lock(mm2_installer: ModelInstallServiceBase) -> None:
     lock_held = threading.Event()
     release_lock = threading.Event()
@@ -714,7 +714,7 @@ def test_prune_jobs_waits_for_the_installer_lock(mm2_installer: ModelInstallServ
     assert prune_completed.is_set()
 
 
-@pytest.mark.timeout(timeout=5, method="thread")
+@pytest.mark.timeout(timeout=30, method="thread")
 def test_import_and_wait_for_installs_fail_before_start(
     mm2_app_config: InvokeAIAppConfig,
     mm2_record_store,
@@ -736,7 +736,7 @@ def test_import_and_wait_for_installs_fail_before_start(
         installer.wait_for_installs(timeout=0.1)
 
 
-@pytest.mark.timeout(timeout=5, method="thread")
+@pytest.mark.timeout(timeout=30, method="thread")
 def test_import_fails_after_startup_failure(
     mm2_app_config: InvokeAIAppConfig,
     mm2_record_store,
@@ -768,7 +768,7 @@ def test_import_fails_after_startup_failure(
         installer.stop()
 
 
-@pytest.mark.timeout(timeout=5, method="thread")
+@pytest.mark.timeout(timeout=30, method="thread")
 def test_base_exception_during_startup_releases_import_waiters(
     mm2_app_config: InvokeAIAppConfig,
     mm2_record_store,


### PR DESCRIPTION
## Summary

Bumps the four `@pytest.mark.timeout(timeout=5, method="thread")` marks in `tests/app/services/model_install/test_model_install.py` (added in #9433) to `timeout=30`, matching the other timeout marks in the file.

## Why

With `method="thread"`, the timeout budget covers fixture setup and teardown as well as the test body. Tearing down the `mm2_download_queue` fixture alone takes up to ~1s (`stop()` joins five worker threads that poll the queue at a 1-second interval), and on a heavily loaded CI runner the total easily exceeds 5s.

This flaked twice on the same day, on different platforms and unrelated branches:

- `py3.11: windows-cpu` on #9447: timed out in `test_base_exception_during_startup_releases_import_waiters`, during download-queue teardown ([job](https://github.com/invoke-ai/InvokeAI/actions/runs/30763055055/job/91536918893)). The same run's slowness is visible elsewhere — `test_missing_models.py` took 98s for 9 tests.
- `py3.11: linux-cpu` on `feat/fp8_quantized_guard`: timed out in `test_import_fails_after_startup_failure` ([job](https://github.com/invoke-ai/InvokeAI/actions/runs/30765881301/job/91544385637)).

Neither stack dump showed a deadlock — the download workers were sitting in their normal 1-second poll loop and the main thread was in routine teardown. The runner was just slow.

The timeout marks exist to catch hangs, not to enforce speed, so the larger budget loses nothing: a genuine hang still fails, just 25 seconds later.

## Testing

- The four affected tests pass locally in 7.5s total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)