### PR TITLE
fix: remove global working directory change in web script (closes #9444)

### DIFF
--- a/scripts/invokeai-web.py
+++ b/scripts/invokeai-web.py
@@ -11,8 +11,8 @@ logging.getLogger("xformers").addFilter(lambda record: "A matching Triton is not
 
 
 def main():
-    # Change working directory to the repo root
-    os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    # Let run_app set the working directory to the repo root if needed.
+    # Avoid global chdir to prevent unintended side effects on path resolution.
     run_app()
 
 


### PR DESCRIPTION
## What
When running InvokeAI via the web script (scripts/invokeai-web.py), the script changes the process's working directory to the repo root before starting the app. This global chdir can interfere with relative path resolution for models, outputs, and other resources, leading to crashes during image generation (especially with certain models like Krea-2).

## Fix
Remove the global `os.chdir` call. The application internally manages its working directory and file paths. This ensures that relative paths are resolved relative to the user's intended location (where they launched the command) and avoids side effects on the rest of the application.

Closes #9444