### PR TITLE
docs: fix typo 'teh' to 'the' in controlLayers/README.md

### DIFF
--- a/invokeai/frontend/web/src/features/controlLayers/README.md
+++ b/invokeai/frontend/web/src/features/controlLayers/README.md
@@ -2,7 +2,7 @@
 
 The canvas is a fairly complex feature. It uses "native" KonvaJS (i.e. not the Konva react bindings) to render a drawing canvas.
 
-It supports layers, drawing, erasing, undo/redo, exporting, backend filters (i.e. filters that require sending image data to teh backend to process) and frontend filters.
+It supports layers, drawing, erasing, undo/redo, exporting, backend filters (i.e. filters that require sending image data to the backend to process) and frontend filters.
 
 ## Broad Strokes of Design
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `invokeai/frontend/web/src/features/controlLayers/README.md` (line 5).

## Problem

Typo: "teh" should be "the".

The problematic text:

```markdown
sending image data to teh backend to process
```

## Fix

Replaced with:

```markdown
sending image data to the backend to process
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text