### PR TITLE
docs: fix typo 'outut' to 'output' in api/README.md

### DIFF
--- a/invokeai/frontend/web/src/services/api/README.md
+++ b/invokeai/frontend/web/src/services/api/README.md
@@ -10,7 +10,7 @@ The API provides an OpenAPI schema and we generate TS types from it. They are st
 
 We use https://github.com/openapi-ts/openapi-typescript/ to generate the types.
 
-- Python script to outut the OpenAPI schema: scripts/generate_openapi_schema.py
+- Python script to output the OpenAPI schema: scripts/generate_openapi_schema.py
 - Node script to call openapi-typescript and generate the TS types: invokeai/frontend/web/scripts/typegen.js
 
 Pipe the output of the python script to the node script to update the types. There is a `make` target that does this in one fell swoop (after activating venv): `make frontend-typegen`


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `invokeai/frontend/web/src/services/api/README.md` (line 13).

## Problem

Typo: "outut" should be "output".

The problematic text:

```markdown
Python script to outut the OpenAPI schema
```

## Fix

Replaced with:

```markdown
Python script to output the OpenAPI schema
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text