### PR TITLE
docs: fix spelling 'approachs' to 'approaches' in gallery/README.md

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/README.md
+++ b/invokeai/frontend/web/src/features/gallery/README.md
@@ -60,7 +60,7 @@ It starts by loading a list of all image names for the selected board or view se
 
 This affords a nice UX, where the user can scroll to any part of their gallery. The scrollbar size never changes.
 
-We've tried some other approachs in the past, but they all had significant UX or implementation issues:
+We've tried some other approaches in the past, but they all had significant UX or implementation issues:
 
 ### Infinite scroll
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `invokeai/frontend/web/src/features/gallery/README.md` (line 63).

## Problem

Spelling error: "approachs" should be "approaches".

The problematic text:

```markdown
We've tried some other approachs in the past
```

## Fix

Replaced with:

```markdown
We've tried some other approaches in the past
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text