### PR TITLE
Fix spelling typos in backend comments and docstrings

### DIFF
--- a/invokeai/backend/image_util/invisible_watermark.py
+++ b/invokeai/backend/image_util/invisible_watermark.py
@@ -1,7 +1,7 @@
 """
 This module defines a singleton object, "invisible_watermark" that
 wraps the invisible watermark model. It respects the global "invisible_watermark"
-configuration variable, that allows the watermarking to be supressed.
+configuration variable, that allows the watermarking to be suppressed.
 """
 
 import cv2

--- a/invokeai/backend/image_util/safety_checker.py
+++ b/invokeai/backend/image_util/safety_checker.py
@@ -1,7 +1,7 @@
 """
 This module defines a singleton object, "safety_checker" that
 wraps the safety_checker model. It respects the global "nsfw_checker"
-configuration variable, that allows the checker to be supressed.
+configuration variable, that allows the checker to be suppressed.
 """
 
 from pathlib import Path

--- a/invokeai/backend/model_manager/load/model_util.py
+++ b/invokeai/backend/model_manager/load/model_util.py
@@ -139,7 +139,7 @@ def calc_model_size_by_fs(model_path: Path, subfolder: Optional[str] = None, var
     bit8_files = {f for f in all_files if ".8bit." in f.name or ".8bit-" in f.name}
     other_files = set(all_files) - fp16_files - bit8_files
 
-    if not variant:  # ModelRepoVariant.DEFAULT evaluates to empty string for compatability with HF
+    if not variant:  # ModelRepoVariant.DEFAULT evaluates to empty string for compatibility with HF
         files = other_files
     elif variant == "fp16":
         files = fp16_files

--- a/invokeai/backend/onnx/onnx_runtime.py
+++ b/invokeai/backend/onnx/onnx_runtime.py
@@ -189,11 +189,11 @@ class IAIOnnxRuntimeModel(RawModel):
         # return self.io_binding.copy_outputs_to_cpu()
         return self.session.run(None, inputs)
 
-    # compatability with RawModel ABC
+    # compatibility with RawModel ABC
     def to(self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None) -> None:
         pass
 
-    # compatability with diffusers load code
+    # compatibility with diffusers load code
     @classmethod
     def from_pretrained(
         cls,


### PR DESCRIPTION
## Summary

Fixes five spelling typos in comments and module docstrings. Docs (comments only), no functional change.

- `invokeai/backend/onnx/onnx_runtime.py:192,196` - `compatability` -> `compatibility`
- `invokeai/backend/model_manager/load/model_util.py:142` - `compatability` -> `compatibility`
- `invokeai/backend/image_util/safety_checker.py:4` - `supressed` -> `suppressed`
- `invokeai/backend/image_util/invisible_watermark.py:4` - `supressed` -> `suppressed`

## Related Issues / Discussions

None.

## QA Instructions

Nothing to test. The changes are confined to comments and docstrings, so no runtime behaviour is affected.

## Merge Plan

Normal merge, nothing sensitive touched.

## Checklist

- [x] The PR has a short but descriptive title, suitable for a changelog
- [ ] Tests added / updated (if applicable)
- [ ] Documentation added / updated (if applicable)
