### PR TITLE
fix krea2 GGUF dequant dtype on mps

### DIFF
--- a/invokeai/backend/model_manager/load/model_loaders/krea2.py
+++ b/invokeai/backend/model_manager/load/model_loaders/krea2.py
@@ -409,7 +409,7 @@ class Krea2GGUFCheckpointModel(ModelLoader):
 
         model_path = Path(config.path)
         target_device = TorchDevice.choose_torch_device()
-        compute_dtype = TorchDevice.choose_bfloat16_safe_dtype(target_device)
+        compute_dtype = TorchDevice.choose_krea2_gguf_dtype(target_device)
 
         # GGMLTensor wrappers (kept on CPU; dequantized on-the-fly by the cache during inference).
         sd = gguf_sd_loader(model_path, compute_dtype=compute_dtype)

--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -431,3 +431,18 @@ class TorchDevice:
         if config.precision == "auto":
             return cls.choose_bfloat16_safe_dtype(device)
         return NAME_TO_PRECISION[config.precision]
+
+    @classmethod
+    def choose_krea2_gguf_dtype(cls, device: Optional[torch.device] = None) -> torch.dtype:
+        """Choose the compute dtype for Krea-2 GGUF weights.
+
+        Krea-2 GGUF dequantization in BF16 is unreliable on MPS, so use FP32 there. On other devices,
+        explicit precision settings are honored and ``auto`` retains the BF16-safe default used by Krea-2.
+        """
+        device = device or cls.choose_torch_device()
+        if device.type == "mps":
+            return torch.float32
+        config = get_config()
+        if config.precision == "auto":
+            return cls.choose_bfloat16_safe_dtype(device)
+        return NAME_TO_PRECISION[config.precision]


### PR DESCRIPTION
## Summary

Fix Krea-2 GGUF generation producing noise on Apple MPS devices.

Krea-2 GGUF dequantization now uses FP32 on MPS, where BF16 dequantization was found to produce noisy images. Other devices retain existing BF16-safe behavior, while explicit precision settings remain honored outside MPS.

## Related Issues / Discussions

None

## QA Instructions

None

## Merge Plan

None

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
