### PR TITLE
docs(ui): pin the scope of the socket's server-disconnect retry bound

### DIFF
--- a/invokeai/frontend/web/src/services/events/useSocketIO.test.tsx
+++ b/invokeai/frontend/web/src/services/events/useSocketIO.test.tsx
@@ -260,6 +260,50 @@ describe('useSocketIO (mounted)', () => {
     expect(sockets[0]?.connect).toHaveBeenCalledTimes(1);
   });
 
+  it('hands a retry that fails at the transport level to socket.io, uncounted', () => {
+    act(() => {
+      store.dispatch(setCredentials({ token: tokenFor(user.user_id, 1), user }));
+    });
+    mount();
+
+    act(() => {
+      sockets[0]?.fire('disconnect', 'io server disconnect');
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(sockets[0]?.connect).toHaveBeenCalledTimes(2);
+
+    // The server is not back yet: the retry fails at the transport level. socket.io reports that
+    // as a `connect_error`, not a `disconnect`, and its manager — re-armed by `connect()` — owns
+    // the recovery from here (#9542). The bounded counter must not see it, and this hook must not
+    // add a second driver to race the manager's.
+    act(() => {
+      sockets[0]?.fire('connect_error', new Error('xhr poll error'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(sockets[0]?.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves the manager free to reconnect without bound after a retry fails', () => {
+    act(() => {
+      store.dispatch(setCredentials({ token: tokenFor(user.user_id, 1), user }));
+    });
+    mount();
+
+    // Deliberate (#9542): the server disconnects sockets for authorization changes and expects
+    // the client back, so a retry that lands while the server is briefly unreachable must be
+    // followed by the manager's own reconnection. `reconnection: false` or a `reconnectionAttempts`
+    // cap would leave this tab with no events and no Invoke button until a reload — in that case,
+    // and in every ordinary outage the manager rides out today.
+    const options = io.mock.calls[0]?.[1];
+    expect(options?.reconnection).not.toBe(false);
+    expect(options?.reconnectionAttempts).toBeUndefined();
+  });
+
   it('gives up after a bounded number of server disconnects', () => {
     act(() => {
       store.dispatch(setCredentials({ token: tokenFor(user.user_id, 1), user }));

--- a/invokeai/frontend/web/src/services/events/useSocketIO.ts
+++ b/invokeai/frontend/web/src/services/events/useSocketIO.ts
@@ -31,6 +31,19 @@ declare global {
  * Bounded, because retrying is only ever right when the client is still welcome: a client that
  * is not gets a connect error, which socket.io does not retry, and the attempts stop there. The
  * count lives with the socket, so a session change (which builds a new one) starts it over.
+ *
+ * The bound covers server-initiated disconnects and nothing else. When one of these retries fails
+ * at the transport level instead — the server is restarting, a proxy is down — socket.io's
+ * manager takes over: `socket.connect()` re-arms its reconnection, and a failed attempt surfaces
+ * as `connect_error` rather than `disconnect`, so the counter here never sees it. That handoff
+ * is unbounded, with the manager's defaults (infinite attempts, 1s doubling to a 5s ceiling, ±50%
+ * jitter), and deliberately so. The server drops sockets for authorization changes and then
+ * expects the client back; capping the manager — `reconnection: false`, or a
+ * `reconnectionAttempts` limit — would strand the tab in exactly the case this retry exists for,
+ * a server briefly unreachable right after such a change, and would hand the same dead end to
+ * every ordinary outage, which the manager rides out on its own today. The two drivers do not
+ * race: a retry here fires once per server disconnect, which needs a connected socket, and
+ * `Socket.connect()` does not open the manager while it is between its own attempts. (#9542)
  */
 const MAX_SERVER_DISCONNECT_RECONNECTS = 5;
 const SERVER_DISCONNECT_RECONNECT_DELAY_MS = 1000;
@@ -116,8 +129,9 @@ export const useSocketIO = () => {
     const disposeEventListeners = setEventListeners({ socket, store, setIsConnected: $isConnected.set });
 
     // See MAX_SERVER_DISCONNECT_RECONNECTS. Only `io server disconnect` is ours to retry —
-    // socket.io reconnects transport-level drops itself, and `io client disconnect` is this
-    // effect's own teardown.
+    // socket.io reconnects transport-level drops itself, including a retry of ours that fails
+    // at the transport level (a `connect_error`, never a `disconnect`), and `io client
+    // disconnect` is this effect's own teardown.
     let serverDisconnects = 0;
     let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
     const reconnectAfterServerDisconnect = (reason: string) => {


### PR DESCRIPTION
## Summary

Resolves #9542 by option 1 from the issue: keep socket.io's own unbounded reconnection as the app's recovery path, and make the scope of the #9540 retry bound explicit in code and tests.

The five-attempt bound in `useSocketIO` governs **server-initiated disconnects only**. When one of those retries fails at the transport level (server restarting, proxy down), socket.io reports it as `connect_error` rather than `disconnect`, and `socket.connect()` has already re-armed the manager's reconnection, so the manager's default backoff (infinite attempts, 1s doubling to a 5s ceiling, ±50% jitter) takes over. Our counter never sees it.

That handoff is deliberate, and this PR says so where the next reader will look:

- **Rationale** on `MAX_SERVER_DISCONNECT_RECONNECTS`: the server drops sockets for authorization changes and expects the client back, so `reconnection: false` or a `reconnectionAttempts` cap would strand the tab exactly when the server is briefly unreachable after such a change, and would hand the same dead end to every ordinary outage the manager rides out today. Also notes why the two drivers cannot race: a retry here fires once per server disconnect (which needs a connected socket), and `Socket.connect()` does not open the manager while it is between its own attempts.
- **Two tests** pin it. A `connect_error` during a retry is left to the manager (the hook adds no second driver), and the socket is built with manager reconnection unbounded.

No behaviour changes. The thread's other conclusion stands too: raising only `reconnectionDelayMax` would not slow the manager's 1s/2s/4s opening steps, so a rate-limit, if ever wanted, needs its own specified policy and reproduction (the four-attempts-in-180ms burst has not reproduced with the lockfile's client versions).

## QA Instructions

Frontend only. `pnpm vitest run src/services/events/useSocketIO.test.tsx` (12 pass). Each new test was checked against the mutation it guards: a `connect_error` handler that retries fails the first, and either `reconnection: false` or `reconnectionAttempts: 5` fails the second, with nothing else affected. All five `pnpm lint:*` scripts pass.

## Checklist

- [x] The PR has a short but descriptive title, suitable for a changelog entry
- [x] Tests added / updated (if applicable)
- [ ] Documentation added / updated (if applicable) — in-code rationale; no user-facing docs cover socket recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z8LWHPW4TfpNCtwUo5yr9
