### PR TITLE
feat(backend): add LoKr/LyCORIS support for Krea-2 LoRAs

### DIFF
--- a/invokeai/backend/model_manager/configs/lora.py
+++ b/invokeai/backend/model_manager/configs/lora.py
@@ -946,6 +946,29 @@ def _has_complete_lora_pair(state_dict: dict[str | int, Any], key_filter: Callab
     return False
 
 
+def _has_complete_lokr_layer(
+    state_dict: dict[str | int, Any], key_filter: Callable[[str], bool] | None = None
+) -> bool:
+    """True if at least one complete LoKr layer exists (lokr_w1 + lokr_w2, or their factored variants).
+
+    A LoKr layer is complete when either:
+    - ``lokr_w1`` and ``lokr_w2`` share the same module prefix, or
+    - the factored form ``lokr_w1_a`` / ``lokr_w1_b`` (or ``lokr_w2_a`` / ``lokr_w2_b``) is present
+      alongside the corresponding direct ``lokr_w2`` / ``lokr_w1``.
+    """
+    string_keys = {key for key in state_dict if isinstance(key, str)}
+    prefixes_with_w1: set[str] = set()
+    prefixes_with_w2: set[str] = set()
+    for key in string_keys:
+        if key_filter is not None and not key_filter(key):
+            continue
+        if key.endswith(".lokr_w1") or key.endswith(".lokr_w1_a"):
+            prefixes_with_w1.add(key.rsplit(".", 1)[0])
+        if key.endswith(".lokr_w2") or key.endswith(".lokr_w2_a"):
+            prefixes_with_w2.add(key.rsplit(".", 1)[0])
+    return bool(prefixes_with_w1 & prefixes_with_w2)
+
+
 # Dotted layouts the converter understands for an explicit Krea-2 override (a transformer-only or
 # text-encoder-only LoRA that lacks the auto-detection text_fusion/time_mod_proj keys still installs under
 # an explicit base). The kohya/LyCORIS layout is deliberately absent - see `_key_is_supported_krea2_layout`.
@@ -994,7 +1017,9 @@ class LoRA_LyCORIS_Krea2_Config(LoRA_LyCORIS_Config_Base, Config_Base):
 
         state_dict = mod.load_state_dict()
         explicit_krea2_override = override_fields.get("base") is BaseModelType.Krea2
-        has_supported_explicit_pair = _has_complete_lora_pair(state_dict, _key_is_supported_krea2_layout)
+        has_supported_explicit_pair = _has_complete_lora_pair(
+            state_dict, _key_is_supported_krea2_layout
+        ) or _has_complete_lokr_layer(state_dict, _key_is_supported_krea2_layout)
         # Reject an orphaned half *anywhere* in the state dict (e.g. a dangling text_fusion half not under
         # the approved prefixes) — it would install here but fail during LoRA conversion at generation time.
         if explicit_krea2_override and has_supported_explicit_pair and _lora_weight_keys_are_all_paired(state_dict):
@@ -1007,13 +1032,17 @@ class LoRA_LyCORIS_Krea2_Config(LoRA_LyCORIS_Config_Base, Config_Base):
     @classmethod
     def _validate_looks_like_lora(cls, mod: ModelOnDisk) -> None:
         """Krea-2 LoRAs have keys like transformer.text_fusion.* / transformer.transformer_blocks.* with
-        a lora_A/lora_B (or lora_down/lora_up) suffix. The text-fusion stage is unique to Krea-2."""
+        a lora_A/lora_B (or lora_down/lora_up) suffix, or a LyCORIS LoKr layer (lokr_w1 + lokr_w2).
+        The text-fusion stage is unique to Krea-2."""
         state_dict = mod.load_state_dict()
-        # Require a *complete* lora_A/B (or lora_down/up) pair, not merely any lora/dora suffix: a file with
-        # only ``dora_scale`` and no A/B weights would pass a suffix check but fail later on missing weights.
-        if not (_has_krea2_lora_keys(state_dict) and _has_complete_lora_pair(state_dict)):
+        # Require a *complete* lora_A/B (or lora_down/up) pair, or a complete LoKr layer (lokr_w1 + lokr_w2).
+        # A file with only ``dora_scale`` and no A/B weights or LoKr weights would pass a suffix check but
+        # fail later on missing weights.
+        has_standard_pair = _has_krea2_lora_keys(state_dict) and _has_complete_lora_pair(state_dict)
+        has_lokr_layer = _has_krea2_lora_keys(state_dict) and _has_complete_lokr_layer(state_dict)
+        if not (has_standard_pair or has_lokr_layer):
             raise NotAMatchError(
-                "model does not match Krea-2 LoRA heuristics (no complete lora_A/B or lora_down/up pair)"
+                "model does not match Krea-2 LoRA heuristics (no complete lora_A/B, lora_down/up, or lokr_w1/w2 layer)"
             )
         # Reject a file with an orphaned LoRA half (a valid layer plus a dangling lora_A/B/down/up); it
         # would install here but fail later during LoRA conversion.

--- a/invokeai/backend/patches/lora_conversions/krea2_lora_conversion_utils.py
+++ b/invokeai/backend/patches/lora_conversions/krea2_lora_conversion_utils.py
@@ -276,6 +276,13 @@ _SUFFIX_TO_VALUE_KEY = {
     ".lora_magnitude_vector.weight": "dora_magnitude",
     ".magnitude": "dora_magnitude",
     ".alpha": "alpha",
+    ".lokr_w1": "lokr_w1",
+    ".lokr_w2": "lokr_w2",
+    ".lokr_w1_a": "lokr_w1_a",
+    ".lokr_w1_b": "lokr_w1_b",
+    ".lokr_w2_a": "lokr_w2_a",
+    ".lokr_w2_b": "lokr_w2_b",
+    ".lokr_t2": "lokr_t2",
 }
 
 

--- a/tests/backend/model_manager/configs/test_krea2_lora_config.py
+++ b/tests/backend/model_manager/configs/test_krea2_lora_config.py
@@ -371,3 +371,99 @@ def test_explicit_krea2_override_accepts_single_module_native_lora(_raise_if_not
     config = LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS, "base": BaseModelType.Krea2})
 
     assert config.base is BaseModelType.Krea2
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_automatic_probe_accepts_pure_lokr_lora(_raise_if_not_file) -> None:
+    # A Krea-2 LoRA that uses LyCORIS LoKr (lokr_w1 + lokr_w2) instead of lora_A/B must be
+    # auto-detected when it carries Krea-2 signature keys (text_fusion / txtfusion / wq+gate).
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "diffusion_model.blocks.0.attn.wq.lokr_w1": object(),
+        "diffusion_model.blocks.0.attn.wq.lokr_w2": object(),
+        "diffusion_model.blocks.0.attn.gate.lokr_w1": object(),
+        "diffusion_model.blocks.0.attn.gate.lokr_w2": object(),
+    }
+    config = LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS})
+    assert config.base is BaseModelType.Krea2
+
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_automatic_probe_accepts_lokr_with_text_fusion(_raise_if_not_file) -> None:
+    # text_fusion is the primary Krea-2 signature; LoKr layers on it must also be accepted.
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "transformer.text_fusion.0.attn.to_q.lokr_w1": object(),
+        "transformer.text_fusion.0.attn.to_q.lokr_w2": object(),
+        "transformer.text_fusion.0.attn.to_q.alpha": object(),
+    }
+    config = LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS})
+    assert config.base is BaseModelType.Krea2
+
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_automatic_probe_rejects_lokr_without_krea2_signature(_raise_if_not_file) -> None:
+    # A pure LoKr file that has no Krea-2 distinguishing keys (no text_fusion / txtfusion /
+    # wq+gate combo) must NOT auto-match Krea-2.
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "transformer.transformer_blocks.0.attn.to_q.lokr_w1": object(),
+        "transformer.transformer_blocks.0.attn.to_q.lokr_w2": object(),
+    }
+    with pytest.raises(NotAMatchError):
+        LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS})
+
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_automatic_probe_rejects_incomplete_lokr_only_w1(_raise_if_not_file) -> None:
+    # lokr_w1 without a matching lokr_w2 is not a complete LoKr layer; reject it.
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "transformer.text_fusion.0.attn.to_q.lokr_w1": object(),
+        # no lokr_w2
+    }
+    with pytest.raises(NotAMatchError):
+        LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS})
+
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_explicit_krea2_override_accepts_lokr_with_diffusion_model_prefix(_raise_if_not_file) -> None:
+    # The explicit override path must also admit LoKr layers under the diffusion_model. prefix.
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "diffusion_model.blocks.0.attn.gate.lokr_w1": object(),
+        "diffusion_model.blocks.0.attn.gate.lokr_w2": object(),
+        "diffusion_model.blocks.0.attn.wq.lokr_w1": object(),
+        "diffusion_model.blocks.0.attn.wq.lokr_w2": object(),
+    }
+    config = LoRA_LyCORIS_Krea2_Config.from_model_on_disk(
+        mod, {**_REQUIRED_FIELDS, "base": BaseModelType.Krea2}
+    )
+    assert config.base is BaseModelType.Krea2
+
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_automatic_probe_accepts_factored_lokr_w1_a_b(_raise_if_not_file) -> None:
+    # The factored form (lokr_w1_a + lokr_w1_b instead of lokr_w1) is also a complete LoKr layer.
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "transformer.text_fusion.0.attn.to_q.lokr_w1_a": object(),
+        "transformer.text_fusion.0.attn.to_q.lokr_w1_b": object(),
+        "transformer.text_fusion.0.attn.to_q.lokr_w2": object(),
+    }
+    config = LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS})
+    assert config.base is BaseModelType.Krea2
+
+
+@patch("invokeai.backend.model_manager.configs.lora.raise_if_not_file")
+def test_automatic_probe_accepts_mixed_lora_and_lokr(_raise_if_not_file) -> None:
+    # A file that mixes standard lora_A/B layers with LoKr layers must be accepted;
+    # this is a valid LyCORIS per-module-algorithm file.
+    mod = MagicMock()
+    mod.load_state_dict.return_value = {
+        "transformer.text_fusion.0.attn.to_q.lora_A.weight": object(),
+        "transformer.text_fusion.0.attn.to_q.lora_B.weight": object(),
+        "transformer.text_fusion.0.attn.to_k.lokr_w1": object(),
+        "transformer.text_fusion.0.attn.to_k.lokr_w2": object(),
+    }
+    config = LoRA_LyCORIS_Krea2_Config.from_model_on_disk(mod, {**_REQUIRED_FIELDS})
+    assert config.base is BaseModelType.Krea2

--- a/tests/backend/patches/lora_conversions/test_krea2_lora_conversion_utils.py
+++ b/tests/backend/patches/lora_conversions/test_krea2_lora_conversion_utils.py
@@ -483,3 +483,121 @@ def test_native_krea2_top_level_linear_keys_are_remapped() -> None:
         f"{KREA2_LORA_TRANSFORMER_PREFIX}{diffusers_module}" for diffusers_module in native_to_diffusers.values()
     }
     assert expected_keys < set(model.layers)
+
+def test_native_lokr_keys_produce_lokr_layer() -> None:
+    # Native (ComfyUI) LoKr keys must be remapped by _maybe_convert_native_krea2_state_dict and
+    # then grouped correctly by _group_by_layer, producing a LoKRLayer instance.
+    from invokeai.backend.patches.layers.lokr_layer import LoKRLayer
+
+    state_dict = {
+        # native layout: blocks→transformer_blocks, attn.gate→attn.to_gate
+        "diffusion_model.blocks.0.attn.gate.lokr_w1": torch.zeros(4, 4, dtype=torch.bfloat16),
+        "diffusion_model.blocks.0.attn.gate.lokr_w2": torch.zeros(1536, 1536, dtype=torch.bfloat16),
+        "diffusion_model.blocks.0.attn.gate.alpha": torch.tensor(1.0, dtype=torch.bfloat16),
+        # second native key so _has_krea2_lora_keys identifies this as Krea-2
+        "diffusion_model.blocks.0.attn.wq.lokr_w1": torch.zeros(4, 4, dtype=torch.bfloat16),
+        "diffusion_model.blocks.0.attn.wq.lokr_w2": torch.zeros(1536, 1536, dtype=torch.bfloat16),
+        "diffusion_model.blocks.0.attn.wq.alpha": torch.tensor(1.0, dtype=torch.bfloat16),
+    }
+
+    model = lora_model_from_krea2_state_dict(state_dict)
+
+    expected_gate = f"{KREA2_LORA_TRANSFORMER_PREFIX}transformer_blocks.0.attn.to_gate"
+    expected_wq = f"{KREA2_LORA_TRANSFORMER_PREFIX}transformer_blocks.0.attn.to_q"
+    assert expected_gate in model.layers, (
+        f"Expected '{expected_gate}' not found. Keys: {list(model.layers.keys())}"
+    )
+    assert expected_wq in model.layers
+    assert isinstance(model.layers[expected_gate], LoKRLayer)
+    assert isinstance(model.layers[expected_wq], LoKRLayer)
+    # w1 and w2 must be populated
+    layer = model.layers[expected_gate]
+    assert layer.w1 is not None
+    assert layer.w2 is not None
+
+
+def test_diffusers_lokr_keys_produce_lokr_layer() -> None:
+    # Diffusers-layout LoKr keys (transformer. prefix, already diffusers names) must group
+    # correctly without going through the native remapper.
+    from invokeai.backend.patches.layers.lokr_layer import LoKRLayer
+
+    state_dict = {
+        "transformer.text_fusion.0.attn.to_q.lokr_w1": torch.zeros(4, 4, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.lokr_w2": torch.zeros(256, 256, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.alpha": torch.tensor(1.0, dtype=torch.bfloat16),
+    }
+
+    model = lora_model_from_krea2_state_dict(state_dict)
+
+    expected_key = f"{KREA2_LORA_TRANSFORMER_PREFIX}text_fusion.0.attn.to_q"
+    assert expected_key in model.layers, (
+        f"Expected '{expected_key}' not found. Keys: {list(model.layers.keys())}"
+    )
+    assert isinstance(model.layers[expected_key], LoKRLayer)
+
+
+def test_factored_lokr_w1_a_b_produces_lokr_layer() -> None:
+    # The factored form (lokr_w1_a + lokr_w1_b) is a valid LoKr variant; all four suffixes
+    # must be grouped into one LoKRLayer with w1=None and w1_a/w1_b populated.
+    from invokeai.backend.patches.layers.lokr_layer import LoKRLayer
+
+    state_dict = {
+        "transformer.text_fusion.0.attn.to_q.lokr_w1_a": torch.zeros(4, 2, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.lokr_w1_b": torch.zeros(2, 4, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.lokr_w2": torch.zeros(256, 256, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.alpha": torch.tensor(1.0, dtype=torch.bfloat16),
+    }
+
+    model = lora_model_from_krea2_state_dict(state_dict)
+
+    expected_key = f"{KREA2_LORA_TRANSFORMER_PREFIX}text_fusion.0.attn.to_q"
+    assert expected_key in model.layers
+    layer = model.layers[expected_key]
+    assert isinstance(layer, LoKRLayer)
+    assert layer.w1 is None       # direct w1 absent — factored form
+    assert layer.w1_a is not None
+    assert layer.w1_b is not None
+    assert layer.w2 is not None
+
+
+def test_mixed_lora_and_lokr_in_same_file() -> None:
+    # A file that mixes standard lora_A/B modules with LoKr modules must produce the
+    # correct layer type for each module independently.
+    from invokeai.backend.patches.layers.lokr_layer import LoKRLayer
+
+    state_dict = {
+        # standard lora_A/B layer
+        "transformer.text_fusion.0.attn.to_q.lora_A.weight": torch.zeros(32, 256, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.lora_B.weight": torch.zeros(256, 32, dtype=torch.bfloat16),
+        # LoKr layer on a different module
+        "transformer.text_fusion.0.attn.to_k.lokr_w1": torch.zeros(4, 4, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_k.lokr_w2": torch.zeros(256, 256, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_k.alpha": torch.tensor(1.0, dtype=torch.bfloat16),
+    }
+
+    model = lora_model_from_krea2_state_dict(state_dict)
+
+    p = KREA2_LORA_TRANSFORMER_PREFIX
+    lora_key = f"{p}text_fusion.0.attn.to_q"
+    lokr_key = f"{p}text_fusion.0.attn.to_k"
+    assert lora_key in model.layers
+    assert lokr_key in model.layers
+    assert isinstance(model.layers[lora_key], LoRALayer)
+    assert isinstance(model.layers[lokr_key], LoKRLayer)
+
+
+def test_lokr_alpha_is_preserved() -> None:
+    # The alpha scalar must survive grouping and be stored on the LoKRLayer.
+    from invokeai.backend.patches.layers.lokr_layer import LoKRLayer
+
+    state_dict = {
+        "transformer.text_fusion.0.attn.to_q.lokr_w1": torch.zeros(4, 4, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.lokr_w2": torch.zeros(256, 256, dtype=torch.bfloat16),
+        "transformer.text_fusion.0.attn.to_q.alpha": torch.tensor(4.0, dtype=torch.bfloat16),
+    }
+
+    model = lora_model_from_krea2_state_dict(state_dict)
+
+    layer = model.layers[f"{KREA2_LORA_TRANSFORMER_PREFIX}text_fusion.0.attn.to_q"]
+    assert isinstance(layer, LoKRLayer)
+    assert layer._alpha == pytest.approx(4.0)


### PR DESCRIPTION
## Summary

Adds support for Krea-2 LoRAs that use the LyCORIS LoKr (Kronecker product) decomposition format — `lokr_w1` + `lokr_w2` keys — instead of the standard diffusers `lora_A/lora_B` format. These are published on Civitai by third-party creators and previously failed at model identification with:

```
NotAMatchError: model does not match Krea-2 LoRA heuristics (no complete lora_A/B or lora_down/up pair)
```

`LoKRLayer` and its dispatcher in `any_lora_layer_from_state_dict` already implement the Kronecker product math for other architectures (FLUX, Anima). This change wires that existing support up for Krea-2 — no new math or layer classes are needed.

Two files changed:
- `configs/lora.py` — add `_has_complete_lokr_layer()` helper; update `LoRA_LyCORIS_Krea2_Config` probe to accept LoKr-only files alongside existing `lora_A/B` check
- `krea2_lora_conversion_utils.py` — add 7 LoKr suffix entries to `_SUFFIX_TO_VALUE_KEY` so `_group_by_layer()` correctly splits them off the module path

Mixed-algorithm files (some modules `lora_A/B`, others `lokr_w1/w2`) are also handled — each module gets the correct layer type independently.

## Related Issues / Discussions

N/A

## QA Instructions

Install a Krea-2 LoKr LoRA from Civitai (identifiable by its ~1.4 GB size and `lokr_w1`/`lokr_w2` keys). Previously these would fail to import. With this change they should install and apply correctly.

To verify the key structure of a suspect file:

```python
from safetensors import safe_open
with safe_open("your_lora.safetensors", framework="pt") as f:
    print(list(f.keys())[:5])
# LoKr files show: [...'.lokr_w1', ...'.lokr_w2', ...'.alpha']
```

## Disclaimer

Entirely vibecoded PR. I tested the changes by building the Dockerfile and setting up a mirror of my regular docker-compose.yml setup, where I installed and used the files that I was previously unable to. From my end the changes work, so I thought I'd send in a PR. Please instruct or correct if any changes need to happen. Thanks.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Tests added / updated (if applicable)_
- [ ] _❗Changes to a redux slice have a corresponding migration_
- [ ] _Documentation added / updated (if applicable)_
- [ ] _Updated `What's New` copy (if doing a release after this PR)_
